### PR TITLE
Pass met_model as a list to get_footprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Version 0.2.0
 
+- `met_model` is now used by `data_processing_surface_notracer`; it is an optional argument, passed as a list with the same length as the number of sites.
+
 - Updated `pblh` filter to work with new variable names in footprints. [#PR 101](https://github.com/openghg/openghg_inversions/pull/101)
 
 - NaNs are filled before converting to numpy and passing data to the inversion. This partly addresses [Issue#97](https://github.com/openghg/openghg_inversions/issues/97).  [#PR 101](https://github.com/openghg/openghg_inversions/pull/101)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # Version 0.2.0
 
-- `met_model` is now used by `data_processing_surface_notracer`; it is an optional argument, passed as a list with the same length as the number of sites.
+- `met_model` is now used by `data_processing_surface_notracer`; it is an optional argument, passed as a list with the same length as the number of sites. [#PR 125](https://github.com/openghg/openghg_inversions/pull/125)
 
 - Updated `pblh` filter to work with new variable names in footprints. [#PR 101](https://github.com/openghg/openghg_inversions/pull/101)
 

--- a/openghg_inversions/get_data.py
+++ b/openghg_inversions/get_data.py
@@ -41,7 +41,7 @@ def data_processing_surface_notracer(
     inlet=None,
     instrument=None,
     calibration_scale=None,
-    met_model=None,
+    met_model: Optional[list] = None,
     fp_model=None,
     fp_height=None,
     fp_species=None,
@@ -96,8 +96,8 @@ def data_processing_surface_notracer(
             (length must match number of sites)
         calibration_scale (str):
             Convert measurements to defined calibration scale
-        met_model (str/opt):
-            Meteorological model used in the LPDM.
+        met_model (list/opt):
+            Meteorological model used in the LPDM. List must be same length as number of sites.
         fp_model (str):
             LPDM used for generating footprints.
         fp_height (list/str):
@@ -143,6 +143,8 @@ def data_processing_surface_notracer(
         fp_height = [None] * nsites
     if obs_data_level is None:
         obs_data_level = [None] * nsites
+    if met_model is None:
+        met_model = [None] * nsites
 
     fp_all = {}
     fp_all[".species"] = species.upper()
@@ -207,6 +209,7 @@ def data_processing_surface_notracer(
                 height=fp_height[i],
                 domain=domain,
                 model=fp_model,
+                met_model=met_model[i],
                 start_date=start_date,
                 end_date=end_date,
                 store=footprint_store,

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -112,7 +112,7 @@ def fixedbasisMCMC(
     obs_store="user",
     footprint_store="user",
     emissions_store="user",
-    met_model=None,
+    met_model: Optional[list] = None,
     fp_model=None,  # Changed to none. When "NAME" specified FPs are not found
     fp_height=None,
     fp_species=None,
@@ -200,7 +200,7 @@ def fixedbasisMCMC(
       emissions_store (str):
         Name of object store containing emissions/flux files
 
-      met_model (str):
+      met_model (list):
         Meteorological model used in the LPDM (e.g. 'ukv')
 
       fp_model (str):


### PR DESCRIPTION
* **Summary of changes**

`met_model` can be passed as list in an ini file, to cover the case where two footprints are distiguished only by met model. The list must have the same length as the number of sites. Values of `None` will be ignored, so for sites where the met model doesn't matter, `None` can be passed.

* **Please check if the PR fulfills these requirements**

- [ ] Tests passing
- [ ] Added an entry to the `CHANGELOG.md` file
