### PR TITLE
Created `make_offset` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # Unreleased
 
+## Model updates
+
+- Offsets can be applied to all but one site (ini option `offset_args = {"drop_first": True}`) or to all sites, which is the default option (ini option `offset_args = {"drop_first": False}`). [#PR 285](https://github.com/openghg/openghg_inversions/pull/285)
+
+## Code changes
+
 - Added offset to PARIS concentration outputs. [#PR 282](https://github.com/openghg/openghg_inversions/pull/282)
 
 # Version 0.3.0

--- a/openghg_inversions/hbmcmc/components.py
+++ b/openghg_inversions/hbmcmc/components.py
@@ -1,0 +1,34 @@
+"""Classes and functions to making self-contained parts of the RHIME model."""
+import numpy as np
+import pandas as pd
+import pymc as pm
+import pytensor.tensor as pt
+from pytensor.tensor import TensorVariable
+
+
+def make_offset(site_indicator: np.ndarray, prior_args: dict, name: str = "offset", output_dim: str = "nmeasure", drop_first: bool = False) -> TensorVariable:
+    """Create an offset inside a PyMC model.
+
+    Note: this *must* be called from inside a PyMC `model` context.
+
+    Args:
+        site_indicator: array with same length as obs, with integers to indicator which site
+          an observation belongs to
+        prior_args: dict of prior args for offset prior
+        name: name for offset in PyMC model
+        output_dim: name of dimension for output
+        drop_first: if True, set first site's offset to zero
+
+    Returns:
+        TensorVariable containing offset vector (to add to modelled observations).
+    """
+    from .inversion_pymc import parse_prior  # TODO move parse_prior into this file?
+
+    sites = np.unique(site_indicator)
+
+    n_sites = len(sites) - 1 if drop_first else len(sites)
+
+    matrix = pd.get_dummies(site_indicator, drop_first=drop_first, dtype=int).values
+    offset_x = parse_prior(name + "0", prior_args, shape=n_sites)
+
+    return pm.Deterministic(name, pt.dot(matrix, offset_x), dims=output_dim)

--- a/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template.ini
+++ b/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template.ini
@@ -148,7 +148,8 @@ xprior = {"pdf" : "normal", "mu" : 1.0, "sigma" : 1}
 bcprior = {"pdf" : "normal", "mu" : 1.0, "sigma" : 0.5}
 sigprior = {"pdf" : "uniform", "lower" : 0.5, "upper" : 3}
 add_offset = False
-#offsetprior = {}
+;offsetprior = {}
+;offset_args = {"drop_first": False}  ;; set to True if you want first site to have offset 0.0
 
 [MCMC.BC_SPLIT]
 ; Boundary conditions setup

--- a/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template_example.ini
+++ b/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template_example.ini
@@ -122,6 +122,7 @@ bcprior  = {"pdf" : "normal", "mu" : 1.0, "sigma" : 1.0}
 sigprior = {"pdf" : "uniform", "lower" : 0.1, "upper" : 3.0}
 ;add_offset = False
 ;offsetprior = {}
+;offset_args = {"drop_first": False}  ;; set to True if you want first site to have offset 0.0
 
 [MCMC.BC_SPLIT]
 ; Boundary conditions setup

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -69,7 +69,8 @@ def fixedbasisMCMC(
     xprior: dict = {"pdf": "truncatednormal", "mu": 1.0, "sigma": 1.0, "lower": 0.0},
     bcprior: dict = {"pdf": "truncatednormal", "mu": 1.0, "sigma": 0.1, "lower": 0.0},
     sigprior: dict = {"pdf": "uniform", "lower": 0.1, "upper": 3},
-    offsetprior: dict = {"pdf": "normal", "mu": 0, "sd": 1},
+    offsetprior: dict = {"pdf": "normal", "mu": 0, "sigma": 1},
+    offset_args: dict | None = None,
     nit: int = int(2.5e5),
     burn: int = 50000,
     tune: int = int(1.25e5),
@@ -186,11 +187,14 @@ def fixedbasisMCMC(
         Note that the standard deviation should be used rather than the
         precision. Currently all variables are considered iid
       bcprior:
-        Same as xrior but for boundary conditions.
+        Same as xprior but for boundary conditions.
       sigprior:
-        Same as xrior but for model error.
+        Same as xprior but for model error.
       offsetprior:
-        Same as xrior but for bias offset. Only used is addoffset=True.
+        Same as xprior but for bias offset. Only used is addoffset=True.
+      offset_args: dictionary of args to pass to `make_offset`. For instance
+        `{"drop_first": False}` will put an offset on all site (rather than using 0
+        offset for the first site).
       nit:
         Number of iterations for MCMC
       burn:
@@ -527,6 +531,7 @@ def fixedbasisMCMC(
             "add_offset": add_offset,
             "verbose": verbose,
             "min_error": min_error,
+            "offset_args": offset_args
         }
 
         if use_bc is True:
@@ -574,6 +579,7 @@ def fixedbasisMCMC(
         post_process_args.update(mcmc_args)
         del post_process_args["nit"]
         del post_process_args["verbose"]
+        del post_process_args["offset_args"]
 
         # add any additional kwargs to mcmc_args (these aren't needed for post processing)
         mcmc_args.update(kwargs)

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -152,6 +152,7 @@ def inferpymc(
     reparameterise_log_normal: bool = False,
     pollution_events_from_obs: bool = False,
     no_model_error: bool = False,
+    offset_args: dict | None = None,
 ) -> dict:
     """Uses PyMC module for Bayesian inference for emissions field, boundary
     conditions and (currently) a single model error value.
@@ -223,6 +224,7 @@ def inferpymc(
       no_model_error:
         When True, only use observation error in likelihood function (omitting min. model error
         and model error from scaling pollution events.)
+      offset_args: optional arguments to pass to `make_offset`.
 
     Returns:
       Dictionary containing:
@@ -310,7 +312,8 @@ def inferpymc(
             mu += mu_bc
 
         if add_offset:
-            offset = make_offset(siteindicator, offsetprior, drop_first=True)
+            offset_args = offset_args or {}
+            offset = make_offset(siteindicator, offsetprior, **offset_args)
             mu += offset
 
         Y = pm.Data("Y", Y, dims="nmeasure")  # type: ignore

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -18,7 +18,7 @@ from pytensor.tensor import TensorVariable
 
 from openghg_inversions import convert
 from openghg_inversions import utils
-from openghg_inversions.hbmcmc.inversionsetup import offset_matrix
+from openghg_inversions.hbmcmc.components import make_offset
 from openghg_inversions.hbmcmc.hbmcmc_output import define_output_filename
 from openghg_inversions.config.version import code_version
 
@@ -271,16 +271,7 @@ def inferpymc(
     nit = int(nit)
 
     # convert siteindicator into a site indexer
-    if sigma_per_site:
-        sites = siteindicator.astype(int)
-        nsites = np.amax(sites) + 1
-    else:
-        sites = np.zeros_like(siteindicator).astype(int)
-        nsites = 1
-    nsigmas = np.amax(sigma_freq_index) + 1
-
-    if add_offset:
-        B = offset_matrix(siteindicator)
+    sites = siteindicator.astype(int) if sigma_per_site else np.zeros_like(siteindicator).astype(int)
 
     coords = _make_coords(Y, Hx, siteindicator, sigma_freq_index, Hbc, sigma_per_site=sigma_per_site, sites=None)
 
@@ -319,9 +310,7 @@ def inferpymc(
             mu += mu_bc
 
         if add_offset:
-            offset0 = parse_prior("offset0", offsetprior, shape=int(nsites - 1))
-            offset_vec = pt.concatenate((np.array([0]), offset0), axis=0)
-            offset = pm.Deterministic("offset", pt.dot(B, offset_vec), dims="nmeasure")
+            offset = make_offset(siteindicator, offsetprior, drop_first=True)
             mu += offset
 
         Y = pm.Data("Y", Y, dims="nmeasure")  # type: ignore

--- a/openghg_inversions/hbmcmc/inversionsetup.py
+++ b/openghg_inversions/hbmcmc/inversionsetup.py
@@ -137,22 +137,3 @@ def sigma_freq_indicies(ytime: np.ndarray, sigma_freq: str | None) -> np.ndarray
         output[:] = np.floor(fractional_freq_time.values).astype(int)
 
     return output
-
-
-def offset_matrix(siteindicator: np.ndarray) -> np.ndarray:
-    """Set up a matrix that can be used to add an offset to each site.
-    This will anchor to the first site (i.e. first site has no offset).
-
-    Args:
-      siteindicator:
-        Array of values used for indicating the indices associated
-        with each site used in the inversion
-
-    Returns:
-      2D array
-    """
-    b = np.zeros((int(len(siteindicator)), int(max(siteindicator)) + 1))
-    for i in range(int(max(siteindicator) + 1)):
-        b[siteindicator == i, i] = 1.0
-
-    return b

--- a/tests/test_full_inversion.py
+++ b/tests/test_full_inversion.py
@@ -130,7 +130,8 @@ def test_full_inversion_pollution_events_from_obs_no_bc(mcmc_args):
 def test_full_inversion_two_sites(mcmc_args, mhd_and_tac_ch4_data_args):
     mcmc_args.update(mhd_and_tac_ch4_data_args)
     mcmc_args["reload_merged_data"] = False
-    print(mcmc_args)
+    mcmc_args["add_offset"] = True
+    mcmc_args["offset_args"] = {"drop_first": True}
     fixedbasisMCMC(**mcmc_args)
 
 


### PR DESCRIPTION
* **Summary of changes**

This function can be used like `parse_prior` inside a PyMC model to create an offset vector.

I also added an option to set the offset of the first site to zero (old behaviour) or not (new option).

Added options to configure offset via ini: extra options can be passed to `make_offset` by passing a dict to
`offset_args` in the ini file. Using `offset_args = {"drop_first": True}` will set the offset for the
first site to zero. The default is now `False`, so each site will have
its own offset.

* **Please check if the PR fulfills these requirements**

- [x] Closes #284
- [x] Tests added and passing
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry to the `CHANGELOG.md` file
- [ ] Added any new requirements to `requirements.txt`
