### PR TITLE
added option to save or reload a merged data object

### DIFF
--- a/openghg_inversions/get_data.py
+++ b/openghg_inversions/get_data.py
@@ -18,6 +18,7 @@ import sys
 import shutil
 import numpy as np
 import pandas as pd
+import pickle
 
 import openghg_inversions.hbmcmc.inversionsetup as setup
 from openghg.retrieve import get_obs_surface, get_flux
@@ -29,7 +30,8 @@ def data_processing_surface_notracer(species, sites, domain, averaging_period, s
                                      met_model=None, fp_model="NAME", fp_height=None,
                                      emissions_name=None, inlet=None, instrument=None, bc_input=None,
                                      bc_store=None, obs_store=None, footprint_store=None, emissions_store=None,
-                                     averagingerror=True):
+                                     averagingerror=True,save_merged_data=False,
+                                     merged_data_name=None,merged_data_dir=None):
 
     """
     Retrieve and prepare fixed-surface datasets from
@@ -205,6 +207,13 @@ def data_processing_surface_notracer(species, sites, domain, averaging_period, s
                                          averaging_period,
                                          inlet=inlet,
                                          instrument=instrument)
+        
+    if save_merged_data == True:
+        fp_out = open(merged_data_dir+merged_data_name, 'wb')
+        pickle.dump(fp_all, fp_out)
+        fp_out.close()
+
+        print(f'\nfp_all saved in {merged_data_dir}\n')
 
     return fp_all
 

--- a/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template.ini
+++ b/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template.ini
@@ -9,6 +9,9 @@
 ; meas_period (list) - Time periods for measurements as a list (must match length of sites)
 ; start_date (str) - Start of observations to extract (format YYYY-MM-DD)
 ; end_date (str) - End of observations to extract (format YYYY-MM-DD) (non-inclusive)
+; save_merged_data (bool) - If True, saves merged data object
+; reload_merged_data (bool) - If True, reads merged data object rather than rerunning get_data
+; merged_data_dir (str) - Path to directory with merged data objects.
 
 species = ''      ; (required)
 use_tracer = False; (required)
@@ -16,6 +19,10 @@ sites = []        ; (required)
 averaging_period = []  ; (required)
 start_date = ''   ; (required - but can be specified on command line instead)
 end_date = ''     ; (required - but can be specified on command line instead)
+
+save_merged_data = False
+reload_merged_data = False
+merged_data_dir = ''
 
 ; inlet (list/None) - Specific inlet height for the site (list - must match number of sites)
 ; instrument (list/None) - Specific instrument for the site (list - must match number of sites)

--- a/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template_example.ini
+++ b/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template_example.ini
@@ -11,6 +11,9 @@
 ;   averaging_period (list) - Time periods for measurements as a list (must match length of sites)
 ;   start_date (str) - Start of observations to extract (format YYYY-MM-DD)
 ;   end_date (str) - End of observations to extract (format YYYY-MM-DD) (non-inclusive)
+; save_merged_data (bool) - If True, saves merged data object
+; reload_merged_data (bool) - If True, reads merged data object rather than rerunning get_data
+; merged_data_dir (str) - Path to directory with merged data objects.
 
 species = "ch4"      ; (required)
 use_tracer = False 
@@ -18,6 +21,10 @@ sites = ["TAC","RGL"]        ; (required)
 averaging_period = ["4H","4H"]  ; (required)
 start_date = "2019-01-01"   ; (required - but can be specified on command line instead)
 end_date = "2019-02-01"     ; (required - but can be specified on command line instead)
+
+save_merged_data = False
+reload_merged_data = False
+merged_data_dir = '/group/chemistry/acrg/'
 
 ; inlet (list/None) - Specific inlet height for the site (list - must match number of sites)
 ; instrument (list/None) - Specific instrument for the site (list - must match number of sites)


### PR DESCRIPTION
I've added an option to `get_data.data_processing_surface_notracer`, to save the merged data object (`fp_all`) to a pickle file.

`hbmcmc.fixedbasisMCMC` then either reads a saved merged data object, or runs the `get_data` process, to extract all the input data for the inversion.

3 new variables have been added to the .ini file, to allow for this:

`reload_merged_data`, `save_merged_data `and `merged_data_dir`