### PR TITLE
Removed function that used matplotlib julian2num

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Version 0.2.0
 
+- removed `julian2time` function from `convert.py` because it used code that was deprecated by `matplotlib`. This function is still available at `github.com/ACRG-Bristol/acrg/acrg/time/convert.py`. [#PR 129](https://github.com/openghg/openghg_inversions/pull/129)
+
 - `met_model` is now used by `data_processing_surface_notracer`; it is an optional argument, passed as a list with the same length as the number of sites. [#PR 125](https://github.com/openghg/openghg_inversions/pull/125)
 
 - Updated `pblh` filter to work with new variable names in footprints. [#PR 101](https://github.com/openghg/openghg_inversions/pull/101)

--- a/openghg_inversions/convert.py
+++ b/openghg_inversions/convert.py
@@ -36,7 +36,6 @@ import calendar
 import dateutil
 import time as tm
 import datetime as dt
-from matplotlib.dates import julian2num, num2date
 
 # from openghg_inversions.utils import synonyms
 
@@ -322,19 +321,6 @@ def decimal2time(frac):
         dates.append(yeardatetime + dt.timedelta(days=daysPerYear * (f - year)))
 
     return return_iter(dates, notIter)
-
-
-def julian2time(dates):
-    """
-    Convert Julian dates (e.g. from IDL) to datetime
-    """
-    dates, notIter = check_iter(dates)
-
-    dates_julian = []
-    for date in dates:
-        dates_julian.append(num2date(julian2num(date)))
-
-    return return_iter(dates_julian, notIter)
 
 
 def convert_to_hours(time):


### PR DESCRIPTION
* **Summary of changes**

The function `julian2num` was deprecated by matplotlib. I just removed the code in inversions that depends on it. This code is available in `acrg/acrg/time/convert.py`

* **Please check if the PR fulfills these requirements**

- [x] Added an entry to the `CHANGELOG.md` file

