### PR TITLE
Removed threshold for filling missing obs. error

### DIFF
--- a/openghg_inversions/inversion_data/get_data.py
+++ b/openghg_inversions/inversion_data/get_data.py
@@ -101,7 +101,14 @@ def add_obs_error(sites: list[str], fp_all: dict, add_averaging_error: bool = Tr
 
         if err0.any():
             percent0 = 100 * err0.mean()
-            logger.warning("`mf_error` is zero/nan for %.2f percent of times at site %s.", percent0, site)
+            logger.warning(
+                (
+                    "`mf_error` is zero/nan for %.2f percent of times at site %s;"
+                    "filling with max(median(mf_error), std(mf))."
+                ),
+                percent0,
+                site,
+            )
 
             mf_err_da = ds["mf_error"].as_numpy()  # load into memory to avoid Dask issues
             fill_value = np.nanmax(
@@ -111,9 +118,6 @@ def add_obs_error(sites: list[str], fp_all: dict, add_averaging_error: bool = Tr
                 ]
             )
             ds["mf_error"] = mf_err_da.where(mf_err_da != 0, fill_value)
-            logger.warning(
-                "More than 10% of `mf_error` is zero/nan, it is thus filled with the max of median `mf_error` and stdev of `mf`."
-            )
             info_msg = (
                 "If `averaging_period` matches the frequency of the obs data, then `mf_variability` "
                 "will be zero. Try setting `averaging_period = None`."

--- a/openghg_inversions/inversion_data/get_data.py
+++ b/openghg_inversions/inversion_data/get_data.py
@@ -103,18 +103,17 @@ def add_obs_error(sites: list[str], fp_all: dict, add_averaging_error: bool = Tr
             percent0 = 100 * err0.mean()
             logger.warning("`mf_error` is zero/nan for %.2f percent of times at site %s.", percent0, site)
 
-            if percent0 > 10:
-                mf_err_da = ds["mf_error"].as_numpy()  # load into memory to avoid Dask issues
-                fill_value = np.nanmax(
-                    [
-                        mf_err_da.where(mf_err_da != 0).dropna(dim="time").median(),
-                        ds["mf"].std(dim="time"),
-                    ]
-                )
-                ds["mf_error"] = mf_err_da.where(mf_err_da != 0, fill_value)
-                logger.warning(
-                    "More than 10% of `mf_error` is zero/nan, it is thus filled with the max of median `mf_error` and stdev of `mf`."
-                )
+            mf_err_da = ds["mf_error"].as_numpy()  # load into memory to avoid Dask issues
+            fill_value = np.nanmax(
+                [
+                    mf_err_da.where(mf_err_da != 0).dropna(dim="time").median(),
+                    ds["mf"].std(dim="time"),
+                ]
+            )
+            ds["mf_error"] = mf_err_da.where(mf_err_da != 0, fill_value)
+            logger.warning(
+                "More than 10% of `mf_error` is zero/nan, it is thus filled with the max of median `mf_error` and stdev of `mf`."
+            )
             info_msg = (
                 "If `averaging_period` matches the frequency of the obs data, then `mf_variability` "
                 "will be zero. Try setting `averaging_period = None`."


### PR DESCRIPTION
* **Summary of changes**

The threshold was previously 10%, but we would like to fill any value where the obs. error is 0.

Any data where the obs. themselves are NaN will be dropped at a later stage (before the data is passed to PyMC).

* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] Tests added and passing
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry to the `CHANGELOG.md` file
- [ ] Added any new requirements to `requirements.txt`
