### PR TITLE
If "id" dimension present, select single value

### DIFF
--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -403,6 +403,9 @@ def fixedbasisMCMC(
         to_compute_site = [dv for dv in to_compute if dv in fp_data[site].data_vars]
         fp_data[site][to_compute_site] = fp_data[site][to_compute_site].compute()
 
+        if "id" in fp_data[site].dims:
+            fp_data[site] = fp_data[site].isel(id=0)
+
     # Get inputs ready
     error = np.zeros(0)
     obs_repeatability = np.zeros(0)


### PR DESCRIPTION
* **Summary of changes**

GOSAT data has "id" and "time" dimensions for `mf`, `mf_error`, etc. This causes problems with inversions when data is concatenated before running PyMC. This PR just selected the first value of `id` to remove the dimension. It looks like all `mf` values are the same for a given time but different `id`.

* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] Tests added and passing
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry to the `CHANGELOG.md` file
- [ ] Added any new requirements to `requirements.txt`
