### PR TITLE
Added offset to PARIS conc outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # OpenGHG Inversions Change Log
 
+# Unreleased
+
+- Added offset to PARIS concentration outputs. [#PR 282](https://github.com/openghg/openghg_inversions/pull/282)
 
 # Version 0.3.0
 

--- a/openghg_inversions/postprocessing/make_paris_outputs.py
+++ b/openghg_inversions/postprocessing/make_paris_outputs.py
@@ -159,12 +159,19 @@ def paris_concentration_outputs(
         .drop_vars("y_obs_error")
     )
 
-    conc_outputs = make_concentration_outputs(inv_out, stats, stats_args).unstack("nmeasure")
+    conc_outputs = make_concentration_outputs(inv_out, stats, stats_args, combine_bc_and_offset=True).unstack("nmeasure")
 
     # rename to match PARIS concentrations template
     def renamer(name: str) -> str:
         when = "apost" if "posterior" in name else "apriori"
-        suffix = "BC" if "bc" in name else ""
+
+        if "bc" in name:
+            suffix = "BC"
+        elif "offset" in name:
+            suffix = "_bias"
+        else:
+            suffix = ""
+
         prefix = "qY" if "quantile" in name else "Y"
         return prefix + when + suffix
 
@@ -177,6 +184,9 @@ def paris_concentration_outputs(
     # We produce these, but they aren't in the template
     if "qYapostBC" in conc_outputs.data_vars:
         conc_outputs = conc_outputs.drop_vars(["qYapostBC", "qYaprioriBC"])
+
+    if "qYapost_bias" in conc_outputs.data_vars:
+        conc_outputs = conc_outputs.drop_vars(["qYapost_bias", "qYapriori_bias"])
 
     conc_attrs = get_data_var_attrs(conc_template_path)
 


### PR DESCRIPTION
* **Summary of changes**

The offset is added to the modelled bc before calculating statistics, and the offset is included as Yapost_bias, Yapriori_bias

The function `make_concentration_outputs` in `make_outputs.py` now has an option to combine offset with BC, and will output offset if available (regardless of combining offset with BC)


* **Please check if the PR fulfills these requirements**

- [x] Closes #280 
- [x] Tests added and passing
- [x] Added an entry to the `CHANGELOG.md` file

