### PR TITLE
Fix for seg fault in CI

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,15 +98,15 @@ def eastasia_country_file(raw_data_path):
 @pytest.fixture
 def country_ds(raw_data_path):
     """Provides EUROPE countryfile dataset"""
-    with xr.open_dataset(raw_data_path / "country_EUROPE.nc") as ds:
-        yield ds
+    ds = xr.load_dataset(raw_data_path / "country_EUROPE.nc")
+    yield ds
 
 
 @pytest.fixture
 def country_ds_eastasia(raw_data_path):
     """Provides EUROPE countryfile dataset"""
-    with xr.open_dataset(raw_data_path / "country_EASTASIA.nc") as ds:
-        yield ds
+    ds = xr.load_dataset(raw_data_path / "country_EASTASIA.nc")
+    yield ds
 
 
 @pytest.fixture(scope="session", autouse=True)


### PR DESCRIPTION
* **Summary of changes**

Github CI was failing, apparently because it was trying to open the country files multiple times during tests. This PR fixes that by loading the country file into memory in the test fixtures.

* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] Tests added and passing
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry to the `CHANGELOG.md` file
- [ ] Added any new requirements to `requirements.txt`
