### PR TITLE
Remove the redefinition of met_model.

### DIFF
--- a/openghg_inversions/inversion_data/getters.py
+++ b/openghg_inversions/inversion_data/getters.py
@@ -263,7 +263,6 @@ def get_footprint_to_match(
     end_date = end_date or obs._end_date
 
     # get available footprint heights
-    met_model = met_model or "not_set"  # replace None with 'not_set'
     fp_kwargs = {
         "site": site,
         "species": species,


### PR DESCRIPTION
If changing `met_model` from `None` to `"not_set"`, `search` is looking for a footprint for which `met_model` is set to `"not_set"` and not for footprint with any met_model.

This was causing the function `get_footprint_to_match` to fail to find any footprint when `met_model` was not explicitely set in the ini file.