### PR TITLE
More flexible filter instrument options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # Version 0.2.0
 
+- Made format for `filtering` in ini file allow for missing sites. Made `inlet`, `instrument`, `fp_height`, `obs_data_level`, and `met_model`
+  accept a single string in the ini file, which will be converted to a list of the correct length.  [#PR 182](https://github.com/openghg/openghg_inversions/pull/182)
+
 - Added code to look for older flux data if none is found between start and end dates [#PR 177](https://github.com/openghg/openghg_inversions/pull/177)
 
 - Moved code related to basis functions from `utils.py` to `basis` submodule [#PR 162](https://github.com/openghg/openghg_inversions/pull/162) 

--- a/openghg_inversions/filters.py
+++ b/openghg_inversions/filters.py
@@ -100,7 +100,7 @@ def filtering(
         dict in same format as datasets_in, with filters applied
 
     """
-    if filters is None:
+    if not filters:
         return datasets_in
 
     # Get list of sites

--- a/openghg_inversions/get_data.py
+++ b/openghg_inversions/get_data.py
@@ -102,13 +102,13 @@ def data_processing_surface_notracer(
     averaging_period: list | str,
     start_date: str,
     end_date: str,
-    obs_data_level: Optional[list | str] = None,
-    inlet: Optional[list | str] = None,
-    instrument: Optional[list | str] = None,
+    obs_data_level: list[str | None] | str | None = None,
+    inlet: list[str | None] | str | None = None,
+    instrument: list[str | None] | str | None = None,
     calibration_scale: Optional[str] = None,
-    met_model: Optional[list] = None,
+    met_model: list[str | None] | str | None = None,
     fp_model: Optional[str] = None,
-    fp_height: Optional[list | str] = None,
+    fp_height: list[str | None] | str | None = None,
     fp_species: Optional[str] = None,
     emissions_name: Optional[list] = None,
     use_bc: Optional[bool] = True,
@@ -219,16 +219,16 @@ def data_processing_surface_notracer(
 
     # Convert 'None' args to list
     nsites = len(sites)
-    if inlet is None:
-        inlet = [None] * nsites
-    if instrument is None:
-        instrument = [None] * nsites
-    if fp_height is None:
-        fp_height = [None] * nsites
-    if obs_data_level is None:
-        obs_data_level = [None] * nsites
-    if met_model is None:
-        met_model = [None] * nsites
+    if inlet is None or isinstance(inlet, str):
+        inlet = [inlet] * nsites
+    if instrument is None or isinstance(instrument, str):
+        instrument = [instrument] * nsites
+    if fp_height is None or isinstance(fp_height, str):
+        fp_height = [fp_height] * nsites
+    if obs_data_level is None or isinstance(obs_data_level, str):
+        obs_data_level = [obs_data_level] * nsites
+    if met_model is None or isinstance(met_model, str):
+        met_model = [met_model] * nsites
 
     fp_all = {}
     fp_all[".species"] = species.upper()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,3 +1,4 @@
+import logging
 import numpy as np
 import pytest
 
@@ -51,6 +52,16 @@ def test_all_filters(merged_data):
             filtering(merged_data, [name])
 
 
+def test_filters_as_none(merged_data):
+    filters = None
+    filtering(merged_data, filters)
+
+
+def test_filters_as_str(merged_data):
+    filters = "pblh_inlet_diff"
+    filtering(merged_data, filters)
+
+
 def test_filters_as_list(merged_data):
     filters = ["pblh_inlet_diff", "pblh_min"]
     filtering(merged_data, filters)
@@ -59,3 +70,12 @@ def test_filters_as_list(merged_data):
 def test_filters_as_dict(merged_data):
     filters = {"TAC": ["pblh_inlet_diff", "pblh_min"]}
     filtering(merged_data, filters)
+
+
+def test_filters_as_dict_with_missing_site(merged_data, capsys):
+    filters = {"TAC": ["pblh_inlet_diff", "pblh_min"]}
+    merged_data["MHD"] = "this will be skipped!"
+    filtering(merged_data, filters)
+
+    logs = capsys.readouterr().err
+    assert "Missing entry for sites ['MHD'] in filters." in logs


### PR DESCRIPTION
* **Summary of changes**

Allow `filtering` argument in ini file to have missing sites. A warning will be logged and these sites will not have any filtering applied.

Allow inlet, instrument, fp_height, obs_data_level, and met_model to be single strings. In this case, that value is used for all sites.


* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] Tests added and passing
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry to the `CHANGELOG.md` file
- [ ] Added any new requirements to `requirements.txt`
