### PR TITLE
only drop NaNs from selected data vars

### DIFF
--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -487,7 +487,14 @@ def fixedbasisMCMC(
         siteindicator = np.zeros(0)
 
         for si, site in enumerate(sites):
-            fp_data[site] = fp_data[site].dropna("time")  # pymc doesn't like NaNs
+            # select variables to drop NaNs from
+            drop_vars = []
+            for var in ["H", "H_bc", "mf", "mf_variability", "mf_repeatability"]:
+                if var in fp_data[site].data_vars:
+                    drop_vars.append(var)
+
+            # pymc doesn't like NaNs, so drop them for the variables used below
+            fp_data[site] = fp_data[site].dropna("time", subset=drop_vars)
 
             if "mf_repeatability" in fp_data[site]:
                 error = np.concatenate((error, fp_data[site].mf_repeatability.values))


### PR DESCRIPTION
* **Summary of changes**

The "scenarios" in `fp_data` have several data variables that aren't needed for the inversion.

Previously, if these variables had NaNs, those times would be dropped from the entire scenario, which results in data being thrown away unnecessarily.

* **Please check if the PR fulfills these requirements**

- [ ] Closes #127
- [ ] Tests added and passing
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry to the `CHANGELOG.md` file
- [ ] Added any new requirements to `requirements.txt`
