### PR TITLE
Changed 'elif' to 'if'

### DIFF
--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -386,7 +386,7 @@ def fixedbasisMCMC(
             print(f"No merged data available at {merged_data_filename} so rerunning this process.\n")
 
     # Get datasets for forward simulations
-    elif rerun_merge:
+    if rerun_merge:
         merged_data_name = f"{species}_{start_date}_{outputname}_merged-data.pickle"
 
         if not use_tracer:


### PR DESCRIPTION
Some recent commits changed `if rerun_merge` to `elif rerun_merge`, which means that if "reload_merged_data" is true, but merged data isn't found, then no data is loaded and `get_data` doesn't return a value.

I reverted this `elif` to `if`, which is the original logic.