### PR TITLE
Fix min_error calculation

### DIFF
--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -84,19 +84,19 @@ def residual_error_method(ds_dict: dict[str, xr.Dataset], average_over: Optional
     )
 
     scaling_factor = float(ds.mf.units)/float(ds.bc_mod.units)
-    ds.update({"mf_mod_rescaled": ("time", ds.mf_mod.values + ds.bc_mod.values / scaling_factor)})
+    ds["modelled_obs"] = ds.mf_mod + ds.bc_mod / scaling_factor
 
     if average_over is not None:
         try:
-            avg = (ds.mf - mf_mod_rescaled_rescaled).sel(site=average_over).mean()
+            avg = (ds.mf - ds.modelled_obs).sel(site=average_over).mean()
         except KeyError as e:
             raise ValueError(
                 f"Can't take average over site {average_over}, it is not in the inversion data."
             ) from e
     else:
-        avg = (ds.mf - ds.mf_mod_rescaled).mean()
+        avg = (ds.mf - ds.modelled_obs).mean()
 
-    res_err_arr = np.sqrt(np.mean((ds.mf - ds.mf_mod_rescaled - avg) ** 2))
+    res_err_arr = np.sqrt(np.mean((ds.mf - ds.modelled_obs - avg) ** 2))
     res_err = res_err_arr.values
 
     return res_err

--- a/tests/test_full_inversion.py
+++ b/tests/test_full_inversion.py
@@ -46,6 +46,14 @@ def test_full_inversion_with_min_error_calc(mcmc_args):
     assert "min_model_error" in out.attrs
 
 
+def test_full_inversion_with_min_error_calc_no_bc(mcmc_args):
+    mcmc_args["calculate_min_error"] = True
+    mcmc_args["use_bc"] = False
+    out = fixedbasisMCMC(**mcmc_args)
+
+    assert "min_model_error" in out.attrs
+
+
 def test_full_inversion_pblh_filter(mcmc_args):
     mcmc_args["filters"] = ["pblh"]
 


### PR DESCRIPTION
* **Summary of changes**
The residual error method used to calculate the min error has been fixed to rescale mf_mod to mf units before calculating (y - y_mod).

* **Please check if the PR fulfills these requirements**

- [x] Closes #140 
- [ ] Tests added and passing
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry to the `CHANGELOG.md` file
- [ ] Added any new requirements to `requirements.txt`
