### PR TITLE
Remove met_model = met_model or 'not_set'

### DIFF
--- a/openghg_inversions/inversion_data/getters.py
+++ b/openghg_inversions/inversion_data/getters.py
@@ -198,8 +198,6 @@ def get_footprint_to_match(
     start_date = start_date or obs._start_date
     end_date = end_date or obs._end_date
 
-    met_model = met_model or "not_set"  # replace None with 'not_set'
-
     # get available footprint heights
     fp_kwargs = {
         "site": site,


### PR DESCRIPTION
* **Summary of changes**
Allow for None met_model to be different that 'not_set' when using fp_height = 'auto'. 
The original line was probably not useful in the first place. 
If people wants to specify 'not_set', they can specify it in the ini file.

* **Please check if the PR fulfills these requirements**

- [x] Closes #252 
- [ ] Tests added and passing
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry to the `CHANGELOG.md` file
- [ ] Added any new requirements to `requirements.txt`
