### PR TITLE
Fix issue #262: when all data are dropped by filtering for a site, inversion fails

### DIFF
--- a/openghg_inversions/filters.py
+++ b/openghg_inversions/filters.py
@@ -142,7 +142,7 @@ def filtering(
                 n_dropped = n_nofilter - n_filter
                 perc_dropped = np.round(n_dropped / n_nofilter * 100, 2)
                 print(f"{filt} filter removed {n_dropped} ({perc_dropped} %) obs at site {site}")
-                if n_filter == 0: break
+                if n_filter == 0: break # no values left, so we won't apply remaining filters
 
     return datasets
 


### PR DESCRIPTION
* **Summary of changes**
1. Add a check to see if all data are removed to deal with the case when there is multiple filters and one (not the last) remove all the site data
2. Delete the site from fp_data

* **Please check if the PR fulfills these requirements**

- [X] Closes #262  (Replace xxxx with the Github issue number)
- [ ] Tests added and passing
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry to the `CHANGELOG.md` file
- [ ] Added any new requirements to `requirements.txt`
