### PR TITLE
Pinned numpy to < 2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ xarray
 pandas
 matplotlib
 scipy
-numpy
+numpy < 2.0
 openghg
 sparse
 tfp-nightly


### PR DESCRIPTION
* **Summary of changes**

Pytensor hasn't upgraded to numpy 2.0 yet so we need to wait for that. OpenGHG is also pinned at numpy < 2.0

* **Please check if the PR fulfills these requirements**

- [x] Added any new requirements to `requirements.txt`
