### PR TITLE
Added pins so that uv install works.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,10 @@ description = "OpenGHG Inversions"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
+    "numpy>=2.0",
+    # Explicit pin: prevents uv backtracking to numba 0.53 / llvmlite 0.36
+    # due to NumPy 2.x + sparse metadata lag
+    "numba>=0.59",
     "pymc",
     "numpyro[cpu]",
     "xarray>=2025.06.0",


### PR DESCRIPTION
* **Summary of changes**

UV is stricter than pip, and needs pins to make sure a recent version of numba is installed.

I did not make the same changes in requirements.txt, since `uv` doesn't use requirements.txt. If pip starts having trouble with the new pins, we can revisit the requirements.txt. (But it looks like CI passed, except for with openghg 0.16, which has problems due to h5py.)

* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] Tests added and passing
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry to the `CHANGELOG.md` file
- [ ] Added any new requirements to `requirements.txt`
