### PR TITLE
Variable length data is no longer compressed

### DIFF
--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -8,7 +8,7 @@
 #   Functions for performing MCMC inversion.
 #   PyMC library used for Bayesian modelling. Updated from PyMc3
 # *****************************************************************************
-
+import re
 import numpy as np
 import pymc as pm
 import pandas as pd

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -596,9 +596,19 @@ def inferpymc_postprocessouts(xouts,bcouts, sigouts, convergence,
         outds.attrs['Date created'] = str(pd.Timestamp('today'))
         outds.attrs['Convergence'] = convergence
         outds.attrs['Repository version'] = code_version()
-        
+
+        # variables with variable length data types shouldn't be compressed
+        # e.g. object ("O") or unicode ("U") type
+        do_not_compress = []
+        dtype_pat = re.compile(r"[<>=]?[UO]")  # regex for Unicode and Object dtypes
+        for dv in outds.data_vars:
+            if dtype_pat.match(outds[dv].data.dtype.str):
+                do_not_compress.append(dv)
+
+        # setting compression levels for data vars in outds
         comp = dict(zlib=True, complevel=5)
-        encoding = {var: comp for var in outds.data_vars}
+        encoding = {var: comp for var in outds.data_vars if var not in do_not_compress}
+
         output_filename = define_output_filename(outputpath,species,domain,outputname,start_date,ext=".nc")
         Path(outputpath).mkdir(parents=True, exist_ok=True)
         outds.to_netcdf(output_filename, encoding=encoding, mode="w")


### PR DESCRIPTION
Compressing variable length data when writing a dataset to netcdf can cause a "Filter Error".

To avoid this, I modified the encoding in `infterpymc_postprocessouts` to not apply `zlib` to data variables whose data type is variable length.

These data types are: "Object" and "Unicode". These are numpy datatypes with codes "O" and "U". I used a regex to parse the datatype string for each data variables, since these strings can start with a symbol to specify the byte-order.

This elimiates the FilterError from the inversion run on Iss18, and the netCDF output seems to be about 1/3 the size of the output if `encoding = None` (i.e. no additional compression from `zlib=True`) is used.

This closes Issue #18.