### PR TITLE
Match footprint heights to obs. inlets

### DIFF
--- a/openghg_inversions/get_data.py
+++ b/openghg_inversions/get_data.py
@@ -449,7 +449,7 @@ def data_processing_surface_notracer(
                         site_data,
                         domain=domain,
                         start_date=start_date,
-                        end_date=end_date
+                        end_date=end_date,
                         model=fp_model,
                         met_model=met_model[i],
                         store=store,

--- a/openghg_inversions/get_data.py
+++ b/openghg_inversions/get_data.py
@@ -454,7 +454,7 @@ def data_processing_surface_notracer(
                         met_model=met_model[i],
                         store=store,
                         fp_species=fp_species,
-                        averaging_period=averaging_period,
+                        averaging_period=averaging_period[i],
                     )
                 else:
                     get_fps = get_footprint(

--- a/openghg_inversions/get_data.py
+++ b/openghg_inversions/get_data.py
@@ -144,6 +144,13 @@ def get_footprint_to_match(
         "end_date": end_date,
     }
     results = search_footprints(**fp_kwargs)
+
+    # check that we got results with inlet values
+    # Note: results `search_footprints` should always have inlet values
+    # so the second check shouldn't be necessary...
+    if not results.results or "inlet" not in results.results:
+        raise SearchError(f"No footprints found for search terms {fp_kwargs}")
+
     fp_heights_strs = list(results.results.inlet.unique())
     fp_heights = _convert_inlets_to_float(fp_heights_strs)
 

--- a/openghg_inversions/get_data.py
+++ b/openghg_inversions/get_data.py
@@ -204,7 +204,7 @@ def get_footprint_to_match(
         metadata["inlet"] = "varies"
         metadata["height"] = "varies"
 
-    data = xr.concat([fp.data for fp in footprints], dim="time")
+    data = xr.concat([fp.data for fp in footprints], dim="time").sortby("time")
 
     return FootprintData(data=data, metadata=metadata)
 

--- a/openghg_inversions/get_data.py
+++ b/openghg_inversions/get_data.py
@@ -188,7 +188,10 @@ def get_footprint_to_match(
     try:
         averaging_period = averaging_period or obs.metadata["averaged_period_str"]
     except KeyError:
-        raise ValueError("`averaging_period` could not be inferred from ObsData; please provide a value.")
+        if "sampling_period" in obs.metadata and "sampling_period_unit" in obs.metadata:
+            averaging_period = f"{obs.metadata['sampling_period']}{obs.metadata['sampling_period_unit']}"
+        else:
+            raise ValueError("`averaging_period` could not be inferred from ObsData; please provide a value.")
 
     # select times from footprints to match with obs
     for i, fp in zip(np.unique(inlets_to_heights), footprints):

--- a/openghg_inversions/get_data.py
+++ b/openghg_inversions/get_data.py
@@ -166,7 +166,7 @@ def get_footprint_to_match(
     # check tolerance
     inlet_tolerance_passed = np.min(distances, axis=1) <= tolerance
     if (s := np.sum(inlet_tolerance_passed)) > 0:
-        warnings.warn(f"{s} times where obs. inlet height was not within {tolerance}m of a footprint height.")
+        logger.warning(f"For site {site}: {s} times where obs. inlet height was not within {tolerance}m of a footprint height.")
         inlets_to_heights = inlets_to_heights[inlet_tolerance_passed]
 
     # footprint heights to load

--- a/openghg_inversions/get_data.py
+++ b/openghg_inversions/get_data.py
@@ -148,7 +148,7 @@ def get_footprint_to_match(
     # check that we got results with inlet values
     # Note: results `search_footprints` should always have inlet values
     # so the second check shouldn't be necessary...
-    if not results.results or "inlet" not in results.results:
+    if results.results.empty or "inlet" not in results.results:
         raise SearchError(f"No footprints found for search terms {fp_kwargs}")
 
     fp_heights_strs = list(results.results.inlet.unique())

--- a/openghg_inversions/get_data.py
+++ b/openghg_inversions/get_data.py
@@ -447,6 +447,7 @@ def data_processing_surface_notracer(
                         met_model=met_model[i],
                         store=store,
                         fp_species=fp_species,
+                        averaging_period=averaging_period,
                     )
                 else:
                     get_fps = get_footprint(

--- a/openghg_inversions/get_data.py
+++ b/openghg_inversions/get_data.py
@@ -442,7 +442,7 @@ def data_processing_surface_notracer(
                     obs_found = True
                     break
         if not obs_found:
-            print("No obs. found, continuing model run without {site}.\n")
+            print(f"No obs. found, continuing model run without {site}.\n")
             continue
         else:
             unit = float(site_data[site].mf.units)

--- a/openghg_inversions/get_data.py
+++ b/openghg_inversions/get_data.py
@@ -126,7 +126,7 @@ def get_footprint_to_match(
     site = obs.metadata["site"]
     species = fp_species or obs.metadata.get("species", "inert")
     if store is None:
-        store = Path(obs.metadata.get("object_store")).name
+        store = Path(obs.metadata.get("object_store", "")).name or "user"
     start_date = obs._start_date
     end_date = obs._end_date
 

--- a/openghg_inversions/get_data.py
+++ b/openghg_inversions/get_data.py
@@ -145,8 +145,6 @@ def get_footprint_to_match(
     fp_heights_strs = list(results.results.inlet.unique())
     fp_heights = _convert_inlets_to_float(fp_heights_strs)
 
-    # convert fp_heights to array of floats
-
     # special case: only a single inlet height
     if "inlet" not in obs.data.data_vars:
         inlet = float(obs.metadata["inlet"][:-1])

--- a/openghg_inversions/get_data.py
+++ b/openghg_inversions/get_data.py
@@ -117,6 +117,8 @@ def get_footprint_to_match(
     obs: ObsData,
     domain: str,
     model: str | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
     met_model: str = "not_set",
     fp_species: str | None = None,
     store: str | None = None,
@@ -127,8 +129,8 @@ def get_footprint_to_match(
     species = fp_species or obs.metadata.get("species", "inert")
     if store is None:
         store = Path(obs.metadata.get("object_store", "")).name or "user"
-    start_date = obs._start_date
-    end_date = obs._end_date
+    start_date = start_date or obs._start_date
+    end_date = end_date or obs._end_date
 
     # get available footprint heights
     fp_kwargs = {
@@ -446,6 +448,8 @@ def data_processing_surface_notracer(
                     get_fps = get_footprint_to_match(
                         site_data,
                         domain=domain,
+                        start_date=start_date,
+                        end_date=end_date
                         model=fp_model,
                         met_model=met_model[i],
                         store=store,

--- a/openghg_inversions/get_data.py
+++ b/openghg_inversions/get_data.py
@@ -201,8 +201,10 @@ def get_footprint_to_match(
 
     # make FootprintData to return
     metadata = footprints[0].metadata
-    metadata["inlet"] = "varies"
-    metadata["height"] = "varies"
+
+    if len(footprints) > 1:
+        metadata["inlet"] = "varies"
+        metadata["height"] = "varies"
 
     data = xr.concat([fp.data for fp in footprints], dim="time")
 


### PR DESCRIPTION
* **Summary of changes**

If `fp_height = "auto"` (or e.g. `fp_height = ["185m", "auto"]`), then the footprint height will be inferred from the obs. data.

This works even if the obs. inlet height varies.

* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] Tests added and passing
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry to the `CHANGELOG.md` file
- [ ] Added any new requirements to `requirements.txt`
