### PR TITLE
Added guess at "time_period" attribute to flux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Added offset to PARIS concentration outputs. [#PR 282](https://github.com/openghg/openghg_inversions/pull/282)
 - Compression added for output PARIS netcdf files. Standard RHIME output now shuffles to save space.
 - Fixed warning messages for zeros/NaNs in `mf_error`. [#PR 292](https://github.com/openghg/openghg_inversions/pull/292)
+- `get_flux_data` tries to infer the "time period" of the flux, which is used to set the time offset for PARIS flux outputs. [#PR 302](https://github.com/openghg/openghg_inversions/pull/302)
 
 # Version 0.3.0
 

--- a/tests/test_get_data.py
+++ b/tests/test_get_data.py
@@ -19,6 +19,7 @@ from openghg_inversions.inversion_data.get_data import (
     data_processing_surface_notracer,
     add_obs_error,
 )
+from openghg_inversions.inversion_data.getters import get_flux_data
 
 
 def test_data_processing_surface_notracer(
@@ -270,3 +271,17 @@ def test_looking_older_flux_files(tac_ch4_data_args, capsys):
 
     # we find older flux data
     assert "Using flux data from 2019-01-01" in stdout
+
+
+@pytest.mark.parametrize("end_date, time_period", [("2019-02-01", "monthly"), ("2020-01-01", "1 year"), ("2019-01-02", "1 year")])
+def test_flux_time_period_infernece(end_date, time_period, tac_ch4_data_args):
+    kwargs = {"sources": tac_ch4_data_args["emissions_name"],
+              "species": tac_ch4_data_args["species"],
+              "domain": tac_ch4_data_args["domain"],
+              "start_date": "2019-01-01",
+              "end_date": end_date,
+              }
+    flux_data = get_flux_data(**kwargs)
+
+    source = tac_ch4_data_args["emissions_name"][0]
+    assert flux_data[source].data.flux.attrs["time_period"] == time_period


### PR DESCRIPTION
* **Summary of changes**

PARIS flux outputs need to know the flux frequency to make the correct time offset.

The way this is done should probably be by passing the period explicitly, but currently it is inferred, and for monthly inversions using annual fluxes, the inferred time period is "1 year".

This PR fixes this by using the length of the inversion period to set the "time period" attribute for flux data in some cases.


* **Please check if the PR fulfills these requirements**

- [x] Closes #258
- [x] Tests added and passing
- [x] Added an entry to the `CHANGELOG.md` file
