### PR TITLE
Skipped test if fp and flux are already aligned

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,21 +4,22 @@ from openghg.retrieve import get_footprint, get_flux
 
 from openghg_inversions.utils import combine_datasets
 
-
 def test_combine_datasets():
     fp = get_footprint(site="tac", domain="europe").data
     flux = get_flux(species="ch4", source="total-ukghg-edgar7", domain="europe").data
 
     comb = combine_datasets(fp, flux, method="nearest")
 
-    with pytest.raises(AssertionError) as exc_info:
-        xr.testing.assert_allclose(flux.flux.squeeze("time").drop_vars("time"), comb.flux.isel(time=0))
-        
-    # coordinates should be different because we aligned the flux to the footprint
-    assert exc_info.match("Differing coordinates")
+    if not (fp.lon == flux.lon).all() or not (fp.lat == flux.lat).all():
+        # check that comb.flux has different coordinates from the original flux
+        with pytest.raises(AssertionError) as exc_info:
+            xr.testing.assert_allclose(flux.flux.squeeze("time").drop_vars("time"), comb.flux.isel(time=0, drop=True))
 
-    # values should not be different
-    with pytest.raises(AssertionError):
-        # the match fails, so this raises an assertion error; if the match is found
-        # no error is raised and pytest complains that it did not see an AssertionError
-        assert exc_info.match("Differing values")
+        # coordinates should be different because we aligned the flux to the footprint
+        assert exc_info.match("Differing coordinates")
+
+        # values should not be different
+        with pytest.raises(AssertionError):
+            # the match fails, so this raises an assertion error; if the match is found
+            # no error is raised and pytest complains that it did not see an AssertionError
+            assert exc_info.match("Differing values")


### PR DESCRIPTION
* **Summary of changes**

Code was added to OpenGHG to align lat and lon coords to domains defined in openghg_defs, so the data used in this test is no longer misaligned on OpenGHG devel (whereas it was misaligned on OpenGHG 0.8)

* **Please check if the PR fulfills these requirements**

- [x] Closes #165 
- [x] Tests added and passing
