### PR TITLE
Basis function fp x flux calculation fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Version 0.2.0
 
+- Fixed issue where missing footprints times were dropped from basis function calculations. [#PR 186](https://github.com/openghg/openghg_inversions/pull/186) 
+
 - Made format for `filtering` in ini file allow for missing sites. Made `inlet`, `instrument`, `fp_height`, `obs_data_level`, and `met_model`
   accept a single string in the ini file, which will be converted to a list of the correct length.  [#PR 182](https://github.com/openghg/openghg_inversions/pull/182)
 

--- a/openghg_inversions/basis/_functions.py
+++ b/openghg_inversions/basis/_functions.py
@@ -191,8 +191,13 @@ def _mean_fp_times_mean_flux(
 
     mean_flux = flux.mean("time")
 
-    fp_total = sum(footprints)  # this seems to be faster than concatentating and summing over new axis
+    # get total times before aligning
     n_measure = sum(len(fp.time) for fp in footprints)
+
+    # align so that all times are used
+    footprints = xr.align(*footprints, join="outer", fill_value=0.0)  # type: ignore  the docs say scalars are accepted as fill values, but type hints don't
+    fp_total = sum(footprints)  # this seems to be faster than concatentating and summing over new axis
+
 
     fp_total = cast(xr.DataArray, fp_total)  # otherwise mypy complains about the next line
     mean_fp = fp_total.sum("time") / n_measure

--- a/tests/test_basis_functions.py
+++ b/tests/test_basis_functions.py
@@ -1,7 +1,35 @@
+import pandas as pd
 import xarray as xr
-from openghg_inversions.basis._functions import basis
+from openghg_inversions.basis._functions import basis, _flux_fp_from_fp_all, _mean_fp_times_mean_flux
 from openghg_inversions.basis import bucketbasisfunction, quadtreebasisfunction
 from openghg_inversions.get_data import data_processing_surface_notracer
+
+
+def test_fp_x_flux(tac_ch4_data_args):
+    fp_all, *_ = data_processing_surface_notracer(**tac_ch4_data_args)
+    emissions_name = [next(iter(fp_all[".flux"].keys()))]
+
+    flux1, fp1 = _flux_fp_from_fp_all(fp_all, emissions_name)
+    mean_fp_flux1 = _mean_fp_times_mean_flux(flux1, fp1)
+
+    # add new site with same footprint -- this should not change the mean over time
+    fp_all["ABC"] = fp_all["TAC"]
+
+    flux2, fp2 = _flux_fp_from_fp_all(fp_all, emissions_name)
+    mean_fp_flux2 = _mean_fp_times_mean_flux(flux2, fp2)
+
+    xr.testing.assert_allclose(mean_fp_flux1, mean_fp_flux2)
+
+    # shift time of second site -- this should not change the mean over time
+    max_time = pd.Timedelta(fp_all["TAC"].time.max().values - fp_all["TAC"].time.min().values)
+    new_time = (fp_all["TAC"].time + max_time)
+    fp_all["ABC"] = fp_all["ABC"].assign_coords(time=new_time)
+
+    flux3, fp3 = _flux_fp_from_fp_all(fp_all, emissions_name)
+    mean_fp_flux3 = _mean_fp_times_mean_flux(flux3, fp3)
+
+    xr.testing.assert_allclose(mean_fp_flux1, mean_fp_flux3)
+
 
 
 def test_quadtree_basis_function(tac_ch4_data_args, raw_data_path):


### PR DESCRIPTION
* **Summary of changes**

xarray alignment was dropping times that were missing from some footprints, which causes problems if there are footprints with non-overlapping times. (Due to footprint_data_merge, these missing times can come from missing obs as well.)

This fixes that problem by explicitly aligning the footprints and filling missing times with 0's.

* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] Tests added and passing
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry to the `CHANGELOG.md` file
- [ ] Added any new requirements to `requirements.txt`
