### PR TITLE
basis functions read in from fp_basis_case now work correctly again

### DIFF
--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -568,6 +568,7 @@ def fixedbasisMCMC(
 
         # Mask of source regions in Hx
         basis_region_mask = np.zeros_like(fp_all[site]["region"].values)
+        
         count = 0        
         for emi in emissions_name:
             count += 1

--- a/openghg_inversions/utils.py
+++ b/openghg_inversions/utils.py
@@ -1001,6 +1001,24 @@ def fp_sensitivity(fp_and_data, domain, basis_case, basis_directory=None, verbos
                        basis_case=basis_case,
                        basis_directory=basis_directory
                       )
+        
+    if 'sector' not in basis_func.coords:
+        print(('No sector info in basis function file, so assuming single basis grid '+
+               'applies to all sectors'))
+        for i,source in enumerate(flux_sources):
+            if i == 0:
+                basis_func_new = np.expand_dims(basis_func['basis'].astype(float),axis=0)
+            else:
+                basis_func_new = np.concatenate((basis_func_new,
+                                                np.expand_dims(basis_func['basis'].astype(float),axis=0)),
+                                                axis=0)
+
+        basis_func['basis'] = xr.DataArray(data=basis_func_new,
+                                           dims=['sector','lat','lon','time'],
+                                           coords={'sector':flux_sources,
+                                                   'lat':basis_func.lat.values,
+                                                   'lon':basis_func.lon.values,
+                                                   'time':basis_func.time.values})
 
     for site in sites:
         for si, source in enumerate(flux_sources):
@@ -1070,7 +1088,7 @@ def fp_sensitivity(fp_and_data, domain, basis_case, basis_directory=None, verbos
             else:
                 print("Warning: Using basis functions without a region dimension may be deprecated shortly.")
 
-                site_bf = combine_datasets(site_bf, basis_func_source, method="ffill")
+                site_bf = combine_datasets(site_bf, basis_func_source, method="nearest")
 
                 H = np.zeros((int(np.max(site_bf.basis)), len(site_bf.time)))
 


### PR DESCRIPTION
The option to use a fixed basis function (specified by the `fp_basis_case` variable) wasn't working in the previous commit, because the code now looks for a `sector` coordinate in the basis function file. 

I've solved this issue (in a slightly fudge-y fix) by adding the `sector` coordinate to the simple basis function file. Then there is a matching basis function grid available for all sectors.

Also, changed the combine datasets method from `ffill` to `nearest` as `ffill` was adding nans at the start of the combined datasets.

I'll rename/move the co2_updates eric branch, once this merge is complete.