### PR TITLE
Added option to use obs to compute pollution event size

### DIFF
--- a/tests/test_full_inversion.py
+++ b/tests/test_full_inversion.py
@@ -59,8 +59,19 @@ def test_inversion_if_merged_data_does_not_exist(mcmc_args):
     fixedbasisMCMC(**mcmc_args)
 
 
+def test_full_inversion_pollution_events_from_obs(mcmc_args):
+    mcmc_args["pollution_events_from_obs"] = True
+    fixedbasisMCMC(**mcmc_args)
+
+
 def test_full_inversion_min_error_no_bc(mcmc_args):
     """Test inversion without boundary conditions."""
+    mcmc_args["use_bc"] = False
+    fixedbasisMCMC(**mcmc_args)
+
+
+def test_full_inversion_pollution_events_from_obs_no_bc(mcmc_args):
+    mcmc_args["pollution_events_from_obs"] = True
     mcmc_args["use_bc"] = False
     fixedbasisMCMC(**mcmc_args)
 


### PR DESCRIPTION
Using the option `pollution_events_from_obs = True` uses the obs minus the modelled baseline as the size of the pollution events in the model-data mismatch error. (If `use_bc` is False, then just the obs are used as the pollution event size.)

This addresses issue #110 