### PR TITLE
Updated paths in conftest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 from collections import Counter, namedtuple
+import getpass
 from pathlib import Path
 import shutil
 import tempfile
@@ -15,6 +16,11 @@ import xarray as xr
 
 _raw_data_path = Path(".").resolve() / "tests/data/"
 
+@pytest.fixture(scope="session", autouse=True)
+def user_data_path():
+    _user_data_path = Path(tempfile.gettempdir()) / f"{getpass.getuser()}_openghg_inversions_test_data"
+    _user_data_path.mkdir(exist_ok=True)
+    return _user_data_path
 
 @pytest.fixture(scope="session")
 def openghg_version():
@@ -30,8 +36,8 @@ def raw_data_path():
 
 
 @pytest.fixture(scope="session")
-def merged_data_dir():
-    return Path(tempfile.gettempdir(), "openghg_inversions_testing_merged_data_dir")
+def merged_data_dir(user_data_path):
+    return user_data_path / "openghg_inversions_testing_merged_data_dir"
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -110,11 +116,11 @@ def country_ds_eastasia(raw_data_path):
 
 
 @pytest.fixture(scope="session", autouse=True)
-def session_config_mocker(using_zarr_store) -> Iterator[None]:
+def session_config_mocker(using_zarr_store, user_data_path) -> Iterator[None]:
     if using_zarr_store:
-        inversions_test_store_path = Path(tempfile.gettempdir(), "openghg_inversions_zarr_testing_store")
+        inversions_test_store_path = user_data_path / "openghg_inversions_zarr_testing_store"
     else:
-        inversions_test_store_path = Path(tempfile.gettempdir(), "openghg_inversions_testing_store")
+        inversions_test_store_path = user_data_path / "openghg_inversions_testing_store"
 
     mock_config = {
         "object_store": {


### PR DESCRIPTION
* **Summary of changes**

Test data is now placed in a subfolder of the temp directory returned by Python's `tempfile.gettempdir()`. This should avoid problems with shared temp directories (e.g. on Blue Pebble).


* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] Tests added and passing
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry to the `CHANGELOG.md` file
- [ ] Added any new requirements to `requirements.txt`
