### PR TITLE
Update RHIME input configuration files

### DIFF
--- a/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template.ini
+++ b/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template.ini
@@ -1,31 +1,39 @@
-; Configuration file for HBMCMC code
+; =======================================================================================
+; Regional Hierarchical Inverse Modelling Environment Configuration File
+; =======================================================================================
+; RHIME configuration file template. Please check through variable paths and 
+; names before running.
 ; Required inputs are marked as such.
 ; All other inputs are optional (defaults will be used)
+; ======================================================================================= 
 
 [INPUT.MEASUREMENTS]
 ; Input values for extracting observations
-; species (str) - species name (see acrg_species_info.json for options) e.g. "ch4"
-; sites (list) - site codes as a list (see acrg_site_info.json for options) e.g. ["MHD"]
-; meas_period (list) - Time periods for measurements as a list (must match length of sites)
-; start_date (str) - Start of observations to extract (format YYYY-MM-DD)
-; end_date (str) - End of observations to extract (format YYYY-MM-DD) (non-inclusive)
-; save_merged_data (bool) - If True, saves merged data object
-; reload_merged_data (bool) - If True, reads merged data object rather than rerunning get_data
-; merged_data_dir (str) - Path to directory with merged data objects.
+; species (str): Species name (check object store for options) e.g. "ch4"
+; use_tracer (bool): Option to use tracer method for inversions
+; sites (list): Site codes as a list (check object store for options) e.g. ["MHD"]
+; averaging_period (list): Averaged time periods for measurements as a list (must match length of sites)
+; start_date (str): Start of observations to extract (format YYYY-MM-DD)
+; end_date (str): End of observations to extract (format YYYY-MM-DD) (non-inclusive)
 
-species = ''      ; (required)
-use_tracer = False; (required)
-sites = []        ; (required)
+species = " "          ; (required)
+use_tracer = False     ; (required)
+sites = []             ; (required)
 averaging_period = []  ; (required)
-start_date = ''   ; (required - but can be specified on command line instead)
-end_date = ''     ; (required - but can be specified on command line instead)
+start_date = " "       ; (required - but can be specified on command line instead)
+end_date = " "         ; (required - but can be specified on command line instead)
+
+; save_merged_data (bool): If True, saves merged data object
+; reload_merged_data (bool): If True, reads merged data object rather than rerunning get_data
+; merged_data_dir (str): Path to directory with merged data objects.
 
 save_merged_data = False
 reload_merged_data = False
-merged_data_dir = ''
+merged_data_dir = " "
 
-; inlet (list/None) - Specific inlet height for the site (list - must match number of sites)
-; instrument (list/None) - Specific instrument for the site (list - must match number of sites)
+; inlet (list/None): Specific measurements inlet height for the site (list - must match number of sites)
+; instrument (list/None): Specific instrument for the site (list - must match number of sites)
+; filters (str): Data filtering approach to apply 
 
 inlet = None
 instrument = None
@@ -33,95 +41,103 @@ filters = []
 
 [INPUT.STORES]
 ; OpenGHG object stores for various data. NB. All data may come from the same 
-;   object store. This facilitates multiple object stores.
-;   bc_store (str) - name of object store with BC data
-;   obs_store (str) - name of object store with measurements data
-;   footprint_store (str) - name of object store with footprints data
-;   emissions_store (str) - emissions_store
+;   object store. This facilitates using multiple object stores.
+; bc_store (str): Name of object store with Boundary Conditions data
+; obs_store (str): Name of object store with measurements data
+; footprint_store (str): Name of object store with footprints data
+; emissions_store (str): Name of flux emissions object store
 
-bc_store=""            ; (required)
-obs_store=""           ; (required)
-footprint_store=""     ; (required)
-emissions_store=""     ; (required)
+bc_store = " "            ; (required)
+obs_store = " "           ; (required)
+footprint_store = " "     ; (required)
+emissions_store = " "     ; (required)
 
 
 [INPUT.PRIORS]
 ; Input values for extracting footprints, emissions and boundary conditions files (also uses values from INPUT.MEASUREMENTS)
-; domain (str) - Name of inversion spatial domain e.g. "EUROPE"
-; met_model (dict/str/None) - either dict corresponding to sites, str. e.g., 'UKV' or None if applies to all sites
-; fp_model (str) - Name of LPDM e.g. "NAME"
-; emissions_name (list) - Name of specific emissions sources as used when adding flux files to the object store
+; domain (str): Name of inversion spatial domain e.g. "EUROPE"
+; met_model (str/None):  e.g., 'UKV' or None if applies to all sites
+; fp_model (str): Name of LPDM footprints e.g. "NAME"
+; fp_height (list/str): List of footprint inlet heights used in model.
+; emissions_name (list): Name of emissions sources as used when adding flux files to the object store
+; bc_input (list/str): Name of boundary conditions data to use from object store
 
-domain = ''           ; (required) 
+domain = " "           ; (required) 
 met_model = None      
 fp_model = None
 fp_height = None
-emissions_name = None
+emissions_name = None  ; (required)
 bc_input = None
 
 [INPUT.BASIS_CASE]
 ; Input values to extract the basis cases to use within the inversion for boundary conditions and emissions
-; bc_basis_case (str) - boundary conditions basis, defaults to "NESW" (looks for file format {bc_basis_case}_{domain}_*.nc)
-; bc_basis_directory (str/None) - directory for bc_basis functions. If None provided, creates new folder in openghg_inversions
-;   expecting to find bc_basis_funciton files there. 
-; fp_basis_case (str/None) - emissions bases:
+; basis_algorithm (str): Choice of basis function algorithm to use. One of "quadtree" or "weighted"
+; bc_basis_case (str): Boundary conditions basis, defaults to "NESW" (looks for file format {bc_basis_case}_{domain}_*.nc)
+; bc_basis_directory (str/None): Directory for bc_basis functions. If None provided, creates new folder in openghg_inversions
+;                                expecting to find bc_basis_funciton files there. 
+; fp_basis_case (str/None): Emissions bases:
 ; - if specified, looks for file format {fp_basis_case}_{domain}_*.nc
-; - if None, creates basis function using quadtree algorithm and associated parameters
-;   - nbasis - Number of basis functions to use for quadtree derived basis function (rounded to %4)
-; basis_directory (str/None) - Directory containing the basis functions (with domain name as subdirectories)
-; country_file (str/None) - Directory with filename  containing the indices of country boundaries in domain
+; - if None, creates basis function using algorithm specified and associated parameters
+; nbasis: Number of basis functions to use for algorithm-specified basis function (rounded to %4) in domain
+; basis_directory (str/None): Directory containing the basis functions (with domain name as subdirectories)
+; country_file (str/None): Directory with filename  containing the indices of country boundaries in domain
 
-
-basis_algorithm = "quadtree"
-bc_basis_case = 'NESW'
+basis_algorithm = " "
+bc_basis_case = "NESW"
 fp_basis_case = None
-nbasis = 100
+nbasis =  
 bc_basis_directory = None
 basis_directory = None
-country_file = ''
+country_file = " "
 
 [MCMC.TYPE]
 ; Which MCMC setup to use. This defines the function which will be called and the expected inputs.
 ; Options include:
 ; "fixed_basis"
 
-mcmc_type = 'fixed_basis'
+mcmc_type = "fixed_basis"
 
 [MCMC.PDF]
 ; Definitions of PDF shape and parameters for inputs
-; - xprior (dict) - emissions
-; - bcprior (dict) - boundary conditions
-; - sigprior (dict) - model error
-
-; Each of these inputs should be dictionary with the name of probability distribution and shape parameters.
+; xprior (dict of dict): Emissions scale factor pdfs for each emissions_name source
+;                        Each key should be either a dictionary of form: {"pdf":"normal","mu":1,"sigma":1}
+; bcprior (dict): Boundary conditions pdf
+; sigprior (dict): Model error pdf
+; add_offset (bool): Set as True to include offsetprior parameter
+; offsetprior (dict): Model-data bias pdf 
+;
+; Each of these prior inputs should be dictionary with the name of probability distribution and shape parameters.
 ; See https://docs.pymc.io/api/distributions/continuous.html
 ; Current options for the "pdf" parameter include:
 
-; - "lognormal" - Log-normal log-likelihood.
-;  - "mu" (float) - Location parameter
-;  - "sigma" (float) - Standard deviation (> 0)
-; e.g. {"pdf":"lognormal", "mu":1, "sigma":1}
+;  - "truncatednormal" : Truncated-normal likelihood.
+;  - "mu" (float) : Location parameter
+;  - "sigma" (float) : Standard deviation (> 0)
+;  - "lower" (float) : Lower bound 
+; e.g. {"pdf" : "truncatednormal", "mu" : 1, "sigma" : 1, "lower" : 0}
 
-; - "uniform" - Continuous uniform log-likelihood.
-;  - "lower" (float) - Lower limit
-;  - "upper" (float) - Upper limit
-; e.g. {"pdf":"uniform", "lower":0.5, "upper":3}
+;  - "uniform" : Continuous uniform log-likelihood.
+;  - "lower" (float) : Lower limit
+;  - "upper" (float) : Upper limit
+; e.g. {"pdf" : "uniform", "lower" : 0.5, "upper" : 3}
 
-; - "halfflat" - Improper flat prior over the positive reals. (no additional parameters necessary)
-; e.g. {"pdf":"halfflat"}
+; - "halfflat" : Improper flat prior over the positive reals. (no additional parameters necessary)
+; e.g. {"pdf" : "halfflat"}
 
-
-xprior = {'pdf':'lognormal', 'mu':1, 'sigma':1}
-bcprior = {'pdf':'lognormal', 'mu':0.004, 'sigma':0.02}
-sigprior = {'pdf':'uniform', 'lower':0.5, 'upper':3}
-
+xprior = {"pdf" : "normal", "mu" : 1.0, "sigma" : 1}
+bcprior = {"pdf" : "normal", "mu" : 1.0, "sigma" : 0.5}
+sigprior = {"pdf" : "uniform", "lower" : 0.5, "upper" : 3}
+dd_offset = False
+#offsetprior = {}
 
 [MCMC.BC_SPLIT]
 ; Boundary conditions setup
-; - bc_freq - The period over which the baseline is estimated. e.g.
-;  - None - one scaling for the whole inversion
+; bc_freq (str/optional): The period over which the baseline is estimated. e.g.
+;  - None - one scaling for the whole inversion period
 ;  - "monthly" - per calendar monthly
 ;  - "*D" (e.g. "30D") - per number of days (e.g. 30 days)
+; sigma_freq (str/optional): Same as bc_freq but for model
+; sigma_per_site (bool): Whether a model sigma value is calculated for each site (True) or all together (False) 
 
 bc_freq = None
 sigma_freq = None
@@ -129,29 +145,30 @@ sigma_per_site = True
 
 [MCMC.ITERATIONS]
 ; Iteration parameters
-; nit (int) - Number of iterations for MCMC
-; burn (int) - Number of iterations to burn in MCMC
-; tune (int) - Number of iterations to use to tune step size
+; nit (int): Number of iterations for MCMC
+; burn (int): Number of iterations to burn/discard in MCMC
+; tune (int): Number of iterations to use to tune step size
 
-nit = 2.5e5
-burn = 50000
-tune = 1.25e5
+nit =     ; (required)
+burn =    ; (required)
+tune =    ; (required)
 
 [MCMC.NCHAIN]
-; Number of chains to run simultaneously. Must be >=2 to allow convergence to be checked.
+; nchain (int): Number of chains to run simultaneously. Must be >=2 to allow convergence to be checked.
 
 nchain = 2
 
 [MCMC.ADD_ERROR]
-; Add variability in averaging period to the measurement error
+; averagingerror (bool): Add variability in averaging period to the measurement error
 
 averagingerror = True
 
 [MCMC.OUTPUT]
 ; Details of where to write the output
-; outputpath (str) - directory to write output
-; outputname (str) - unique identifier for output/run name.
+; outputformat (str): 
+; outputpath (str): Directory to write output
+; outputname (str): Unique identifier for output/run name.
 
-outputpath = ''  ; (required)
-outputname = ''  ; (required)
+outputpath = " "  ; (required)
+outputname = " "  ; (required)
 

--- a/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template_example.ini
+++ b/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template_example.ini
@@ -1,131 +1,126 @@
-; --- Updated December 2022 ----
-; Configuration file for OpenGHG_HBMCMC code
+; =======================================================================================
+; Regional Hierarchical Inverse Modelling Environment Example Configuration File
+; =======================================================================================
+; RHIME example configuration file for CH4. Please check through variable paths and 
+; names before running.
 ; Required inputs are marked as such.
 ; All other inputs are optional (defaults will be used)
+; ======================================================================================= 
 
 [INPUT.MEASUREMENTS]
 ; Input values for extracting observations
-;   species (str) - species name (see acrg_species_info.json for options) e.g. "ch4"
-;   use_tracer (bool) - use tracer inversion model
-;   sites (list) - site codes as a list (see acrg_site_info.json for options) e.g. ["MHD"]
-;   averaging_period (list) - Time periods for measurements as a list (must match length of sites)
-;   start_date (str) - Start of observations to extract (format YYYY-MM-DD)
-;   end_date (str) - End of observations to extract (format YYYY-MM-DD) (non-inclusive)
-; save_merged_data (bool) - If True, saves merged data object
-; reload_merged_data (bool) - If True, reads merged data object rather than rerunning get_data
-; merged_data_dir (str) - Path to directory with merged data objects.
+; species (str): Species name (check object store for options) e.g. "ch4"
+; use_tracer (bool): Option to use tracer method for inversions
+; sites (list): Site codes as a list (check object store for options) e.g. ["MHD"]
+; averaging_period (list): Averaged time periods for measurements as a list (must match length of sites)
+; start_date (str): Start of observations to extract (format YYYY-MM-DD)
+; end_date (str): End of observations to extract (format YYYY-MM-DD) (non-inclusive)
 
-species = "ch4"      ; (required)
-use_tracer = False 
-sites = ["TAC","RGL"]        ; (required)
-averaging_period = ["4H","4H"]  ; (required)
-start_date = "2019-01-01"   ; (required - but can be specified on command line instead)
-end_date = "2019-02-01"     ; (required - but can be specified on command line instead)
+species = "ch4"                  ; (required)
+use_tracer = False               ; (required)
+sites = ["TAC", "RGL"]           ; (required)
+averaging_period = ["4H", "4H"]  ; (required)
+start_date = "2019-01-01"        ; (required - but can be specified on command line instead)
+end_date = "2019-02-01"          ; (required - but can be specified on command line instead)
+
+; save_merged_data (bool): If True, saves merged data object
+; reload_merged_data (bool): If True, reads merged data object rather than rerunning get_data
+; merged_data_dir (str): Path to directory with merged data objects.
 
 save_merged_data = False
 reload_merged_data = False
-merged_data_dir = '/group/chemistry/acrg/'
+merged_data_dir = "/group/chemistry/acrg/"
 
-; inlet (list/None) - Specific inlet height for the site (list - must match number of sites)
-; instrument (list/None) - Specific instrument for the site (list - must match number of sites)
-; filters (list/None) - Specify any data filtering to apply to observations 
+; inlet (list/None): Specific measurements inlet height for the site (list - must match number of sites)
+; instrument (list/None): Specific instrument for the site (list - must match number of sites)
+; filters (str): Data filtering approach to apply 
 
-inlet = ["185m","90m"]
+inlet = ["185m", "90m"]
 instrument = [None, None]
 ;filters = ["localness"]
  
 [INPUT.STORES]
 ; OpenGHG object stores for various data. NB. All data may come from the same 
-; object store. This facilitates multiple object stores.
-;   bc_store (str) - name of object store with BC data
-;   obs_store (str) - name of object store with measurements data
-;   footprint_store (str) - name of object store with footprints data
-;   emissions_store (str) - emissions_store
+;   object store. This facilitates using multiple object stores.
+; bc_store (str): Name of object store with Boundary Conditions data
+; obs_store (str): Name of object store with measurements data
+; footprint_store (str): Name of object store with footprints data
+; emissions_store (str): Name of flux emissions object store
 
-bc_store="paris_openghg_store"        ; (required) 
-obs_store="paris_openghg_store"       ; (required)
-footprint_store="paris_openghg_store"     ; (required)
-emissions_store="paris_openghg_store"     ; (required)
-
+bc_store = "paris_openghg_store"        ; (required) 
+obs_store = "paris_openghg_store"       ; (required)
+footprint_store = "paris_openghg_store"     ; (required)
+emissions_store = "paris_openghg_store"     ; (required)
 
 [INPUT.PRIORS]
 ; Input values for extracting footprints, emissions and boundary conditions files (also uses values from INPUT.MEASUREMENTS)
-;   domain (str) - Name of inversion spatial domain e.g. 'EUROPE'
-;   met_model (dict/str/None) - either dict corresponding to sites, str. e.g., 'UKV' or None if applies to all sites
-;   fp_model (str) - Name of LPDM used for footprints e.g. 'NAME'
-;   fp_height (list) - Inlet height used for footprints (sometimes differs from measurement inlet height e.g. Cabauw)
-;   emissions_name (list) - List of the source keywords used for retrieving flux files from the object store
+; domain (str): Name of inversion spatial domain e.g. "EUROPE"
+; met_model (str/None):  e.g., 'UKV' or None if applies to all sites
+; fp_model (str): Name of LPDM footprints e.g. "NAME"
+; fp_height (list/str): List of footprint inlet heights used in model.
+; emissions_name (list): Name of emissions sources as used when adding flux files to the object store
+; bc_input (list/str): Name of boundary conditions data to use from object store
 
 domain = "EUROPE"           ; (required)
 met_model = "UKV"
 fp_model = "NAME"
-fp_height = ["185m","90m"]
+fp_height = ["185m", "90m"]
 emissions_name = ["edgar-annual-total"]
 bc_input = "camsv19"
 
 [INPUT.BASIS_CASE]
 ; Input values to extract the basis cases to use within the inversion for boundary conditions and emissions
-;   basis_algorithm (str) - Select basis function algorithm to use to create basis functions, or use None when inputting a basis function file
-;     - "quadtree" - use this input when using quadtree algorithm. NB. Does NOT create basis function regions that distinguish between land/sea
-;     - "weighted" - use this input for generic weighted algorithm based on fp * emissions data. NB. DOES create basis function regions that distinguish between land/sea
-;     - None - use None when using premade basis function file
-;   bc_basis_case (str) - boundary conditions basis, defaults to "NESW" (looks for file format {bc_basis_case}_{domain}_*.nc)
-;   fp_basis_case (str/None) - emissions bases:
-;     - if specified, looks for file format {fp_basis_case}_{domain}_*.nc
-;     - if None, creates basis function using quadtree algorithm and associated parameters
-;   nbasis - Number of basis functions to use for quadtree derived basis function (rounded to %4)
-;   basis_directory (str/None) - Directory containing the basis functions (with domain name as subdirectories)
-;   bc_basis_directory (str/None) - Directory containing the boundary condition basis functions NB. Defaults to dir in OpenGHG_Inversions
-;   country_file (str/None) - Directory to the country definitions file
-
+; basis_algorithm (str): Choice of basis function algorithm to use. One of "quadtree" or "weighted"
+; bc_basis_case (str): Boundary conditions basis, defaults to "NESW" (looks for file format {bc_basis_case}_{domain}_*.nc)
+; bc_basis_directory (str/None): Directory for bc_basis functions. If None provided, creates new folder in openghg_inversions
+;                                expecting to find bc_basis_funciton files there. 
+; fp_basis_case (str/None): Emissions bases:
+; - if specified, looks for file format {fp_basis_case}_{domain}_*.nc
+; - if None, creates basis function using algorithm specified and associated parameters
+; nbasis: Number of basis functions to use for algorithm-specified basis function (rounded to %4) in domain
+; basis_directory (str/None): Directory containing the basis functions (with domain name as subdirectories)
+; country_file (str/None): Directory with filename  containing the indices of country boundaries in domain
 
 basis_algorithm = "quadtree" 
 bc_basis_case = "NESW"
 fp_basis_case = None
-nbasis = 100
+nbasis = 50
 basis_directory = "/group/chemistry/acrg/LPDM/basis_functions/"
 bc_basis_directory = None
-country_file = "/user/work/wz22079/country_masks/country-EUROPE-UKMO-2023.nc"  
-
+country_file = "/group/chemistry/acrg/PARIS_results_sharing/country_masks/EUROPE_EEZ_PARIS_gapfilled.nc"  
 
 [MCMC.TYPE]
 ; Which MCMC setup to use. This defines the function which will be called and the expected inputs.
 ; Options include:
-;   "fixed_basis"
+; - "fixed_basis"
 
 mcmc_type = "fixed_basis"
 
 [MCMC.PDF]
 ; Definitions of PDF shape and parameters for inputs
-;   xprior (dict) - emissions
-;   bcprior (dict) - boundary conditions
-;   sigprior (dict) - model error
-; Each of these inputs should be dictionary with the name of probability distribution and shape parameters.
+; xprior (dict): Emissions scale factor pdfs for fluxes
+; bcprior (dict): Boundary conditions pdf
+; sigprior (dict): Model error pdf
+; add_offset (bool): Set as True to include offsetprior parameter
+; offsetprior (dict): Model-data bias pdf 
+;
+; Each of these prior inputs should be dictionary with the name of probability distribution and shape parameters.
 ; See https://docs.pymc.io/api/distributions/continuous.html
 ; Current options for the "pdf" parameter include:
-; - "lognormal" - Log-normal log-likelihood.
-;   o "mu" (float) - Location parameter
-;   o "sd" or "sigma" (float) - Standard deviation (> 0)
-; e.g. {"pdf":"lognormal", "mu":1, "sd":1}
-;
-; - "uniform" - Continuous uniform log-likelihood.
-;   o "lower" (float) - Lower limit
-;   o "upper" (float) - Upper limit
-; e.g. {"pdf":"uniform", "lower":0.5, "upper":3}
-;
-; - "halfflat" - Improper flat prior over the positive reals. (no additional parameters necessary)
-; e.g. {"pdf":"halfflat"}
 
-xprior   = {"pdf":"lognormal", "mu":0.346573, "sigma":0.693147}
-bcprior  = {"pdf":"lognormal", "mu":0.346573, "sigma":0.693147}
-sigprior = {"pdf":"uniform", "lower":0.1, "upper":3.0}
+xprior   = {"pdf" : "normal", "mu" : 1.0, "sigma" : 1.0}
+bcprior  = {"pdf" : "normal", "mu" : 1.0, "sigma" : 1.0}
+sigprior = {"pdf" : "uniform", "lower" : 0.1, "upper" : 3.0}
+;add_offset = False
+;offsetprior = {}
 
 [MCMC.BC_SPLIT]
-; Boundary conditions setup
-;   bc_freq - The period over which the baseline is estimated. e.g.
-;    - None - one scaling for the whole inversion
-;    - "monthly" - per calendar monthly
-;    - "*D" (e.g. "30D") - per number of days (e.g. 30 days)
+; bc_freq (str/optional): The period over which the baseline is estimated. e.g.
+;  - None - one scaling for the whole inversion period
+;  - "monthly" - per calendar monthly
+;  - "*D" (e.g. "30D") - per number of days (e.g. 30 days)
+; sigma_freq (str/optional): Same as bc_freq but for model
+; sigma_per_site (bool): Whether a model sigma value is calculated for each site (True) or all together (False) 
 
 bc_freq = "monthly"
 sigma_freq = None
@@ -133,28 +128,28 @@ sigma_per_site = True
 
 [MCMC.ITERATIONS]
 ; Iteration parameters
-;   nit (int) - Number of iterations for MCMC
-;   burn (int) - Number of iterations to burn in MCMC
-;   tune (int) - Number of iterations to use to tune step size
+; nit (int): Number of iterations for MCMC
+; burn (int): Number of iterations to burn/discard in MCMC
+; tune (int): Number of iterations to use to tune step size
 
-nit = 2.5e5 
-burn = 50000
-tune = 1.25e4
+nit = 25000 
+burn = 2000
+tune = 2000
 
 [MCMC.NCHAIN]
-; Number of chains to run simultaneously. Must be >=2 to allow convergence to be checked.
+; nchain (int): Number of chains to run simultaneously. Must be >=2 to allow convergence to be checked.
 
 nchain = 2
 
 [MCMC.ADD_ERROR]
-; Add variability in averaging period to the measurement error
+; averagingerror (bool): Add variability in averaging period to the measurement error
 
 averaging_error = True
 
 [MCMC.OUTPUT]
 ; Details of where to write the output
-; outputpath (str) - directory to write output
-; outputname (str) - unique identifier for output/run name.
+; outputpath (str): Directory to write output
+; outputname (str): Unique identifier for output/run name.
 
-outputpath = "/user/work/wz22079/hbmcmc_es_tests/"  ; (required)
-outputname = "test_250000it"  ; (required)
+outputpath = ""  ; (required)
+outputname = "my_first_rhime_inversion"  ; (required)

--- a/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template_example.ini
+++ b/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template_example.ini
@@ -151,5 +151,5 @@ averaging_error = True
 ; outputpath (str): Directory to write output
 ; outputname (str): Unique identifier for output/run name.
 
-outputpath = ""  ; (required)
+outputpath = " "  ; (required)
 outputname = "my_first_rhime_inversion"  ; (required)


### PR DESCRIPTION
# Tidied up and updated the RHIME input files
PR to merge in updates made to the input files so they are more accessible and descriptive for new users of RHIME

## Example input configuration file
- Tidied up and updated file variable descriptions in the comments
- Changed data paths so they are not directed to e.g. wz22079 user directory 
- Changed example pdfs for hyper-parameters. Using Lognormal distributions in the example file is confusing. 
- Reduced no. of MCMC iterations and basis functions. Example input file is really to check the inversion runs and not designed for "science"

## Template configuration file
- Tidied up and updated file variable descriptions in the comments. Matches with the example file
- Formatted file 
- Changed example PDFs as above 
- Made sure all variable options available (as per previous `main' input file)