### PR TITLE
Fix: expand time dimension in BC data only if it doesn't already exist.

### DIFF
--- a/openghg_inversions/inversion_data/serialise.py
+++ b/openghg_inversions/inversion_data/serialise.py
@@ -355,7 +355,9 @@ def fp_all_from_dataset(ds: xr.Dataset) -> dict:
     except KeyError:
         pass
     else:
-        bc_ds = bc_ds.expand_dims({"time": [ds.time.min().values]}).transpose(..., "time")
+        if "time" not in bc_ds.dims:
+            bc_ds = bc_ds.expand_dims({"time": [ds.time.min().values]}).transpose(..., "time")
+            
         fp_all[".bc"] = BoundaryConditionsData(data=bc_ds, metadata={})
 
     species = ds.attrs.get("species", None)


### PR DESCRIPTION
* **Summary of changes**
Fix `load_merged_data`: Expand time dimension in BC data only if it doesn't already exist.

* **Please check if the PR fulfills these requirements**

- [x] Closes #260 
- [ ] Tests added and passing
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry to the `CHANGELOG.md` file
- [ ] Added any new requirements to `requirements.txt`
