### PR TITLE
Updated version checker for git not found error

### DIFF
--- a/openghg_inversions/config/version.py
+++ b/openghg_inversions/config/version.py
@@ -37,7 +37,7 @@ def code_version():
             check=True,
             text=True,
         )
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, FileNotFoundError):
         print(
             "WARNING: Unable to identify version using git."
             " Check that git is available to the python process."


### PR DESCRIPTION
The right error to catch is `FileNotFoundError`, which is raised if e.g. `/usr/bin/git` is not found.