### PR TITLE
Updates to min_model_error, to bring it up to date with changes in eric_devel etc.

### DIFF
--- a/openghg_inversions/basis_functions.py
+++ b/openghg_inversions/basis_functions.py
@@ -357,7 +357,7 @@ def optimize_nregions(bucket, grid, nregion, tol):
         bucket = bucket * 0.995
         return optimize_nregions(bucket, grid, nregion, tol)
 
-    elif get_nregions(mybucket, fps) > nregion - tol:
+    elif get_nregions(bucket, grid) > nregion - tol:
         bucket = bucket * 1.005
         return optimize_nregions(bucket, grid, nregion, tol)
 
@@ -523,7 +523,7 @@ def bucketbasisfunction(
     base = np.expand_dims(bucket_basis, axis=2)
 
     time = [pd.to_datetime(start_date)]
-    newds = xray.Dataset(
+    newds = xr.Dataset(
         {"basis": (["lat", "lon", "time"], base)},
         coords={"time": (["time"], time), "lat": (["lat"], lat), "lon": (["lon"], lon)},
     )

--- a/openghg_inversions/get_data.py
+++ b/openghg_inversions/get_data.py
@@ -174,7 +174,7 @@ def data_processing_surface_notracer(species, sites, domain, averaging_period, s
         elif len(emissions_name) >1:
             model_scenario_dict = {}
  
-            for source in emissions_sources:
+            for source in emissions_name:
                 model_scenario=ModelScenario(site=site,
                                              species=species,
                                              inlet=inlet[i],
@@ -239,7 +239,8 @@ def data_processing_surface_notracer(species, sites, domain, averaging_period, s
                                          end_date,
                                          averaging_period,
                                          inlet=inlet,
-                                         instrument=instrument)
+                                         instrument=instrument,
+                                         store=obs_store)
         
     if save_merged_data == True:
         fp_out = open(merged_data_dir+merged_data_name, 'wb')

--- a/openghg_inversions/get_data.py
+++ b/openghg_inversions/get_data.py
@@ -262,7 +262,7 @@ def data_processing_surface_notracer(species, sites, domain, averaging_period, s
                                          store=obs_store)
         
     if save_merged_data == True:
-        fp_out = open(merged_data_dir+merged_data_name, 'wb')
+        fp_out = open(os.path.join(merged_data_dir,merged_data_name), 'wb')
         pickle.dump(fp_all, fp_out)
         fp_out.close()
 

--- a/openghg_inversions/get_data.py
+++ b/openghg_inversions/get_data.py
@@ -111,113 +111,132 @@ def data_processing_surface_notracer(species, sites, domain, averaging_period, s
     footprint_dict={}
     scales={}
     check_scales=[]
+    
+    site_indices_to_keep = []
 
     for i, site in enumerate(sites):
-        # Get observations
-        site_data=get_obs_surface(site=site,
-                                  species=species.lower(),
-                                  inlet=inlet[i],
-                                  start_date=start_date,
-                                  end_date=end_date,
-                                  average=averaging_period[i],
-                                  instrument=instrument[i],
-                                  store=obs_store)
+        
+        try:
+            # Get observations
+            site_data=get_obs_surface(site=site,
+                                    species=species.lower(),
+                                    inlet=inlet[i],
+                                    start_date=start_date,
+                                    end_date=end_date,
+                                    average=averaging_period[i],
+                                    instrument=instrument[i],
+                                    store=obs_store)
 
-        unit=float(site_data[site].mf.units)
+            unit=float(site_data[site].mf.units)
 
-        # Get footprints
-        get_fps = get_footprint(site=site,
-                                height=fp_height[i],
+            # Get footprints
+            get_fps = get_footprint(site=site,
+                                    height=fp_height[i],
+                                    domain=domain,
+                                    model=fp_model,
+                                    start_date=start_date,
+                                    end_date=end_date,
+                                    store=footprint_store)
+            footprint_dict[site] = get_fps
+
+
+            # Get boundary conditions
+            get_bc_data = get_bc(species=species,
                                 domain=domain,
-                                model=fp_model,
+                                bc_input=bc_input,
                                 start_date=start_date,
                                 end_date=end_date,
-                                store=footprint_store)
-        footprint_dict[site] = get_fps
+                                store=bc_store)
 
 
-        # Get boundary conditions
-        get_bc_data = get_bc(species=species,
-                             domain=domain,
-                             bc_input=bc_input,
-                             start_date=start_date,
-                             end_date=end_date,
-                             store=bc_store)
+            # Divide by trace gas species units
+            # See if R+G can include this 'behind the scenes'
+            get_bc_data.data.vmr_n.values = get_bc_data.data.vmr_n.values/unit
+            get_bc_data.data.vmr_e.values = get_bc_data.data.vmr_e.values/unit
+            get_bc_data.data.vmr_s.values = get_bc_data.data.vmr_s.values/unit
+            get_bc_data.data.vmr_w.values = get_bc_data.data.vmr_w.values/unit
+            my_bc = BoundaryConditionsData(get_bc_data.data.transpose("height","lat","lon","time"),
+                                            get_bc_data.metadata)
+            fp_all['.bc']=my_bc
 
-
-        # Divide by trace gas species units
-        # See if R+G can include this 'behind the scenes'
-        get_bc_data.data.vmr_n.values = get_bc_data.data.vmr_n.values/unit
-        get_bc_data.data.vmr_e.values = get_bc_data.data.vmr_e.values/unit
-        get_bc_data.data.vmr_s.values = get_bc_data.data.vmr_s.values/unit
-        get_bc_data.data.vmr_w.values = get_bc_data.data.vmr_w.values/unit
-        my_bc = BoundaryConditionsData(get_bc_data.data.transpose("height","lat","lon","time"),
-                                           get_bc_data.metadata)
-        fp_all['.bc']=my_bc
-
-        # Create ModelScenario object for all emissions_sectors
-        # and combine into one object
-        if len(emissions_name) == 1:
-            model_scenario=ModelScenario(site=site,
-                                         species=species,
-                                         inlet=inlet[i],
-                                         start_date=start_date,
-                                         end_date=end_date,
-                                         obs=site_data,
-                                         footprint=footprint_dict[site],
-                                         flux=flux_dict,
-                                         bc=my_bc)
-
-            scenario_combined=model_scenario.footprints_data_merge()
-            scenario_combined.bc_mod.values = scenario_combined.bc_mod.values * unit
-
-        elif len(emissions_name) >1:
-            model_scenario_dict = {}
- 
-            for source in emissions_name:
+            # Create ModelScenario object for all emissions_sectors
+            # and combine into one object
+            if len(emissions_name) == 1:
                 model_scenario=ModelScenario(site=site,
-                                             species=species,
-                                             inlet=inlet[i],
-                                             start_date=start_date,
-                                             end_date=end_date,
-                                             obs=site_data,
-                                             footprint=footprint_dict[site],
-                                             flux=flux_dict,
-                                             bc=my_bc)
+                                            species=species,
+                                            inlet=inlet[i],
+                                            start_date=start_date,
+                                            end_date=end_date,
+                                            obs=site_data,
+                                            footprint=footprint_dict[site],
+                                            flux=flux_dict,
+                                            bc=my_bc)
 
-                scenario_sector=model_scenario.footprints_data_merge(sources=source)
-                model_scenario_dict["mf_mod_high_res_"+source] = scenario_sector["mf_mod_high_res"]       
+                scenario_combined=model_scenario.footprints_data_merge()
+                scenario_combined.bc_mod.values = scenario_combined.bc_mod.values * unit
 
-            model_scenario=ModelScenario(site=site,
-                                         species=species,
-                                         inlet=inlet[i],
-                                         start_date=start_date,
-                                         end_date=end_date,
-                                         obs=site_data,
-                                         footprint=footprint_dict[site],
-                                         flux=flux_dict,
-                                         bc=my_bc)
+            elif len(emissions_name) >1:
+                model_scenario_dict = {}
+    
+                for source in emissions_name:
+                    model_scenario=ModelScenario(site=site,
+                                                species=species,
+                                                inlet=inlet[i],
+                                                start_date=start_date,
+                                                end_date=end_date,
+                                                obs=site_data,
+                                                footprint=footprint_dict[site],
+                                                flux=flux_dict,
+                                                bc=my_bc)
 
-            scenario_combined=model_scenario.footprints_data_merge()
+                    scenario_sector=model_scenario.footprints_data_merge(sources=source)
+                    model_scenario_dict["mf_mod_high_res_"+source] = scenario_sector["mf_mod_high_res"]       
 
-            for key in model_scenario_dict.keys():
-                scenario_combined[key] = model_scenario_dict[key]
-            
-            scenario_combined.bc_mod.values = scenario_combined.bc_mod.values * unit
+                model_scenario=ModelScenario(site=site,
+                                            species=species,
+                                            inlet=inlet[i],
+                                            start_date=start_date,
+                                            end_date=end_date,
+                                            obs=site_data,
+                                            footprint=footprint_dict[site],
+                                            flux=flux_dict,
+                                            bc=my_bc)
 
-        fp_all[site]=scenario_combined
+                scenario_combined=model_scenario.footprints_data_merge()
 
-        # Check consistency of measurement scales between sites
-        check_scales+=[scenario_combined.scale]
-        if not all (s==check_scales[0] for s in check_scales):
-            rt=[]
-            for i in check_scales:
-                if isinstance(i, list): rt.extend(flatten(i))
+                for key in model_scenario_dict.keys():
+                    scenario_combined[key] = model_scenario_dict[key]
+                
+                scenario_combined.bc_mod.values = scenario_combined.bc_mod.values * unit
+
+            fp_all[site]=scenario_combined
+
+            # Check consistency of measurement scales between sites
+            check_scales+=[scenario_combined.scale]
+            if not all (s==check_scales[0] for s in check_scales):
+                rt=[]
+                for i in check_scales:
+                    if isinstance(i, list): rt.extend(flatten(i))
+                else:
+                    rt.append(i)
+                scales[site]=rt
             else:
-                rt.append(i)
-            scales[site]=rt
-        else:
-            scales[site]=check_scales[0]
+                scales[site]=check_scales[0]
+                
+            site_indices_to_keep.append(i)
+                
+        except:
+            print(f'\nError in reading in data for {site}, possibly because there is no obs for this time period.'+
+                  f'\nContinuing model run without {site}.\n')
+            
+    # if data was not extracted correctly for any sites, drop these from the rest of the inversion
+    if len(site_indices_to_keep) < len(sites):
+        
+        sites = [sites[s] for s in site_indices_to_keep]
+        inlet = [inlet[s] for s in site_indices_to_keep]
+        fp_height = [fp_height[s] for s in site_indices_to_keep]
+        instrument = [instrument[s] for s in site_indices_to_keep]
+        averaging_period = [averaging_period[s] for s in site_indices_to_keep]
 
     fp_all['.scales']=scales
     fp_all['.units']=float(scenario_combined.mf.units)
@@ -249,7 +268,7 @@ def data_processing_surface_notracer(species, sites, domain, averaging_period, s
 
         print(f'\nfp_all saved in {merged_data_dir}\n')
 
-    return fp_all
+    return fp_all,sites,inlet,fp_height,instrument,averaging_period
 
 
 

--- a/openghg_inversions/get_data.py
+++ b/openghg_inversions/get_data.py
@@ -25,6 +25,7 @@ from openghg.retrieve import get_obs_surface, get_flux
 from openghg.retrieve import get_bc, get_footprint
 from openghg.analyse import ModelScenario
 from openghg.dataobjects import BoundaryConditionsData
+from openghg.types import SearchError
 
 def data_processing_surface_notracer(species, sites, domain, averaging_period, start_date, end_date,
                                      met_model=None, fp_model="NAME", fp_height=None,
@@ -225,7 +226,7 @@ def data_processing_surface_notracer(species, sites, domain, averaging_period, s
                 
             site_indices_to_keep.append(i)
                 
-        except:
+        except SearchError:
             print(f'\nError in reading in data for {site}, possibly because there is no obs for this time period.'+
                   f'\nContinuing model run without {site}.\n')
             

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -382,7 +382,7 @@ def fixedbasisMCMC(
         merged_data_name = f"{species}_{start_date}_{outputname}_merged-data.pickle"
 
         if use_tracer == False:
-            fp_all = get_data.data_processing_surface_notracer(
+            fp_all,sites,inlet,fp_height,instrument,averaging_period = get_data.data_processing_surface_notracer(
                 species,
                 sites,
                 domain,

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -167,7 +167,8 @@ def basis_functions_wrapper(
 
     elif basis_algorithm == None:
         basis_directory = basis_directory
-
+        tempdir = None
+        
     else:
         raise ValueError(
             "Basis algorithm not recognised. Please use either 'quadtree' or 'weighted', or input a basis function file"
@@ -376,9 +377,24 @@ def fixedbasisMCMC(
 
         else:
             print(f"No merged data available at {merged_data_filename} so rerunning this process.\n")
+            
+        sites_merged = [s for s in fp_all.keys() if '.' not in s]
+
+        if len(sites) != len(sites_merged):
+            
+            keep_i = [i for i,s in enumerate(sites) if s in sites_merged]
+            s_dropped = [s for s in sites if s not in sites_merged]
+            
+            sites = [s for i,s in enumerate(sites) if i in keep_i]
+            inlet = [s for i,s in enumerate(inlet) if i in keep_i]
+            fp_height = [s for i,s in enumerate(fp_height) if i in keep_i]
+            instrument = [s for i,s in enumerate(instrument) if i in keep_i]
+            averaging_period = [s for i,s in enumerate(averaging_period) if i in keep_i]
+            
+            print(f'\nDropping {s_dropped} sites as they are not included in the merged data object.\n')
 
     # Get datasets for forward simulations
-    if rerun_merge == True:
+    elif rerun_merge == True:
         merged_data_name = f"{species}_{start_date}_{outputname}_merged-data.pickle"
 
         if use_tracer == False:
@@ -509,7 +525,7 @@ def fixedbasisMCMC(
         )
 
         # Process and save inversion output
-        mcmc.inferpymc_postprocessouts(
+        out = mcmc.inferpymc_postprocessouts(
             xouts,
             bcouts,
             sigouts,
@@ -567,6 +583,8 @@ def fixedbasisMCMC(
             shutil.rmtree(tempdir)
 
     print("---- Inversion completed ----")
+    
+    return out
 
 
 def rerun_output(input_file, outputname, outputpath, verbose=False):

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -127,6 +127,7 @@ def basis_functions_wrapper(
         if fp_basis_case != None:
             print("Basis case %s supplied but quadtree_basis set to True" % fp_basis_case)
             print("Assuming you want to use %s " % fp_basis_case)
+            tempdir = None
         else:
             tempdir = basis.quadtreebasisfunction(
                 emissions_name,
@@ -148,6 +149,7 @@ def basis_functions_wrapper(
         if fp_basis_case != None:
             print("Basis case %s supplied but bucket_basis set to True" % fp_basis_case)
             print("Assuming you want to use %s " % fp_basis_case)
+            tempdir = None
         else:
             tempdir = basis.bucketbasisfunction(
                 emissions_name,

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -524,8 +524,8 @@ def inferpymc_postprocessouts(
     if rerun_file is not None:
         flux_array_all = np.expand_dims(rerun_file.fluxapriori.values, 2)
     else:
-        if emissions_name == None:
-            raise NameError("Emissions name not provided.")
+        if emissions_name is None:
+            raise ValueError("Emissions name not provided.")
         else:
             emds = fp_data['.flux'][emissions_name[0]]
             flux_array_all = emds.data.flux.values

--- a/openghg_inversions/hbmcmc/inversionsetup.py
+++ b/openghg_inversions/hbmcmc/inversionsetup.py
@@ -34,7 +34,7 @@ def opends(fn):
         return ds
 
 def addaveragingerror(fp_all, sites, species, start_date, end_date, meas_period,  
-                      inlet=None, instrument=None):
+                      inlet=None, instrument=None,store=None):
     '''
     Adds the variablility within the averaging period to the mole fraction error.
     -----------------------------------
@@ -70,7 +70,8 @@ def addaveragingerror(fp_all, sites, species, start_date, end_date, meas_period,
                                   instrument=instrument[i],
                                   average=meas_period[i],
                                   start_date=start_date,
-                                  end_date=end_date)
+                                  end_date=end_date,
+                                  store=store)
 
         sitedataerr=pd.DataFrame(get_obs.data.mf, index=get_obs.data.time.values)
 

--- a/openghg_inversions/utils.py
+++ b/openghg_inversions/utils.py
@@ -222,7 +222,7 @@ def filtering(datasets_in, filters, keep_missing=False):
             "nighttime"         : Only b/w 23:00 - 03:00 inclusive
             "noon"              : Only 12:00 fp and obs used
             "daily_median"      : calculates the daily median
-            "pblh_gt_threshold" :
+            "pblh"              : Only keeps times when pblh is > 50m away from the obs height
             "local_influence"   : Only keep times when localness is low
             "six_hr_mean"       :
             "local_lapse"       :
@@ -412,10 +412,15 @@ def filtering(datasets_in, filters, keep_missing=False):
     # Apply filtering
     for site in sites:
         for filt in filters:
+            n_nofilter = datasets[site].time.values.shape[0]
             if filt in ["daily_median", "six_hr_mean", "pblh"]:
                 datasets[site] = filtering_functions[filt](datasets[site], keep_missing=keep_missing)
             else:
                 datasets[site] = filtering_functions[filt](datasets[site], site, keep_missing=keep_missing)
+            n_filter = datasets[site].time.values.shape[0]
+            n_dropped = n_nofilter - n_filter
+            perc_dropped = np.round(n_dropped/n_nofilter*100,2)
+            print(f'{filt} filter removed {n_dropped} ({perc_dropped} %) obs at site {site}')
 
     return datasets
 


### PR DESCRIPTION
This branch can be merged into min_model_error when everyone else is ready to start turning min_model_error into the new 'main' branch of the repo.

Updates on this branch include:

- A fix for reading in the correct prior fluxes, when creating the posterior country fluxes and saving everything after the inversion. The prior fluxes are now read directly from the merged data object, and the correct monthly/annual flux is sliced from the full flux object. This includes taking an average flux across a range of months, if the inversion is across mulitple months.

- A try/except loop which drops sites from the inversion if the data merge process doesn't work for that site (which normally happens if there's no obs).

- Adding in a print out of the number and % of obs that are removed by each filter, at each site.

 - Fixes for saving and reading in the merged data object, including modifying the site variable (and associated heights etc.) if these aren't found in the merged data object.

- Some minor bug fixes, including some in the basis function creation process and some variable names.