### PR TITLE
Make min_error a minimum value and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ This is not a comprehensive list (see the docstring for `fixedbasisMCMC` in the 
   - Default value is `False`
   - If `True`, the "outer regions" of the (`EUROPE`) domain use basis regions specified by a file provided by the Met Office (from their "InTem" model), and the "inner region", which includes the UK, is fit using our basis algorithms.
   - This option is only available for the `EUROPE` domain currently.
-- `compute_min_error`: compute the minimum model error on the fly using the "residual error method"
+- `compute_min_error`: compute min_error (see below) on the fly using the "residual error method"
 
 
 ##### Parameters for `inferpymc`
@@ -152,7 +152,7 @@ This is not a comprehensive list (see the docstring for `fixedbasisMCMC` in the 
 As mentioned above, any keyword argument passed to `fixedbasisMCMC` (either by an `ini` file or from `--kwargs` on the command line) that is not recognised by `fixedbasisMCMC` is passed on to `inferpymc`.
 
 These parameters include:
-- `min_error`: a non-negative float value that is added to the model and observation error in the likelihood of the Bayesian model.
+- `min_error`: a non-negative float value specifying a lower bound for the model-measurement mismatch error (i.e. the error on (y - y_mod)).
 - `nuts_sampler`: a string, which defaults to `"pymc"`. The other option is `"numpyro"`, which will the [JAX](https://jax.readthedocs.io/en/latest/index.html) accelerated sampler from [Numpyro](https://num.pyro.ai/en/stable/index.html); this tends to be significantly faster than the NUTS sampler built into PyMC.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -154,6 +154,9 @@ As mentioned above, any keyword argument passed to `fixedbasisMCMC` (either by a
 These parameters include:
 - `min_error`: a non-negative float value specifying a lower bound for the model-measurement mismatch error (i.e. the error on (y - y_mod)).
 - `nuts_sampler`: a string, which defaults to `"pymc"`. The other option is `"numpyro"`, which will the [JAX](https://jax.readthedocs.io/en/latest/index.html) accelerated sampler from [Numpyro](https://num.pyro.ai/en/stable/index.html); this tends to be significantly faster than the NUTS sampler built into PyMC.
+- `pollution_events_from_obs`: Determines whether the model error is calculated as a fraction of:
+  - the measured enhancement above the modelled baseline (if `True`)
+  - the prior modelled enhancement (if `False`)
 
 ## Contributing
 

--- a/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template.ini
+++ b/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template.ini
@@ -181,14 +181,34 @@ tune =    ; (required)
 nchain = 2
 
 [MCMC.OPTIONS]
-; averagingerror (bool): Add variability in averaging period to the measurement error
+; averaging_error (bool): Add variability in averaging period to the measurement error (Note: currently this
+;                         doesn't work correctly)
+; min_error (float): value specifying a lower bound for the model-measurement mismatch error (i.e. the error on
+;                    (y - y_mod)). Ignored if compute_min_error = True.
+; fix_basis_outer_regions (bool): If True, the "outer regions" of the domain use basis regions specified by a
+;                                 file provided by the Met Office (from their "InTem" model), and the "inner
+;                                 region", which includes the UK, is fit using our basis algorithms.
+; use_bc (bool): defaults to True. If False, no boundary conditions will be used in the inversion. This
+;                implicitly assumes that contributions from the boundary have been subtracted from the
+;                observations.
+; nuts_sampler (str): defaults to "pymc". The other option is "numpyro", which will the JAX accelerated sampler
+;                     from Numpyro; this tends to be significantly faster than the NUTS sampler built into PyMC.
+; save_trace (bool): If True, the arviz InferenceData output from sampling will be saved to the output path of
+;                    the inversion, with a file name of the form f"{outputname}{start_data}_trace.nc.
+;                    Alternatively, you can pass a path (including filename), and that path will be used.
+; compute_min_error (bool): computes min_error on the fly using the "residual error method"
+; pollution_events_from_obs (bool): Determines whether the model error is calculated as a fraction of:
+;                                   - the measured enhancement above the modelled baseline (if True)
+;                                   - the prior modelled enhancement (if False)
 
 averaging_error = True
 min_error = 0.0
 fix_basis_outer_regions = False
+use_bc = True                    
 nuts_sampler = "numpyro"
 save_trace = True
 compute_min_error = True
+pollution_events_from_obs = True
 
 [MCMC.OUTPUT]
 ; Details of where to write the output

--- a/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template.ini
+++ b/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template.ini
@@ -10,7 +10,6 @@
 [INPUT.MEASUREMENTS]
 ; Input values for extracting observations
 ; species (str): Species name (check object store for options) e.g. "ch4"
-; use_bc (bool): Option to solve for boundary conditions in inversion
 ; use_tracer (bool): Option to use tracer method for inversions
 ; sites (list): Site codes as a list (check object store for options) e.g. ["MHD"]
 ; averaging_period (list): Averaged time periods for measurements as a list (must match length of sites)
@@ -18,7 +17,6 @@
 ; end_date (str): End of observations to extract (format YYYY-MM-DD) (non-inclusive)
 
 species = ""           ; (required)
-use_bc = True          
 use_tracer = False     ; (required)
 sites = []             ; (required)
 averaging_period = []  ; (required)

--- a/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template.ini
+++ b/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template.ini
@@ -194,7 +194,7 @@ nchain = 2
 ; save_trace (bool): If True, the arviz InferenceData output from sampling will be saved to the output path of
 ;                    the inversion, with a file name of the form f"{outputname}{start_data}_trace.nc.
 ;                    Alternatively, you can pass a path (including filename), and that path will be used.
-; compute_min_error (bool): computes min_error on the fly using the "residual error method"
+; calculate_min_error (bool): computes min_error on the fly using the "residual error method"
 ; pollution_events_from_obs (bool): Determines whether the model error is calculated as a fraction of:
 ;                                   - the measured enhancement above the modelled baseline (if True)
 ;                                   - the prior modelled enhancement (if False)
@@ -205,7 +205,7 @@ fix_basis_outer_regions = False
 use_bc = True                    
 nuts_sampler = "numpyro"
 save_trace = True
-compute_min_error = True
+calculate_min_error = True
 pollution_events_from_obs = True
 
 [MCMC.OUTPUT]

--- a/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template_example.ini
+++ b/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template_example.ini
@@ -10,7 +10,6 @@
 [INPUT.MEASUREMENTS]
 ; Input values for extracting observations
 ; species (str): Species name (check object store for options) e.g. "ch4"
-; use_bc (bool): Option to solve for boundary conditions in inversion
 ; use_tracer (bool): Option to use tracer method for inversions
 ; sites (list): Site codes as a list (check object store for options) e.g. ["MHD"]
 ; averaging_period (list): Averaged time periods for measurements as a list (must match length of sites)
@@ -18,7 +17,6 @@
 ; end_date (str): End of observations to extract (format YYYY-MM-DD) (non-inclusive)
 
 species = "ch4"                  ; (required)
-use_bc = True                    
 use_tracer = False               ; (required)
 sites = ["TAC", "RGL"]           ; (required)
 averaging_period = ["4H", "4H"]  ; (required)
@@ -151,14 +149,34 @@ tune = 10000
 nchain = 4
 
 [MCMC.OPTIONS]
-; averagingerror (bool): Add variability in averaging period to the measurement error
+; averaging_error (bool): Add variability in averaging period to the measurement error (Note: currently this
+;                         doesn't work correctly)
+; min_error (float): value specifying a lower bound for the model-measurement mismatch error (i.e. the error on
+;                    (y - y_mod)). Ignored if compute_min_error = True.
+; fix_basis_outer_regions (bool): If True, the "outer regions" of the domain use basis regions specified by a
+;                                 file provided by the Met Office (from their "InTem" model), and the "inner
+;                                 region", which includes the UK, is fit using our basis algorithms.
+; use_bc (bool): defaults to True. If False, no boundary conditions will be used in the inversion. This
+;                implicitly assumes that contributions from the boundary have been subtracted from the
+;                observations.
+; nuts_sampler (str): defaults to "pymc". The other option is "numpyro", which will the JAX accelerated sampler
+;                     from Numpyro; this tends to be significantly faster than the NUTS sampler built into PyMC.
+; save_trace (bool): If True, the arviz InferenceData output from sampling will be saved to the output path of
+;                    the inversion, with a file name of the form f"{outputname}{start_data}_trace.nc.
+;                    Alternatively, you can pass a path (including filename), and that path will be used.
+; compute_min_error (bool): computes min_error on the fly using the "residual error method"
+; pollution_events_from_obs (bool): Determines whether the model error is calculated as a fraction of:
+;                                   - the measured enhancement above the modelled baseline (if True)
+;                                   - the prior modelled enhancement (if False)
 
 averaging_error = True
 min_error = 0.0
 fix_basis_outer_regions = False
+use_bc = True                    
 nuts_sampler = "numpyro"
 save_trace = True
 compute_min_error = True
+pollution_events_from_obs = True
 
 [MCMC.OUTPUT]
 ; Details of where to write the output

--- a/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template_example.ini
+++ b/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template_example.ini
@@ -164,7 +164,7 @@ nchain = 4
 ; save_trace (bool): If True, the arviz InferenceData output from sampling will be saved to the output path of
 ;                    the inversion, with a file name of the form f"{outputname}{start_data}_trace.nc.
 ;                    Alternatively, you can pass a path (including filename), and that path will be used.
-; compute_min_error (bool): computes min_error on the fly using the "residual error method"
+; calculate_min_error (bool): computes min_error on the fly using the "residual error method"
 ; pollution_events_from_obs (bool): Determines whether the model error is calculated as a fraction of:
 ;                                   - the measured enhancement above the modelled baseline (if True)
 ;                                   - the prior modelled enhancement (if False)
@@ -175,7 +175,7 @@ fix_basis_outer_regions = False
 use_bc = True                    
 nuts_sampler = "numpyro"
 save_trace = True
-compute_min_error = True
+calculate_min_error = True
 pollution_events_from_obs = True
 
 [MCMC.OUTPUT]

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -285,7 +285,7 @@ def inferpymc(
             pollution_event = np.abs(pt.dot(hx, x))
 
         pollution_event_scaled_error = pollution_event * sig[sites, sigma_freq_index]
-        epsilon = pt.sqrt(error**2 + pollution_event_scaled_error**2 + min_error**2)
+        epsilon = pt.maximum(pt.sqrt(error**2 + pollution_event_scaled_error**2), min_error)
         y = pm.Normal("y", mu=mu, sigma=epsilon, observed=Y, shape=ny)
 
         step1 = pm.NUTS(vars=step1_vars)


### PR DESCRIPTION
Changed inferpymc so that it interprets min_error as a minimum value (lower bound) rather than adding it to the other errors for all points. This addresses Issue #116 .

Needs looking at by someone who understands pytensors before approval - I'm not certain that what I've done here is correct.