### PR TITLE
Optimisations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 # Unreleased
 
+## Code changes
+
+- Optimisations for speeding up data processing (also some improvements to memory usage during MCMC and postprocessing). [#PR 311](https://github.com/openghg/openghg_inversions/pull/311)
+- Removed duplicate code for computing "fp x flux" and "bc sensitivity" matrices. This is done using `ModelScenario` now. This also means that units are aligned using `pint`. [#PR 305](https://github.com/openghg/openghg_inversions/pull/305)
+- Removed threshold for filling missing obs. error. [#PR 306](https://github.com/openghg/openghg_inversions/pull/306)
+
+# Version 0.4.0
+
 ## Model updates
 
 - Offsets can be applied to all but one site (ini option `offset_args = {"drop_first": True}`) or to all sites, which is the default option (ini option `offset_args = {"drop_first": False}`). [#PR 285](https://github.com/openghg/openghg_inversions/pull/285)

--- a/openghg_inversions/array_ops.py
+++ b/openghg_inversions/array_ops.py
@@ -15,6 +15,7 @@ work correctly.
 from typing import Any, overload, TypeVar
 from collections.abc import Sequence
 
+from dask.array.core import Array as DaskArray
 import numpy as np
 import pandas as pd
 import xarray as xr
@@ -135,3 +136,25 @@ def align_sparse_lat_lon(sparse_da: xr.DataArray, other_array: DataWithCoords) -
                          f"coordinates: {len(sparse_da.lat)} != {len(other_array.lat)}")
 
     return sparse_da.assign_coords(lat=other_array.lat, lon=other_array.lon)
+
+
+def _sparse_dask_to_dense(da: DaskArray) -> DaskArray:
+    """Convert chunks of dask array from sparse to dense."""
+    return da.map_blocks(lambda arr: arr.todense())  # type: ignore
+
+
+def to_dense(da: xr.DataArray) -> xr.DataArray:
+    """Convert sparse to numpy.
+
+    If the data array has chunks, these are preserved, but the underlying arrays are converted.
+    Does nothing if chunks are already numpy.
+    """
+    if not isinstance(da.data, DaskArray):  # type: ignore
+        return da.as_numpy()
+
+    # check chunk types
+    if isinstance(da.data._meta, SparseArray):
+        # hack to apply the Sparse `todense()` method to chunks
+        return xr.apply_ufunc(_sparse_dask_to_dense, da, dask="allowed")
+
+    return da

--- a/openghg_inversions/array_ops.py
+++ b/openghg_inversions/array_ops.py
@@ -58,7 +58,7 @@ def get_xr_dummies(
         stack_dim = "".join([str(dim) for dim in da.dims])
         da = da.stack({stack_dim: da.dims})
 
-    dummies = pd.get_dummies(da.values, dtype=int, sparse=return_sparse)
+    dummies = pd.get_dummies(da.values, dtype="float32", sparse=return_sparse)
 
     # put dummies into DataArray with the right coords and dims
     values = COO.from_scipy_sparse(dummies.sparse.to_coo()) if return_sparse else dummies.values

--- a/openghg_inversions/basis/_helpers.py
+++ b/openghg_inversions/basis/_helpers.py
@@ -2,7 +2,7 @@
 
 import xarray as xr
 
-from openghg_inversions.array_ops import get_xr_dummies, sparse_xr_dot
+from openghg_inversions.array_ops import get_xr_dummies, sparse_xr_dot, to_dense
 from ._functions import basis_boundary_conditions
 
 
@@ -105,7 +105,7 @@ def apply_fp_basis_functions(
     if sensitivity.dims[:2] != ("region", "time"):
         sensitivity = sensitivity.transpose("region", "time", ...)
 
-    return sensitivity.as_numpy()
+    return to_dense(sensitivity)
 
 
 def bc_sensitivity(

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -409,13 +409,19 @@ def fixedbasisMCMC(
         output_path=basis_output_path,
     )
 
-    # Apply compute before filtering to avoid dask issue
-    for site in sites:
-      fp_data[site] = fp_data[site].compute()
 
     # Apply named filters to the data
     if filters is not None:
-        fp_data = filtering(fp_data, filters)
+        try:
+            fp_data = filtering(fp_data, filters)
+        except ValueError:
+            # possible dask issue, but should be fixed
+            # https://github.com/openghg/openghg_inversions/issues/264
+            #
+            # Apply compute before filtering to avoid dask issue
+            for site in sites:
+                fp_data[site] = fp_data[site].compute()
+            fp_data = filtering(fp_data, filters)
 
     # check for sites dropped by filtering
     dropped_sites = []

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -442,6 +442,13 @@ def fixedbasisMCMC(
     if use_tracer:
         raise ValueError("Model does not currently include tracer model. Watch this space")
 
+    # Trigger dask computations
+    # we only compute the variables we need below
+    to_compute = ["H", "H_bc", "mf", "mf_error", "mf_repeatability", "mf_variability", "bc_mod", "mf_mod"]
+    for site in sites:
+        to_compute_site = [dv for dv in to_compute if dv in fp_data[site].data_vars]
+        fp_data[site][to_compute_site] = fp_data[site][to_compute_site].compute()
+
     # Get inputs ready
     error = np.zeros(0)
     obs_repeatability = np.zeros(0)

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -589,6 +589,12 @@ def fixedbasisMCMC(
         "min_error": min_error,
     }
 
+    # cast float64 to float32
+    for k in list(post_process_args.keys()):  # use list to get keys before modifying dict
+        v = post_process_args[k]
+        if isinstance(v, np.ndarray) and v.dtype == "float64":
+            post_process_args[k] = v.astype("float32")
+
     # add mcmc_args to post_process_args
     # and delete a few we don't need
     post_process_args.update(mcmc_args)

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -703,6 +703,9 @@ def fixedbasisMCMC(
         )
 
         outputs = basic_output(inv_out, country_file=country_file)
+        end_post = time.time()
+        print(f"Post processing Complete. Time taken = {end_post-start_post:.2f} seconds")
+
         return outputs
 
     if paris_postprocessing:
@@ -740,6 +743,9 @@ def fixedbasisMCMC(
 
         logging.info("PARIS concentration outputs saved to", conc_output_filename)
         logging.info("PARIS flux outputs saved to", flux_output_filename)
+
+        end_post = time.time()
+        print(f"Post processing Complete. Time taken = {end_post-start_post:.2f} seconds")
 
         return xr.merge([conc_outs, flux_outs.rename(time="flux_time")])
 

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -7,6 +7,12 @@ import getpass
 from pathlib import Path
 
 import numpy as np
+
+# import pytensor before pymc so we can set config values
+import pytensor
+pytensor.config.floatX = "float32"
+pytensor.config.warn_float64 = "warn"
+
 import pymc as pm
 import pandas as pd
 import xarray as xr

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -139,10 +139,10 @@ def inferpymc(
     bcprior: dict = {"pdf": "normal", "mu": 1.0, "sigma": 1.0},
     sigprior: dict = {"pdf": "uniform", "lower": 0.1, "upper": 3.0},
     nuts_sampler: str = "pymc",
-    nit: int = int(2.5e5),
-    burn: int = 50000,
-    tune: int = int(1.25e5),
-    nchain: int = 2,
+    nit: int = 20000,
+    burn: int = 10000,
+    tune: int = 10000,
+    nchain: int = 4,
     sigma_per_site: bool = True,
     offsetprior: dict = {"pdf": "normal", "mu": 0, "sigma": 1},
     add_offset: bool = False,
@@ -408,7 +408,7 @@ def inferpymc(
         "step1": step1,
         "step2": step2,
         "model": model,
-        "trace": trace,
+        "trace": trace.isel(draw=slice(burn, None)),  # remove
     }
 
     if use_bc:

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -405,6 +405,15 @@ def inferpymc(
     else:
         Ytrace = posterior_burned.mu + OFFtrace
 
+
+    # truncate trace and sample prior and predictive distributions
+    trace = trace.isel(draw=slice(burn, None))
+    ndraw = nit - burn
+    trace.extend(pm.sample_prior_predictive(ndraw, model))
+    trace.extend(pm.sample_posterior_predictive(trace, model=model, var_names=["y"]))
+
+
+
     result = {
         "xouts": xouts,
         "sigouts": sigouts,
@@ -414,7 +423,7 @@ def inferpymc(
         "step1": step1,
         "step2": step2,
         "model": model,
-        "trace": trace.isel(draw=slice(burn, None)),  # remove
+        "trace": trace,
     }
 
     if use_bc:

--- a/openghg_inversions/inversion_data/getters.py
+++ b/openghg_inversions/inversion_data/getters.py
@@ -131,6 +131,11 @@ def get_flux_data(
         # add flux data to result dict
         flux_dict[source] = flux_data
 
+    # cast to float32 to avoid up-casting H matrix
+    for v in flux_dict.values():
+        if v.data.flux.dtype != "float32":
+            v.data["flux"] = v.data.flux.astype("float32")
+
     return flux_dict
 
 

--- a/openghg_inversions/postprocessing/countries.py
+++ b/openghg_inversions/postprocessing/countries.py
@@ -258,7 +258,7 @@ class Countries:
                 )
                 self.matrix = xr.concat([self.matrix, region_matrix], dim="country")
 
-        self.area_grid = get_area_grid(countries.lat, countries.lon)
+        self.area_grid = get_area_grid(countries.lat, countries.lon).astype("float32")
 
         # restrict matrix to selected countries
         if country_selections is not None:

--- a/openghg_inversions/postprocessing/inversion_output.py
+++ b/openghg_inversions/postprocessing/inversion_output.py
@@ -297,6 +297,10 @@ class InversionOutput:
             warnings.warn("Cannot sample predictive distributions without PyMC model.")
             return None
 
+        # don't recompute if prior and predictive samples already present
+        if all(group in self.trace for group in ("posterior_predictive", "prior", "prior_predictive")):
+            return None
+
         if ndraw is None:
             ndraw = self.trace.posterior.sizes["draw"]
 

--- a/openghg_inversions/postprocessing/make_paris_outputs.py
+++ b/openghg_inversions/postprocessing/make_paris_outputs.py
@@ -243,8 +243,9 @@ def paris_flux_output(
     country_outs = country_outs * 1e-3  # convert g/yr to kg/yr
 
     # add country mask
-    country_path = get_country_file_path(country_file)
-    countries = Countries(xr.open_dataset(country_path), country_code="alpha3")
+    countries = Countries.from_file(
+        country_file=country_file, country_code="alpha3", domain=inv_out.domain
+    )
 
     country_fraction = countries.matrix.as_numpy().rename("country_fraction")
 

--- a/openghg_inversions/postprocessing/stats.py
+++ b/openghg_inversions/postprocessing/stats.py
@@ -55,7 +55,9 @@ def quantiles(
         xr.Dataset of specified quantiles, with a new `quantile` dimension.
 
     """
-    return ds.quantile(q=quantiles, dim=sample_dim)
+    # cast to float32 since quantiles involve interpolation, and this always converts to
+    # float64 in numpy and scipy interpolation routines
+    return ds.quantile(q=quantiles, dim=sample_dim).astype("float32")
 
 
 @register_stat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openghg_inversions"
-version = "0.2.0"
+version = "0.4.0"
 
 authors = [{name = "Eric Saboya", email = "eric.saboya@bristol.ac.uk"}]
 maintainers = [{name = "Brendan Murphy", email = "brendan.murphy@bristol.ac.uk"}]
@@ -19,14 +19,16 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "pymc",
-    "numpyro",
-    "xarray>=2024.10.0",
+    "numpyro[cpu]",
+    "xarray>=2025.08.0",
     "pandas",
     "matplotlib",
     "scipy", 
     "numpy",
     "openghg",
-    "sparse"
+    "sparse",
+    "flox",
+    "opt_einsum",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ requires-python = ">=3.10"
 dependencies = [
     "pymc",
     "numpyro[cpu]",
-    "xarray>=2025.08.0",
+    "xarray>=2025.06.0",
     "pandas",
     "matplotlib",
     "scipy", 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpyro[cpu]
 pymc
-xarray >= 2024.10
+xarray >= 2025.08
 pandas
 matplotlib
 scipy
@@ -8,3 +8,5 @@ numpy
 openghg
 sparse
 tfp-nightly
+flox
+opt_einsum

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpyro[cpu]
 pymc
-xarray >= 2025.08
+xarray >= 2025.06
 pandas
 matplotlib
 scipy


### PR DESCRIPTION
* **Summary of changes**

Various optimisations found while trying to find out why the new set-up (with fp_x_flux from ModelScenario and pint units) is slower than before.

Inversions got slower after PR #305, in particular the data processing before MCMC was a lot slower.

With a test set-up of 1 month of CH4 data for 5 sites, we had:
- Before PR 305: time 23:39, mem 3.32 GB
- After PR 305: time 25:40, mem 6.98 GB

~After this PR the same run takes: time 18:24, mem 1.2GB.~
After this PR the same run takes: time 12:23, mem 1.04GB.

With 8 cores on SLURM, using `sampler_kwargs = {"blas_cores": 8}` in the ini file, the run takes: time 6:54, mem 1.21GB.

------

Some of these changes would have improved performance before PR 305. The key change here is to explicitly compute `H` and `H_bc` after they have been added to the same dataset. This allows Dask to reuse shared computations for these steps (the main shared step is aligning obs. and footprint).

I also made sure that we are not converting from float32 to float64 unnecessarily, this means that memory usage during MCMC should be half of what it was before (unless the traces are being output as float 32). This also required setting some config options in pytensor before importing pymc.

A few changes in the post processing makes sure the outputs are float32 (for the most part, variability and repeatability are float64, but these are small anyway).

Changes:
- Explicitly trigger compute on fp_data[site]: This will allow dask to optimise over computations that share data (e.g.
H and H_bc)
- Make fp_sensitivity lazy: removed `.as_numpy()`, which causes the H matrix to be computed. This was done originally to avoid having a sparse arrays underlying the dask array in the xr.DataArray. Instead a new function was added that converts only the chunks from sparse to dense. This means that fp_sensitivity and bc_sensitivity are both lazy, so dask can optimized their computation when fp_data is computed.
- Added timing statements for basis func wrapper: this info could be useful to have in SLURM logs

- Removed early .compute() statement: this was a workaround for a dask issue that's been fixed. As a fallback, I added a try/accept that will call .compute if the dask issue happens.
- Remove unnecessary transposes: there are a lot of "transpose" tasks in the dask task graph, although I don't think `.transpose(...)` is the reason for there being so many dask "tranpose" tasks. I think that is due to xarray's `apply_ufunc` transposing "core dims" to the end of arrays.
- Add postprocessing timing statements: there was one, but it only runs for the original HBMCMC output, not the part outputs.
- Burn draws from raw trace: we weren't doing this and it means we're storing more data than we need
to. I also decreased the default number of iterations, although 20,000 is
probably still too high.
- Make sure data is float32 before MCMC: if there are different data types then they might get upcast during
MCMC, which means memory use could double.
- Make sure flux is float32: if not, then fp_x_flux will be float64, despite the footprint only being
float32. We need to do this before the data is given to ModelScenario.
- Add guard clause for "use tracer": not an optimisation, but if use_tracer is true, we know we can raise an
error right away. (Note: this makes it look like there were a lot of changes to hbmcmc.py, but it was mostly un-indenting code.)
- Added flox and opt-einsum to dependencies: it seems like opt-einsum is installed by default, but flox isn't, and
without flox groupby/resample can be very slow on xarray.
- Reduce precision of dummy matrix: the matrix only contains 0's and 1's, so it doesn't need to be int64. I
switched it to float32, since we're using multiplying other float32s.


* **Please check if the PR fulfills these requirements**

- [x] Closes Issue #312 
- [x] Tests added and passing
- [x] Added an entry to the `CHANGELOG.md` file
- [x] Added any new requirements to `requirements.txt`
