### PR TITLE
Bugfix git error handling

### DIFF
--- a/openghg_inversions/config/version.py
+++ b/openghg_inversions/config/version.py
@@ -37,7 +37,7 @@ def code_version():
             check=True,
             text=True,
         )
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, FileNotFoundError):
         print(
             "WARNING: Unable to identify version using git."
             " Check that git is available to the python process."


### PR DESCRIPTION
The code for finding the version of openghg inversions used in a run causes an inversion to fail if git is not installed, which might be the case if running a slurm batch job. This updates the error handling to fix this.