### PR TITLE
Specify fp species in ini file

### DIFF
--- a/openghg_inversions/get_data.py
+++ b/openghg_inversions/get_data.py
@@ -44,6 +44,7 @@ def data_processing_surface_notracer(
     met_model=None,
     fp_model=None,
     fp_height=None,
+    fp_species=None,
     emissions_name=None,
     use_bc=True,
     bc_input=None,
@@ -101,6 +102,8 @@ def data_processing_surface_notracer(
             LPDM used for generating footprints.
         fp_height (list/str):
             Inlet height used in footprints for corresponding sites.
+        fp_species (str):
+            Species name associated with footprints in the object store
         emissions_name (list):
             List of keywords args associated with emissions files
             in the object store.
@@ -199,30 +202,16 @@ def data_processing_surface_notracer(
 
         # Get footprints data
         try:
-            # Ensure HiTRes CO2 footprints are obtained if
-            # using CO2
-            if species.lower() == "co2":
-                get_fps = get_footprint(
-                    site=site,
-                    height=fp_height[i],
-                    domain=domain,
-                    model=fp_model,
-                    start_date=start_date,
-                    end_date=end_date,
-                    store=footprint_store,
-                    species=species.lower(),
-                )
-
-            else:
-                get_fps = get_footprint(
-                    site=site,
-                    height=fp_height[i],
-                    domain=domain,
-                    model=fp_model,
-                    start_date=start_date,
-                    end_date=end_date,
-                    store=footprint_store,
-                )
+            get_fps = get_footprint(
+                site=site,
+                height=fp_height[i],
+                domain=domain,
+                model=fp_model,
+                start_date=start_date,
+                end_date=end_date,
+                store=footprint_store,
+                species=fp_species,
+            )
         except SearchError:
             print(
                 f"\nNo footprint data found for {site} with inlet/height {fp_height[i]}, model {fp_model}, and domain {domain}.",

--- a/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template.ini
+++ b/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template.ini
@@ -10,6 +10,7 @@
 [INPUT.MEASUREMENTS]
 ; Input values for extracting observations
 ; species (str): Species name (check object store for options) e.g. "ch4"
+; use_bc (bool): Option to solve for boundary conditions in inversion
 ; use_tracer (bool): Option to use tracer method for inversions
 ; sites (list): Site codes as a list (check object store for options) e.g. ["MHD"]
 ; averaging_period (list): Averaged time periods for measurements as a list (must match length of sites)
@@ -17,6 +18,7 @@
 ; end_date (str): End of observations to extract (format YYYY-MM-DD) (non-inclusive)
 
 species = ""           ; (required)
+use_bc = True          
 use_tracer = False     ; (required)
 sites = []             ; (required)
 averaging_period = []  ; (required)
@@ -63,6 +65,7 @@ emissions_store = " "     ; (required)
 ; met_model (str/None):  e.g., 'UKV' or None if applies to all sites
 ; fp_model (str): Name of LPDM footprints e.g. "NAME"
 ; fp_height (list/str): List of footprint inlet heights used in model.
+; fp_species (str): Species name associated with footprints in the object store
 ; emissions_name (list): Name of emissions sources as used when adding flux files to the object store
 ; bc_input (list/str): Name of boundary conditions data to use from object store
 
@@ -70,6 +73,7 @@ domain = " "               ; (required)
 met_model = None       
 fp_model = None
 fp_height = None
+fp_species = None
 emissions_name = [None]   ; (required)
 bc_input = None
 
@@ -90,14 +94,14 @@ basis_algorithm = " "
 bc_basis_case = "NESW"
 fp_basis_case = None
 nbasis =
-bc_basis_directory = None
 basis_directory = None
+bc_basis_directory = None
 country_file = " "
 
 [MCMC.TYPE]
 ; Which MCMC setup to use. This defines the function which will be called and the expected inputs.
 ; Options include:
-; "fixed_basis"
+; - "fixed_basis"
 
 mcmc_type = "fixed_basis"
 
@@ -145,7 +149,7 @@ mcmc_type = "fixed_basis"
 xprior = {"pdf" : "normal", "mu" : 1.0, "sigma" : 1}
 bcprior = {"pdf" : "normal", "mu" : 1.0, "sigma" : 0.5}
 sigprior = {"pdf" : "uniform", "lower" : 0.5, "upper" : 3}
-dd_offset = False
+add_offset = False
 #offsetprior = {}
 
 [MCMC.BC_SPLIT]
@@ -179,9 +183,12 @@ nchain = 2
 [MCMC.OPTIONS]
 ; averagingerror (bool): Add variability in averaging period to the measurement error
 
-averagingerror = True
-min_error = 1.0
+averaging_error = True
+min_error = 0.0
 fix_basis_outer_regions = False
+nuts_sampler = "numpyro"
+save_trace = True
+compute_min_error = True
 
 [MCMC.OUTPUT]
 ; Details of where to write the output

--- a/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template.ini
+++ b/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template.ini
@@ -65,7 +65,7 @@ emissions_store = " "     ; (required)
 ; met_model (str/None):  e.g., 'UKV' or None if applies to all sites
 ; fp_model (str): Name of LPDM footprints e.g. "NAME"
 ; fp_height (list/str): List of footprint inlet heights used in model.
-; fp_species (str): Species name associated with footprints in the object store
+; fp_species (str): Species name associated with footprints in the object store  (can be "inert")
 ; emissions_name (list): Name of emissions sources as used when adding flux files to the object store
 ; bc_input (list/str): Name of boundary conditions data to use from object store
 

--- a/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template_example.ini
+++ b/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template_example.ini
@@ -64,7 +64,7 @@ emissions_store = "paris_openghg_store"     ; (required)
 ; met_model (str/None):  e.g., 'UKV' or None if applies to all sites
 ; fp_model (str): Name of LPDM footprints e.g. "NAME"
 ; fp_height (list/str): List of footprint inlet heights used in model.
-; fp_species (str): Species name associated with footprints in the object store
+; fp_species (str): Species name associated with footprints in the object store (can be "inert")
 ; emissions_name (list): Name of emissions sources as used when adding flux files to the object store
 ; bc_input (list/str): Name of boundary conditions data to use from object store
 

--- a/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template_example.ini
+++ b/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template_example.ini
@@ -64,6 +64,7 @@ emissions_store = "paris_openghg_store"     ; (required)
 ; met_model (str/None):  e.g., 'UKV' or None if applies to all sites
 ; fp_model (str): Name of LPDM footprints e.g. "NAME"
 ; fp_height (list/str): List of footprint inlet heights used in model.
+; fp_species (str): Species name associated with footprints in the object store
 ; emissions_name (list): Name of emissions sources as used when adding flux files to the object store
 ; bc_input (list/str): Name of boundary conditions data to use from object store
 
@@ -71,6 +72,7 @@ domain = "EUROPE"           ; (required)
 met_model = None
 fp_model = None
 fp_height = ["185m", "90m"]
+fp_species = None
 emissions_name = ["edgar-annual-total"]
 bc_input = "camsv19"
 
@@ -121,6 +123,7 @@ sigprior = {"pdf" : "uniform", "lower" : 0.1, "upper" : 3.0}
 ;offsetprior = {}
 
 [MCMC.BC_SPLIT]
+; Boundary conditions setup
 ; bc_freq (str/optional): The period over which the baseline is estimated. e.g.
 ;  - None - one scaling for the whole inversion period
 ;  - "monthly" - per calendar monthly
@@ -150,20 +153,17 @@ nchain = 4
 [MCMC.OPTIONS]
 ; averagingerror (bool): Add variability in averaging period to the measurement error
 
-averagingerror = True
-min_error = 20.0
+averaging_error = True
+min_error = 0.0
 fix_basis_outer_regions = False
-use_bc = True
 nuts_sampler = "numpyro"
 save_trace = True
 compute_min_error = True
-
 
 [MCMC.OUTPUT]
 ; Details of where to write the output
 ; outputpath (str): Directory to write output
 ; outputname (str): Unique identifier for output/run name.
-
 
 outputpath = "/group/chemistry/acrg/ES/"  ; (required)
 outputname = "my_first_rhime_inversion"  ; (required)

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -115,6 +115,7 @@ def fixedbasisMCMC(
     met_model=None,
     fp_model=None,  # Changed to none. When "NAME" specified FPs are not found
     fp_height=None,
+    fp_species=None,
     emissions_name=None,
     inlet=None,
     instrument=None,
@@ -207,6 +208,9 @@ def fixedbasisMCMC(
 
       fp_height (list):
         Inlet height modelled for sites in LPDM (must match number of sites)
+
+      fp_species (str):
+        Species name associated with footprints in the object store
 
       emissions_name (list):
         List of keyword "source" args used for retrieving emissions files
@@ -410,6 +414,7 @@ def fixedbasisMCMC(
                 met_model=met_model,
                 fp_model=fp_model,
                 fp_height=fp_height,
+                fp_species=fp_species,
                 emissions_name=emissions_name,
                 inlet=inlet,
                 instrument=instrument,


### PR DESCRIPTION
Adding the ability to specify fp_species, so that you can retrieve footprints from a store that contains inert footprints and species-specific footprints.

This addresses issue #113 