### PR TITLE
Get obs update

### DIFF
--- a/openghg_inversions/get_data.py
+++ b/openghg_inversions/get_data.py
@@ -1,11 +1,10 @@
 # *****************************************************************************
-# Created: 30 Nov. 2023
-# Author: Eric Saboya, School of Geographical Sciences, University of Bristol
-# Contact: eric.saboya@bristol.ac.uk
+# get_data.py
+# Author: Atmospheric Chemistry Research Group, University of Bristol
 # *****************************************************************************
 # About
-# Different functions for retrieving appropriate datasets for forward
-# simulations
+# Functions for retrieving observations and datasets for creating forward
+# simulations and 
 #
 # Current options include:
 # - "data_processing_surface_notracer": Surface based measurements, without tracers
@@ -32,12 +31,14 @@ def data_processing_surface_notracer(
     averaging_period,
     start_date,
     end_date,
+    obs_data_level,
+    inlet=None,
+    instrument=None,
+    calibration_scale=None,
     met_model=None,
     fp_model="NAME",
     fp_height=None,
     emissions_name=None,
-    inlet=None,
-    instrument=None,
     bc_input=None,
     bc_store=None,
     obs_store=None,
@@ -51,7 +52,8 @@ def data_processing_surface_notracer(
     """
     Retrieve and prepare fixed-surface datasets from
     specified OpenGHG object stores for forward
-    simulations that do not use tracers
+    simulations and model-data comparisons that do not 
+    use tracers
     ---------------------------------------------
     Args:
         species (str):
@@ -74,6 +76,17 @@ def data_processing_surface_notracer(
         end_date (str):
             Date until which to gather data
             e.g. "2020-02-01"
+        obs_data_level (list/str):
+            ICOS observations data level. For non-ICOS sites
+            use "None"
+        inlet (list/str/opt):
+            Specific inlet height for the site observations 
+            (length must match number of sites)
+        instrument (list/str/opt):
+            Specific instrument for the site 
+            (length must match number of sites) 
+        calibration_scale (str):
+            Convert measurements to defined calibration scale 
         met_model (str/opt):
             Meteorological model used in the LPDM.
         fp_model (str):
@@ -83,12 +96,6 @@ def data_processing_surface_notracer(
         emissions_name (list):
             List of keywords args associated with emissions files
             in the object store.
-        inlet (str/list, optional):
-            Specific inlet height for the site observations.
-            (length must match number of sites)
-        instrument (str/list, optional):
-            Specific instrument for the site
-            (length must match number of sites).
         bc_store (str):
             Name of object store to retrieve boundary conditions data from
         obs_store (str):
@@ -98,9 +105,14 @@ def data_processing_surface_notracer(
         emissions_store (str):
             Name of object store to retrieve emissions data from
         averagingerror (bool/opt):
-          Adds the variability in the averaging period to the measurement
-          error if set to True.
-
+            Adds the variability in the averaging period to the measurement
+            error if set to True.
+        save_merged_data (bool/opt, default=False):
+            Save forward simulations data and observations 
+        merged_data_name (str/opt):
+            Filename for saved forward simulations data and observations
+        merged_data_dir (str/opt):
+            Directory path for for saved forward simulations data and observations
     """
 
     # Change list of sites to upper case equivalent as

--- a/openghg_inversions/get_data.py
+++ b/openghg_inversions/get_data.py
@@ -1,6 +1,7 @@
 # *****************************************************************************
 # get_data.py
 # Author: Atmospheric Chemistry Research Group, University of Bristol
+# Created: Nov. 2023
 # *****************************************************************************
 # About
 # Functions for retrieving observations and datasets for creating forward
@@ -31,7 +32,7 @@ def data_processing_surface_notracer(
     averaging_period,
     start_date,
     end_date,
-    obs_data_level,
+    obs_data_level=None,
     inlet=None,
     instrument=None,
     calibration_scale=None,

--- a/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template.ini
+++ b/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template.ini
@@ -1,127 +1,147 @@
-; Configuration file for HBMCMC code
+; =======================================================================================
+; Regional Hierarchical Inverse Modelling Environment Configuration File
+; =======================================================================================
+; RHIME configuration file template. Please check through variable paths and 
+; names before running.
 ; Required inputs are marked as such.
 ; All other inputs are optional (defaults will be used)
+; ======================================================================================= 
 
 [INPUT.MEASUREMENTS]
 ; Input values for extracting observations
-; species (str) - species name (see acrg_species_info.json for options) e.g. "ch4"
-; sites (list) - site codes as a list (see acrg_site_info.json for options) e.g. ["MHD"]
-; meas_period (list) - Time periods for measurements as a list (must match length of sites)
-; start_date (str) - Start of observations to extract (format YYYY-MM-DD)
-; end_date (str) - End of observations to extract (format YYYY-MM-DD) (non-inclusive)
-; save_merged_data (bool) - If True, saves merged data object
-; reload_merged_data (bool) - If True, reads merged data object rather than rerunning get_data
-; merged_data_dir (str) - Path to directory with merged data objects.
+; species (str): Species name (check object store for options) e.g. "ch4"
+; use_tracer (bool): Option to use tracer method for inversions
+; sites (list): Site codes as a list (check object store for options) e.g. ["MHD"]
+; averaging_period (list): Averaged time periods for measurements as a list (must match length of sites)
+; start_date (str): Start of observations to extract (format YYYY-MM-DD)
+; end_date (str): End of observations to extract (format YYYY-MM-DD) (non-inclusive)
 
-species = ''      ; (required)
-use_tracer = False; (required)
-sites = []        ; (required)
+species = ""           ; (required)
+use_tracer = False     ; (required)
+sites = []             ; (required)
 averaging_period = []  ; (required)
-start_date = ''   ; (required - but can be specified on command line instead)
-end_date = ''     ; (required - but can be specified on command line instead)
+start_date = " "       ; (required - but can be specified on command line instead)
+end_date = " "         ; (required - but can be specified on command line instead)
+
+; save_merged_data (bool): If True, saves merged data object
+; reload_merged_data (bool): If True, reads merged data object rather than rerunning get_data
+; merged_data_dir (str): Path to directory with merged data objects.
 
 save_merged_data = False
 reload_merged_data = False
-merged_data_dir = ''
+merged_data_dir = " "
 
-; inlet (list/None) - Specific inlet height for the site (list - must match number of sites)
-; instrument (list/None) - Specific instrument for the site (list - must match number of sites)
+; inlet (list/None): Specific measurements inlet height for the site (list - must match number of sites)
+; instrument (list/None): Specific instrument for the site (list - must match number of sites)
+; calibration_scale (str): Measurement calibration scale to use
+; obs_data_level (list/str): Measurement data quality level 
+; filters (str): Data filtering approach to apply 
 
 inlet = None
 instrument = None
+calibration_scale = None
+obs_data_level = None
 filters = []
 
 [INPUT.STORES]
 ; OpenGHG object stores for various data. NB. All data may come from the same 
-;   object store. This facilitates multiple object stores.
-;   bc_store (str) - name of object store with BC data
-;   obs_store (str) - name of object store with measurements data
-;   footprint_store (str) - name of object store with footprints data
-;   emissions_store (str) - emissions_store
+;   object store. This facilitates using multiple object stores.
+; bc_store (str): Name of object store with Boundary Conditions data
+; obs_store (str): Name of object store with measurements data
+; footprint_store (str): Name of object store with footprints data
+; emissions_store (str): Name of flux emissions object store
 
-bc_store=""            ; (required)
-obs_store=""           ; (required)
-footprint_store=""     ; (required)
-emissions_store=""     ; (required)
+bc_store = " "            ; (required)
+obs_store = " "           ; (required)
+footprint_store = " "     ; (required)
+emissions_store = " "     ; (required)
 
 
 [INPUT.PRIORS]
 ; Input values for extracting footprints, emissions and boundary conditions files (also uses values from INPUT.MEASUREMENTS)
-; domain (str) - Name of inversion spatial domain e.g. "EUROPE"
-; met_model (dict/str/None) - either dict corresponding to sites, str. e.g., 'UKV' or None if applies to all sites
-; fp_model (str) - Name of LPDM e.g. "NAME"
-; emissions_name (list) - Name of specific emissions sources as used when adding flux files to the object store
+; domain (str): Name of inversion spatial domain e.g. "EUROPE"
+; met_model (str/None):  e.g., 'UKV' or None if applies to all sites
+; fp_model (str): Name of LPDM footprints e.g. "NAME"
+; fp_height (list/str): List of footprint inlet heights used in model.
+; emissions_name (list): Name of emissions sources as used when adding flux files to the object store
+; bc_input (list/str): Name of boundary conditions data to use from object store
 
-domain = ''           ; (required) 
-met_model = None      
+domain = " "               ; (required) 
+met_model = None       
 fp_model = None
 fp_height = None
-emissions_name = None
+emissions_name = [None]   ; (required)
 bc_input = None
 
 [INPUT.BASIS_CASE]
 ; Input values to extract the basis cases to use within the inversion for boundary conditions and emissions
-; bc_basis_case (str) - boundary conditions basis, defaults to "NESW" (looks for file format {bc_basis_case}_{domain}_*.nc)
-; bc_basis_directory (str/None) - directory for bc_basis functions. If None provided, creates new folder in openghg_inversions
-;   expecting to find bc_basis_funciton files there. 
-; fp_basis_case (str/None) - emissions bases:
+; basis_algorithm (str): Choice of basis function algorithm to use. One of "quadtree" or "weighted"
+; bc_basis_case (str): Boundary conditions basis, defaults to "NESW" (looks for file format {bc_basis_case}_{domain}_*.nc)
+; bc_basis_directory (str/None): Directory for bc_basis functions. If None provided, creates new folder in openghg_inversions
+;                                expecting to find bc_basis_funciton files there. 
+; fp_basis_case (str/None): Emissions bases:
 ; - if specified, looks for file format {fp_basis_case}_{domain}_*.nc
-; - if None, creates basis function using quadtree algorithm and associated parameters
-;   - nbasis - Number of basis functions to use for quadtree derived basis function (rounded to %4)
-; basis_directory (str/None) - Directory containing the basis functions (with domain name as subdirectories)
-; country_file (str/None) - Directory with filename  containing the indices of country boundaries in domain
+; - if None, creates basis function using algorithm specified and associated parameters
+; nbasis: Number of basis functions to use for algorithm-specified basis function (rounded to %4) in domain
+; basis_directory (str/None): Directory containing the basis functions (with domain name as subdirectories)
+; country_file (str/None): Directory with filename  containing the indices of country boundaries in domain
 
-
-basis_algorithm = "quadtree"
-bc_basis_case = 'NESW'
+basis_algorithm = " "
+bc_basis_case = "NESW"
 fp_basis_case = None
-nbasis = 100
+nbasis = 
 bc_basis_directory = None
 basis_directory = None
-country_file = ''
+country_file = " "
 
 [MCMC.TYPE]
 ; Which MCMC setup to use. This defines the function which will be called and the expected inputs.
 ; Options include:
 ; "fixed_basis"
 
-mcmc_type = 'fixed_basis'
+mcmc_type = "fixed_basis"
 
 [MCMC.PDF]
 ; Definitions of PDF shape and parameters for inputs
-; - xprior (dict) - emissions
-; - bcprior (dict) - boundary conditions
-; - sigprior (dict) - model error
-
-; Each of these inputs should be dictionary with the name of probability distribution and shape parameters.
+; xprior (dict of dict): Emissions scale factor pdfs for each emissions_name source
+;                        Each key should be either a dictionary of form: {"pdf":"normal","mu":1,"sigma":1}
+; bcprior (dict): Boundary conditions pdf
+; sigprior (dict): Model error pdf
+; add_offset (bool): Set as True to include offsetprior parameter
+; offsetprior (dict): Model-data bias pdf 
+;
+; Each of these prior inputs should be dictionary with the name of probability distribution and shape parameters.
 ; See https://docs.pymc.io/api/distributions/continuous.html
 ; Current options for the "pdf" parameter include:
+;
+;  - "truncatednormal" : Truncated-normal likelihood.
+;  - "mu" (float) : Location parameter
+;  - "sigma" (float) : Standard deviation (> 0)
+;  - "lower" (float) : Lower bound 
+; e.g. {"pdf" : "truncatednormal", "mu" : 1, "sigma" : 1, "lower" : 0}
+;
+;  - "uniform" : Continuous uniform log-likelihood.
+;  - "lower" (float) : Lower limit
+;  - "upper" (float) : Upper limit
+; e.g. {"pdf" : "uniform", "lower" : 0.5, "upper" : 3}
+;
+; - "halfflat" : Improper flat prior over the positive reals. (no additional parameters necessary)
+; e.g. {"pdf" : "halfflat"}
 
-; - "lognormal" - Log-normal log-likelihood.
-;  - "mu" (float) - Location parameter
-;  - "sigma" (float) - Standard deviation (> 0)
-; e.g. {"pdf":"lognormal", "mu":1, "sigma":1}
-
-; - "uniform" - Continuous uniform log-likelihood.
-;  - "lower" (float) - Lower limit
-;  - "upper" (float) - Upper limit
-; e.g. {"pdf":"uniform", "lower":0.5, "upper":3}
-
-; - "halfflat" - Improper flat prior over the positive reals. (no additional parameters necessary)
-; e.g. {"pdf":"halfflat"}
-
-
-xprior = {'pdf':'lognormal', 'mu':1, 'sigma':1}
-bcprior = {'pdf':'lognormal', 'mu':0.004, 'sigma':0.02}
-sigprior = {'pdf':'uniform', 'lower':0.5, 'upper':3}
-
+xprior = {"pdf" : "normal", "mu" : 1.0, "sigma" : 1}
+bcprior = {"pdf" : "normal", "mu" : 1.0, "sigma" : 0.5}
+sigprior = {"pdf" : "uniform", "lower" : 0.5, "upper" : 3}
+add_offset = False
+#offsetprior = {}
 
 [MCMC.BC_SPLIT]
 ; Boundary conditions setup
-; - bc_freq - The period over which the baseline is estimated. e.g.
-;  - None - one scaling for the whole inversion
+; bc_freq (str/optional): The period over which the baseline is estimated. e.g.
+;  - None - one scaling for the whole inversion period
 ;  - "monthly" - per calendar monthly
 ;  - "*D" (e.g. "30D") - per number of days (e.g. 30 days)
+; sigma_freq (str/optional): Same as bc_freq but for model
+; sigma_per_site (bool): Whether a model sigma value is calculated for each site (True) or all together (False) 
 
 bc_freq = None
 sigma_freq = None
@@ -129,29 +149,30 @@ sigma_per_site = True
 
 [MCMC.ITERATIONS]
 ; Iteration parameters
-; nit (int) - Number of iterations for MCMC
-; burn (int) - Number of iterations to burn in MCMC
-; tune (int) - Number of iterations to use to tune step size
+; nit (int): Number of iterations for MCMC
+; burn (int): Number of iterations to burn/discard in MCMC
+; tune (int): Number of iterations to use to tune step size
 
-nit = 2.5e5
-burn = 50000
-tune = 1.25e5
+nit =     ; (required)
+burn =    ; (required)
+tune =    ; (required)
 
 [MCMC.NCHAIN]
-; Number of chains to run simultaneously. Must be >=2 to allow convergence to be checked.
+; nchain (int): Number of chains to run simultaneously. Must be >=2 to allow convergence to be checked.
 
 nchain = 2
 
 [MCMC.ADD_ERROR]
-; Add variability in averaging period to the measurement error
+; averagingerror (bool): Add variability in averaging period to the measurement error
 
 averagingerror = True
 
 [MCMC.OUTPUT]
 ; Details of where to write the output
-; outputpath (str) - directory to write output
-; outputname (str) - unique identifier for output/run name.
+; outputpath (str): Directory to write output
+; outputname (str): Unique identifier for output/run name.
 
-outputpath = ''  ; (required)
-outputname = ''  ; (required)
+outputpath = " "  ; (required)
+outputname = " "  ; (required)
+
 

--- a/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template_example.ini
+++ b/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template_example.ini
@@ -1,131 +1,130 @@
-; --- Updated December 2022 ----
-; Configuration file for OpenGHG_HBMCMC code
+; =======================================================================================
+; Regional Hierarchical Inverse Modelling Environment Example Configuration File
+; =======================================================================================
+; RHIME example configuration file for CH4. Please check through variable paths and 
+; names before running.
 ; Required inputs are marked as such.
 ; All other inputs are optional (defaults will be used)
+; ======================================================================================= 
 
 [INPUT.MEASUREMENTS]
 ; Input values for extracting observations
-;   species (str) - species name (see acrg_species_info.json for options) e.g. "ch4"
-;   use_tracer (bool) - use tracer inversion model
-;   sites (list) - site codes as a list (see acrg_site_info.json for options) e.g. ["MHD"]
-;   averaging_period (list) - Time periods for measurements as a list (must match length of sites)
-;   start_date (str) - Start of observations to extract (format YYYY-MM-DD)
-;   end_date (str) - End of observations to extract (format YYYY-MM-DD) (non-inclusive)
-; save_merged_data (bool) - If True, saves merged data object
-; reload_merged_data (bool) - If True, reads merged data object rather than rerunning get_data
-; merged_data_dir (str) - Path to directory with merged data objects.
+; species (str): Species name (check object store for options) e.g. "ch4"
+; use_tracer (bool): Option to use tracer method for inversions
+; sites (list): Site codes as a list (check object store for options) e.g. ["MHD"]
+; averaging_period (list): Averaged time periods for measurements as a list (must match length of sites)
+; start_date (str): Start of observations to extract (format YYYY-MM-DD)
+; end_date (str): End of observations to extract (format YYYY-MM-DD) (non-inclusive)
 
-species = "ch4"      ; (required)
-use_tracer = False 
-sites = ["TAC","RGL"]        ; (required)
-averaging_period = ["4H","4H"]  ; (required)
-start_date = "2019-01-01"   ; (required - but can be specified on command line instead)
-end_date = "2019-02-01"     ; (required - but can be specified on command line instead)
+species = "ch4"                  ; (required)
+use_tracer = False               ; (required)
+sites = ["TAC", "RGL"]           ; (required)
+averaging_period = ["4H", "4H"]  ; (required)
+start_date = "2019-01-01"        ; (required - but can be specified on command line instead)
+end_date = "2019-02-01"          ; (required - but can be specified on command line instead)
+
+; save_merged_data (bool): If True, saves merged data object
+; reload_merged_data (bool): If True, reads merged data object rather than rerunning get_data
+; merged_data_dir (str): Path to directory with merged data objects.
 
 save_merged_data = False
 reload_merged_data = False
-merged_data_dir = '/group/chemistry/acrg/'
+merged_data_dir = "/group/chemistry/acrg/"
 
-; inlet (list/None) - Specific inlet height for the site (list - must match number of sites)
-; instrument (list/None) - Specific instrument for the site (list - must match number of sites)
-; filters (list/None) - Specify any data filtering to apply to observations 
+; inlet (list/None): Specific measurements inlet height for the site (list - must match number of sites)
+; instrument (list/None): Specific instrument for the site (list - must match number of sites)
+; calibration_scale (str): Measurement calibration scale to use
+; obs_data_level (list/str): Measurement data quality level 
+; filters (str): Data filtering approach to apply 
 
-inlet = ["185m","90m"]
+inlet = ["185m", "90m"]
 instrument = [None, None]
+;calibration_scale = None
+obs_data_level = [None, None]
 ;filters = ["localness"]
- 
+  
 [INPUT.STORES]
 ; OpenGHG object stores for various data. NB. All data may come from the same 
-; object store. This facilitates multiple object stores.
-;   bc_store (str) - name of object store with BC data
-;   obs_store (str) - name of object store with measurements data
-;   footprint_store (str) - name of object store with footprints data
-;   emissions_store (str) - emissions_store
+;   object store. This facilitates using multiple object stores.
+; bc_store (str): Name of object store with Boundary Conditions data
+; obs_store (str): Name of object store with measurements data
+; footprint_store (str): Name of object store with footprints data
+; emissions_store (str): Name of flux emissions object store
 
-bc_store="paris_openghg_store"        ; (required) 
-obs_store="paris_openghg_store"       ; (required)
-footprint_store="paris_openghg_store"     ; (required)
-emissions_store="paris_openghg_store"     ; (required)
-
+bc_store = "paris_openghg_store"        ; (required) 
+obs_store = "paris_openghg_store"       ; (required)
+footprint_store = "paris_openghg_store"     ; (required)
+emissions_store = "paris_openghg_store"     ; (required)
 
 [INPUT.PRIORS]
 ; Input values for extracting footprints, emissions and boundary conditions files (also uses values from INPUT.MEASUREMENTS)
-;   domain (str) - Name of inversion spatial domain e.g. 'EUROPE'
-;   met_model (dict/str/None) - either dict corresponding to sites, str. e.g., 'UKV' or None if applies to all sites
-;   fp_model (str) - Name of LPDM used for footprints e.g. 'NAME'
-;   fp_height (list) - Inlet height used for footprints (sometimes differs from measurement inlet height e.g. Cabauw)
-;   emissions_name (list) - List of the source keywords used for retrieving flux files from the object store
+; domain (str): Name of inversion spatial domain e.g. "EUROPE"
+; met_model (str/None):  e.g., 'UKV' or None if applies to all sites
+; fp_model (str): Name of LPDM footprints e.g. "NAME"
+; fp_height (list/str): List of footprint inlet heights used in model.
+; emissions_name (list): Name of emissions sources as used when adding flux files to the object store
+; bc_input (list/str): Name of boundary conditions data to use from object store
 
 domain = "EUROPE"           ; (required)
 met_model = "UKV"
 fp_model = "NAME"
-fp_height = ["185m","90m"]
+fp_height = ["185m", "90m"]
 emissions_name = ["edgar-annual-total"]
 bc_input = "camsv19"
 
 [INPUT.BASIS_CASE]
 ; Input values to extract the basis cases to use within the inversion for boundary conditions and emissions
-;   basis_algorithm (str) - Select basis function algorithm to use to create basis functions, or use None when inputting a basis function file
-;     - "quadtree" - use this input when using quadtree algorithm. NB. Does NOT create basis function regions that distinguish between land/sea
-;     - "weighted" - use this input for generic weighted algorithm based on fp * emissions data. NB. DOES create basis function regions that distinguish between land/sea
-;     - None - use None when using premade basis function file
-;   bc_basis_case (str) - boundary conditions basis, defaults to "NESW" (looks for file format {bc_basis_case}_{domain}_*.nc)
-;   fp_basis_case (str/None) - emissions bases:
-;     - if specified, looks for file format {fp_basis_case}_{domain}_*.nc
-;     - if None, creates basis function using quadtree algorithm and associated parameters
-;   nbasis - Number of basis functions to use for quadtree derived basis function (rounded to %4)
-;   basis_directory (str/None) - Directory containing the basis functions (with domain name as subdirectories)
-;   bc_basis_directory (str/None) - Directory containing the boundary condition basis functions NB. Defaults to dir in OpenGHG_Inversions
-;   country_file (str/None) - Directory to the country definitions file
-
+; basis_algorithm (str): Choice of basis function algorithm to use. One of "quadtree" or "weighted"
+; bc_basis_case (str): Boundary conditions basis, defaults to "NESW" (looks for file format {bc_basis_case}_{domain}_*.nc)
+; bc_basis_directory (str/None): Directory for bc_basis functions. If None provided, creates new folder in openghg_inversions
+;                                expecting to find bc_basis_funciton files there. 
+; fp_basis_case (str/None): Emissions bases:
+; - if specified, looks for file format {fp_basis_case}_{domain}_*.nc
+; - if None, creates basis function using algorithm specified and associated parameters
+; nbasis: Number of basis functions to use for algorithm-specified basis function (rounded to %4) in domain
+; basis_directory (str/None): Directory containing the basis functions (with domain name as subdirectories)
+; country_file (str/None): Directory with filename  containing the indices of country boundaries in domain
 
 basis_algorithm = "quadtree" 
 bc_basis_case = "NESW"
 fp_basis_case = None
-nbasis = 100
+nbasis = 50
 basis_directory = "/group/chemistry/acrg/LPDM/basis_functions/"
 bc_basis_directory = None
-country_file = "/user/work/wz22079/country_masks/country-EUROPE-UKMO-2023.nc"  
-
+country_file = "/group/chemistry/acrg/PARIS_results_sharing/country_masks/EUROPE_EEZ_PARIS_gapfilled.nc"  
 
 [MCMC.TYPE]
 ; Which MCMC setup to use. This defines the function which will be called and the expected inputs.
 ; Options include:
-;   "fixed_basis"
+; - "fixed_basis"
 
 mcmc_type = "fixed_basis"
 
 [MCMC.PDF]
 ; Definitions of PDF shape and parameters for inputs
-;   xprior (dict) - emissions
-;   bcprior (dict) - boundary conditions
-;   sigprior (dict) - model error
-; Each of these inputs should be dictionary with the name of probability distribution and shape parameters.
+; xprior (dict): Emissions scale factor pdfs for fluxes
+; bcprior (dict): Boundary conditions pdf
+; sigprior (dict): Model error pdf
+; add_offset (bool): Set as True to include offsetprior parameter
+; offsetprior (dict): Model-data bias pdf 
+;
+; Each of these prior inputs should be dictionary with the name of probability distribution and shape parameters.
 ; See https://docs.pymc.io/api/distributions/continuous.html
 ; Current options for the "pdf" parameter include:
-; - "lognormal" - Log-normal log-likelihood.
-;   o "mu" (float) - Location parameter
-;   o "sd" or "sigma" (float) - Standard deviation (> 0)
-; e.g. {"pdf":"lognormal", "mu":1, "sd":1}
-;
-; - "uniform" - Continuous uniform log-likelihood.
-;   o "lower" (float) - Lower limit
-;   o "upper" (float) - Upper limit
-; e.g. {"pdf":"uniform", "lower":0.5, "upper":3}
-;
-; - "halfflat" - Improper flat prior over the positive reals. (no additional parameters necessary)
-; e.g. {"pdf":"halfflat"}
 
-xprior   = {"pdf":"lognormal", "mu":0.346573, "sigma":0.693147}
-bcprior  = {"pdf":"lognormal", "mu":0.346573, "sigma":0.693147}
-sigprior = {"pdf":"uniform", "lower":0.1, "upper":3.0}
+xprior   = {"pdf" : "normal", "mu" : 1.0, "sigma" : 1.0}
+bcprior  = {"pdf" : "normal", "mu" : 1.0, "sigma" : 1.0}
+sigprior = {"pdf" : "uniform", "lower" : 0.1, "upper" : 3.0}
+;add_offset = False
+;offsetprior = {}
 
 [MCMC.BC_SPLIT]
-; Boundary conditions setup
-;   bc_freq - The period over which the baseline is estimated. e.g.
-;    - None - one scaling for the whole inversion
-;    - "monthly" - per calendar monthly
-;    - "*D" (e.g. "30D") - per number of days (e.g. 30 days)
+; bc_freq (str/optional): The period over which the baseline is estimated. e.g.
+;  - None - one scaling for the whole inversion period
+;  - "monthly" - per calendar monthly
+;  - "*D" (e.g. "30D") - per number of days (e.g. 30 days)
+; sigma_freq (str/optional): Same as bc_freq but for model
+; sigma_per_site (bool): Whether a model sigma value is calculated for each site (True) or all together (False) 
 
 bc_freq = "monthly"
 sigma_freq = None
@@ -133,28 +132,28 @@ sigma_per_site = True
 
 [MCMC.ITERATIONS]
 ; Iteration parameters
-;   nit (int) - Number of iterations for MCMC
-;   burn (int) - Number of iterations to burn in MCMC
-;   tune (int) - Number of iterations to use to tune step size
+; nit (int): Number of iterations for MCMC
+; burn (int): Number of iterations to burn/discard in MCMC
+; tune (int): Number of iterations to use to tune step size
 
-nit = 2.5e5 
-burn = 50000
-tune = 1.25e4
+nit = 25000 
+burn = 2000
+tune = 2000
 
 [MCMC.NCHAIN]
-; Number of chains to run simultaneously. Must be >=2 to allow convergence to be checked.
+; nchain (int): Number of chains to run simultaneously. Must be >=2 to allow convergence to be checked.
 
 nchain = 2
 
 [MCMC.ADD_ERROR]
-; Add variability in averaging period to the measurement error
+; averagingerror (bool): Add variability in averaging period to the measurement error
 
 averaging_error = True
 
 [MCMC.OUTPUT]
 ; Details of where to write the output
-; outputpath (str) - directory to write output
-; outputname (str) - unique identifier for output/run name.
+; outputpath (str): Directory to write output
+; outputname (str): Unique identifier for output/run name.
 
-outputpath = "/user/work/wz22079/hbmcmc_es_tests/"  ; (required)
-outputname = "test_250000it"  ; (required)
+outputpath = " "  ; (required)
+outputname = "my_first_rhime_inversion"  ; (required)

--- a/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template_example.ini
+++ b/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template_example.ini
@@ -52,7 +52,7 @@ obs_data_level = [None, None]
 ; emissions_store (str): Name of flux emissions object store
 
 bc_store = "paris_openghg_store"        ; (required) 
-obs_store = "paris_openghg_store"       ; (required)
+obs_store = "obs_store"       ; (required)
 footprint_store = "paris_openghg_store"     ; (required)
 emissions_store = "paris_openghg_store"     ; (required)
 
@@ -66,8 +66,8 @@ emissions_store = "paris_openghg_store"     ; (required)
 ; bc_input (list/str): Name of boundary conditions data to use from object store
 
 domain = "EUROPE"           ; (required)
-met_model = "UKV"
-fp_model = "NAME"
+met_model = None 
+fp_model = None
 fp_height = ["185m", "90m"]
 emissions_name = ["edgar-annual-total"]
 bc_input = "camsv19"

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -90,9 +90,9 @@ def inferpymc(
     error,
     siteindicator,
     sigma_freq_index,
-    xprior={"pdf": "lognormal", "mu": 1, "sigma": 1},
-    bcprior={"pdf": "lognormal", "mu": 0.004, "sigma": 0.02},
-    sigprior={"pdf": "uniform", "lower": 0.5, "upper": 3},
+    xprior={"pdf": "normal", "mu": 1.0, "sigma": 1.0},
+    bcprior={"pdf": "normal", "mu": 1.0, "sigma": 1.0},
+    sigprior={"pdf": "uniform", "lower": 0.1, "upper": 3.0},
     nit=2.5e5,
     burn=50000,
     tune=1.25e5,
@@ -102,7 +102,7 @@ def inferpymc(
     add_offset=False,
     verbose=False,
     min_error=0.0,
-    save_trace: Optional[Union[str, Path]] = None,
+    save_trace = False,
 ):
     """
     Uses PyMC module for Bayesian inference for emissions field, boundary
@@ -221,8 +221,8 @@ def inferpymc(
             nit, tune=int(tune), chains=nchain, step=[step1, step2], progressbar=verbose, cores=nchain
         )  # step=pm.Metropolis())#  #target_accept=0.8,
 
-    if save_trace:
-        trace.to_netcdf(str(save_trace), engine="netcdf4")
+    #if save_trace:
+    #    trace.to_netcdf(str(save_trace), engine="netcdf4")
 
     outs = trace.posterior["x"][0, burn:nit]
     bcouts = trace.posterior["xbc"][0, burn:nit]


### PR DESCRIPTION
The following updates that primarily relate to get_obs.py have been made: 

**get_obs.py**
- input option for calibration scale (update propagates to `hbmcmc.py` and `.ini` files)
- input option for measurement data quality (update propagates to `hbmcmc.py` and `.ini` files)
- block for creating lists of `None` for args that specify just `None` (helps with for loop cycling)
- Added species option for retrieving footprints so CO2 footprints are specified 
- Streamlined the `model_scenario` part of the code so only 1 model scenario object is created instead of N
- added option for calculating `mf_mod` for different fluxes with specification of whether it is `mf_mod` or `mf_mod_high_res`
- Fixes issue #52 from Stephen P. if no site data found process now exits 

**hbmcmc.py**
- Changed default prior PDFs to something more sensible 
- added new args and added documentation to function 
- Tidied up docs and comments in file 

**inversion_pymc**
- Inversion does not run with `save_trace` block. Had to comment out in order for example .ini to run 

**ini files**
- updated example files so they actually run on BP 
- added new variables 
- tidied up commenting etc. 


NB. when using `fp_model=NAME` as an arg, fps are not retrieved. Changed default to None.