### PR TITLE
Tox setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ dependencies = [
 "Home" = "https://github.com/openghg/openghg_inversions"
 "Bug Tracker" = "https://github.com/openghg/openghg_inversions/issues"
 
+[project.entry-points.tox]
+openghg_prev_minor = "toxfile.py"
+
 [tool.setuptools.packages.find]
 where = ["."]
 
@@ -42,3 +45,7 @@ openghg_inversions = ["data/*"]
 [tool.black]
 line-length = 110
 target-version = ["py310"]
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+testpaths = ["tests"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@
 flake8
 pytest >= 6.2.5
 black
+tox >= 4.24

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+[tox]
+min_version = 4.24
+isolated_build = True
+env_list =
+    py310-openghg{Cur,Prev,Dev}
+
+[testenv]
+description =
+    openghgDev: "Run tests under {base_python} on OpenGHG devel branch."
+    openghgCur: "Run tests under {base_python} on current OpenGHG release."
+    openghgPrev: "Run tests under {base_python} on previous OpenGHG minor release."
+deps =
+    pytest
+    openghgDev: git+https://github.com/openghg/openghg.git@devel
+    openghgPrev: {openghg_prev_minor}
+commands =
+    pytest {posargs:tests}

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,8 @@ min_version = 4.24
 isolated_build = True
 env_list =
     py310-openghg{Cur,Prev,Dev}
+    lint
+    type
 
 [testenv]
 description =
@@ -15,3 +17,20 @@ deps =
     openghgPrev: {openghg_prev_minor}
 commands =
     pytest {posargs:tests}
+
+[testenv:lint]
+description = "Run linters."
+skip_install = true
+deps =
+    black
+    flake8
+commands =
+    black --check {posargs:.}
+    flake8 {posargs:.}
+
+[testenv:type]
+description = "Run type checker."
+deps =
+    mypy
+commands =
+    mypy {posargs:openghg_inversions}

--- a/toxfile.py
+++ b/toxfile.py
@@ -1,0 +1,37 @@
+"""tox plugins
+
+The plugin defined here adds the penultimate minor version of OpenGHG
+to the tox config (defined in `tox.ini`).
+"""
+import re
+from collections import namedtuple
+
+import requests
+
+from tox.config.sets import ConfigSet
+from tox.session.state import State
+from tox.plugin import impl
+
+
+version_pat = re.compile(r"[0-9]+\.[0-9]+\.[0-9]+")
+Version = namedtuple("Version", "major minor patch")
+
+
+def get_version_tags(org: str, repo: str) -> list[Version]:
+    """Get list of Versions from github repo."""
+    r = requests.get(f"https://api.github.com/repos/{org}/{repo}/tags")
+    version_strings = [x["name"] for x in r.json() if version_pat.match(x["name"])]
+    versions = [Version(*map(int, vstr.split("."))) for vstr in version_strings]
+    return versions
+
+
+# get previous release version of OpenGHG
+openghg_versions = get_version_tags("openghg", "openghg")
+current_major, current_minor, _ = openghg_versions[0]
+prev_minor = current_minor - 1
+prev_openghg_release_version = next(filter(lambda v: v.minor == prev_minor, openghg_versions))
+prev_openghg_release = ".".join(map(str, prev_openghg_release_version))
+
+@impl
+def tox_add_core_config(core_conf: ConfigSet, state: State) -> None:
+    core_conf.add_constant("openghg_prev_minor", "penultimate minor release of OpenGHG", f"openghg=={prev_openghg_release}")


### PR DESCRIPTION
* **Summary of changes**

Added `tox` setup to run tests against multiple versions of OpenGHG (locally, without pushing to Github).

Calling `tox -p` will run tests against OpenGHG devel and the last two releases of OpenGHG, and run black, flake8, and mypy.

To specify individual jobs, you can use, e.g.:

`tox -e openghgDev`

to run the tests against the devel branch.

Use `tox -l` to list all options.

To pass arguments to pytest, mypy, black, etc, you can use, e.g.

`tox -- "openghg_inversions/hbmcmc"`

which will pass the positional argument `"openghg_inversions/hbmcmc"` to the commands invoked by `tox`.

* **Please check if the PR fulfills these requirements**

- [x] Added an entry to the `CHANGELOG.md` file
- [x] Added any new requirements to `requirements.txt`
