### PR TITLE
co2_updates_eric_testing now running through correctly

### DIFF
--- a/openghg_inversions/basis_functions.py
+++ b/openghg_inversions/basis_functions.py
@@ -261,7 +261,7 @@ def load_landsea_indices():
     land = 1
     sea = 0
     """
-    landsea_indices = xr.open_dataset("/user/home/wz22079/my_openghg/openghg_inversions/countries/country-EUROPE-UKMO-landsea-2023.nc")
+    landsea_indices = xr.open_dataset("/group/chemistry/acrg/LPDM/countries/country-EUROPE-UKMO-landsea-2023.nc")
     return landsea_indices["country"].values
 
 

--- a/openghg_inversions/get_data.py
+++ b/openghg_inversions/get_data.py
@@ -287,11 +287,11 @@ def data_processing_surface_notracer(
             check_scales += [scenario_combined.scale]
             if not all(s == check_scales[0] for s in check_scales):
                 rt = []
-                for i in check_scales:
-                    if isinstance(i, list):
-                        rt.extend(flatten(i))
+                for c in check_scales:
+                    if isinstance(c, list):
+                        rt.extend(flatten(c))
                 else:
-                    rt.append(i)
+                    rt.append(c)
                 scales[site] = rt
             else:
                 scales[site] = check_scales[0]

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -526,7 +526,8 @@ def fixedbasisMCMC(
 
     for si, site in enumerate(sites):
         fp_data[site].attrs["Domain"] = domain
-
+        
+    #return fp_data
 
     # Inverse models
     if use_tracer is False:

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -225,7 +225,7 @@ def inferpymc(
           
         #CHANGES: removed .concatenate lines and replaced with sums, as 
         # dimensions of modelled mf weren't correct
-        # could add the .concatenate back in and use a .sum too:
+        # or, could add the .concatenate back in and use a .sum too:
         # mu = pm.math.sum(pm.math.concatenate(hx_dot_x),axis=0)
 
         if add_offset:
@@ -237,8 +237,6 @@ def inferpymc(
         else:
             #mu = pm.math.concatenate(hx_dot_x) + pm.math.dot(hbc, xbc)
             mu = hx_dot_x + pm.math.dot(hbc, xbc)
-            
-        print(mu.shape.eval())
 
         # Calculate model error
         #model_error = pm.math.abs(pm.math.concatenate(hx_dot_x)) * sig[sites, sigma_freq_index]
@@ -857,8 +855,11 @@ def inferpymc_postprocessouts(
         outds.attrs["Offset Prior"] = "".join(["{0},{1},".format(k, v) for k, v in offsetprior.items()])[:-1]
     outds.attrs["Creator"] = getpass.getuser()
     outds.attrs["Date created"] = str(pd.Timestamp("today"))
-    outds.attrs["Convergence"] = convergence
-    outds.attrs["Repository version"] = code_version()
+    outds.attrs["Convergence"] = str(convergence)
+    try:
+        outds.attrs["Repository version"] = code_version()
+    except:
+        print('Cannot find code version, check this function.')
 
     # variables with variable length data types shouldn't be compressed
     # e.g. object ("O") or unicode ("U") type
@@ -874,6 +875,6 @@ def inferpymc_postprocessouts(
 
     output_filename = define_output_filename(outputpath, species, domain, outputname, start_date, ext=".nc")
     Path(outputpath).mkdir(parents=True, exist_ok=True)
-#    outds.to_netcdf(output_filename, encoding=encoding, mode="w")
+    outds.to_netcdf(output_filename, encoding=encoding, mode="w")
 
     return outds

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -226,7 +226,7 @@ def inferpymc(
         #CHANGES: removed .concatenate lines and replaced with sums, as 
         # dimensions of modelled mf weren't correct
         # could add the .concatenate back in and use a .sum too:
-        # mu = pm.math.sum(pm.math.conctenate(hx_dot_x),axis=0)
+        # mu = pm.math.sum(pm.math.concatenate(hx_dot_x),axis=0)
 
         if add_offset:
             offset = parseprior("offset", offsetprior, shape=nsites - 1)
@@ -466,15 +466,16 @@ def inferpymc_postprocessouts(
     # Get parameters for output file
     sectors = list(xouts.keys())         # Emissions sectors
     nit = xouts[sectors[0]].shape[0]     # No. of MCMC samples
-    nx = Hx.shape[0]                     # No. of stacked scaling regions / basis functions
+    #nx = Hx.shape[0]                     # No. of stacked scaling regions / basis functions
     ny = len(Y)                          # No. of collated atmospheric measurements 
     nbc = Hbc.shape[0]                   # No. of BCs
-    noff = offsetouts.shape[0] 
+    noff = offsetouts.shape[0]
+    nbasis = [xouts[s].shape[1] for s in sectors]
 
     nui = np.arange(2)
     steps = np.arange(nit)
     nmeasure = np.arange(ny)
-    nparam = np.arange(nx)
+    #nparam = np.arange(nx)
     nBC = np.arange(nbc)
     nOFF = np.arange(noff)
     # YBCtrace = np.dot(Hbc.T,bcouts.T)
@@ -555,14 +556,15 @@ def inferpymc_postprocessouts(
         for si, site in enumerate(sites):
             site_lat[si] = fp_data[site].release_lat.values[0]
             site_lon[si] = fp_data[site].release_lon.values[0]
-        bfds = fp_data[".basis"]
+        basis_time_index = np.where(fp_data['.basis'].time.values == np.datetime64(start_date))[0][0]
+        bfds = fp_data[".basis"][:,:,:,basis_time_index]
 
     # Calculate mean and mode posterior scale map and flux field
     scalemap_mu = np.zeros_like(bfds.values)
     scalemap_mode = np.zeros_like(bfds.values)
 
     for i in range(len(sectors)):
-        bfds_i = bfds[i, :, : ,:] 
+        bfds_i = bfds[i, :, :] 
 
         for npm in range(0, int(np.max(bfds_i))):
             scalemap_mu[i][bfds_i.values == (npm + 1)] = np.mean(xouts[sectors[i]][:, npm])
@@ -605,10 +607,12 @@ def inferpymc_postprocessouts(
         for m in np.unique(allmonths):
             apriori_flux += flux_array_all[:, :, :, m] * np.sum(allmonths == m) / len(allmonths)
 
-    flux = np.squeeze(scalemap_mode) * np.squeeze(apriori_flux)
+    #flux = np.squeeze(scalemap_mode,axis=-1) * np.squeeze(apriori_flux,axis=-1)
+    flux = scalemap_mode * apriori_flux
 
     # Basis functions to save
-    bfarray = np.squeeze(bfds.values - 1)
+    #bfarray = np.squeeze(bfds.values - 1)
+    bfarray = bfds.values - 1
 
     # Calculate country totals
     area = utils.areagrid(lat, lon)
@@ -677,7 +681,6 @@ def inferpymc_postprocessouts(
         cntry95[i, ci, :] = pm.stats.hdi(cntrytottrace.values, 0.95)
         cntryprior[i, ci] = cntrytotprior
 
-
     # Make output netcdf file
     outds = xr.Dataset(
         {
@@ -701,7 +704,7 @@ def inferpymc_postprocessouts(
             "YmodmodeBC": (["nmeasure"], YmodmodeBC),
             "Ymod95BC": (["nmeasure", "nUI"], Ymod95BC),
             "Ymod68BC": (["nmeasure", "nUI"], Ymod68BC),
-            "xtrace": (["fluxsectors", "steps", "nparam"], np.array(list(xouts.values()))),
+            #"xtrace": (["fluxsectors", "steps", "nparam"], np.array(list(xouts.values()))),
             "bctrace": (["steps", "nBC"], bcouts.values),
             "sigtrace": (["steps", "nsigma_site", "nsigma_time"], sigouts.values),
             "siteindicator": (["nmeasure"], siteindicator),
@@ -713,7 +716,7 @@ def inferpymc_postprocessouts(
             "fluxmode": (["fluxsectors", "lat", "lon"], flux),
             "scalingmean": (["fluxsectors", "lat", "lon"], scalemap_mu),
             "scalingmode": (["fluxsectors", "lat", "lon"], scalemap_mode),
-            "basisfunctions": (["lat", "lon"], bfarray),
+            "basisfunctions": (["fluxsectors","lat", "lon"], bfarray),
 
             "countrymean": (["fluxsectors", "countrynames"], cntrymean),
             "countrymedian": (["fluxsectors", "countrynames"], cntrymedian),
@@ -723,12 +726,12 @@ def inferpymc_postprocessouts(
             "country95": (["fluxsectors", "countrynames", "nUI"], cntry95),
             "countryapriori": (["fluxsectors", "countrynames"], cntryprior),
             "countrydefinition": (["lat", "lon"], cntrygrid),
-            "xsensitivity": (["nmeasure", "nparam"], Hx.T),
+            #"xsensitivity": (["nmeasure", "nparam"], Hx.T),
             "bcsensitivity": (["nmeasure", "nBC"], Hbc.T),
         },
         coords={
             "stepnum": (["steps"], steps),
-            "paramnum": (["nlatent"], nparam),
+            #"paramnum": (["nlatent"], nparam),
             "numBC": (["nBC"], nBC),
             "measurenum": (["nmeasure"], nmeasure),
             "UInum": (["nUI"], nui),
@@ -738,9 +741,22 @@ def inferpymc_postprocessouts(
             "lat": (["lat"], lat),
             "lon": (["lon"], lon),
             "countrynames": (["countrynames"], cntrynames),
-            "fluxsectors": (["fluxsectors"], sectors),
+            "fluxsectors": (["fluxsectors"], np.array(sectors)),
         },
     )
+
+    Hx_split_array = np.split(Hx,np.cumsum(nbasis)[:-1],axis=0) #split full stacked H matrix into sectors
+    Hx_split = dict(zip(sectors,Hx_split_array)) #turn into dictionary
+    
+    for i,s in enumerate(sectors):
+        
+        outds.coords[f'nbasis_{s}'] = ([f'nbasis_{s}'],np.arange(nbasis[i]))
+        outds[f'xtrace_{s}'] = (['steps',f'nbasis_{s}'],xouts[s].values)
+        outds[f'xtrace_{s}'].attrs["longname"] = f"trace of unitless scaling factors for {s} emissions parameters"
+        
+        outds[f'xsensitivity_{s}'] = (['nmeasure',f'nbasis_{s}'],Hx_split[s].T)
+        outds[f'xsensitivity_{s}'].attrs["units"] = obs_units + " " + "mol/mol"
+        outds[f'xsensitivity_{s}'].attrs["longname"] = f"{s} emissions sensitivity timeseries"
 
     outds.fluxmode.attrs["units"] = "mol/m2/s"
     outds.fluxapriori.attrs["units"] = "mol/m2/s"
@@ -770,7 +786,7 @@ def inferpymc_postprocessouts(
     outds.country95.attrs["units"] = country_units
     outds.countrysd.attrs["units"] = country_units
     outds.countryapriori.attrs["units"] = country_units
-    outds.xsensitivity.attrs["units"] = obs_units + " " + "mol/mol"
+    #outds.xsensitivity.attrs["units"] = obs_units + " " + "mol/mol"
     outds.bcsensitivity.attrs["units"] = obs_units + " " + "mol/mol"
     outds.sigtrace.attrs["units"] = obs_units + " " + "mol/mol"
 
@@ -802,7 +818,7 @@ def inferpymc_postprocessouts(
     outds.Ymod95BC.attrs[
         "longname"
     ] = " 0.95 Bayesian credible interval of posterior simulated boundary conditions"
-    outds.xtrace.attrs["longname"] = "trace of unitless scaling factors for emissions parameters"
+    #outds.xtrace.attrs["longname"] = "trace of unitless scaling factors for emissions parameters"
     outds.bctrace.attrs["longname"] = "trace of unitless scaling factors for boundary condition parameters"
     outds.sigtrace.attrs["longname"] = "trace of model error parameters"
     outds.siteindicator.attrs["longname"] = "index of site of measurement corresponding to sitenames"
@@ -823,7 +839,7 @@ def inferpymc_postprocessouts(
     outds.countrysd.attrs["longname"] = "standard deviation of ocean and country totals"
     outds.countryapriori.attrs["longname"] = "prior mean of ocean and country totals"
     outds.countrydefinition.attrs["longname"] = "grid definition of countries"
-    outds.xsensitivity.attrs["longname"] = "emissions sensitivity timeseries"
+    #outds.xsensitivity.attrs["longname"] = "emissions sensitivity timeseries"
     outds.bcsensitivity.attrs["longname"] = "boundary conditions sensitivity timeseries"
 
     outds.attrs["Start date"] = start_date

--- a/openghg_inversions/utils.py
+++ b/openghg_inversions/utils.py
@@ -1097,11 +1097,11 @@ def fp_sensitivity(fp_and_data, domain, basis_case, basis_directory=None, verbos
                 concat_sensitivity = xr.concat((concat_sensitivity, sensitivity), dim="region")
 
             sub_basis_cases = 0
-
+            
             if source in basis_func["sector"].values:
                 source_ind = np.where(basis_func["sector"].values == source)[0]
                 basis_case_key = basis_func["sector"][source_ind]
-                
+                    
             elif "all" in basis_case.keys():
                 source_ind = 0
                 basis_case_key = "all"


### PR DESCRIPTION
A few minor changes required to get `co2_updates_eric` to run an inversion all the way through:

- Split up xtrace and Hx in the output dataset, because each sector can now have different numbers of basis functions, so Hx and xtrace are different shapes. I split these up using the size of the xout variable.
- Switched `np.concatenate` to more a basic sum, when adding together modelled `H.x`, as this line was failing when only using one sector. This works for single or multi sector runs now.
- Changed path for land/sea definition file to shared area.
- Other minor fixes for the output dataset creation.

Small checks made:

- I ran a couple of my old single-sector PARIS inversions using this branch, and the results were almost identical to those from the currently working main branch. So updates here shouldn't have impacted how the single-sector inversion works.