### PR TITLE
Change way we infer ouput frequency

### DIFF
--- a/openghg_inversions/inversion_data/getters.py
+++ b/openghg_inversions/inversion_data/getters.py
@@ -122,9 +122,10 @@ def get_flux_data(
             or (inferred_time_period_str == "other")
         ):
             flux_data.data.flux.attrs["time_period"] = existing_time_period_str
-        elif "month" in existing_time_period_str.lower():
-            logger.warning("Monthly flux detected, but inversion period is {time_period.days} days. Setting flux time_period to 'monthly'.")
-            flux_data.data.flux.attrs["time_period"] = existing_time_period_str
+        elif "month" in existing_time_period_str.lower() and inferred_time_period_str == "yearly":
+            flux_data.data = flux_data.data.resample(time="YS").mean()
+            flux_data.data.flux.attrs["time_period"] = inferred_time_period_str
+            logger.warning(f"Monthly flux detected, but inversion period is {time_period.days} days. Resampling flux to 'yearly'.")
         else:
             flux_data.data.flux.attrs["time_period"] = inferred_time_period_str
 


### PR DESCRIPTION
* **Summary of changes**
When the ini file has start and end date one year apart (annual freq) and the flux has a monthly freq, the freq use for the inversion is set to annual and the flux is resampled at an annual freq (xr.Dataset.resample(time="YS")).



* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] Tests added and passing
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry to the `CHANGELOG.md` file
- [ ] Added any new requirements to `requirements.txt`
