### PR TITLE
Adjust the flux start_date to align with the flux data's temporal resolution

### DIFF
--- a/openghg_inversions/get_data.py
+++ b/openghg_inversions/get_data.py
@@ -27,7 +27,7 @@ import xarray as xr
 
 from openghg.analyse import ModelScenario
 from openghg.dataobjects import ObsData, BoundaryConditionsData, FluxData, FootprintData
-from openghg.retrieve import get_bc, get_flux, get_footprint, get_obs_surface, search_footprints
+from openghg.retrieve import get_bc, get_flux, get_footprint, get_obs_surface, search_footprints, search_flux
 from openghg.types import SearchError
 from openghg.util import timestamp_now
 
@@ -223,6 +223,24 @@ def get_footprint_to_match(
 
     return FootprintData(data=data, metadata=metadata)
 
+def adjust_flux_start_date(start_date: str, species: str, source: str, domain: str, store: str):
+    """
+    Adjusts the flux start_date to align with the flux data's temporal resolution.
+    """
+
+    flux_search = search_flux(species=species, source=source, domain=domain, store=store)
+    flux_period = flux_search.results["time_period"][0]
+
+    start_date_flux = pd.to_datetime(start_date)
+
+    if flux_period=="1 year":
+        if not start_date_flux.is_year_start:
+            start_date_flux = start_date_flux - pd.offsets.YearBegin()
+    elif flux_period=="1 month":
+        if not start_date_flux.is_month_start:
+            start_date_flux = start_date_flux - pd.offsets.MonthBegin()
+
+    return start_date_flux
 
 def data_processing_surface_notracer(
     species: str,
@@ -367,11 +385,12 @@ def data_processing_surface_notracer(
     for source in emissions_name:
         logging.Logger.disabled = True  # suppress confusing OpenGHG warnings
         try:
+            start_date_flux = adjust_flux_start_date(start_date, species, source, domain, emissions_store)
             get_flux_data = get_flux(
                 species=species,
                 domain=domain,
                 source=source,
-                start_date=start_date,
+                start_date=start_date_flux,
                 end_date=end_date,
                 store=emissions_store,
             )


### PR DESCRIPTION
Add adjust_flux_start_date to adjust the flux start_date to the beginning of the year or the month depending on the flux's time_period. In order to use, for e.g., 2012-01-01 annual flux prior for inversions starting in 2012-07-01.

* **Summary of changes**


* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] Tests added and passing
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry to the `CHANGELOG.md` file
- [ ] Added any new requirements to `requirements.txt`
