### PR TITLE
Add basis functions object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added the ability to process TCCON data, along with additional output variables `obs_prior_factor` and `obs_prior_upper_level_factor`. [PR #327](https://github.com/openghg/openghg_inversions/pull/327)
 - Fixed bug introduced by PR 327, which caused "prior factor" variables filled with None values to be passed to post-processing. [PR #353](https://github.com/openghg/openghg_inversions/pull/353)
 - Added new `inversion_inputs.py` with helper functions for creating the inputs to the PyMC code. Tests added to check compatibility with older `inversionsetup.py` helpers. [PR #356](https://github.com/openghg/openghg_inversions/pull/356)
+- Added `BasisFunctions` object (backed by `BasisOperator` objects) and tests to confirm that these preserve existing behaviour when computing H matrices. These classes will be used to refactor the basis functions wrapper in a future PR. [PR #358](https://github.com/openghg/openghg_inversions/pull/358)
 
 # Version 0.6.0
 

--- a/openghg_inversions/array_ops.py
+++ b/openghg_inversions/array_ops.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 
 from collections.abc import Hashable, Iterable, Mapping, Sequence
 from typing import Any, overload, TypeVar
+import warnings
 
 from dask.array.core import Array as DaskArray
 import numpy as np
@@ -243,7 +244,6 @@ def force_align(
         ValueError: If a dimension is missing, sizes differ, or coordinates
             differ beyond tolerance.
     """
-
     dims = tuple(dims)
 
     for dim in dims:
@@ -253,7 +253,7 @@ def force_align(
             raise ValueError(f"Dimension {dim!r} not present in reference.")
 
         if obj.sizes[dim] != reference.sizes[dim]:
-            raise ValueError(f"Size mismatch along {dim!r}: " f"{obj.sizes[dim]} != {reference.sizes[dim]}")
+            raise ValueError(f"Size mismatch along {dim!r}: {obj.sizes[dim]} != {reference.sizes[dim]}")
 
         if not np.allclose(
             obj.coords[dim].values,
@@ -262,7 +262,7 @@ def force_align(
             atol=atol,
         ):
             raise ValueError(
-                f"Coordinate mismatch along {dim!r} beyond tolerance " f"(rtol={rtol}, atol={atol})."
+                f"Coordinate mismatch along {dim!r} beyond tolerance (rtol={rtol}, atol={atol})."
             )
 
     coord_updates = {dim: reference.coords[dim] for dim in dims}
@@ -277,7 +277,7 @@ def force_align(
 
 
 def concat_gather_data_arrays(
-    da_dict: Mapping[Hashable, xr.DataArray],
+    da_dict: Mapping[str, xr.DataArray],
     key_dim: str,
     ragged_dim: str,
     stack_dim: str | None = None,
@@ -333,7 +333,7 @@ def concat_gather_data_arrays(
 
 
 def concat_gather_datasets(
-    ds_dict: Mapping[Hashable, xr.Dataset],
+    ds_dict: Mapping[str, xr.Dataset],
     key_dim: str,
     ragged_dim: str,
     stack_dim: str | None = None,
@@ -381,3 +381,98 @@ def concat_gather_datatree(
         gathered_dvs[dv] = concat_gather_data_arrays(da_dict, key_dim, ragged_dim, stack_dim, **concat_kwargs)
 
     return xr.Dataset(gathered_dvs)
+
+
+# ----------------------------------------
+# Align to multi-index
+# ----------------------------------------
+
+
+def align_to_multi_index_level_values(
+    da: xr.DataArray,
+    *,
+    multi_index: xr.DataArray,
+    multi_dim: str,
+    level: str,
+    other_dim: str,
+) -> xr.DataArray:
+    """Broadcast `da(other_dim, ...)` onto `multi_dim` using a MultiIndex level.
+
+    Raises a ValueError if any other MultiIndex level names are already present
+    as coordinate variables on `da`, because this creates ambiguous/conflicting
+    index ownership when the MultiIndex is assigned.
+
+    Args:
+        da: DataArray to align, e.g. `fp_x_flux` with dimension `other_dim="source"`.
+        multi_index: Coordinate for the MultiIndex dimension (e.g. `basis_matrix["state"]`).
+            Must be a MultiIndex coordinate that includes the level named by `level`.
+        multi_dim: Name of the MultiIndex dimension to align onto (e.g. `"state"`).
+        level: Name of the MultiIndex level within `multi_index` to use for alignment
+            (e.g. `"source"`).
+        other_dim: Dimension on `da` that corresponds to `level` (e.g. `"source"`).
+
+    Returns:
+        A DataArray aligned to `multi_dim`, with a canonical MultiIndex coordinate
+        installed on `multi_dim`.
+
+    Raises:
+        ValueError: If `level` is not a level of `multi_index`, or if other level
+            names are already present as coordinates on `da`.
+    """
+    if other_dim not in da.dims:
+        return da
+
+    # Check if da has dims or coords with the same name as the levels of multi_index, besides
+    # the level/other_dim that we want to broadcast over.
+
+    # Determine MultiIndex level names
+    try:
+        mi = multi_index.to_index()  # pandas.MultiIndex
+    except Exception as e:  # pragma: no cover
+        raise ValueError("multi_index must be a MultiIndex coordinate DataArray.") from e
+
+    if getattr(mi, "names", None) is None:
+        raise ValueError("multi_index must be backed by a pandas.MultiIndex.")
+
+    level_names = list(mi.names)
+    if level not in level_names:
+        raise ValueError(f"Requested level {level!r} not found in multi_index levels {level_names!r}.")
+
+    # If other MultiIndex levels already exist as coordinate variables on `da`,
+    # assigning the MultiIndex will conflict (xarray will try to merge coords with same names).
+    other_levels = [n for n in level_names if n != level]
+    present_as_coords = [n for n in other_levels if n in da.coords]
+    if present_as_coords:
+        raise ValueError(
+            "Cannot align to MultiIndex level because the following MultiIndex level "
+            f"name(s) already exist as coordinate variables on the input DataArray: "
+            f"{present_as_coords!r}. "
+            "This causes coordinate/index conflicts when installing the MultiIndex. "
+            "Drop or rename these coordinate(s) first, or avoid this alignment path."
+        )
+
+    # Optionally warn if other levels appear as *dimensions* (but not coords).
+    # This can still be surprising semantically, even if it does not immediately conflict.
+    present_as_dims_only = [n for n in other_levels if (n in da.dims and n not in da.coords)]
+    if present_as_dims_only:
+        warnings.warn(
+            "Aligning to MultiIndex level while other level name(s) are present "
+            f"as dimensions without coordinates: {present_as_dims_only!r}. "
+            "This may be semantically ambiguous; consider stacking instead.",
+            UserWarning,
+            stacklevel=2,
+        )
+
+    # Vectorized selection in the order of the level values (dim becomes multi_dim)
+    level_values = multi_index[level]
+    da_sel = da.sel({other_dim: level_values})
+
+    # Drop the old coordinate variable for the selected dimension to avoid the
+    # subtle xarray MultiIndex registry/ownership bug.
+    if other_dim in da_sel.coords:
+        da_sel = da_sel.reset_coords(other_dim, drop=True)
+
+    # Install canonical MultiIndex on multi_dim (brings back level coords cleanly)
+    da_sel = da_sel.assign_coords({multi_dim: multi_index})
+
+    return da_sel

--- a/openghg_inversions/array_ops.py
+++ b/openghg_inversions/array_ops.py
@@ -9,12 +9,40 @@ Functions
 get_xr_dummies
     Applies pandas ``get_dummies`` to xarray DataArrays.
 sparse_xr_dot
-    Multiplies a Dataset or DataArray by a DataArray with sparse 
+    Multiplies a Dataset or DataArray by a DataArray with sparse
     underlying array. The built-in xarray functionality doesn't work correctly.
+
+
+Coordinate Alignment Policy
+---------------------------
+
+Spatial coordinates (e.g. ``lat`` and ``lon``) are treated as structural
+invariants of the inversion workflow. Although grids are expected to be
+identical, small floating-point differences can arise from I/O, reprojection,
+or sparse/dask operations.
+
+Because xarray uses strict, label-based alignment, even negligible coordinate
+differences can trigger unintended reindexing, interpolation, or alignment
+errors.
+
+To avoid this, we:
+
+1. Validate numerical equivalence within tolerance.
+2. Force coordinate identity via ``assign_coords`` when validation passes.
+
+This ensures deterministic arithmetic, prevents silent interpolation, and
+keeps grid equivalence an explicit, testable invariant.
+
+The main function that does this is ``force_align``; there is a legacy
+function ``align_sparse_lat_lon`` that was introduced as a work-around to
+an xarray issue, which now is written in terms of ``force_align``.
+
 """
 
+from __future__ import annotations
+
+from collections.abc import Hashable, Iterable, Mapping, Sequence
 from typing import Any, overload, TypeVar
-from collections.abc import Sequence
 
 from dask.array.core import Array as DaskArray
 import numpy as np
@@ -22,7 +50,6 @@ import pandas as pd
 import xarray as xr
 from sparse import COO, SparseArray
 from xarray.core.common import DataWithCoords, is_chunked_array  # type: ignore
-
 
 # type for xr.Dataset *or* xr.DataArray
 DataSetOrArray = TypeVar("DataSetOrArray", bound=DataWithCoords)
@@ -81,7 +108,9 @@ def sparse_xr_dot(da1: xr.DataArray, da2: xr.DataArray, dim: list[str] | None = 
 def sparse_xr_dot(da1: xr.DataArray, da2: xr.Dataset, dim: list[str] | None = None) -> xr.Dataset: ...
 
 
-def sparse_xr_dot(da1: xr.DataArray, da2: xr.DataArray | xr.Dataset, dim: list[str] | None = None) -> xr.DataArray | xr.Dataset:
+def sparse_xr_dot(
+    da1: xr.DataArray, da2: xr.DataArray | xr.Dataset, dim: list[str] | None = None
+) -> xr.DataArray | xr.Dataset:
     """Compute the matrix "dot" of a tuple of DataArrays with sparse.COO values.
 
     This multiplies and sums over all common dimensions of the input DataArrays, and
@@ -116,27 +145,40 @@ def sparse_xr_dot(da1: xr.DataArray, da2: xr.DataArray | xr.Dataset, dim: list[s
     return da2.map(lambda x: xr.dot(da1, x, dim=dim))
 
 
-def align_sparse_lat_lon(sparse_da: xr.DataArray, other_array: DataWithCoords) -> xr.DataArray:
-    """Align lat/lon coordinates of sparse_da with lat/lon coordinates from other_array.
+def align_sparse_lat_lon(
+    sparse_da: xr.DataArray,
+    other_array: xr.DataArray | xr.Dataset,
+    *,
+    rtol: float = 1e-05,
+    atol: float = 1e-08,
+) -> xr.DataArray:
+    """Align lat/lon coordinates of sparse_da with those from other_array.
 
-    NOTE: This is a work-around for an xarray Issue: https://github.com/pydata/xarray/issues/3445
+    NOTE: Workaround for xarray issue #3445:
+    https://github.com/pydata/xarray/issues/3445
+
+    Validates numerical closeness of coordinates before forcing coordinate
+    identity. No interpolation or reindexing is performed.
 
     Args:
-        sparse_da: xarray DataArray with sparse underlying array
-        other_array: xarray Dataset or DataArray whose lat/lon coordinates should be used
-            to replace the lat/lon coordinates in sparse_da
+        sparse_da: DataArray with sparse backend.
+        other_array: Dataset or DataArray providing canonical lat/lon coords.
+        rtol: Relative tolerance for coordinate comparison.
+        atol: Absolute tolerance for coordinate comparison.
 
     Returns:
-        xr.DataArray: copy of sparse_da with lat/lon coords from other_array
-    """
-    if len(sparse_da.lon) != len(other_array.lon):
-        raise ValueError("Both arrays must have the same number lon "
-                         f"coordinates: {len(sparse_da.lon)} != {len(other_array.lon)}")
-    if len(sparse_da.lat) != len(other_array.lat):
-        raise ValueError("Both arrays must have the same number lat "
-                         f"coordinates: {len(sparse_da.lat)} != {len(other_array.lat)}")
+        Copy of sparse_da with lat/lon coords replaced by those from other_array.
 
-    return sparse_da.assign_coords(lat=other_array.lat, lon=other_array.lon)
+    Raises:
+        ValueError: If sizes differ or coordinates differ beyond tolerance.
+    """
+    return force_align(
+        sparse_da,
+        other_array,
+        dims=("lat", "lon"),
+        rtol=rtol,
+        atol=atol,
+    )
 
 
 def _sparse_dask_to_dense(da: DaskArray) -> DaskArray:
@@ -159,3 +201,183 @@ def to_dense(da: xr.DataArray) -> xr.DataArray:
         return xr.apply_ufunc(_sparse_dask_to_dense, da, dask="allowed")
 
     return da
+
+
+T = TypeVar("T", xr.DataArray, xr.Dataset)
+
+
+def force_align(
+    obj: T,
+    reference: xr.DataArray | xr.Dataset,
+    *,
+    dims: Iterable[Hashable],
+    rtol: float = 1e-05,
+    atol: float = 1e-08,
+) -> T:
+    """Force coordinate identity with a reference object along given dimensions.
+
+    This function verifies that `obj` and `reference` share numerically
+    equivalent coordinates (within tolerance) along the specified dimensions.
+    If validation succeeds, the coordinates of `obj` are reassigned to be
+    identical (object identity) to those of `reference`.
+
+    No interpolation or reindexing is performed. If coordinates differ beyond
+    tolerance, a ValueError is raised.
+
+    Args:
+        obj: The xarray DataArray or Dataset whose coordinates will be
+            validated and reassigned.
+        reference: The object providing canonical coordinates. Must contain
+            the specified dimensions.
+        dims: Dimensions along which to validate and enforce coordinate
+            identity (e.g., ["lat", "lon"]).
+        rtol: Relative tolerance for coordinate comparison. Defaults to
+            NumPy's default (1e-5).
+        atol: Absolute tolerance for coordinate comparison. Defaults to
+            NumPy's default (1e-8).
+
+    Returns:
+        The same type as `obj`, with validated coordinates reassigned.
+
+    Raises:
+        ValueError: If a dimension is missing, sizes differ, or coordinates
+            differ beyond tolerance.
+    """
+
+    dims = tuple(dims)
+
+    for dim in dims:
+        if dim not in obj.dims:
+            raise ValueError(f"Dimension {dim!r} not present in object.")
+        if dim not in reference.dims:
+            raise ValueError(f"Dimension {dim!r} not present in reference.")
+
+        if obj.sizes[dim] != reference.sizes[dim]:
+            raise ValueError(f"Size mismatch along {dim!r}: " f"{obj.sizes[dim]} != {reference.sizes[dim]}")
+
+        if not np.allclose(
+            obj.coords[dim].values,
+            reference.coords[dim].values,
+            rtol=rtol,
+            atol=atol,
+        ):
+            raise ValueError(
+                f"Coordinate mismatch along {dim!r} beyond tolerance " f"(rtol={rtol}, atol={atol})."
+            )
+
+    coord_updates = {dim: reference.coords[dim] for dim in dims}
+
+    # assign_coords is non-mutating and preserves type
+    return obj.assign_coords(coord_updates)
+
+
+# -----------------------------------------------
+# Gather concat for concatenating ragged arrays
+# -----------------------------------------------
+
+
+def concat_gather_data_arrays(
+    da_dict: Mapping[Hashable, xr.DataArray],
+    key_dim: str,
+    ragged_dim: str,
+    stack_dim: str | None = None,
+    **concat_kwargs,
+) -> xr.DataArray:
+    """Concatenate DataArrays by gathering along ragged coordinate.
+
+    For example, if the keys are site codes and the ragged dimension is time,
+    then the "stacked dimension" will be the usual `nmeasure` coordinate.
+
+    Args:
+        da_dict: dictionary of DataArrays
+        key_dim: dimension name for the keys of the dictionary
+        ragged_dim: name of the ragged dimension
+        stack_dim: name for the "stacked" multi-index dimension
+        **concat_kwargs: arguments to pass to xr.concat
+
+    Returns:
+        Combined DataArray with new stacked dimension.
+
+    """
+    stack_dim = stack_dim or (key_dim + "_" + ragged_dim)
+
+    pieces: list[xr.DataArray] = []
+    key_vals: list[np.ndarray] = []
+    ragged_vals: list[np.ndarray] = []
+
+    for k, v in da_dict.items():
+        piece = v.rename({ragged_dim: stack_dim})
+        pieces.append(piece)
+
+        n = piece.sizes[stack_dim]
+
+        # make site indicator
+        key_val = np.full(n, k)
+        key_vals.append(key_val)
+
+        # record times
+        ragged_vals.append(v[ragged_dim].values)
+
+    # concat pieces
+    da = xr.concat(pieces, dim=stack_dim, **concat_kwargs)
+
+    # now create and assign multi-index
+    key_indicator = np.concatenate(key_vals)
+    concat_ragged = np.concatenate(ragged_vals)
+    multiindex = pd.MultiIndex.from_arrays([key_indicator, concat_ragged], names=[key_dim, ragged_dim])
+    xr_multiindex = xr.Coordinates.from_pandas_multiindex(multiindex, stack_dim)
+
+    da = da.assign_coords(xr_multiindex)
+
+    return da
+
+
+def concat_gather_datasets(
+    ds_dict: Mapping[Hashable, xr.Dataset],
+    key_dim: str,
+    ragged_dim: str,
+    stack_dim: str | None = None,
+    **concat_kwargs,
+) -> xr.Dataset:
+    """Concatenate dictionary of xr.Datasets by gathering ragged coordinates.
+
+    This assumes that all datasets have the same data variables.
+
+    TODO: need to handle missing data variables.
+    """
+    dvs = next(iter(ds_dict.values())).data_vars
+
+    # check that all data vars are present
+    for k, v in ds_dict.items():
+        if any(dv not in v.data_vars for dv in dvs):
+            missing_dvs = [dv for dv in dvs if dv not in v.data_vars]
+            raise ValueError(
+                f"Datasets do not all have the same data variables: Dataset for key {k} missing {missing_dvs}"
+            )
+
+    gathered_dvs = {}
+
+    for dv in dvs:
+        da_dict = {k: v[dv] for k, v in ds_dict.items()}
+        gathered_dvs[dv] = concat_gather_data_arrays(da_dict, key_dim, ragged_dim, stack_dim, **concat_kwargs)
+
+    return xr.Dataset(gathered_dvs)
+
+
+def concat_gather_datatree(
+    dt: xr.DataTree, key_dim: str, ragged_dim: str, stack_dim: str | None = None, **concat_kwargs
+) -> xr.Dataset:
+    """Concatenate xr.DataTree children by gathering ragged coordinates.
+
+    This assumes that all children have the same data variables.
+    """
+    ds_dict = {str(k): v.to_dataset() for k, v in dt.items()}
+    dvs = next(iter(ds_dict.values())).data_vars
+
+    gathered_dvs = {}
+
+    for dv in dvs:
+        da_dict = {k: v[dv] for k, v in ds_dict.items()}
+        gathered_dvs[dv] = concat_gather_data_arrays(da_dict, key_dim, ragged_dim, stack_dim, **concat_kwargs)
+
+    return xr.Dataset(gathered_dvs)

--- a/openghg_inversions/array_ops.py
+++ b/openghg_inversions/array_ops.py
@@ -272,6 +272,20 @@ def force_align(
 
 
 # -----------------------------------------------
+#  Concat for dictionary of DataArrays
+# -----------------------------------------------
+
+
+def concat_data_arrays(
+    da_dict: Mapping[str, xr.DataArray],
+    key_dim: str,
+    **concat_kwargs,
+) -> xr.DataArray:
+    to_concat = [v.expand_dims({key_dim: [k]}) for k, v in da_dict.items()]
+    return xr.concat(to_concat, dim=key_dim, **concat_kwargs)
+
+
+# -----------------------------------------------
 # Gather concat for concatenating ragged arrays
 # -----------------------------------------------
 

--- a/openghg_inversions/basis/basis_functions.py
+++ b/openghg_inversions/basis/basis_functions.py
@@ -1,0 +1,304 @@
+"""BasisFunctions object to encapsulate representation of basis.
+
+Example usage:
+
+>> def apply_basis_functions(ds: xr.Dataset, bf: BasisFunctions) -> xr.Dataset:
+>>     if "fp_x_flux" not in ds:
+>>         return ds
+>>     return bf.sensitivities(ds.fp_x_flux).rename("H").to_dataset()
+
+"""
+
+from pathlib import Path
+from typing import Self, cast
+import warnings
+
+import numpy as np
+import xarray as xr
+
+from openghg_inversions.array_ops import force_align, concat_gather_data_arrays, get_xr_dummies
+from openghg_inversions.config.paths import Paths
+from openghg_inversions.utils import read_netcdfs
+
+openghginv_path = Paths.openghginv
+
+
+class BasisFunctions:
+    """Basis functions for flux sensitivities.
+
+    This class provides methods for using aggregation or "bucket" basis functions.
+    This means that the basis functions can be represented as a 2D lat/lon array, with
+    integer labels for each basis region.
+
+    We do not allow time varying basis functions with this class.
+    TODO: revisit this?
+
+    Though basis functions are usually applied to the combined footprint x flux array,
+    to use the basis functions in post-processing, we also need the flux used in the inversion.
+
+    If the flux varies with time, then we need to align this with other time coordinates.
+    Currently, this is not supported.
+    TODO: add support for time varying flux?
+
+    TODO: construct from matrix with "regions" already by default, and add "from_flat" as class method?
+    Or make the base class do that, and make a subclass for bucket basis functions?
+    """
+
+    def __init__(
+        self,
+        basis_flat: xr.DataArray,
+        flux: xr.DataArray,
+        region_dim: str = "region",
+        chunks: dict | None = None,
+    ):
+        self.basis_flat = basis_flat.isel(time=0, drop=True) if "time" in basis_flat.dims else basis_flat
+        self.flux = flux.reindex_like(self.basis_flat, method="nearest")  # align lat/lon
+
+        self.region_dim = region_dim
+        self.basis_matrix = get_xr_dummies(basis_flat, cat_dim=self.region_dim)
+
+        if chunks is not None:
+            self.basis_matrix = self.basis_matrix.chunk(**chunks)
+        else:
+            self.basis_matrix = self.basis_matrix.chunk()
+
+        self.labels = np.unique(basis_flat)
+        self.labels_shuffled = np.unique(basis_flat)
+        np.random.shuffle(self.labels_shuffled)  # TODO make method so this can be re-shuffled
+
+        self.interpolation_matrix = self.basis_matrix * self.flux
+
+        # Currently no support for flux times
+        if self.interpolation_matrix.sizes.get("time", 0) > 1:
+            warnings.warn("Dropping time from interpolation matrix.")
+            self.interpolation_matrix = self.interpolation_matrix.isel(time=0, drop=True)
+        elif "time" in self.interpolation_matrix.dims:
+            self.interpolation_matrix = self.interpolation_matrix.squeeze("time", drop=True)
+
+    # TODO: make generic over DataArray and Dataset
+    # TODO: add alignment option
+    def interpolate(self, data: xr.DataArray, flux: bool = False) -> xr.DataArray:
+        """Map from regions to lat/lon."""
+        if self.region_dim not in data.dims:
+            raise ValueError(
+                f"Region dim {self.region_dim} missing (data dims {data.dims}); cannot interpolate."
+            )
+        if flux:
+            return xr.dot(self.interpolation_matrix, data, dim=self.region_dim)
+        return xr.dot(self.basis_matrix, data, dim=self.region_dim)
+
+    def sensitivity(self, fp_x_flux: xr.DataArray) -> xr.DataArray:
+        """Create sensitivity ("H") matrix from footprint x flux array."""
+        # TODO: check this still works if we have a stacked source/region dimension in the basis function
+        interp = self.basis_matrix.reindex_like(fp_x_flux, method="nearest")  # should align lat/lon
+        interp = interp.transpose("lat", "lon", ...)
+        return (
+            xr.dot(fp_x_flux, interp, dim=["lat", "lon"]).as_numpy().transpose(self.region_dim, "time", ...)
+        )
+
+    def save(self, path: str | Path) -> None:
+        to_save = xr.Dataset({"basis": self.basis_flat, "flux": self.flux})
+        to_save.to_netcdf(path, mode="w")
+
+    @classmethod
+    def load(cls, path: str | Path) -> Self:
+        ds = xr.open_dataset(path)
+        return cls(basis_flat=ds.basis, flux=ds.flux)
+
+    def save_acrg(
+        self,
+        basis_algorithm: str,
+        output_dir: str,
+        domain: str,
+        species: str,
+        output_name: str | None = None,
+    ) -> None:
+        """Save basis functions to netCDF.
+
+        Args:
+          basis_algorithm (str):
+            name of basis algorithm (e.g. "quadtree" or "weighted")
+          output_dir (str):
+            root directory to save basis functions
+          domain (str):
+            domain of inversion; basis is saved in a "domain" directory inside `output_dir`
+          species (str):
+            species of inversion
+          output_name (str,optional):
+            File output name
+            Default None
+
+        Returns:
+            None. Saves basis dataset to netCDF.
+        """
+        basis_out_path = Path(output_dir, domain.upper())
+
+        if not basis_out_path.exists():
+            basis_out_path.mkdir(parents=True)
+
+        start_date = str(self.basis_flat.time.min().values)[:7]  # year and month
+
+        if output_name is None:
+            output_name = f"{basis_algorithm}_{species}_{domain}_{start_date}.nc"
+        else:
+            output_name = f"{basis_algorithm}_{species}-{output_name}_{domain}_{start_date}.nc"
+
+        self.save(basis_out_path / output_name)
+
+    @classmethod
+    def load_acrg(
+        cls,
+        domain: str,
+        basis_case: str,
+        basis_directory: str | None = None,
+        flux: xr.DataArray | None = None,
+    ) -> Self:
+        """Read in basis function(s) from file given basis case and domain, and return as an
+        xarray Dataset.
+
+        The basis function files should be stored as on paths of the form:
+            <basis_directory>/<domain>/<basis_case>_<domain>*.nc
+
+        For instance: domain = EUROPE, basis_directory = /group/chem/acrg/LPDM/basis_functions,
+        and basis_case = sub_transd would find files such as:
+
+            /group/chem/acrg/LPDM/basis_functions/EUROPE/sub_transd_EUROPE_2014.nc
+
+        Basis functions created by algorithms in OpenGHG inversions will be stored using
+        this path format.
+
+        Args:
+            domain: domain name. The basis files should be sub-categorised by the domain.
+            basis_case: basis case to read in. Examples of basis cases are "voronoi", "sub-transd",
+                "sub-country_mask", "INTEM".
+            basis_directory: basis_directory can be specified if files are not in the default
+                directory (i.e. `openghg_inversions/basis_functions`). Must point to a directory that
+                contains subfolders organized by domain.
+            flux: needs to be provided if not found in stored files.
+
+        Returns:
+            BasisFunction object corresponding to combined matching basis functions
+        """
+
+        if basis_directory is None:
+            basis_path = openghginv_path / "basis_functions"
+            if not basis_path.exists():
+                basis_path.mkdir()
+                raise ValueError(
+                    f"Default basis directory {basis_path} was empty. "
+                    "Add basis files or specify `basis_path`."
+                )
+        else:
+            basis_path = Path(basis_directory)
+
+        file_path = (basis_path / domain).glob(f"{basis_case}_{domain}*.nc")
+        files = sorted(list(file_path))
+
+        if len(files) == 0:
+            raise FileNotFoundError(
+                f"Can't find basis function files for domain '{domain}'" f"and basis_case '{basis_case}' "
+            )
+
+        basis_ds = read_netcdfs(files)
+
+        if "flux" not in basis_ds and flux is None:
+            raise ValueError("Flux not stored with basis functions; please provide flux.")
+
+        flux = cast(xr.DataArray, basis_ds.get("flux") or flux)
+
+        return cls(basis_ds.basis, flux=flux)
+
+    # @classmethod
+    # def from_algorithm(cls) -> Self:
+    #     """Compute basis from algorithm."""
+    #     pass
+
+    def plot(self, shuffle=False, **kwargs) -> None:
+        """Plot basis.
+
+        Shuffle labels to make regions easier to see.
+        """
+        if not shuffle:
+            self.basis_flat.plot(**kwargs)
+        else:
+            bf_shuf = self.basis_flat.copy()
+            bf_shuf.values = self.labels_shuffled[self.basis_flat.values.astype(int) - 1]
+            bf_shuf.plot(**kwargs)
+
+
+class MultiSectorBasisFunctions(BasisFunctions):
+    def __init__(
+        self,
+        basis_flat: dict[str, xr.DataArray],
+        flux: dict[str, xr.DataArray],
+        region_dim: str = "region",
+        chunks: dict | None = None,
+    ):
+        assert all(k in flux for k in basis_flat.keys()), "basis flat and flux must have same keys"
+
+        self.basis_flat = {
+            k: v.isel(time=0, drop=True) if "time" in v.dims else v for k, v in basis_flat.items()
+        }
+
+        flux_aligned = {
+            k: v.reindex_like(self.basis_flat[k], method="nearest") for k, v in flux.items()
+        }  # align lat/lon
+        flux_to_concat = [v.expand_dims({"source": [k]}) for k, v in flux_aligned.items()]
+        self.flux = xr.concat(flux_to_concat, dim="source")
+
+        self.region_dim = region_dim
+        self.sectoral_basis_matrices = {
+            k: get_xr_dummies(v, cat_dim="sector_region") for k, v in self.basis_flat.items()
+        }
+        self.basis_matrix = concat_gather_data_arrays(
+            self.sectoral_basis_matrices,
+            key_dim="source",
+            ragged_dim="sector_region",
+            stack_dim=self.region_dim,
+        )
+
+        if chunks is not None:
+            self.basis_matrix = self.basis_matrix.chunk(**chunks)
+        else:
+            self.basis_matrix = self.basis_matrix.chunk()
+
+        # TODO: decide what to do about labels and plotting
+        # self.labels = np.unique(basis_flat)
+        # self.labels_shuffled = np.unique(basis_flat)
+        # np.random.shuffle(self.labels_shuffled)  # TODO make method so this can be re-shuffled
+
+        # need to explicitly broadcast flux source to match "source" level
+        # of region multi-index
+        self.interpolation_matrix = self.basis_matrix * self._align_source(self.flux)
+
+        # Currently no support for flux times
+        if self.interpolation_matrix.sizes.get("time", 0) > 1:
+            warnings.warn("Dropping time from interpolation matrix.")
+            self.interpolation_matrix = self.interpolation_matrix.isel(time=0, drop=True)
+        elif "time" in self.interpolation_matrix.dims:
+            self.interpolation_matrix = self.interpolation_matrix.squeeze("time", drop=True)
+
+    def _align_source(self, other: xr.DataArray) -> xr.DataArray:
+        if "source" not in other.dims:
+            # nothing to align
+            return other
+        region_index = self.basis_matrix[self.region_dim]
+        other_on_region = other.sel(source=region_index.source)
+
+        # Force region coordinate to be identical
+        other_on_region = other_on_region.assign_coords({self.region_dim: region_index})
+
+        # Drop source coordinate to prevent alignment conflict
+        other_on_region = other_on_region.drop_vars("source")
+
+        return other_on_region
+
+    def sensitivity(self, fp_x_flux: xr.DataArray) -> xr.DataArray:
+        """Create sensitivity ("H") matrix from footprint x flux array."""
+        # TODO: check this still works if we have a stacked source/region dimension in the basis function
+        interp = force_align(self.basis_matrix, fp_x_flux, dims=["lat", "lon"])
+        interp = interp.transpose("lat", "lon", ...)
+        return xr.dot(self._align_source(fp_x_flux), interp, dim=["lat", "lon"]).as_numpy()
+
+    def plot(self, shuffle=False, **kwargs) -> None:
+        raise NotImplementedError()

--- a/openghg_inversions/basis/basis_functions.py
+++ b/openghg_inversions/basis/basis_functions.py
@@ -179,7 +179,6 @@ class BasisFunctions:
         Returns:
             BasisFunction object corresponding to combined matching basis functions
         """
-
         if basis_directory is None:
             basis_path = openghginv_path / "basis_functions"
             if not basis_path.exists():
@@ -196,7 +195,7 @@ class BasisFunctions:
 
         if len(files) == 0:
             raise FileNotFoundError(
-                f"Can't find basis function files for domain '{domain}'" f"and basis_case '{basis_case}' "
+                f"Can't find basis function files for domain '{domain}'and basis_case '{basis_case}' "
             )
 
         basis_ds = read_netcdfs(files)
@@ -234,7 +233,7 @@ class MultiSectorBasisFunctions(BasisFunctions):
         region_dim: str = "region",
         chunks: dict | None = None,
     ):
-        assert all(k in flux for k in basis_flat.keys()), "basis flat and flux must have same keys"
+        assert all(k in flux for k in basis_flat), "basis flat and flux must have same keys"
 
         self.basis_flat = {
             k: v.isel(time=0, drop=True) if "time" in v.dims else v for k, v in basis_flat.items()

--- a/openghg_inversions/basis/basis_functions.py
+++ b/openghg_inversions/basis/basis_functions.py
@@ -26,6 +26,7 @@ from openghg_inversions.basis.operators import (
     BasisOperator,
     BucketBasisOperator,
     MultiSourceBucketBasisOperator,
+    RegionLabels,
 )
 from openghg_inversions.config.paths import Paths
 
@@ -54,7 +55,7 @@ class FluxWeightedBasis:
         basis_flat: xr.DataArray,
         flux: xr.DataArray,
         *,
-        region_labels: xr.DataArray | None = None,
+        region_labels: RegionLabels = "range0",
         operator_kwargs: Mapping[str, Any] | None = None,
     ) -> FluxWeightedBasis:
         """Construct from a single-source (standard) flattened basis array.
@@ -64,8 +65,10 @@ class FluxWeightedBasis:
                 (or whatever grid dims the operator expects). Values should label regions.
             flux: Flux on the same grid dims as `basis_flat`. May optionally contain extra dims such
                 as `time` or `source`; these will be carried along by downstream operations.
-            region_labels: Optional labels corresponding to region IDs. If not provided, the operator
-                will infer labels (typically from unique values of `basis_flat`).
+            region_labels: Policy for the output state coordinate labels:
+                - `"range0"`: `0..N-1` (legacy-friendly)
+                - `"range1"`: `1..N`
+                - `"basis_values"`: use the unique positive labels found in `basis_flat`.
             operator_kwargs: Optional kwargs forwarded to `BucketBasisOperator`.
 
         Returns:
@@ -84,7 +87,6 @@ class FluxWeightedBasis:
         basis_flat: Mapping[str, xr.DataArray],
         flux: xr.DataArray | Mapping[str, xr.DataArray],
         *,
-        region_labels: Mapping[str, xr.DataArray] | None = None,
         operator_kwargs: Mapping[str, Any] | None = None,
     ) -> FluxWeightedBasis:
         """Construct from a multi-source flattened basis mapping.
@@ -94,16 +96,12 @@ class FluxWeightedBasis:
                 Each value should be a DataArray on the inversion grid (e.g. dims like (lat, lon)).
             flux: Flux on the inversion grid. Commonly has a `source` dimension coordinate matching
                 the keys of `basis_flat`, but this is not required at construction time.
-            region_labels: Optional mapping from source name to region labels for that source's basis.
-                If not provided, the operator will infer labels per source.
             operator_kwargs: Optional kwargs forwarded to `MultiSourceBucketBasisOperator`.
 
         Returns:
             A FluxWeightedBasis pairing a MultiSourceBucketBasisOperator with the provided flux.
         """
         kwargs: dict[str, Any] = dict(operator_kwargs or {})
-        if region_labels is not None:
-            kwargs["region_labels"] = dict(region_labels)
 
         operator = MultiSourceBucketBasisOperator(basis_flat=dict(basis_flat), **kwargs)
 
@@ -123,23 +121,21 @@ class FluxWeightedBasis:
         Raises:
             KeyError: If serialisation would overwrite an existing group name.
         """
-        dt = xr.DataTree()
+        dt_basis = self.operator.to_datatree()
+
+        # Store flux as a dataset to preserve name/attrs cleanly.
+        flux = self.flux.rename("flux")
+        dt_flux = xr.DataTree(xr.Dataset({"flux": flux}))
+
+        dt_dict = {"basis": dt_basis, "flux": dt_flux}
+
+        dt = xr.DataTree.from_dict(dt_dict)
         dt.attrs.update(
             {
                 "schema": "openghg_inversions.flux_weighted_basis",
                 "schema_version": 1,
             }
         )
-
-        dt_basis = self.operator.to_datatree()
-
-        # Store flux as a dataset to preserve name/attrs cleanly.
-        flux = self.flux.rename("flux")
-
-        dt_flux = xr.DataTree(xr.Dataset({"flux": flux}))
-
-        dt["basis"] = dt_basis
-        dt["flux"] = dt_flux
         return dt
 
     @classmethod
@@ -177,7 +173,7 @@ class FluxWeightedBasis:
 
         return cls(operator=operator, flux=flux)
 
-    def sensitivity(self, fp_x_flux: xr.DataArray) -> xr.DataArray:
+    def sensitivity(self, fp_x_flux: xr.DataArray, fillna: bool = True) -> xr.DataArray:
         """Compute sensitivity (grid -> state) via the underlying operator.
 
         This is typically used to form the reduced Jacobian:
@@ -186,11 +182,12 @@ class FluxWeightedBasis:
         Args:
             fp_x_flux: Footprints multiplied by flux, on the inversion grid dims.
                 May contain extra dims (e.g. time, site, source).
+            fillna: if True, fill NaNs in fp_x_flux with 0.0.
 
         Returns:
             Sensitivity with a `state`-like dimension as defined by the operator.
         """
-        return self.operator.sensitivity(fp_x_flux)
+        return self.operator.sensitivity(fp_x_flux, fillna=fillna)
 
     def interpolate(self, state: xr.DataArray, *, flux: bool = False) -> xr.DataArray:
         """Interpolate from state vector to the grid.
@@ -233,7 +230,7 @@ class FluxWeightedBasis:
             return data.plot(**plot_kwargs)
 
         if isinstance(basis_flat, dict):
-            sources = list(basis_flat.keys())
+            sources = sorted(list(basis_flat.keys()))  # sort for stable plotting order
             n = len(sources)
             if n == 0:
                 raise ValueError("Empty multi-source basis_flat; nothing to plot.")

--- a/openghg_inversions/basis/basis_functions.py
+++ b/openghg_inversions/basis/basis_functions.py
@@ -28,9 +28,6 @@ from openghg_inversions.basis.operators import (
     MultiSourceBucketBasisOperator,
     RegionLabels,
 )
-from openghg_inversions.config.paths import Paths
-
-openghginv_path = Paths.openghginv
 
 
 @dataclass(frozen=True, slots=True)
@@ -164,7 +161,10 @@ class FluxWeightedBasis:
         if "flux" not in dt:
             raise KeyError("Missing 'flux' group in DataTree.")
 
-        operator = BasisOperator.decode_datatree(dt["basis"])
+        if not isinstance(dt["basis"], xr.DataTree):
+            raise ValueError("'basis' is not an xr.DataTree.")
+
+        operator = BasisOperator.decode_datatree(dt["basis"])  # type: ignore [arg-type]
 
         ds_flux = dt["flux"].to_dataset()
         if "flux" not in ds_flux:

--- a/openghg_inversions/basis/basis_functions.py
+++ b/openghg_inversions/basis/basis_functions.py
@@ -5,299 +5,282 @@ Example usage:
 >> def apply_basis_functions(ds: xr.Dataset, bf: BasisFunctions) -> xr.Dataset:
 >>     if "fp_x_flux" not in ds:
 >>         return ds
->>     return bf.sensitivities(ds.fp_x_flux).rename("H").to_dataset()
+>>     return bf.sensitivity(ds.fp_x_flux).rename("H").to_dataset()
 
 """
 
-from pathlib import Path
-from typing import Self, cast
-import warnings
+from __future__ import annotations
 
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+import matplotlib.pyplot as plt
 import numpy as np
 import xarray as xr
 
-from openghg_inversions.array_ops import force_align, concat_gather_data_arrays, get_xr_dummies
+from openghg_inversions.array_ops import (
+    concat_data_arrays,
+)
+from openghg_inversions.basis.operators import (
+    BasisOperator,
+    BucketBasisOperator,
+    MultiSourceBucketBasisOperator,
+)
 from openghg_inversions.config.paths import Paths
-from openghg_inversions.utils import read_netcdfs
 
 openghginv_path = Paths.openghginv
 
 
-class BasisFunctions:
-    """Basis functions for flux sensitivities.
+@dataclass(frozen=True, slots=True)
+class FluxWeightedBasis:
+    """A thin wrapper pairing a BasisOperator with a flux field.
 
-    This class provides methods for using aggregation or "bucket" basis functions.
-    This means that the basis functions can be represented as a 2D lat/lon array, with
-    integer labels for each basis region.
+    This class is intentionally lightweight: it stores the operator and the flux, and provides
+    constructors that build the appropriate operator from a basis representation.
 
-    We do not allow time varying basis functions with this class.
-    TODO: revisit this?
-
-    Though basis functions are usually applied to the combined footprint x flux array,
-    to use the basis functions in post-processing, we also need the flux used in the inversion.
-
-    If the flux varies with time, then we need to align this with other time coordinates.
-    Currently, this is not supported.
-    TODO: add support for time varying flux?
-
-    TODO: construct from matrix with "regions" already by default, and add "from_flat" as class method?
-    Or make the base class do that, and make a subclass for bucket basis functions?
+    Notes:
+        - A flux with a `source` dimension can still be paired with a `BucketBasisOperator`; in that case
+          the same basis is applied to each source when broadcasting occurs in downstream operations.
+        - Alignment/broadcasting details are currently delegated to the operator implementations.
     """
 
-    def __init__(
-        self,
+    operator: BasisOperator
+    flux: xr.DataArray
+
+    @classmethod
+    def from_basis_flat(
+        cls,
         basis_flat: xr.DataArray,
         flux: xr.DataArray,
-        region_dim: str = "region",
-        chunks: dict | None = None,
-    ):
-        self.basis_flat = basis_flat.isel(time=0, drop=True) if "time" in basis_flat.dims else basis_flat
-        self.flux = flux.reindex_like(self.basis_flat, method="nearest")  # align lat/lon
-
-        self.region_dim = region_dim
-        self.basis_matrix = get_xr_dummies(basis_flat, cat_dim=self.region_dim)
-
-        if chunks is not None:
-            self.basis_matrix = self.basis_matrix.chunk(**chunks)
-        else:
-            self.basis_matrix = self.basis_matrix.chunk()
-
-        self.labels = np.unique(basis_flat)
-        self.labels_shuffled = np.unique(basis_flat)
-        np.random.shuffle(self.labels_shuffled)  # TODO make method so this can be re-shuffled
-
-        self.interpolation_matrix = self.basis_matrix * self.flux
-
-        # Currently no support for flux times
-        if self.interpolation_matrix.sizes.get("time", 0) > 1:
-            warnings.warn("Dropping time from interpolation matrix.")
-            self.interpolation_matrix = self.interpolation_matrix.isel(time=0, drop=True)
-        elif "time" in self.interpolation_matrix.dims:
-            self.interpolation_matrix = self.interpolation_matrix.squeeze("time", drop=True)
-
-    # TODO: make generic over DataArray and Dataset
-    # TODO: add alignment option
-    def interpolate(self, data: xr.DataArray, flux: bool = False) -> xr.DataArray:
-        """Map from regions to lat/lon."""
-        if self.region_dim not in data.dims:
-            raise ValueError(
-                f"Region dim {self.region_dim} missing (data dims {data.dims}); cannot interpolate."
-            )
-        if flux:
-            return xr.dot(self.interpolation_matrix, data, dim=self.region_dim)
-        return xr.dot(self.basis_matrix, data, dim=self.region_dim)
-
-    def sensitivity(self, fp_x_flux: xr.DataArray) -> xr.DataArray:
-        """Create sensitivity ("H") matrix from footprint x flux array."""
-        # TODO: check this still works if we have a stacked source/region dimension in the basis function
-        interp = self.basis_matrix.reindex_like(fp_x_flux, method="nearest")  # should align lat/lon
-        interp = interp.transpose("lat", "lon", ...)
-        return (
-            xr.dot(fp_x_flux, interp, dim=["lat", "lon"]).as_numpy().transpose(self.region_dim, "time", ...)
-        )
-
-    def save(self, path: str | Path) -> None:
-        to_save = xr.Dataset({"basis": self.basis_flat, "flux": self.flux})
-        to_save.to_netcdf(path, mode="w")
-
-    @classmethod
-    def load(cls, path: str | Path) -> Self:
-        ds = xr.open_dataset(path)
-        return cls(basis_flat=ds.basis, flux=ds.flux)
-
-    def save_acrg(
-        self,
-        basis_algorithm: str,
-        output_dir: str,
-        domain: str,
-        species: str,
-        output_name: str | None = None,
-    ) -> None:
-        """Save basis functions to netCDF.
+        *,
+        region_labels: xr.DataArray | None = None,
+        operator_kwargs: Mapping[str, Any] | None = None,
+    ) -> FluxWeightedBasis:
+        """Construct from a single-source (standard) flattened basis array.
 
         Args:
-          basis_algorithm (str):
-            name of basis algorithm (e.g. "quadtree" or "weighted")
-          output_dir (str):
-            root directory to save basis functions
-          domain (str):
-            domain of inversion; basis is saved in a "domain" directory inside `output_dir`
-          species (str):
-            species of inversion
-          output_name (str,optional):
-            File output name
-            Default None
+            basis_flat: Flattened basis labels on the inversion grid, e.g. dims like (lat, lon)
+                (or whatever grid dims the operator expects). Values should label regions.
+            flux: Flux on the same grid dims as `basis_flat`. May optionally contain extra dims such
+                as `time` or `source`; these will be carried along by downstream operations.
+            region_labels: Optional labels corresponding to region IDs. If not provided, the operator
+                will infer labels (typically from unique values of `basis_flat`).
+            operator_kwargs: Optional kwargs forwarded to `BucketBasisOperator`.
 
         Returns:
-            None. Saves basis dataset to netCDF.
+            A FluxWeightedBasis pairing a BucketBasisOperator with the provided flux.
         """
-        basis_out_path = Path(output_dir, domain.upper())
+        kwargs: dict[str, Any] = dict(operator_kwargs or {})
+        if region_labels is not None:
+            kwargs["region_labels"] = region_labels
 
-        if not basis_out_path.exists():
-            basis_out_path.mkdir(parents=True)
-
-        start_date = str(self.basis_flat.time.min().values)[:7]  # year and month
-
-        if output_name is None:
-            output_name = f"{basis_algorithm}_{species}_{domain}_{start_date}.nc"
-        else:
-            output_name = f"{basis_algorithm}_{species}-{output_name}_{domain}_{start_date}.nc"
-
-        self.save(basis_out_path / output_name)
+        operator = BucketBasisOperator(basis_flat=basis_flat, **kwargs)
+        return cls(operator=operator, flux=flux)
 
     @classmethod
-    def load_acrg(
+    def from_multi_source_basis_flat(
         cls,
-        domain: str,
-        basis_case: str,
-        basis_directory: str | None = None,
-        flux: xr.DataArray | None = None,
-    ) -> Self:
-        """Read in basis function(s) from file given basis case and domain, and return as an
-        xarray Dataset.
-
-        The basis function files should be stored as on paths of the form:
-            <basis_directory>/<domain>/<basis_case>_<domain>*.nc
-
-        For instance: domain = EUROPE, basis_directory = /group/chem/acrg/LPDM/basis_functions,
-        and basis_case = sub_transd would find files such as:
-
-            /group/chem/acrg/LPDM/basis_functions/EUROPE/sub_transd_EUROPE_2014.nc
-
-        Basis functions created by algorithms in OpenGHG inversions will be stored using
-        this path format.
+        basis_flat: Mapping[str, xr.DataArray],
+        flux: xr.DataArray | Mapping[str, xr.DataArray],
+        *,
+        region_labels: Mapping[str, xr.DataArray] | None = None,
+        operator_kwargs: Mapping[str, Any] | None = None,
+    ) -> FluxWeightedBasis:
+        """Construct from a multi-source flattened basis mapping.
 
         Args:
-            domain: domain name. The basis files should be sub-categorised by the domain.
-            basis_case: basis case to read in. Examples of basis cases are "voronoi", "sub-transd",
-                "sub-country_mask", "INTEM".
-            basis_directory: basis_directory can be specified if files are not in the default
-                directory (i.e. `openghg_inversions/basis_functions`). Must point to a directory that
-                contains subfolders organized by domain.
-            flux: needs to be provided if not found in stored files.
+            basis_flat: Mapping from source name to that source's flattened basis labels on the grid.
+                Each value should be a DataArray on the inversion grid (e.g. dims like (lat, lon)).
+            flux: Flux on the inversion grid. Commonly has a `source` dimension coordinate matching
+                the keys of `basis_flat`, but this is not required at construction time.
+            region_labels: Optional mapping from source name to region labels for that source's basis.
+                If not provided, the operator will infer labels per source.
+            operator_kwargs: Optional kwargs forwarded to `MultiSourceBucketBasisOperator`.
 
         Returns:
-            BasisFunction object corresponding to combined matching basis functions
+            A FluxWeightedBasis pairing a MultiSourceBucketBasisOperator with the provided flux.
         """
-        if basis_directory is None:
-            basis_path = openghginv_path / "basis_functions"
-            if not basis_path.exists():
-                basis_path.mkdir()
-                raise ValueError(
-                    f"Default basis directory {basis_path} was empty. "
-                    "Add basis files or specify `basis_path`."
-                )
-        else:
-            basis_path = Path(basis_directory)
+        kwargs: dict[str, Any] = dict(operator_kwargs or {})
+        if region_labels is not None:
+            kwargs["region_labels"] = dict(region_labels)
 
-        file_path = (basis_path / domain).glob(f"{basis_case}_{domain}*.nc")
-        files = sorted(list(file_path))
+        operator = MultiSourceBucketBasisOperator(basis_flat=dict(basis_flat), **kwargs)
 
-        if len(files) == 0:
-            raise FileNotFoundError(
-                f"Can't find basis function files for domain '{domain}'and basis_case '{basis_case}' "
-            )
+        if not isinstance(flux, xr.DataArray):
+            flux = concat_data_arrays(flux, key_dim="source")
 
-        basis_ds = read_netcdfs(files)
+        return cls(operator=operator, flux=flux)
 
-        if "flux" not in basis_ds and flux is None:
-            raise ValueError("Flux not stored with basis functions; please provide flux.")
+    def to_datatree(self) -> xr.DataTree:
+        """Serialise to a DataTree with `basis` and `flux` groups.
 
-        flux = cast(xr.DataArray, basis_ds.get("flux") or flux)
+        Returns:
+            A DataTree with:
+              - `basis`: BasisOperator DataTree (via operator.to_datatree()).
+              - `flux`: a Dataset containing the flux DataArray as variable `flux`.
 
-        return cls(basis_ds.basis, flux=flux)
-
-    # @classmethod
-    # def from_algorithm(cls) -> Self:
-    #     """Compute basis from algorithm."""
-    #     pass
-
-    def plot(self, shuffle=False, **kwargs) -> None:
-        """Plot basis.
-
-        Shuffle labels to make regions easier to see.
+        Raises:
+            KeyError: If serialisation would overwrite an existing group name.
         """
-        if not shuffle:
-            self.basis_flat.plot(**kwargs)
-        else:
-            bf_shuf = self.basis_flat.copy()
-            bf_shuf.values = self.labels_shuffled[self.basis_flat.values.astype(int) - 1]
-            bf_shuf.plot(**kwargs)
-
-
-class MultiSectorBasisFunctions(BasisFunctions):
-    def __init__(
-        self,
-        basis_flat: dict[str, xr.DataArray],
-        flux: dict[str, xr.DataArray],
-        region_dim: str = "region",
-        chunks: dict | None = None,
-    ):
-        assert all(k in flux for k in basis_flat), "basis flat and flux must have same keys"
-
-        self.basis_flat = {
-            k: v.isel(time=0, drop=True) if "time" in v.dims else v for k, v in basis_flat.items()
-        }
-
-        flux_aligned = {
-            k: v.reindex_like(self.basis_flat[k], method="nearest") for k, v in flux.items()
-        }  # align lat/lon
-        flux_to_concat = [v.expand_dims({"source": [k]}) for k, v in flux_aligned.items()]
-        self.flux = xr.concat(flux_to_concat, dim="source")
-
-        self.region_dim = region_dim
-        self.sectoral_basis_matrices = {
-            k: get_xr_dummies(v, cat_dim="sector_region") for k, v in self.basis_flat.items()
-        }
-        self.basis_matrix = concat_gather_data_arrays(
-            self.sectoral_basis_matrices,
-            key_dim="source",
-            ragged_dim="sector_region",
-            stack_dim=self.region_dim,
+        dt = xr.DataTree()
+        dt.attrs.update(
+            {
+                "schema": "openghg_inversions.flux_weighted_basis",
+                "schema_version": 1,
+            }
         )
 
-        if chunks is not None:
-            self.basis_matrix = self.basis_matrix.chunk(**chunks)
-        else:
-            self.basis_matrix = self.basis_matrix.chunk()
+        dt_basis = self.operator.to_datatree()
 
-        # TODO: decide what to do about labels and plotting
-        # self.labels = np.unique(basis_flat)
-        # self.labels_shuffled = np.unique(basis_flat)
-        # np.random.shuffle(self.labels_shuffled)  # TODO make method so this can be re-shuffled
+        # Store flux as a dataset to preserve name/attrs cleanly.
+        flux = self.flux.rename("flux")
 
-        # need to explicitly broadcast flux source to match "source" level
-        # of region multi-index
-        self.interpolation_matrix = self.basis_matrix * self._align_source(self.flux)
+        dt_flux = xr.DataTree(xr.Dataset({"flux": flux}))
 
-        # Currently no support for flux times
-        if self.interpolation_matrix.sizes.get("time", 0) > 1:
-            warnings.warn("Dropping time from interpolation matrix.")
-            self.interpolation_matrix = self.interpolation_matrix.isel(time=0, drop=True)
-        elif "time" in self.interpolation_matrix.dims:
-            self.interpolation_matrix = self.interpolation_matrix.squeeze("time", drop=True)
+        dt["basis"] = dt_basis
+        dt["flux"] = dt_flux
+        return dt
 
-    def _align_source(self, other: xr.DataArray) -> xr.DataArray:
-        if "source" not in other.dims:
-            # nothing to align
-            return other
-        region_index = self.basis_matrix[self.region_dim]
-        other_on_region = other.sel(source=region_index.source)
+    @classmethod
+    def from_datatree(cls, dt: xr.DataTree) -> FluxWeightedBasis:
+        """Deserialise from a DataTree produced by `to_datatree`.
 
-        # Force region coordinate to be identical
-        other_on_region = other_on_region.assign_coords({self.region_dim: region_index})
+        Args:
+            dt: DataTree with `basis` and `flux` groups.
 
-        # Drop source coordinate to prevent alignment conflict
-        other_on_region = other_on_region.drop_vars("source")
+        Returns:
+            A FluxWeightedBasis instance.
 
-        return other_on_region
+        Raises:
+            KeyError: If required groups are missing.
+            ValueError: If schema/version mismatch or flux variable missing.
+        """
+        schema = dt.attrs.get("schema", None)
+        version = dt.attrs.get("schema_version", None)
+        if schema is not None and schema != "openghg_inversions.flux_weighted_basis":
+            raise ValueError(f"Unexpected schema: {schema!r}")
+        if version is not None and int(version) != 1:
+            raise ValueError(f"Unexpected schema_version: {version!r}")
+
+        if "basis" not in dt:
+            raise KeyError("Missing 'basis' group in DataTree.")
+        if "flux" not in dt:
+            raise KeyError("Missing 'flux' group in DataTree.")
+
+        operator = BasisOperator.decode_datatree(dt["basis"])
+
+        ds_flux = dt["flux"].to_dataset()
+        if "flux" not in ds_flux:
+            raise ValueError("Missing variable 'flux' in dt['flux'] dataset.")
+        flux = ds_flux["flux"]
+
+        return cls(operator=operator, flux=flux)
 
     def sensitivity(self, fp_x_flux: xr.DataArray) -> xr.DataArray:
-        """Create sensitivity ("H") matrix from footprint x flux array."""
-        # TODO: check this still works if we have a stacked source/region dimension in the basis function
-        interp = force_align(self.basis_matrix, fp_x_flux, dims=["lat", "lon"])
-        interp = interp.transpose("lat", "lon", ...)
-        return xr.dot(self._align_source(fp_x_flux), interp, dim=["lat", "lon"]).as_numpy()
+        """Compute sensitivity (grid -> state) via the underlying operator.
 
-    def plot(self, shuffle=False, **kwargs) -> None:
-        raise NotImplementedError()
+        This is typically used to form the reduced Jacobian:
+            H = operator.sensitivity(fp_x_flux)
+
+        Args:
+            fp_x_flux: Footprints multiplied by flux, on the inversion grid dims.
+                May contain extra dims (e.g. time, site, source).
+
+        Returns:
+            Sensitivity with a `state`-like dimension as defined by the operator.
+        """
+        return self.operator.sensitivity(fp_x_flux)
+
+    def interpolate(self, state: xr.DataArray, *, flux: bool = False) -> xr.DataArray:
+        """Interpolate from state vector to the grid.
+
+        Args:
+            state: State vector values with dim matching the operator's state dim (usually `state`).
+            flux: If True, apply flux-weighting using `self.flux` as weights. If False, returns the
+                unweighted basis interpolation.
+
+        Returns:
+            Interpolated gridded array on the operator grid dims, with any non-dot dims preserved.
+        """
+        if not flux:
+            return self.operator.interpolate(state)
+
+        # TODO: test if _align_source_like_state is needed here
+        return self.operator.interpolate(state, weights=self.flux)
+
+    def plot(self, *, shuffle: bool = False, **plot_kwargs: Any) -> Any:
+        """Plot basis labels.
+
+        - For single-source basis, returns the result of xarray's plot call.
+        - For multi-source basis, creates one subplot per source and returns (fig, axes).
+
+        Args:
+            shuffle: If True, randomly permute region labels for visual separation.
+            **plot_kwargs: Forwarded to xarray's `.plot()`.
+
+        Returns:
+            Plotting object(s). For multi-source, returns (fig, axes).
+        """
+        basis_flat = getattr(self.operator, "basis_flat", None)
+        if basis_flat is None:
+            raise AttributeError("Operator does not expose `basis_flat`; cannot plot.")
+
+        if isinstance(basis_flat, xr.DataArray):
+            data = basis_flat
+            if shuffle:
+                data = _shuffle_region_labels(data)
+            return data.plot(**plot_kwargs)
+
+        if isinstance(basis_flat, dict):
+            sources = list(basis_flat.keys())
+            n = len(sources)
+            if n == 0:
+                raise ValueError("Empty multi-source basis_flat; nothing to plot.")
+
+            # Simple layout: one row per source.
+            fig, axes = plt.subplots(nrows=n, ncols=1, figsize=(7, 3.0 * n), squeeze=False)
+            axes_flat = axes[:, 0]
+
+            for ax, source in zip(axes_flat, sources, strict=True):
+                data = basis_flat[source]
+                if shuffle:
+                    data = _shuffle_region_labels(data)
+                data.plot(ax=ax, **plot_kwargs)
+                ax.set_title(str(source))
+
+            fig.tight_layout()
+            return fig, axes_flat
+
+        raise TypeError(f"Unexpected type for operator.basis_flat: {type(basis_flat)!r}")
+
+
+def _shuffle_region_labels(basis_flat: xr.DataArray) -> xr.DataArray:
+    """Shuffle integer-like region labels for plotting clarity.
+
+    This preserves NaNs/masked values and only permutes the set of unique finite labels.
+    """
+    values = basis_flat.values
+    finite = np.isfinite(values)
+    if not np.any(finite):
+        return basis_flat
+
+    labels = np.unique(values[finite])
+    # Only shuffle if we have at least 2 labels.
+    if labels.size < 2:
+        return basis_flat
+
+    perm = labels.copy()
+    rng = np.random.default_rng()
+    rng.shuffle(perm)
+    mapping = dict(zip(labels.tolist(), perm.tolist(), strict=True))
+
+    shuffled = values.copy()
+    for old, new in mapping.items():
+        shuffled[values == old] = new
+
+    return basis_flat.copy(data=shuffled)
+
+
+# Friendly alias
+BasisFunctions = FluxWeightedBasis

--- a/openghg_inversions/basis/operators.py
+++ b/openghg_inversions/basis/operators.py
@@ -119,7 +119,7 @@ def get_basis_operator_class(kind: str) -> type[BasisOperator]:
         return _BASIS_OPERATOR_REGISTRY[kind]
     except KeyError as e:
         raise KeyError(
-            f"Unknown BasisOperator kind '{kind}'. " f"Known kinds: {sorted(_BASIS_OPERATOR_REGISTRY)}"
+            f"Unknown BasisOperator kind '{kind}'. Known kinds: {sorted(_BASIS_OPERATOR_REGISTRY)}"
         ) from e
 
 
@@ -316,6 +316,7 @@ class BasisOperator(ABC):
 # ----------------------------
 # Helper functions
 # ----------------------------
+
 
 def drop_singleton_time(da: xr.DataArray, *, name: str = "basis_flat") -> xr.DataArray:
     """Drop a singleton ``time`` dimension if present; otherwise raise.
@@ -548,7 +549,9 @@ class MultiSourceBucketBasisOperator(BasisOperator):
         self.region_in_source_dim = region_in_source_dim
 
         # Canonicalise: 2D, consistent lat/lon assumed for now.
-        self.basis_flat = {k: drop_singleton_time(v, name=f"basis_flat[{k!r}]") for k, v in basis_flat.items()}
+        self.basis_flat = {
+            k: drop_singleton_time(v, name=f"basis_flat[{k!r}]") for k, v in basis_flat.items()
+        }
         self.basis_flat = {k: v.rename("basis_flat") for k, v in self.basis_flat.items()}
 
         # Build per-source dummy matrices with ragged region_in_source dim
@@ -638,7 +641,7 @@ class MultiSourceBucketBasisOperator(BasisOperator):
         include a separate coordinate named like a MultiIndex level (e.g. `source_dim`).
 
         Args:
-            state_array: State vector defined on `meta.state_dim`.
+            state: State vector defined on `meta.state_dim`.
             weights: Optional gridded weights (e.g. prior fluxes) on `meta.grid_dims`. May
                 optionally include `source_dim` for per-source weights.
 

--- a/openghg_inversions/basis/operators.py
+++ b/openghg_inversions/basis/operators.py
@@ -314,6 +314,42 @@ class BasisOperator(ABC):
 
 
 # ----------------------------
+# Helper functions
+# ----------------------------
+
+def drop_singleton_time(da: xr.DataArray, *, name: str = "basis_flat") -> xr.DataArray:
+    """Drop a singleton ``time`` dimension if present; otherwise raise.
+
+    This is a strict helper intended for basis operators that assume a 2D basis over
+    the grid dims. It avoids silently discarding time-varying basis information.
+
+    Args:
+        da: Input DataArray which may or may not have a ``time`` dimension.
+        name: Label used in error messages to identify what is being checked.
+
+    Returns:
+        ``da`` with ``time`` removed if it exists and has length 1, otherwise ``da``
+        unchanged.
+
+    Raises:
+        ValueError: If ``time`` exists and has length not equal to 1.
+    """
+    if "time" not in da.dims:
+        return da
+
+    time_size = da.sizes.get("time")
+    if time_size != 1:
+        raise ValueError(
+            f"{name} has a non-singleton 'time' dimension (size={time_size}); "
+            "cannot drop time without losing time-varying basis information. "
+            "Please pass a 2D basis without 'time'."
+        )
+
+    # Use squeeze to remove the dim (and drop the coordinate variable if it becomes scalar).
+    return da.squeeze("time", drop=True)
+
+
+# ----------------------------
 # Concrete operators
 # ----------------------------
 
@@ -359,8 +395,9 @@ class BucketBasisOperator(BasisOperator):
         self._meta = meta
 
         # store canonical 2D basis
-        self.basis_flat = basis_flat.isel(time=0, drop=True) if "time" in basis_flat.dims else basis_flat
+        self.basis_flat = drop_singleton_time(basis_flat, name="basis_flat")
         self.basis_flat = self.basis_flat.rename("basis_flat")
+
         self.region_labels = region_labels
 
         # create dummy matrix (grid -> state)
@@ -511,9 +548,7 @@ class MultiSourceBucketBasisOperator(BasisOperator):
         self.region_in_source_dim = region_in_source_dim
 
         # Canonicalise: 2D, consistent lat/lon assumed for now.
-        self.basis_flat = {
-            k: (v.isel(time=0, drop=True) if "time" in v.dims else v) for k, v in basis_flat.items()
-        }
+        self.basis_flat = {k: drop_singleton_time(v, name=f"basis_flat[{k!r}]") for k, v in basis_flat.items()}
         self.basis_flat = {k: v.rename("basis_flat") for k, v in self.basis_flat.items()}
 
         # Build per-source dummy matrices with ragged region_in_source dim

--- a/openghg_inversions/basis/operators.py
+++ b/openghg_inversions/basis/operators.py
@@ -185,7 +185,7 @@ class BasisOperator(ABC):
         """
         raise NotImplementedError
 
-    def sensitivity(self, fp_x_flux: xr.DataArray) -> xr.DataArray:
+    def sensitivity(self, fp_x_flux: xr.DataArray, fillna: bool = True) -> xr.DataArray:
         """Computes the sensitivity matrix ("H") by dotting over the grid.
 
         This implements the common bucket-basis reduction:
@@ -201,6 +201,7 @@ class BasisOperator(ABC):
         Args:
             fp_x_flux: Footprint x flux array to reduce. Must contain all
                 `meta.grid_dims`.
+            fillna: if True, fill NaNs in fp_x_flux with 0.0.
 
         Returns:
             Sensitivity matrix with dimension `meta.state_dim` and any remaining
@@ -210,7 +211,10 @@ class BasisOperator(ABC):
         mat_aligned = mat_aligned.transpose(*self.meta.grid_dims, ...)
 
         # xr.dot keeps non-dot dims from both arguments
-        h = xr.dot(fp_x_flux, mat_aligned, dim=list(self.meta.grid_dims)).as_numpy()
+        if fillna:
+            h = xr.dot(fp_x_flux.fillna(0.0), mat_aligned, dim=list(self.meta.grid_dims)).as_numpy()
+        else:
+            h = xr.dot(fp_x_flux, mat_aligned, dim=list(self.meta.grid_dims)).as_numpy()
 
         # canonical ordering (state_dim first if present)
         if self.meta.state_dim in h.dims:
@@ -565,7 +569,7 @@ class MultiSourceBucketBasisOperator(BasisOperator):
             other_dim=self.source_dim,
         )
 
-    def sensitivity(self, fp_x_flux: xr.DataArray) -> xr.DataArray:
+    def sensitivity(self, fp_x_flux: xr.DataArray, fillna: bool = True) -> xr.DataArray:
         """Compute sensitivity for multisource fp_x_flux.
 
         Overrides base method to broadcast the fp_x_flux `source` dim onto the gathered `state` dim.
@@ -575,7 +579,10 @@ class MultiSourceBucketBasisOperator(BasisOperator):
 
         fp_on_state = self._align_source_like_state(fp_x_flux)
 
-        h = xr.dot(fp_on_state, mat_aligned, dim=list(self.meta.grid_dims)).as_numpy()
+        if fillna:
+            h = xr.dot(fp_on_state.fillna(0.0), mat_aligned, dim=list(self.meta.grid_dims)).as_numpy()
+        else:
+            h = xr.dot(fp_on_state, mat_aligned, dim=list(self.meta.grid_dims)).as_numpy()
 
         if self.meta.state_dim in h.dims:
             if "time" in h.dims:
@@ -583,6 +590,44 @@ class MultiSourceBucketBasisOperator(BasisOperator):
             else:
                 h = h.transpose(self.meta.state_dim, ...)
         return h
+
+    def interpolate(self, state: xr.DataArray, weights: xr.DataArray | None = None) -> xr.DataArray:
+        """Interpolate/reconstruct a gridded field from a state vector.
+
+        For MultiSourceBucketBasisOperator, `weights` may include a `source_dim` that is also a
+        level name in the gathered MultiIndex on `meta.state_dim`. In that case we broadcast
+        weights along the gathered state axis (repeating per-source weights across all regions
+        within that source) by replacing `source_dim` with `meta.state_dim`.
+
+        The state vector itself is expected to be defined on `meta.state_dim` and should not
+        include a separate coordinate named like a MultiIndex level (e.g. `source_dim`).
+
+        Args:
+            state_array: State vector defined on `meta.state_dim`.
+            weights: Optional gridded weights (e.g. prior fluxes) on `meta.grid_dims`. May
+                optionally include `source_dim` for per-source weights.
+
+        Returns:
+            Gridded reconstructed field on `meta.grid_dims`.
+        """
+        if self.meta.state_dim not in state.dims:
+            raise ValueError(
+                f"Expected state_array to have dim '{self.meta.state_dim}', got dims {state.dims}"
+            )
+
+        mat = self.basis_matrix
+
+        if weights is not None:
+            weights_aligned = force_align(weights, mat, dims=list(self.meta.grid_dims))
+
+            # broadcast source if necessary
+            weights_aligned = self._align_source_like_state(weights_aligned)
+
+            mat = mat * weights_aligned
+
+        out = xr.dot(mat, state, dim=self.meta.state_dim).as_numpy()
+        out = out.transpose(*self.meta.grid_dims, ...)
+        return out
 
     # ---- DataTree IO ----
 

--- a/openghg_inversions/basis/operators.py
+++ b/openghg_inversions/basis/operators.py
@@ -1,0 +1,433 @@
+"""Basis operator classes (new API; does not yet replace legacy basis_functions.py).
+
+Design goals
+------------
+1) Separate the *partition/aggregation operator* (basis functions) from any *flux weighting*.
+   - The basis operator represents a linear map from a grid (lat/lon) to a reduced state space.
+   - Flux weighting (multiplying by flux on the grid, interpolation to maps, covariance transforms)
+     is handled by a separate wrapper class (planned: FluxWeightedBasis) so that:
+       * sensitivity(fp_x_flux) does not require flux (since fp_x_flux is already precomputed),
+       * but flux-aware operations remain available when needed.
+
+2) Canonical "state" dimension.
+   - Operators expose a single state dimension (default name: "state").
+   - In multisource/multisector cases with ragged per-source region counts, the state coordinate
+     becomes a MultiIndex over (source, region_in_source). This avoids padding with zeros.
+
+3) Minimal metadata (BasisMeta).
+   - We only need to know which dims to dot over (grid_dims) and the state_dim name.
+   - Any special alignment hacks are implemented in concrete subclasses rather than inferred from metadata.
+
+4) Serialization via xarray.DataTree.
+   - BasisOperator.to_datatree() returns a self-describing DataTree with schema/kind/version attrs.
+   - BasisOperator.decode_datatree(dt) dispatches to the correct registered subclass based on dt.attrs["kind"].
+   - For multisource operators, the canonical serialized representation stores per-source flat basis arrays
+     under dt["basis_flat"][<source>], keeping storage compact and natural.
+
+How to use
+----------
+- Construct a basis operator:
+    op = BucketBasisOperator(basis_flat)                         # single-sector
+    op = MultiSourceBucketBasisOperator({"a": bf_a, "b": bf_b})   # ragged multisource
+
+- Compute sensitivities:
+    H = op.sensitivity(fp_x_flux)
+
+  where fp_x_flux is an xarray.DataArray with at least the grid dims (lat, lon), and typically time.
+  In multisource workflows, fp_x_flux often has a separate dimension "source". The multisource operator
+  implements an alignment/broadcast hack so that the fp_x_flux source dimension can be matched against
+  the MultiIndex level "source" stored on the state coordinate.
+
+- Serialize/deserialize:
+    dt = op.to_datatree()
+    op2 = BasisOperator.decode_datatree(dt)
+
+Notes:
+-----
+- This module is an initial step in refactoring. It is intended to coexist with the legacy
+  basis_functions.py until the old APIs are reimplemented using these operators and tests are migrated.
+
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import ClassVar, Literal, Self
+
+import numpy as np
+import xarray as xr
+
+from openghg_inversions.array_ops import (
+    concat_gather_data_arrays,
+    force_align,
+    get_xr_dummies,
+)
+
+# ----------------------------
+# Registry
+# ----------------------------
+
+_BASIS_OPERATOR_REGISTRY: dict[str, type[BasisOperator]] = {}
+
+
+def register_basis_operator(kind: str):
+    """Decorator to register BasisOperator subclasses for DataTree deserialisation."""
+
+    def _decorator(cls: type[BasisOperator]) -> type[BasisOperator]:
+        if kind in _BASIS_OPERATOR_REGISTRY and _BASIS_OPERATOR_REGISTRY[kind] is not cls:
+            raise ValueError(
+                f"BasisOperator kind '{kind}' already registered with {_BASIS_OPERATOR_REGISTRY[kind]}"
+            )
+        _BASIS_OPERATOR_REGISTRY[kind] = cls
+        cls.kind = kind  # type: ignore[attr-defined]
+        return cls
+
+    return _decorator
+
+
+def get_basis_operator_class(kind: str) -> type[BasisOperator]:
+    try:
+        return _BASIS_OPERATOR_REGISTRY[kind]
+    except KeyError as e:
+        raise KeyError(
+            f"Unknown BasisOperator kind '{kind}'. " f"Known kinds: {sorted(_BASIS_OPERATOR_REGISTRY)}"
+        ) from e
+
+
+# ----------------------------
+# Metadata
+# ----------------------------
+
+
+@dataclass(frozen=True)
+class BasisMeta:
+    """Minimal metadata needed to apply the operator.
+
+    grid_dims are the dims to dot over when computing sensitivities.
+    state_dim is the canonical output dim for the reduced state vector.
+    """
+
+    grid_dims: tuple[str, ...] = ("lat", "lon")
+    state_dim: str = "state"
+
+
+# ----------------------------
+# Base class
+# ----------------------------
+
+
+class BasisOperator(ABC):
+    """Abstract basis operator.
+
+    Concrete subclasses must define:
+    - meta (grid dims + state dim)
+    - basis_matrix: one-hot/dummy matrix with dims (*grid_dims, state_dim)
+    - to_datatree / from_datatree
+
+    The default sensitivity implementation assumes fp_x_flux has the grid dims and
+    any extra dims (e.g. time, source) are preserved.
+    """
+
+    # stable kind string used for serialization dispatch
+    kind: ClassVar[str]
+
+    schema: ClassVar[str] = "openghg_inversions.basis_operator"
+    schema_version: ClassVar[int] = 1
+
+    @property
+    @abstractmethod
+    def meta(self) -> BasisMeta:
+        """Operator metadata (must be provided by subclasses)."""
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def basis_matrix(self) -> xr.DataArray:
+        """Dummy matrix mapping grid -> state.
+
+        Expected dims: (*grid_dims, state_dim)
+        (state_dim may be a MultiIndex coordinate)
+        """
+        raise NotImplementedError
+
+    def sensitivity(self, fp_x_flux: xr.DataArray) -> xr.DataArray:
+        """Compute H = fp_x_flux dot basis_matrix over grid dims."""
+        B = force_align(self.basis_matrix, fp_x_flux, dims=list(self.meta.grid_dims))
+        B = B.transpose(*self.meta.grid_dims, ...)
+
+        # xr.dot keeps non-dot dims from both arguments
+        H = xr.dot(fp_x_flux, B, dim=list(self.meta.grid_dims)).as_numpy()
+
+        # canonical ordering (state_dim first if present)
+        if self.meta.state_dim in H.dims:
+            if "time" in H.dims:
+                H = H.transpose(self.meta.state_dim, "time", ...)
+            else:
+                H = H.transpose(self.meta.state_dim, ...)
+        return H
+
+    def interpolate(self, state: xr.DataArray, weights: xr.DataArray | None = None) -> xr.DataArray:
+        """Map from state -> grid by multiplying the dummy matrix by state.
+
+        If weights is provided (e.g. flux), use (basis_matrix * weights) as the interpolation matrix.
+        """
+        if self.meta.state_dim not in state.dims:
+            raise ValueError(f"State dim '{self.meta.state_dim}' missing from state dims {state.dims}")
+        M = self.basis_matrix
+        if weights is not None:
+            weights_aligned = force_align(weights, M, dims=list(self.meta.grid_dims))
+            M = M * weights_aligned
+        return xr.dot(M, state, dim=self.meta.state_dim)
+
+    # ---- DataTree IO ----
+
+    @abstractmethod
+    def to_datatree(self) -> xr.DataTree:
+        raise NotImplementedError
+
+    @classmethod
+    @abstractmethod
+    def from_datatree(cls, dt: xr.DataTree) -> Self:
+        raise NotImplementedError
+
+    @classmethod
+    def decode_datatree(cls, dt: xr.DataTree) -> BasisOperator:
+        """Generic dispatcher from DataTree -> concrete BasisOperator."""
+        schema = dt.attrs.get("schema")
+        if schema != cls.schema:
+            raise ValueError(f"Unexpected schema '{schema}', expected '{cls.schema}'")
+
+        version = int(dt.attrs.get("schema_version", -1))
+        if version != cls.schema_version:
+            raise ValueError(f"Unsupported schema_version {version}; expected {cls.schema_version}")
+
+        kind = dt.attrs.get("kind")
+        if not kind:
+            raise ValueError("Missing dt.attrs['kind'] for BasisOperator dispatch.")
+
+        op_cls = get_basis_operator_class(str(kind))
+        return op_cls.from_datatree(dt)
+
+
+# ----------------------------
+# Concrete operators
+# ----------------------------
+
+# By convention, basis region numbering starts at 1, but for a while the
+# region coordinate started at 0;
+RegionLabels = Literal["range0", "range1", "basis_values"]
+
+
+@register_basis_operator("bucket")
+class BucketBasisOperator(BasisOperator):
+    """Single flat bucket basis: basis_flat(lat, lon) with integer region labels.
+
+    Stores basis_flat and constructs basis_matrix via get_xr_dummies.
+    """
+
+    def __init__(
+        self,
+        basis_flat: xr.DataArray,
+        *,
+        meta: BasisMeta | None = None,
+        state_dim: str | None = None,
+        region_labels: RegionLabels = "range0",
+        chunks: dict[str, int] | None = None,
+    ):
+        meta = meta or BasisMeta()
+        if state_dim is not None:
+            meta = BasisMeta(grid_dims=meta.grid_dims, state_dim=state_dim)
+        self._meta = meta
+
+        # store canonical 2D basis
+        self.basis_flat = basis_flat.isel(time=0, drop=True) if "time" in basis_flat.dims else basis_flat
+        self.region_labels = region_labels
+
+        # create dummy matrix (grid -> state)
+        # cat_dim name must match meta.state_dim
+        mat = get_xr_dummies(self.basis_flat, cat_dim=self.meta.state_dim)
+
+        # optionally override state coordinate policy
+        mat = self._apply_region_labels_policy(mat)
+
+        # chunking
+        mat = mat.chunk(chunks) if chunks is not None else mat.chunk()
+
+        self._basis_matrix = mat
+
+    @property
+    def meta(self) -> BasisMeta:
+        return self._meta
+
+    @property
+    def basis_matrix(self) -> xr.DataArray:
+        return self._basis_matrix
+
+    def _apply_region_labels_policy(self, mat: xr.DataArray) -> xr.DataArray:
+        # Determine basis label values present (assume positive ints, often 1..N)
+        labels = np.unique(self.basis_flat.values.astype(int))
+        labels = labels[labels > 0]
+        n = len(labels)
+
+        if self.region_labels == "range0":
+            coord = np.arange(n, dtype=int)
+        elif self.region_labels == "range1":
+            coord = np.arange(1, n + 1, dtype=int)
+        elif self.region_labels == "basis_values":
+            coord = labels.astype(int)
+        else:
+            raise ValueError(f"Unknown region_labels policy: {self.region_labels}")
+
+        # Assign coordinate. Important: this assumes get_xr_dummies created state columns
+        # ordered by sorted unique labels > 0. If that assumption changes, we must reindex.
+        return mat.assign_coords({self.meta.state_dim: coord})
+
+    # ---- DataTree IO ----
+
+    def to_datatree(self) -> xr.DataTree:
+        ds = xr.Dataset({"basis_flat": self.basis_flat})
+        dt = xr.DataTree(ds)
+        dt.attrs.update(
+            {
+                "schema": self.schema,
+                "schema_version": self.schema_version,
+                "kind": self.kind,
+                "grid_dims": self.meta.grid_dims,
+                "state_dim": self.meta.state_dim,
+                "region_labels": self.region_labels,
+            }
+        )
+        return dt
+
+    @classmethod
+    def from_datatree(cls, dt: xr.DataTree) -> Self:
+        ds = dt.to_dataset()
+
+        basis_flat = ds["basis_flat"]
+        meta = BasisMeta(
+            grid_dims=tuple(dt.attrs.get("grid_dims", ("lat", "lon"))),
+            state_dim=str(dt.attrs.get("state_dim", "state")),
+        )
+        region_labels = str(dt.attrs.get("region_labels", "range0"))
+
+        return cls(
+            basis_flat=basis_flat,
+            meta=meta,
+            region_labels=region_labels,  # type: ignore[arg-type]
+        )
+
+
+@register_basis_operator("multisource_bucket")
+class MultiSourceBucketBasisOperator(BasisOperator):
+    """Multiple flat bases keyed by source, with potentially ragged region counts.
+
+    Canonical state_dim is a gathered MultiIndex over (source, region_in_source).
+    """
+
+    def __init__(
+        self,
+        basis_flat: dict[str, xr.DataArray],
+        *,
+        meta: BasisMeta | None = None,
+        source_dim: str = "source",
+        region_in_source_dim: str = "region_in_source",
+        state_dim: str | None = None,
+        chunks: dict[str, int] | None = None,
+    ):
+        meta = meta or BasisMeta()
+        if state_dim is not None:
+            meta = BasisMeta(grid_dims=meta.grid_dims, state_dim=state_dim)
+        self._meta = meta
+
+        if not basis_flat:
+            raise ValueError("basis_flat dict is empty.")
+
+        self.source_dim = source_dim
+        self.region_in_source_dim = region_in_source_dim
+
+        # Canonicalise: 2D, consistent lat/lon assumed for now.
+        self.basis_flat = {
+            k: (v.isel(time=0, drop=True) if "time" in v.dims else v) for k, v in basis_flat.items()
+        }
+
+        # Build per-source dummy matrices with ragged region_in_source dim
+        mats: dict[str, xr.DataArray] = {}
+        for src, bf in self.basis_flat.items():
+            # use region_in_source_dim so we can gather it
+            mats[src] = get_xr_dummies(bf, cat_dim=self.region_in_source_dim)
+
+        # Gather concat over source + region_in_source_dim into state_dim
+        # Result has dims (*grid_dims, state_dim) and state_dim is a MultiIndex
+        mat = concat_gather_data_arrays(
+            mats,
+            key_dim=self.source_dim,
+            ragged_dim=self.region_in_source_dim,
+            stack_dim=self.meta.state_dim,
+        )
+
+        # chunking
+        mat = mat.chunk(chunks) if chunks is not None else mat.chunk()
+
+        self._basis_matrix = mat
+
+    @property
+    def meta(self) -> BasisMeta:
+        return self._meta
+
+    @property
+    def basis_matrix(self) -> xr.DataArray:
+        return self._basis_matrix
+
+    # ---- DataTree IO ----
+
+    def to_datatree(self) -> xr.DataTree:
+        # root: metadata only (empty dataset OK)
+        dt = xr.DataTree(xr.Dataset())
+        dt.attrs.update(
+            {
+                "schema": self.schema,
+                "schema_version": self.schema_version,
+                "kind": self.kind,
+                "grid_dims": self.meta.grid_dims,
+                "state_dim": self.meta.state_dim,
+                "source_dim": self.source_dim,
+                "region_in_source_dim": self.region_in_source_dim,
+            }
+        )
+
+        # store basis_flat per source as children
+        basis_group = xr.DataTree(xr.Dataset())
+        dt["basis_flat"] = basis_group
+
+        for src, bf in self.basis_flat.items():
+            basis_group[src] = xr.DataTree(xr.Dataset({"basis_flat": bf}))
+
+        return dt
+
+    @classmethod
+    def from_datatree(cls, dt: xr.DataTree) -> Self:
+        meta = BasisMeta(
+            grid_dims=tuple(dt.attrs.get("grid_dims", ("lat", "lon"))),
+            state_dim=str(dt.attrs.get("state_dim", "state")),
+        )
+        source_dim = str(dt.attrs.get("source_dim", "source"))
+        region_in_source_dim = str(dt.attrs.get("region_in_source_dim", "region_in_source"))
+
+        if "basis_flat" not in dt:
+            raise ValueError("Expected child node 'basis_flat' in DataTree.")
+
+        basis_node = dt["basis_flat"]
+        basis_flat: dict[str, xr.DataArray] = {}
+        for src, child in basis_node.items():
+            ds = child.to_dataset()
+            if "basis_flat" not in ds:
+                raise ValueError(f"Missing 'basis_flat' variable for source '{src}'.")
+            basis_flat[str(src)] = ds["basis_flat"]
+
+        return cls(
+            basis_flat=basis_flat,
+            meta=meta,
+            source_dim=source_dim,
+            region_in_source_dim=region_in_source_dim,
+        )

--- a/openghg_inversions/basis/operators.py
+++ b/openghg_inversions/basis/operators.py
@@ -53,7 +53,8 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import ClassVar, Literal, Self
+from typing import ClassVar, Literal
+from typing_extensions import Self
 
 import numpy as np
 import xarray as xr

--- a/openghg_inversions/basis/operators.py
+++ b/openghg_inversions/basis/operators.py
@@ -59,6 +59,7 @@ import numpy as np
 import xarray as xr
 
 from openghg_inversions.array_ops import (
+    align_to_multi_index_level_values,
     concat_gather_data_arrays,
     force_align,
     get_xr_dummies,
@@ -72,7 +73,22 @@ _BASIS_OPERATOR_REGISTRY: dict[str, type[BasisOperator]] = {}
 
 
 def register_basis_operator(kind: str):
-    """Decorator to register BasisOperator subclasses for DataTree deserialisation."""
+    """Registers a `BasisOperator` subclass for DataTree deserialisation.
+
+    This decorator builds a small module-level registry mapping a stable `kind`
+    string (stored in `dt.attrs["kind"]`) to a concrete `BasisOperator` subclass.
+
+    Args:
+        kind: Stable key identifying the operator type on disk. This is written to
+            `dt.attrs["kind"]` by `BasisOperator.to_datatree()` and used by
+            `BasisOperator.decode_datatree()`.
+
+    Returns:
+        A class decorator that registers the decorated class under `kind`.
+
+    Raises:
+        ValueError: If `kind` is already registered to a different class.
+    """
 
     def _decorator(cls: type[BasisOperator]) -> type[BasisOperator]:
         if kind in _BASIS_OPERATOR_REGISTRY and _BASIS_OPERATOR_REGISTRY[kind] is not cls:
@@ -87,6 +103,17 @@ def register_basis_operator(kind: str):
 
 
 def get_basis_operator_class(kind: str) -> type[BasisOperator]:
+    """Looks up a registered `BasisOperator` subclass.
+
+    Args:
+        kind: Registry key for the operator type (e.g. `"bucket"`).
+
+    Returns:
+        The registered `BasisOperator` subclass.
+
+    Raises:
+        KeyError: If `kind` is not registered.
+    """
     try:
         return _BASIS_OPERATOR_REGISTRY[kind]
     except KeyError as e:
@@ -102,10 +129,16 @@ def get_basis_operator_class(kind: str) -> type[BasisOperator]:
 
 @dataclass(frozen=True)
 class BasisMeta:
-    """Minimal metadata needed to apply the operator.
+    """Metadata describing how to apply a basis operator.
 
-    grid_dims are the dims to dot over when computing sensitivities.
-    state_dim is the canonical output dim for the reduced state vector.
+    The intent is to keep this minimal: we only store what is needed for the
+    default implementations of `BasisOperator.sensitivity` and
+    `BasisOperator.interpolate`.
+
+    Attributes:
+        grid_dims: Dimensions to dot over when reducing a gridded quantity to the
+            reduced state (typically `("lat", "lon")`).
+        state_dim: Canonical dimension name for the reduced state axis.
     """
 
     grid_dims: tuple[str, ...] = ("lat", "lon")
@@ -152,48 +185,113 @@ class BasisOperator(ABC):
         raise NotImplementedError
 
     def sensitivity(self, fp_x_flux: xr.DataArray) -> xr.DataArray:
-        """Compute H = fp_x_flux dot basis_matrix over grid dims."""
-        B = force_align(self.basis_matrix, fp_x_flux, dims=list(self.meta.grid_dims))
-        B = B.transpose(*self.meta.grid_dims, ...)
+        """Computes the sensitivity matrix ("H") by dotting over the grid.
+
+        This implements the common bucket-basis reduction:
+
+        - `fp_x_flux` is a gridded quantity with dimensions that include
+          `meta.grid_dims` (typically `lat` and `lon`) and usually a `time` dimension.
+        - `basis_matrix` is a one-hot/dummy matrix that maps each grid cell to exactly
+          one basis region/state.
+
+        The returned array keeps all non-grid dimensions from `fp_x_flux` and includes
+        the reduced state dimension `meta.state_dim`.
+
+        Args:
+            fp_x_flux: Footprint x flux array to reduce. Must contain all
+                `meta.grid_dims`.
+
+        Returns:
+            Sensitivity matrix with dimension `meta.state_dim` and any remaining
+            non-grid dimensions (e.g. `time`).
+        """
+        mat_aligned = force_align(self.basis_matrix, fp_x_flux, dims=list(self.meta.grid_dims))
+        mat_aligned = mat_aligned.transpose(*self.meta.grid_dims, ...)
 
         # xr.dot keeps non-dot dims from both arguments
-        H = xr.dot(fp_x_flux, B, dim=list(self.meta.grid_dims)).as_numpy()
+        h = xr.dot(fp_x_flux, mat_aligned, dim=list(self.meta.grid_dims)).as_numpy()
 
         # canonical ordering (state_dim first if present)
-        if self.meta.state_dim in H.dims:
-            if "time" in H.dims:
-                H = H.transpose(self.meta.state_dim, "time", ...)
+        if self.meta.state_dim in h.dims:
+            if "time" in h.dims:
+                h = h.transpose(self.meta.state_dim, "time", ...)
             else:
-                H = H.transpose(self.meta.state_dim, ...)
-        return H
+                h = h.transpose(self.meta.state_dim, ...)
+        return h
 
     def interpolate(self, state: xr.DataArray, weights: xr.DataArray | None = None) -> xr.DataArray:
-        """Map from state -> grid by multiplying the dummy matrix by state.
+        """Interpolates/reconstructs a gridded field from a state vector.
 
-        If weights is provided (e.g. flux), use (basis_matrix * weights) as the interpolation matrix.
+        This maps from the reduced basis space back to the grid by multiplying the
+        basis dummy matrix by a state vector.
+
+        If `weights` is provided (e.g. a flux field on the grid), it is multiplied
+        elementwise with the basis matrix before interpolation. This corresponds to
+        using a flux-weighted interpolation operator.
+
+        Args:
+            state: State vector with dimension `meta.state_dim`.
+            weights: Optional gridded weights with dimensions matching `meta.grid_dims`
+                (and broadcastable to `basis_matrix`).
+
+        Returns:
+            Reconstructed gridded field with dimensions including `meta.grid_dims`.
+
+        Raises:
+            ValueError: If `meta.state_dim` is not a dimension of `state`.
         """
         if self.meta.state_dim not in state.dims:
             raise ValueError(f"State dim '{self.meta.state_dim}' missing from state dims {state.dims}")
-        M = self.basis_matrix
+        mat = self.basis_matrix
         if weights is not None:
-            weights_aligned = force_align(weights, M, dims=list(self.meta.grid_dims))
-            M = M * weights_aligned
-        return xr.dot(M, state, dim=self.meta.state_dim)
+            weights_aligned = force_align(weights, mat, dims=list(self.meta.grid_dims))
+            mat = mat * weights_aligned
+        return xr.dot(mat, state, dim=self.meta.state_dim)
 
     # ---- DataTree IO ----
 
     @abstractmethod
     def to_datatree(self) -> xr.DataTree:
+        """Serialises this operator to an `xarray.DataTree`.
+
+        The returned DataTree is intended to be self-describing. It must include enough
+        information to allow round-tripping via `BasisOperator.decode_datatree()`.
+
+        Returns:
+            DataTree representation of the operator.
+        """
         raise NotImplementedError
 
     @classmethod
     @abstractmethod
     def from_datatree(cls, dt: xr.DataTree) -> Self:
+        """Constructs an operator instance from an `xarray.DataTree`.
+
+        Concrete subclasses implement this to load whatever canonical representation
+        they write in `to_datatree()`.
+
+        Args:
+            dt: DataTree created by `to_datatree()`.
+
+        Returns:
+            An instance of the operator.
+        """
         raise NotImplementedError
 
     @classmethod
     def decode_datatree(cls, dt: xr.DataTree) -> BasisOperator:
-        """Generic dispatcher from DataTree -> concrete BasisOperator."""
+        """Dispatches a DataTree to the correct registered operator subclass.
+
+        Args:
+            dt: DataTree representation of a basis operator.
+
+        Returns:
+            A concrete `BasisOperator` instance.
+
+        Raises:
+            ValueError: If the schema or schema version is unsupported.
+            KeyError: If the `kind` is not registered.
+        """
         schema = dt.attrs.get("schema")
         if schema != cls.schema:
             raise ValueError(f"Unexpected schema '{schema}', expected '{cls.schema}'")
@@ -214,8 +312,10 @@ class BasisOperator(ABC):
 # Concrete operators
 # ----------------------------
 
-# By convention, basis region numbering starts at 1, but for a while the
-# region coordinate started at 0;
+# By convention, basis region numbering starts at 1, but some code had
+# a region coordinate started at 0. You can choose a range index starting
+# at 0 (i.e. 0, 1, ..., N-1) or at 1 (i.e. 1, 2, ..., N), or "basis_values"
+# which will use whatever values are in the flat basis array values.
 RegionLabels = Literal["range0", "range1", "basis_values"]
 
 
@@ -234,7 +334,20 @@ class BucketBasisOperator(BasisOperator):
         state_dim: str | None = None,
         region_labels: RegionLabels = "range0",
         chunks: dict[str, int] | None = None,
-    ):
+    ) -> None:
+        """Creates a single-source bucket basis operator.
+
+        Args:
+            basis_flat: Integer-labelled basis array on the grid (typically `(lat, lon)`).
+                If a singleton `time` dimension is present, it is dropped.
+            meta: Metadata describing grid and state dimension names.
+            state_dim: Optional override of `meta.state_dim`.
+            region_labels: Policy for the output state coordinate labels:
+                - `"range0"`: `0..N-1` (legacy-friendly)
+                - `"range1"`: `1..N`
+                - `"basis_values"`: use the unique positive labels found in `basis_flat`.
+            chunks: Optional chunking to apply to the basis matrix.
+        """
         meta = meta or BasisMeta()
         if state_dim is not None:
             meta = BasisMeta(grid_dims=meta.grid_dims, state_dim=state_dim)
@@ -242,6 +355,7 @@ class BucketBasisOperator(BasisOperator):
 
         # store canonical 2D basis
         self.basis_flat = basis_flat.isel(time=0, drop=True) if "time" in basis_flat.dims else basis_flat
+        self.basis_flat = self.basis_flat.rename("basis_flat")
         self.region_labels = region_labels
 
         # create dummy matrix (grid -> state)
@@ -258,13 +372,27 @@ class BucketBasisOperator(BasisOperator):
 
     @property
     def meta(self) -> BasisMeta:
+        """Basis metadata."""
         return self._meta
 
     @property
     def basis_matrix(self) -> xr.DataArray:
+        """Basis matrix."""
         return self._basis_matrix
 
     def _apply_region_labels_policy(self, mat: xr.DataArray) -> xr.DataArray:
+        """Applies the configured `region_labels` policy to the state coordinate.
+
+        Args:
+            mat: Dummy matrix returned by `get_xr_dummies`.
+
+        Returns:
+            `mat` with an updated state coordinate.
+
+        Notes:
+            This assumes `get_xr_dummies` orders categories in ascending order of the
+            unique positive labels in `basis_flat`.
+        """
         # Determine basis label values present (assume positive ints, often 1..N)
         labels = np.unique(self.basis_flat.values.astype(int))
         labels = labels[labels > 0]
@@ -286,6 +414,12 @@ class BucketBasisOperator(BasisOperator):
     # ---- DataTree IO ----
 
     def to_datatree(self) -> xr.DataTree:
+        """Serialises the operator to a DataTree.
+
+        Returns:
+            A DataTree with a dataset containing `basis_flat` and attributes sufficient
+            to reconstruct the operator.
+        """
         ds = xr.Dataset({"basis_flat": self.basis_flat})
         dt = xr.DataTree(ds)
         dt.attrs.update(
@@ -302,6 +436,14 @@ class BucketBasisOperator(BasisOperator):
 
     @classmethod
     def from_datatree(cls, dt: xr.DataTree) -> Self:
+        """Deserialises a `BucketBasisOperator` from a DataTree.
+
+        Args:
+            dt: DataTree produced by `BucketBasisOperator.to_datatree()`.
+
+        Returns:
+            A reconstructed `BucketBasisOperator`.
+        """
         ds = dt.to_dataset()
 
         basis_flat = ds["basis_flat"]
@@ -334,7 +476,24 @@ class MultiSourceBucketBasisOperator(BasisOperator):
         region_in_source_dim: str = "region_in_source",
         state_dim: str | None = None,
         chunks: dict[str, int] | None = None,
-    ):
+    ) -> None:
+        """Creates a multisource bucket basis operator with ragged per-source regions.
+
+        The canonical state dimension is a gathered MultiIndex over
+        `(source, region_in_source)`, stored on the single dimension `meta.state_dim`.
+
+        Args:
+            basis_flat: Mapping from source name to a 2D integer-labelled basis array
+                (typically `(lat, lon)`).
+            meta: Metadata describing grid and state dimension names.
+            source_dim: Name of the source dimension/level.
+            region_in_source_dim: Name for the per-source region index level.
+            state_dim: Optional override of `meta.state_dim`.
+            chunks: Optional chunking to apply to the gathered basis matrix.
+
+        Raises:
+            ValueError: If `basis_flat` is empty.
+        """
         meta = meta or BasisMeta()
         if state_dim is not None:
             meta = BasisMeta(grid_dims=meta.grid_dims, state_dim=state_dim)
@@ -350,6 +509,7 @@ class MultiSourceBucketBasisOperator(BasisOperator):
         self.basis_flat = {
             k: (v.isel(time=0, drop=True) if "time" in v.dims else v) for k, v in basis_flat.items()
         }
+        self.basis_flat = {k: v.rename("basis_flat") for k, v in self.basis_flat.items()}
 
         # Build per-source dummy matrices with ragged region_in_source dim
         mats: dict[str, xr.DataArray] = {}
@@ -373,17 +533,69 @@ class MultiSourceBucketBasisOperator(BasisOperator):
 
     @property
     def meta(self) -> BasisMeta:
+        """Basis metadata."""
         return self._meta
 
     @property
     def basis_matrix(self) -> xr.DataArray:
+        """Basis matrix."""
         return self._basis_matrix
+
+    def _align_source_like_state(self, other: xr.DataArray) -> xr.DataArray:
+        """Broadcast `other(source, ...)` onto `state` using the state MultiIndex level `source`.
+
+        This implements the "source alignment hack" used in the earlier prototype:
+        - basis_matrix has dim `state` with MultiIndex levels (source, region_in_source)
+        - fp_x_flux has dim `source`
+        - to multiply fp_x_flux by basis_matrix we need to index fp_x_flux by the state.source order
+
+        Returns an array indexed by `state` and no longer carrying the original `source` coord var.
+        """
+        if self.source_dim not in other.dims:
+            return other
+
+        state_index = self.basis_matrix[self.meta.state_dim]
+
+        return align_to_multi_index_level_values(
+            other,
+            multi_index=state_index,
+            multi_dim=self.meta.state_dim,
+            level=self.source_dim,
+            other_dim=self.source_dim,
+        )
+
+    def sensitivity(self, fp_x_flux: xr.DataArray) -> xr.DataArray:
+        """Compute sensitivity for multisource fp_x_flux.
+
+        Overrides base method to broadcast the fp_x_flux `source` dim onto the gathered `state` dim.
+        """
+        mat_aligned = force_align(self.basis_matrix, fp_x_flux, dims=list(self.meta.grid_dims))
+        mat_aligned = mat_aligned.transpose(*self.meta.grid_dims, ...)
+
+        fp_on_state = self._align_source_like_state(fp_x_flux)
+
+        h = xr.dot(fp_on_state, mat_aligned, dim=list(self.meta.grid_dims)).as_numpy()
+
+        if self.meta.state_dim in h.dims:
+            if "time" in h.dims:
+                h = h.transpose(self.meta.state_dim, "time", ...)
+            else:
+                h = h.transpose(self.meta.state_dim, ...)
+        return h
 
     # ---- DataTree IO ----
 
     def to_datatree(self) -> xr.DataTree:
+        """Serialises the multisource operator to a DataTree.
+
+        The returned DataTree stores per-source `basis_flat` arrays as children under
+        `dt["basis_flat"][<source>]`.
+
+        Returns:
+            DataTree representation of the operator.
+        """
         # root: metadata only (empty dataset OK)
-        dt = xr.DataTree(xr.Dataset())
+        dt = xr.DataTree()
         dt.attrs.update(
             {
                 "schema": self.schema,
@@ -397,16 +609,22 @@ class MultiSourceBucketBasisOperator(BasisOperator):
         )
 
         # store basis_flat per source as children
-        basis_group = xr.DataTree(xr.Dataset())
-        dt["basis_flat"] = basis_group
-
-        for src, bf in self.basis_flat.items():
-            basis_group[src] = xr.DataTree(xr.Dataset({"basis_flat": bf}))
+        dt["basis_flat"] = xr.DataTree.from_dict(
+            {src: xr.Dataset({"basis_flat": bf}) for src, bf in self.basis_flat.items()}
+        )
 
         return dt
 
     @classmethod
     def from_datatree(cls, dt: xr.DataTree) -> Self:
+        """Deserialises a `MultiSourceBucketBasisOperator` from a DataTree.
+
+        Args:
+            dt: DataTree produced by `MultiSourceBucketBasisOperator.to_datatree()`.
+
+        Returns:
+            A reconstructed `MultiSourceBucketBasisOperator`.
+        """
         meta = BasisMeta(
             grid_dims=tuple(dt.attrs.get("grid_dims", ("lat", "lon"))),
             state_dim=str(dt.attrs.get("state_dim", "state")),

--- a/openghg_inversions/basis/operators.py
+++ b/openghg_inversions/basis/operators.py
@@ -1,4 +1,4 @@
-"""Basis operator classes (new API; does not yet replace legacy basis_functions.py).
+"""Basis operator classes
 
 Design goals
 ------------
@@ -42,11 +42,10 @@ How to use
     dt = op.to_datatree()
     op2 = BasisOperator.decode_datatree(dt)
 
-Notes:
+Notes
 -----
-- This module is an initial step in refactoring. It is intended to coexist with the legacy
-  basis_functions.py until the old APIs are reimplemented using these operators and tests are migrated.
-
+- Currently, basis operators cannot have a time dimension. If the input flat array has
+  a time dimension with more than one coordinate value, an error is raised.
 """
 
 from __future__ import annotations

--- a/openghg_inversions/inversion_inputs.py
+++ b/openghg_inversions/inversion_inputs.py
@@ -1,6 +1,5 @@
 """Functions for creating the inputs needed by PyMC."""
 
-from collections.abc import Hashable, Mapping
 import datetime as dt
 from typing import Any, Literal
 
@@ -8,118 +7,10 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
-from openghg_inversions.array_ops import get_xr_dummies
+from openghg_inversions.array_ops import get_xr_dummies, concat_gather_datasets
 from openghg_inversions.model_error import percentile_error_method, residual_error_method, xr_setup_min_error
 
 DatetimeLike = str | dt.datetime | np.datetime64 | pd.Timestamp
-
-
-# HELPERS
-def concat_gather_data_arrays(
-    da_dict: Mapping[Hashable, xr.DataArray],
-    key_dim: str,
-    ragged_dim: str,
-    stack_dim: str | None = None,
-    **concat_kwargs,
-) -> xr.DataArray:
-    """Concatenate DataArrays by gathering along ragged coordinate.
-
-    For example, if the keys are site codes and the ragged dimension is time,
-    then the "stacked dimension" will be the usual `nmeasure` coordinate.
-
-    Args:
-        da_dict: dictionary of DataArrays
-        key_dim: dimension name for the keys of the dictionary
-        ragged_dim: name of the ragged dimension
-        stack_dim: name for the "stacked" multi-index dimension
-        **concat_kwargs: arguments to pass to xr.concat
-
-    Returns:
-        Combined DataArray with new stacked dimension.
-
-    """
-    stack_dim = stack_dim or (key_dim + "_" + ragged_dim)
-
-    pieces: list[xr.DataArray] = []
-    key_vals: list[np.ndarray] = []
-    ragged_vals: list[np.ndarray] = []
-
-    for k, v in da_dict.items():
-        piece = v.rename({ragged_dim: stack_dim})
-        pieces.append(piece)
-
-        n = piece.sizes[stack_dim]
-
-        # make site indicator
-        key_val = np.full(n, k)
-        key_vals.append(key_val)
-
-        # record times
-        ragged_vals.append(v[ragged_dim].values)
-
-    # concat pieces
-    da = xr.concat(pieces, dim=stack_dim, **concat_kwargs)
-
-    # now create and assign multi-index
-    key_indicator = np.concatenate(key_vals)
-    concat_ragged = np.concatenate(ragged_vals)
-    multiindex = pd.MultiIndex.from_arrays([key_indicator, concat_ragged], names=[key_dim, ragged_dim])
-    xr_multiindex = xr.Coordinates.from_pandas_multiindex(multiindex, stack_dim)
-
-    da = da.assign_coords(xr_multiindex)
-
-    return da
-
-
-def concat_gather_datasets(
-    ds_dict: Mapping[Hashable, xr.Dataset],
-    key_dim: str,
-    ragged_dim: str,
-    stack_dim: str | None = None,
-    **concat_kwargs,
-) -> xr.Dataset:
-    """Concatenate dictionary of xr.Datasets by gathering ragged coordinates.
-
-    This assumes that all datasets have the same data variables.
-
-    TODO: need to handle missing data variables.
-    """
-    dvs = next(iter(ds_dict.values())).data_vars
-
-    # check that all data vars are present
-    for k, v in ds_dict.items():
-        if any(dv not in v.data_vars for dv in dvs):
-            missing_dvs = [dv for dv in dvs if dv not in v.data_vars]
-            raise ValueError(
-                f"Datasets do not all have the same data variables: Dataset for key {k} missing {missing_dvs}"
-            )
-
-    gathered_dvs = {}
-
-    for dv in dvs:
-        da_dict = {k: v[dv] for k, v in ds_dict.items()}
-        gathered_dvs[dv] = concat_gather_data_arrays(da_dict, key_dim, ragged_dim, stack_dim, **concat_kwargs)
-
-    return xr.Dataset(gathered_dvs)
-
-
-def concat_gather_datatree(
-    dt: xr.DataTree, key_dim: str, ragged_dim: str, stack_dim: str | None = None, **concat_kwargs
-) -> xr.Dataset:
-    """Concatenate xr.DataTree children by gathering ragged coordinates.
-
-    This assumes that all children have the same data variables.
-    """
-    ds_dict = {str(k): v.to_dataset() for k, v in dt.items()}
-    dvs = next(iter(ds_dict.values())).data_vars
-
-    gathered_dvs = {}
-
-    for dv in dvs:
-        da_dict = {k: v[dv] for k, v in ds_dict.items()}
-        gathered_dvs[dv] = concat_gather_data_arrays(da_dict, key_dim, ragged_dim, stack_dim, **concat_kwargs)
-
-    return xr.Dataset(gathered_dvs)
 
 
 def xr_unique_inv(da: xr.DataArray, sort: bool = True) -> xr.DataArray:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,7 +2,10 @@
 
 Mainly for creating fake data.
 """
-import numpy  as np
+
+from __future__ import annotations
+
+import numpy as np
 import pandas as pd
 import xarray as xr
 
@@ -21,11 +24,13 @@ rng = np.random.default_rng(seed=123)
 
 
 def basis_function(nlat: int, nlon: int, nbasis: int) -> xr.DataArray:
-    values = rng.integers(1, nbasis, size=nlat*nlon, endpoint=True).reshape((nlat, nlon))
+    values = rng.integers(1, nbasis, size=nlat * nlon, endpoint=True).reshape((nlat, nlon))
     return lat_lon_data(nlat, nlon, values)
 
 
-def lat_lon_time_data(nlat: int, nlon: int, start: str, end: str, ntime: int, values: np.ndarray | list | None = None) -> xr.DataArray:
+def lat_lon_time_data(
+    nlat: int, nlon: int, start: str, end: str, ntime: int, values: np.ndarray | list | None = None
+) -> xr.DataArray:
     lat = np.arange(nlat)
     lon = np.arange(nlon)
     time = pd.date_range(start, end, ntime)
@@ -40,3 +45,172 @@ def footprint(nlat: int, nlon: int, start: str, end: str, ntime: int) -> xr.Data
     values = np.broadcast_to(np.arange(1, ntime + 1), (nlat, nlon, ntime))
 
     return lat_lon_time_data(nlat, nlon, start, end, ntime, values)
+
+
+def make_time_coord(ntime: int, start: str = "2019-01-01T00:00:00") -> xr.DataArray:
+    """Simple hourly time coordinate."""
+    t = pd.date_range(start=start, periods=ntime, freq="1h")
+    return xr.DataArray(t, dims="time", name="time")
+
+
+def make_lat_lon_coords(nlat: int, nlon: int) -> tuple[xr.DataArray, xr.DataArray]:
+    lat = xr.DataArray(np.arange(nlat, dtype=float), dims="lat", name="lat")
+    lon = xr.DataArray(np.arange(nlon, dtype=float), dims="lon", name="lon")
+    return lat, lon
+
+
+# ----------------------------------------
+# BASIS FUNCTIONS HELPERS
+# ----------------------------------------
+def make_fp_x_flux(
+    nlat: int = 2,
+    nlon: int = 2,
+    ntime: int = 3,
+    values: np.ndarray | None = None,
+    start: str = "2019-01-01T00:00:00",
+    name: str = "fp_x_flux",
+) -> xr.DataArray:
+    """Create synthetic fp_x_flux(lat, lon, time)."""
+    lat, lon = make_lat_lon_coords(nlat, nlon)
+    time = make_time_coord(ntime, start=start)
+
+    if values is None:
+        # deterministic: increasing with time, constant over lat/lon
+        base = np.arange(1, ntime + 1, dtype=float)
+        values = np.broadcast_to(base, (nlat, nlon, ntime))
+
+    return xr.DataArray(
+        values, coords={"lat": lat, "lon": lon, "time": time}, dims=("lat", "lon", "time"), name=name
+    )
+
+
+def make_fp_x_flux_sectoral(
+    sources: list[str],
+    nlat: int = 2,
+    nlon: int = 2,
+    ntime: int = 3,
+    values_by_source: dict[str, np.ndarray] | None = None,
+    start: str = "2019-01-01T00:00:00",
+    name: str = "fp_x_flux_sectoral",
+) -> xr.DataArray:
+    """Create synthetic fp_x_flux_sectoral(source, lat, lon, time)."""
+    pieces = []
+    for i, s in enumerate(sources):
+        if values_by_source is None:
+            # deterministic distinct sources: (i+1) * fp_x_flux
+            fp = make_fp_x_flux(nlat, nlon, ntime, start=start, name=name)
+            fp = fp * float(i + 1)
+        else:
+            fp = make_fp_x_flux(nlat, nlon, ntime, values=values_by_source[s], start=start, name=name)
+        pieces.append(fp.expand_dims(source=[s]))
+
+    return xr.concat(pieces, dim="source")
+
+
+def make_basis_flat_from_blocks(
+    blocks: list[list[int]],
+    region_start: int = 1,
+    name: str = "basis",
+) -> xr.DataArray:
+    """Create a small deterministic basis_flat(lat, lon) from integer labels.
+
+    blocks is a nested python list shaped (nlat, nlon) with labels starting at 1 by default.
+    """
+    arr = np.asarray(blocks, dtype=int)
+    if arr.min() < region_start:
+        raise ValueError("Basis labels must start from region_start (default 1).")
+    nlat, nlon = arr.shape
+    lat, lon = make_lat_lon_coords(nlat, nlon)
+    return xr.DataArray(arr, coords={"lat": lat, "lon": lon}, dims=("lat", "lon"), name=name)
+
+
+def expected_H_from_basis_sum(
+    fp_x_flux: xr.DataArray, basis_flat: xr.DataArray, region_dim: str = "region"
+) -> xr.DataArray:
+    """Compute expected H(region, time) by explicit summation (slow, tiny arrays only).
+
+    This is used for deterministic synthetic tests.
+    """
+    # unique region labels, sorted
+    labels = np.unique(basis_flat.values.astype(int))
+    labels = labels[labels > 0]
+
+    out = []
+    for i, lab in enumerate(labels):
+        mask = xr.where(basis_flat == lab, 1.0, 0.0)
+        # sum over lat/lon
+        h_lab = (fp_x_flux * mask).sum(("lat", "lon"))
+
+        # use 0..N-1, consistent with apply_fp_basis_functions
+        out.append(h_lab.expand_dims({region_dim: [i]}))
+
+    H = xr.concat(out, dim=region_dim).transpose(region_dim, "time")
+    return H
+
+
+def old_apply_fp_basis_functions_like(
+    fp_x_flux: xr.DataArray, basis_flat: xr.DataArray, region_dim: str = "region"
+) -> xr.DataArray:
+    """Mimic legacy apply_fp_basis_functions using xarray only (no sparse).
+
+    This is useful in tests to avoid importing private sparse helpers.
+    """
+    # NOTE: legacy aligns basis to fp_x_flux.isel(time=0), join="override"
+    _, basis_aligned = xr.align(fp_x_flux.isel(time=0), basis_flat, join="override")
+
+    labels = np.unique(basis_aligned.values.astype(int))
+    labels = labels[labels > 0]  # basis uses labels 1..N by convention
+
+    pieces = []
+    for i, lab in enumerate(labels):
+        mask = xr.where(basis_aligned == lab, 1.0, 0.0)
+        h_lab = (fp_x_flux.fillna(0.0) * mask).sum(("lat", "lon"))
+
+        # use 0..N-1, consistent with apply_fp_basis_functions
+        pieces.append(h_lab.expand_dims({region_dim: [i]}))
+
+    H = xr.concat(pieces, dim=region_dim).transpose(region_dim, "time")
+    return H
+
+
+def convert_old_multisector_H_to_gathered(
+    H_old: xr.DataArray,
+    *,
+    source_dim: str = "source",
+    region_dim: str = "region",
+    gathered_dim: str = "region",
+    sector_region_dim: str = "sector_region",
+    drop_zero_rows: bool = True,
+) -> xr.DataArray:
+    """Convert legacy padded multisector sensitivity to gathered MultiIndex region.
+
+    Legacy H is typically: (region=max_regions, time, source).
+    Output is: (region=(source, sector_region), time) where region is a MultiIndex.
+
+    We drop (source, sector_region) rows that are all-zero across time (and any other dims).
+    """
+    if source_dim not in H_old.dims:
+        raise ValueError(f"Expected source dim {source_dim!r} in H_old.dims={H_old.dims}")
+    if region_dim not in H_old.dims:
+        raise ValueError(f"Expected region dim {region_dim!r} in H_old.dims={H_old.dims}")
+
+    H = H_old.rename({region_dim: sector_region_dim})
+
+    # Make sure sector_region is an integer coordinate; legacy region sometimes starts at 0
+    # but for your padded H it looks like region starts at 0 in some places; keep as-is.
+    # If you want to enforce 0/1-based, do it upstream.
+    H = H.stack({gathered_dim: (source_dim, sector_region_dim)})
+
+    if drop_zero_rows:
+        # drop rows where the entire "row" across non-region dims is 0
+        other_dims = [d for d in H.dims if d != gathered_dim]
+        is_nonzero = (H != 0).any(dim=other_dims)
+        H = H.isel({gathered_dim: is_nonzero.values})
+
+    # transpose to (region, time, ...) canonical-ish
+    if "time" in H.dims:
+        H = H.transpose(gathered_dim, "time", ...)
+    else:
+        H = H.transpose(gathered_dim, ...)
+
+    return H

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -179,7 +179,7 @@ def convert_old_multisector_H_to_gathered(
     source_dim: str = "source",
     region_dim: str = "region",
     gathered_dim: str = "region",
-    sector_region_dim: str = "sector_region",
+    source_region_dim: str = "region_in_source",
     drop_zero_rows: bool = True,
 ) -> xr.DataArray:
     """Convert legacy padded multisector sensitivity to gathered MultiIndex region.
@@ -194,12 +194,12 @@ def convert_old_multisector_H_to_gathered(
     if region_dim not in H_old.dims:
         raise ValueError(f"Expected region dim {region_dim!r} in H_old.dims={H_old.dims}")
 
-    H = H_old.rename({region_dim: sector_region_dim})
+    H = H_old.rename({region_dim: source_region_dim})
 
     # Make sure sector_region is an integer coordinate; legacy region sometimes starts at 0
     # but for your padded H it looks like region starts at 0 in some places; keep as-is.
     # If you want to enforce 0/1-based, do it upstream.
-    H = H.stack({gathered_dim: (source_dim, sector_region_dim)})
+    H = H.stack({gathered_dim: (source_dim, source_region_dim)})
 
     if drop_zero_rows:
         # drop rows where the entire "row" across non-region dims is 0

--- a/tests/test_array_ops.py
+++ b/tests/test_array_ops.py
@@ -1,9 +1,113 @@
+import numpy as np
 import pandas as pd
+import pytest
 import sparse
 import xarray as xr
 
+from openghg_inversions.array_ops import align_to_multi_index_level_values
+
+
 def test_transpose():
-    dums = pd.get_dummies([0]*3 + [1]*4 + [2]*5, dtype=int, sparse=True)
+    dums = pd.get_dummies([0] * 3 + [1] * 4 + [2] * 5, dtype=int, sparse=True)
     sparse_dums = sparse.COO.from_scipy_sparse(dums.sparse.to_coo())
     da = xr.DataArray(sparse_dums)
     da.transpose()
+
+
+def test_align_to_multi_index_level_values_broadcasts_source_to_state():
+    """Test aligning coordinate to multi-index level coordinate broadcasts correctly."""
+    # da(source, time)
+    source = xr.DataArray(["A", "B"], dims="source", name="source")
+    time = xr.DataArray(pd.date_range("2020-01-01", periods=3, freq="1h"), dims="time", name="time")
+
+    da = xr.DataArray(
+        np.array([[10.0, 11.0, 12.0], [20.0, 21.0, 22.0]]),
+        dims=("source", "time"),
+        coords={"source": source, "time": time},
+        name="da",
+    )
+
+    # MultiIndex for state: (source, region_in_source) with repetition of source labels
+    mi = pd.MultiIndex.from_arrays(
+        [["B", "A", "B", "A"], [0, 0, 1, 2]],
+        names=["source", "region_in_source"],
+    )
+
+    # align to multi index
+    state_index = xr.Coordinates.from_pandas_multiindex(mi, "state")["state"]
+
+    res = align_to_multi_index_level_values(
+        da,
+        multi_index=state_index,
+        multi_dim="state",
+        level="source",
+        other_dim="source",
+    )
+
+    # Dims: state, time (source dim is replaced)
+    assert res.dims == ("state", "time")
+
+    # The state coordinate should be exactly the MultiIndex we provided
+    xr.testing.assert_identical(res["state"], state_index)
+
+    # The original "source" coordinate variable should be dropped to avoid alignment conflicts
+    # (it's still available as a level on the MultiIndex)
+    # assert "source" not in res.coords
+
+    # Values: each row picks from da at the corresponding state.source
+    expected = np.vstack(
+        [
+            da.sel(source="B").values,
+            da.sel(source="A").values,
+            da.sel(source="B").values,
+            da.sel(source="A").values,
+        ]
+    )
+    np.testing.assert_allclose(res.values, expected)
+
+    expected_da = xr.DataArray(
+        expected,
+        dims=("state", "time"),
+        coords={**xr.Coordinates.from_pandas_multiindex(mi, "state"), **{"time": time}},
+        name="da",
+    )
+    xr.testing.assert_identical(res, expected_da)
+
+    # This multiplication (or any operation that causes alignment) can fail if
+    # the coordinate for `other_dim` is not dropped before assigning the MultiIndex.
+    # The test here is just that this doesn't cause an error.
+    _ = res * expected_da
+
+
+def test_align_to_multi_index_level_values_with_other_level_as_coord_raises():
+    """Test that an error is raised if aligning to a MultiIndex would cause coord conflict."""
+    da = xr.DataArray(
+        np.arange(12).reshape(3, 4), dims=("a", "b"), coords={"a": np.arange(3), "b": np.arange(4)}
+    )
+
+    da_stack = da.stack(c=("a", "b"))
+    mi = da_stack.coords["c"]
+
+    with pytest.raises(ValueError):
+        _ = align_to_multi_index_level_values(da, multi_index=mi, multi_dim="c", level="a", other_dim="a")
+
+
+def test_align_to_multi_index_level_values_with_other_level_as_dim_warns():
+    """Test that we can align a dataset to one level of multiindex even if it has both levels as dims.
+
+    This should emit a warning that this is potentially confusing.
+    """
+    da = xr.DataArray(np.arange(12).reshape(3, 4), dims=("a", "b"))
+
+    da_stack = da.stack(c=("a", "b"))
+    mi = da_stack.coords["c"]
+
+    with pytest.warns(
+        UserWarning,
+        match=r"Aligning to MultiIndex level.*\'b\'.*semantically ambiguous",
+    ):
+        da_aligned = align_to_multi_index_level_values(
+            da, multi_index=mi, multi_dim="c", level="a", other_dim="a"
+        )
+
+    xr.testing.assert_equal(da_stack.a, da_aligned.a)

--- a/tests/test_basis_functions.py
+++ b/tests/test_basis_functions.py
@@ -1,13 +1,34 @@
 import numpy as np
 import pandas as pd
+import pytest
 import xarray as xr
 
-from openghg_inversions.basis._functions import basis, _flux_fp_from_fp_all, _mean_fp_times_mean_flux
-from openghg_inversions.basis import bucketbasisfunction, quadtreebasisfunction, fixed_outer_regions_basis
-from openghg_inversions.basis._helpers import fp_sensitivity
+from openghg_inversions.basis._functions import (
+    basis,
+    basis_functions,
+    _flux_fp_from_fp_all,
+    _mean_fp_times_mean_flux,
+)
+from openghg_inversions.basis import (
+    basis_functions_wrapper,
+    bucketbasisfunction,
+    quadtreebasisfunction,
+    fixed_outer_regions_basis,
+)
+from openghg_inversions.basis.basis_functions import BasisFunctions, MultiSectorBasisFunctions
+from openghg_inversions.basis._helpers import apply_fp_basis_functions, fp_sensitivity
 from openghg_inversions.inversion_data import data_processing_surface_notracer
 
 from helpers import basis_function, footprint
+from helpers import (
+    convert_old_multisector_H_to_gathered,
+    make_basis_flat_from_blocks,
+    make_fp_x_flux,
+    make_fp_x_flux_sectoral,
+    expected_H_from_basis_sum,
+    old_apply_fp_basis_functions_like,
+)
+
 
 def test_fp_x_flux(tac_ch4_data_args):
     fp_all, *_ = data_processing_surface_notracer(**tac_ch4_data_args)
@@ -26,14 +47,13 @@ def test_fp_x_flux(tac_ch4_data_args):
 
     # shift time of second site -- this should not change the mean over time
     max_time = pd.Timedelta(fp_all["TAC"].time.max().values - fp_all["TAC"].time.min().values)
-    new_time = (fp_all["TAC"].time + max_time)
+    new_time = fp_all["TAC"].time + max_time
     fp_all["ABC"] = fp_all["ABC"].assign_coords(time=new_time)
 
     flux3, fp3 = _flux_fp_from_fp_all(fp_all, emissions_name)
     mean_fp_flux3 = _mean_fp_times_mean_flux(flux3, fp3)
 
     xr.testing.assert_allclose(mean_fp_flux1, mean_fp_flux3)
-
 
 
 def test_quadtree_basis_function(tac_ch4_data_args, raw_data_path):
@@ -46,11 +66,7 @@ def test_quadtree_basis_function(tac_ch4_data_args, raw_data_path):
     fp_all, *_ = data_processing_surface_notracer(**tac_ch4_data_args)
     emissions_name = next(iter(fp_all[".flux"].keys()))
     basis_func = quadtreebasisfunction(
-        emissions_name=[emissions_name],
-        fp_all=fp_all,
-        start_date="2019-01-01",
-        seed=42,
-        domain="EUROPE"
+        emissions_name=[emissions_name], fp_all=fp_all, start_date="2019-01-01", seed=42, domain="EUROPE"
     )
 
     basis_func_reloaded = basis(
@@ -79,7 +95,6 @@ def test_bucket_basis_function(tac_ch4_data_args, raw_data_path):
         nbasis=98,
     )
 
-
     basis_func_reloaded = basis(
         domain="EUROPE", basis_case="bucket_ch4-test_basis", basis_directory=raw_data_path / "basis"
     )
@@ -88,11 +103,12 @@ def test_bucket_basis_function(tac_ch4_data_args, raw_data_path):
     # dataset to data array
     xr.testing.assert_allclose(basis_func, basis_func_reloaded.basis)
 
+
 def test_fixed_outer_region_basis_function(tac_ch4_data_args, raw_data_path):
-    """Check if fixed outer region basis created wtih seed 42 and TAC CH4 args matches 
+    """Check if fixed outer region basis created wtih seed 42 and TAC CH4 args matches
     a basis created with the same argumenst and saved to file.
-    
-    This is to check against changes in the code from when this test was made 
+
+    This is to check against changes in the code from when this test was made
     (2 Sep 2024)
     """
     fp_all, *_ = data_processing_surface_notracer(**tac_ch4_data_args)
@@ -102,11 +118,13 @@ def test_fixed_outer_region_basis_function(tac_ch4_data_args, raw_data_path):
         fp_all=fp_all,
         start_date="2019-01-01",
         domain="EUROPE",
-        basis_algorithm='weighted'
+        basis_algorithm="weighted",
     )
 
     basis_func_reloaded = basis(
-        domain="EUROPE", basis_case="fixed_outer_region_ch4-test_basis", basis_directory=raw_data_path / "basis"
+        domain="EUROPE",
+        basis_case="fixed_outer_region_ch4-test_basis",
+        basis_directory=raw_data_path / "basis",
     )
 
     # TODO: create new "fixed" basis function file, since we've switched basis functions from
@@ -172,3 +190,210 @@ def test_fp_sensitivity_two_flux_sectors_two_basis_funcs():
 
         # the footprint values at time 0 are 1, and at time 1 are 2
         np.testing.assert_allclose(2 * h.isel(time=0), h.isel(time=1))
+
+
+def test_basisfunctions_sensitivity_synthetic_matches_explicit_sum():
+    # 2x2 grid, 3 times, basis has 2 regions: top row region 1, bottom row region 2
+    basis = make_basis_flat_from_blocks([[1, 1], [2, 2]])
+
+    fp_x_flux = make_fp_x_flux(nlat=2, nlon=2, ntime=3)
+
+    # flux is only used for interpolation_matrix etc; sensitivity uses basis_matrix only
+    # but BasisFunctions requires flux; use ones
+    flux = xr.ones_like(basis, dtype=float)
+
+    bf = BasisFunctions(basis_flat=basis, flux=flux)
+
+    H_new = bf.sensitivity(fp_x_flux)
+
+    H_expected = expected_H_from_basis_sum(fp_x_flux, basis)
+
+    xr.testing.assert_allclose(H_new, H_expected)
+
+
+def test_basisfunctions_sensitivity_synthetic_multisector_shared_basis():
+    sources = ["A", "B"]
+    basis = make_basis_flat_from_blocks([[1, 1], [2, 2]])
+
+    fp_x_flux_sectoral = make_fp_x_flux_sectoral(sources=sources, nlat=2, nlon=2, ntime=3)
+
+    flux = xr.ones_like(basis, dtype=float)
+    bf = BasisFunctions(basis_flat=basis, flux=flux)
+
+    H = bf.sensitivity(fp_x_flux_sectoral)
+
+    # Expected: same as single-sector, but computed per source and carried through source dim.
+    # bf.sensitivity preserves non-(lat,lon) dims, so expect (source, time, region) or (source, region, time)
+    # We enforce canonical order via transpose below.
+    H = H.transpose("region", "time", "source")
+
+    # Construct expected by explicit summation for each source
+    expected_pieces = []
+    for s in sources:
+        Hs = expected_H_from_basis_sum(fp_x_flux_sectoral.sel(source=s), basis)  # (region, time)
+        expected_pieces.append(Hs.expand_dims(source=[s]))
+    H_expected = xr.concat(expected_pieces, dim="source").transpose("region", "time", "source")
+
+    xr.testing.assert_allclose(H, H_expected)
+
+
+def test_basisfunctions_sensitivity_regression_matches_legacy_like():
+    basis = make_basis_flat_from_blocks([[1, 1], [2, 2]])
+    fp_x_flux = make_fp_x_flux(nlat=2, nlon=2, ntime=4)
+
+    flux = xr.ones_like(basis, dtype=float)
+    bf = BasisFunctions(basis_flat=basis, flux=flux)
+
+    H_new = bf.sensitivity(fp_x_flux)  # (region, time)
+    H_old = old_apply_fp_basis_functions_like(fp_x_flux, basis)  # (region, time)
+
+    xr.testing.assert_allclose(H_new, H_old)
+
+
+def test_synthetic_no_all_zero_state_rows_when_fp_positive_everywhere():
+    basis = make_basis_flat_from_blocks([[1, 1], [2, 2]])
+    fp_x_flux = make_fp_x_flux(nlat=2, nlon=2, ntime=3, values=np.ones((2, 2, 3)))
+
+    flux = xr.ones_like(basis, dtype=float)
+    bf = BasisFunctions(basis_flat=basis, flux=flux)
+
+    H = bf.sensitivity(fp_x_flux)  # (region, time)
+
+    # For strictly positive fp_x_flux and nonempty basis regions, each region row should be > 0 somewhere
+    assert (H > 0).any(dim="time").all().item()
+
+
+# @pytest.mark.slow
+def test_basisfunctions_sensitivity_matches_apply_fp_basis_functions_real_data():
+    data_args = {
+        "species": "ch4",
+        "sites": ["MHD", "TAC"],
+        "start_date": "2019-01-01",
+        "end_date": "2019-01-02",
+        "bc_store": "inversions_tests",
+        "obs_store": "inversions_tests",
+        "footprint_store": "inversions_tests",
+        "emissions_store": "inversions_tests",
+        "inlet": ["10m", "185m"],
+        "instrument": ["gcmd", "picarro"],
+        "domain": "EUROPE",
+        "fp_height": ["10m", "185m"],
+        "fp_model": "NAME",
+        "emissions_name": ["total-ukghg-edgar7"],
+        "averaging_period": ["1h", "1h"],
+    }
+
+    fp_all, *_ = data_processing_surface_notracer(**data_args)
+
+    basis_args = {
+        "species": "ch4",
+        "domain": "EUROPE",
+        "start_date": "2019-01-01",
+        "emissions_name": ["total-ukghg-edgar7"],
+        "nbasis": 20,
+        "use_bc": True,
+        "basis_algorithm": "weighted",
+        "bc_basis_case": "NESW",
+    }
+
+    fp_all_with_basis = basis_functions_wrapper(fp_all, **basis_args)
+
+    site = "MHD"
+    ds = fp_all_with_basis[site]
+
+    # old sensitivity (already computed by wrapper) is ds["H"]; but we want to call the legacy fn directly too
+    H_old = apply_fp_basis_functions(ds.fp_x_flux, fp_all_with_basis[".basis"])
+
+    # new sensitivity
+    # Need a flux field; the wrapper has fp_all_with_basis[".flux"][source].data.flux
+    flux_source = next(iter(fp_all_with_basis[".flux"].keys()))
+    flux = fp_all_with_basis[".flux"][flux_source].data.flux
+
+    bf = BasisFunctions(basis_flat=fp_all_with_basis[".basis"], flux=flux)
+    H_new = bf.sensitivity(ds.fp_x_flux)
+
+    # Ensure same dim order for comparison
+    if H_new.dims != H_old.dims:
+        H_new = H_new.transpose(*H_old.dims)
+
+    xr.testing.assert_allclose(H_new, H_old)
+
+    # now test vs. result of basis_functions_wrapper
+    H_old = ds.H
+
+    if H_new.dims != H_old.dims:
+        H_new = H_new.transpose(*H_old.dims)
+
+    xr.testing.assert_allclose(H_new, H_old)
+
+
+# @pytest.mark.slow
+def test_multisector_ragged_new_matches_old_after_conversion():
+    # --- Load test-suite data (same as notebook) ---
+    data_args = {
+        "species": "ch4",
+        "sites": ["MHD", "TAC"],
+        "start_date": "2019-01-01",
+        "end_date": "2019-01-02",
+        "bc_store": "inversions_tests",
+        "obs_store": "inversions_tests",
+        "footprint_store": "inversions_tests",
+        "emissions_store": "inversions_tests",
+        "inlet": ["10m", "185m"],
+        "instrument": ["gcmd", "picarro"],
+        "domain": "EUROPE",
+        "fp_height": ["10m", "185m"],
+        "fp_model": "NAME",
+        "emissions_name": ["total-ukghg-edgar7"],
+        "averaging_period": ["1h", "1h"],
+    }
+    fp_all, *_ = data_processing_surface_notracer(**data_args)
+
+    # --- Make a "sectoral" fp_x_flux like your notebook did ---
+    fp_all_sectoral = fp_all.copy()
+    fp_all_sectoral[".flux"] = fp_all[".flux"].copy()
+    fp_all_sectoral[".flux"]["sector2"] = fp_all_sectoral[".flux"]["total-ukghg-edgar7"]
+
+    for k, v in fp_all_sectoral.items():
+        if str(k).startswith("."):
+            continue
+        ds = v["fp_x_flux"]
+        to_concat = [
+            ds.expand_dims({"source": ["total-ukghg-edgar7"]}),
+            ds.expand_dims({"source": ["sector2"]}),
+        ]
+        v["fp_x_flux_sectoral"] = xr.concat(to_concat, dim="source")
+
+    # --- Build two different basis partitions (ragged region counts) ---
+    weighted_basis_args_1 = {
+        "domain": "EUROPE",
+        "start_date": "2019-01-01",
+        "emissions_name": ["total-ukghg-edgar7"],
+        "nbasis": 20,
+    }
+    weighted_basis_args_2 = {
+        "domain": "EUROPE",
+        "start_date": "2019-01-01",
+        "emissions_name": ["sector2"],
+        "nbasis": 30,
+    }
+
+    basis1 = basis_functions["weighted"].algorithm(fp_all_sectoral, **weighted_basis_args_1)
+    basis2 = basis_functions["weighted"].algorithm(fp_all_sectoral, **weighted_basis_args_2)
+
+    basis_dict = {"total-ukghg-edgar7": basis1, "sector2": basis2}
+
+    # --- Old behaviour: fp_sensitivity pads to max(region) and introduces zero rows for missing regions ---
+    fp_old = fp_sensitivity(fp_all_sectoral.copy(), basis_func=basis_dict)
+    site = "MHD"
+    H_old = fp_old[site]["H"]  # (region=max, time, source)
+
+    # Convert old padded to gathered multiindex region and drop all-zero rows
+    H_old_gathered = convert_old_multisector_H_to_gathered(H_old)
+
+    # --- New behaviour
+    flux_dict = {k: v.data.flux for k, v in fp_all_sectoral[".flux"].items()}
+    multisector_bf = MultiSectorBasisFunctions(basis_flat=basis_dict, flux=flux_dict)
+
+    H_new_gathered = multisector_bf.sensitivity(fp_all_sectoral[site].fp_x_flux_sectoral)
+    xr.testing.assert_allclose(H_new_gathered, H_old_gathered)

--- a/tests/test_basis_functions.py
+++ b/tests/test_basis_functions.py
@@ -19,7 +19,6 @@ from openghg_inversions.basis.basis_functions import BasisFunctions
 from openghg_inversions.basis.operators import (
     BucketBasisOperator,
     MultiSourceBucketBasisOperator,
-    BasisOperator,
 )
 from openghg_inversions.basis._helpers import apply_fp_basis_functions, fp_sensitivity
 from openghg_inversions.inversion_data import data_processing_surface_notracer
@@ -36,6 +35,12 @@ from helpers import (
 
 
 def test_fp_x_flux(tac_ch4_data_args):
+    """Test that mean(fp) * mean(flux) is invariant to duplicating sites and shifting time coords.
+
+    This is a regression test for legacy preprocessing helpers `_flux_fp_from_fp_all` and
+    `_mean_fp_times_mean_flux`: changing site membership or time coordinates (without changing
+    values) should not change the mean footprint×flux product.
+    """
     fp_all, *_ = data_processing_surface_notracer(**tac_ch4_data_args)
     emissions_name = [next(iter(fp_all[".flux"].keys()))]
 
@@ -198,6 +203,18 @@ def test_fp_sensitivity_two_flux_sectors_two_basis_funcs():
 
 
 def test_basisfunctions_sensitivity_synthetic_matches_explicit_sum():
+    """Sensitivity on a tiny synthetic example matches explicit region-wise summation.
+
+    This is the most important unit-level correctness test for the new BasisOperator/BasisFunctions
+    pathway: it checks that the sensitivity (grid -> state) produced by the new code matches a
+    hand-computed result for a 2x2 grid with two regions.
+
+    Notes:
+        - The flux field is set to ones because sensitivity should depend only on the basis partition
+          (i.e. the operator / basis_matrix), not on flux weighting.
+        - Expected result is produced by `expected_H_from_basis_sum`, which explicitly sums fp_x_flux
+          over grid cells belonging to each region.
+    """
     # 2x2 grid, 3 times, basis has 2 regions: top row region 1, bottom row region 2
     basis = make_basis_flat_from_blocks([[1, 1], [2, 2]])
 
@@ -217,6 +234,18 @@ def test_basisfunctions_sensitivity_synthetic_matches_explicit_sum():
 
 
 def test_basisfunctions_sensitivity_synthetic_multisector_shared_basis():
+    """A single basis partition can be applied independently across multiple sources.
+
+    This reflects the common use case where footprints/flux are sectoral (have a `source` dimension),
+    but the spatial basis partition is shared across sectors.
+
+    The new `BasisFunctions.sensitivity` should:
+        - carry through the non-grid dimension `source`, and
+        - produce the same per-source sensitivity you would get by running the single-source
+          calculation separately for each source.
+
+    This is a regression guard for xarray broadcasting / dot behaviour.
+    """
     sources = ["A", "B"]
     basis = make_basis_flat_from_blocks([[1, 1], [2, 2]])
 
@@ -244,6 +273,14 @@ def test_basisfunctions_sensitivity_synthetic_multisector_shared_basis():
 
 
 def test_basisfunctions_sensitivity_regression_matches_legacy_like():
+    """Regression test: new sensitivity matches a simplified legacy implementation.
+
+    We compare:
+        - `BasisFunctions.sensitivity(fp_x_flux)` (new pathway using BasisOperator), vs
+        - `old_apply_fp_basis_functions_like(fp_x_flux, basis)` (a direct/legacy-style computation).
+
+    This test is intentionally small and synthetic to make failures easy to debug.
+    """
     basis = make_basis_flat_from_blocks([[1, 1], [2, 2]])
     fp_x_flux = make_fp_x_flux(nlat=2, nlon=2, ntime=4)
 
@@ -257,10 +294,14 @@ def test_basisfunctions_sensitivity_regression_matches_legacy_like():
 
 
 def test_synthetic_no_all_zero_state_rows_when_fp_positive_everywhere():
-    """Check that no columns are zero when fp x flux is positive.
+    """No all-zero state rows should appear when fp_x_flux is strictly positive.
 
-    This is more of an issue when using a dictionary of basis functions
-    to create multisector sensitivities.
+    This guards against a class of bugs that historically occurred when:
+        - using a dictionary of basis functions (sectoral / multi-source), and
+        - padding region dimensions to a common maximum region index.
+
+    In the new gathered/MultiIndex formulation, we should not introduce missing-region rows that are
+    entirely zero when the underlying footprint×flux field is strictly positive everywhere.
     """
     basis = make_basis_flat_from_blocks([[1, 1], [2, 2]])
     fp_x_flux = make_fp_x_flux(nlat=2, nlon=2, ntime=3, values=np.ones((2, 2, 3)))
@@ -276,6 +317,16 @@ def test_synthetic_no_all_zero_state_rows_when_fp_positive_everywhere():
 
 # @pytest.mark.slow
 def test_basisfunctions_sensitivity_matches_apply_fp_basis_functions_real_data():
+    """New sensitivity matches legacy `apply_fp_basis_functions` for real test-suite data.
+
+    This is a higher-level integration test:
+        - It uses `basis_functions_wrapper` to construct the legacy basis and compute H.
+        - It then reconstructs a `BasisFunctions` instance using the same basis and a representative
+          flux field, and verifies `BasisFunctions.sensitivity(ds.fp_x_flux)` matches the legacy H.
+
+    This guards against coordinate alignment, dimension ordering, and subtle differences in the
+    region-labelling conventions on real-world data.
+    """
     data_args = {
         "species": "ch4",
         "sites": ["MHD", "TAC"],
@@ -343,6 +394,23 @@ def test_basisfunctions_sensitivity_matches_apply_fp_basis_functions_real_data()
 
 # @pytest.mark.slow
 def test_multisector_ragged_new_matches_old_after_conversion():
+    """Ragged multi-source: new gathered H matches legacy padded H after conversion.
+
+    Historically, multi-sector sensitivities were represented as a padded array:
+        H_old(region=max_regions, time, source)
+    where missing regions for a given source were represented by all-zero rows.
+
+    The new MultiSourceBucketBasisOperator produces a gathered representation with a MultiIndex:
+        H_new(region=(source, region_in_source), time)
+
+    This test:
+        1) Computes the old padded H via `fp_sensitivity` with two different bases (ragged region counts).
+        2) Converts H_old -> gathered MultiIndex using `convert_old_multisector_H_to_gathered`.
+        3) Computes H_new with `BasisFunctions.from_multi_source_basis_flat(...).sensitivity(...)`.
+        4) Asserts equality.
+
+    This is the key equivalence test justifying the new MultiIndex-based operator.
+    """
     # --- Load test-suite data (same as notebook) ---
     data_args = {
         "species": "ch4",
@@ -452,6 +520,16 @@ def _make_simple_state_trace(
 # DataTree roundtrip tests for FluxWeightedBasis/BasisFunctions wrapper
 # --------------------------------------------------------------------------------------
 def test_basisfunctions_roundtrip_datatree_single_source():
+    """FluxWeightedBasis/BasisFunctions DataTree roundtrip for a single-source basis.
+
+    Ensures wrapper-level serialization is stable:
+        - `BasisFunctions.to_datatree()` stores operator metadata under group "basis"
+          (via `operator.to_datatree()`),
+        - stores flux under group "flux" with variable name "flux",
+        - and `BasisFunctions.from_datatree()` reconstructs an equivalent object.
+
+    We assert both flux and operator internals (basis_flat and basis_matrix) are identical.
+    """
     basis = make_basis_flat_from_blocks([[1, 1], [2, 2]])
     flux = xr.ones_like(basis, dtype=float).rename("flux")
 
@@ -467,6 +545,17 @@ def test_basisfunctions_roundtrip_datatree_single_source():
 
 
 def test_basisfunctions_roundtrip_datatree_multisource_flux_mapping():
+    """DataTree roundtrip for multi-source basis and flux supplied as a mapping.
+
+    This specifically exercises the constructor path where flux is provided as:
+        {"A": flux_A(lat, lon), "B": flux_B(lat, lon)}
+    which is concatenated into a single DataArray with a `source` dimension.
+
+    We then roundtrip through DataTree and check:
+        - operator type is MultiSourceBucketBasisOperator,
+        - basis_flat dict keys are preserved,
+        - basis_matrix and flux are identical.
+    """
     basis_a = make_basis_flat_from_blocks([[1, 1], [2, 2]])
     basis_b = make_basis_flat_from_blocks([[1, 2], [1, 2]])
     basis = {"A": basis_a, "B": basis_b}
@@ -498,6 +587,14 @@ def test_basisfunctions_roundtrip_datatree_multisource_flux_mapping():
 # Interpolate tests (wrapper-level): intended PyMC-like state traces
 # --------------------------------------------------------------------------------------
 def test_basisfunctions_interpolate_no_flux_weights_trace_dims_propagate():
+    """Interpolate a PyMC-like state trace to the grid (no flux weighting).
+
+    We construct a tiny state vector with dims (region, draw) to mimic posterior samples and verify:
+        - output dims are (lat, lon, draw),
+        - grid cells in a region take the corresponding region value for each draw.
+
+    This is a regression guard for dimension propagation and dot/broadcast behaviour.
+    """
     # Basis: top row region 0, bottom row region 1 (labels 1/2 -> regions 0/1)
     basis = make_basis_flat_from_blocks([[1, 1], [2, 2]])
     flux = xr.ones_like(basis, dtype=float)
@@ -523,6 +620,14 @@ def test_basisfunctions_interpolate_no_flux_weights_trace_dims_propagate():
 
 
 def test_basisfunctions_interpolate_with_flux_weights_trace_dims_propagate():
+    """Interpolate a PyMC-like state trace with flux-weighting.
+
+    This tests the common "state -> flux field" step:
+        flux_field(lat, lon, draw) = interpolate(state(region, draw), weights=flux(lat, lon))
+
+    Using a non-uniform flux field on a 2x2 grid makes it easy to verify that weighting is applied
+    correctly, not just that shapes line up.
+    """
     basis = make_basis_flat_from_blocks([[1, 1], [2, 2]])
 
     # Make flux non-uniform on the grid so we verify weighting actually occurs
@@ -548,6 +653,15 @@ def test_basisfunctions_interpolate_with_flux_weights_trace_dims_propagate():
 
 
 def test_basisfunctions_interpolate_trace_with_chain_dim():
+    """Interpolate a state trace that includes a `chain` dimension.
+
+    Many workflows keep posterior draws as (region, chain, draw). Even if in practice users often
+    select a single chain, we ensure that:
+        - chain is preserved as a non-dot dimension,
+        - results differ between chains when the input differs.
+
+    This guards against accidentally squeezing/dropping the chain dimension.
+    """
     basis = make_basis_flat_from_blocks([[1, 1], [2, 2]])
     flux = xr.ones_like(basis, dtype=float)
 
@@ -574,6 +688,18 @@ def test_basisfunctions_interpolate_trace_with_chain_dim():
 # Multi-source equivalence: gathered MultiIndex vs legacy padded H conversion
 # --------------------------------------------------------------------------------------
 def test_multisource_sensitivity_matches_legacy_padded_conversion_smoke():
+    """Smoke test: gathered multi-source sensitivity matches legacy padded->gathered conversion.
+
+    This test is intentionally simple (same basis for each source, small synthetic fp_x_flux) and
+    checks that:
+
+        H_new(region=(source, region_in_source), time)
+        ==
+        convert_old_multisector_H_to_gathered(H_old(region, time, source))
+
+    It provides quick feedback that the gathered/MultiIndex representation remains consistent with
+    older expectations, without requiring the heavier "ragged basis + real data" test.
+    """
     # Use small deterministic basis and footprints; simplest: same basis per source but different scaling.
     sources = ["A", "B"]
     basis = make_basis_flat_from_blocks([[1, 1], [2, 2]])

--- a/tests/test_basis_functions.py
+++ b/tests/test_basis_functions.py
@@ -251,6 +251,11 @@ def test_basisfunctions_sensitivity_regression_matches_legacy_like():
 
 
 def test_synthetic_no_all_zero_state_rows_when_fp_positive_everywhere():
+    """Check that no columns are zero when fp x flux is positive.
+
+    This is more of an issue when using a dictionary of basis functions
+    to create multisector sensitivities.
+    """
     basis = make_basis_flat_from_blocks([[1, 1], [2, 2]])
     fp_x_flux = make_fp_x_flux(nlat=2, nlon=2, ntime=3, values=np.ones((2, 2, 3)))
 

--- a/tests/test_basis_functions.py
+++ b/tests/test_basis_functions.py
@@ -115,8 +115,8 @@ def test_bucket_basis_function(tac_ch4_data_args, raw_data_path):
 
 
 def test_fixed_outer_region_basis_function(tac_ch4_data_args, raw_data_path):
-    """Check if fixed outer region basis created wtih seed 42 and TAC CH4 args matches
-    a basis created with the same argumenst and saved to file.
+    """Check if fixed outer region basis created with seed 42 and TAC CH4 args matches
+    a basis created with the same arguments and saved to file.
 
     This is to check against changes in the code from when this test was made
     (2 Sep 2024)

--- a/tests/test_basis_functions.py
+++ b/tests/test_basis_functions.py
@@ -15,7 +15,12 @@ from openghg_inversions.basis import (
     quadtreebasisfunction,
     fixed_outer_regions_basis,
 )
-from openghg_inversions.basis.basis_functions import BasisFunctions, MultiSectorBasisFunctions
+from openghg_inversions.basis.basis_functions import BasisFunctions
+from openghg_inversions.basis.operators import (
+    BucketBasisOperator,
+    MultiSourceBucketBasisOperator,
+    BasisOperator,
+)
 from openghg_inversions.basis._helpers import apply_fp_basis_functions, fp_sensitivity
 from openghg_inversions.inversion_data import data_processing_surface_notracer
 
@@ -202,7 +207,7 @@ def test_basisfunctions_sensitivity_synthetic_matches_explicit_sum():
     # but BasisFunctions requires flux; use ones
     flux = xr.ones_like(basis, dtype=float)
 
-    bf = BasisFunctions(basis_flat=basis, flux=flux)
+    bf = BasisFunctions.from_basis_flat(basis_flat=basis, flux=flux, operator_kwargs={"state_dim": "region"})
 
     H_new = bf.sensitivity(fp_x_flux)
 
@@ -218,7 +223,8 @@ def test_basisfunctions_sensitivity_synthetic_multisector_shared_basis():
     fp_x_flux_sectoral = make_fp_x_flux_sectoral(sources=sources, nlat=2, nlon=2, ntime=3)
 
     flux = xr.ones_like(basis, dtype=float)
-    bf = BasisFunctions(basis_flat=basis, flux=flux)
+
+    bf = BasisFunctions.from_basis_flat(basis_flat=basis, flux=flux, operator_kwargs={"state_dim": "region"})
 
     H = bf.sensitivity(fp_x_flux_sectoral)
 
@@ -242,7 +248,7 @@ def test_basisfunctions_sensitivity_regression_matches_legacy_like():
     fp_x_flux = make_fp_x_flux(nlat=2, nlon=2, ntime=4)
 
     flux = xr.ones_like(basis, dtype=float)
-    bf = BasisFunctions(basis_flat=basis, flux=flux)
+    bf = BasisFunctions.from_basis_flat(basis_flat=basis, flux=flux, operator_kwargs={"state_dim": "region"})
 
     H_new = bf.sensitivity(fp_x_flux)  # (region, time)
     H_old = old_apply_fp_basis_functions_like(fp_x_flux, basis)  # (region, time)
@@ -260,7 +266,7 @@ def test_synthetic_no_all_zero_state_rows_when_fp_positive_everywhere():
     fp_x_flux = make_fp_x_flux(nlat=2, nlon=2, ntime=3, values=np.ones((2, 2, 3)))
 
     flux = xr.ones_like(basis, dtype=float)
-    bf = BasisFunctions(basis_flat=basis, flux=flux)
+    bf = BasisFunctions.from_basis_flat(basis_flat=basis, flux=flux, operator_kwargs={"state_dim": "region"})
 
     H = bf.sensitivity(fp_x_flux)  # (region, time)
 
@@ -314,7 +320,10 @@ def test_basisfunctions_sensitivity_matches_apply_fp_basis_functions_real_data()
     flux_source = next(iter(fp_all_with_basis[".flux"].keys()))
     flux = fp_all_with_basis[".flux"][flux_source].data.flux
 
-    bf = BasisFunctions(basis_flat=fp_all_with_basis[".basis"], flux=flux)
+    # bf = BasisFunctions(basis_flat=fp_all_with_basis[".basis"], flux=flux)
+    bf = BasisFunctions.from_basis_flat(
+        basis_flat=fp_all_with_basis[".basis"], flux=flux, operator_kwargs={"state_dim": "region"}
+    )
     H_new = bf.sensitivity(ds.fp_x_flux)
 
     # Ensure same dim order for comparison
@@ -398,7 +407,209 @@ def test_multisector_ragged_new_matches_old_after_conversion():
 
     # --- New behaviour
     flux_dict = {k: v.data.flux for k, v in fp_all_sectoral[".flux"].items()}
-    multisector_bf = MultiSectorBasisFunctions(basis_flat=basis_dict, flux=flux_dict)
+
+    multisector_bf = BasisFunctions.from_multi_source_basis_flat(
+        basis_flat=basis_dict, flux=flux_dict, operator_kwargs={"state_dim": "region"}
+    )
 
     H_new_gathered = multisector_bf.sensitivity(fp_all_sectoral[site].fp_x_flux_sectoral)
     xr.testing.assert_allclose(H_new_gathered, H_old_gathered)
+
+
+def _make_simple_state_trace(
+    *,
+    region_dim: str = "region",
+    draw_dim: str = "draw",
+    chain_dim: str | None = None,
+    region_values: list[float] = [10.0, 100.0],
+    draw_values: list[int] = [0, 1, 2],
+) -> xr.DataArray:
+    """Make a tiny deterministic PyMC-like trace array for interpolate tests."""
+    state = xr.DataArray(
+        np.asarray(region_values, dtype=float),
+        dims=(region_dim,),
+        coords={region_dim: np.arange(len(region_values))},
+        name="state",
+    )
+
+    draws = xr.DataArray(np.asarray(draw_values, dtype=int), dims=(draw_dim,), name=draw_dim)
+    state = state.expand_dims({draw_dim: draws})
+
+    # Make draws vary slightly so we catch broadcasting issues.
+    # region r has values region_values[r] + draw
+    state = state + xr.DataArray(np.asarray(draw_values, dtype=float), dims=(draw_dim,))
+
+    if chain_dim is not None:
+        chain = xr.DataArray(np.asarray([0, 1], dtype=int), dims=(chain_dim,), name=chain_dim)
+        state = state.expand_dims({chain_dim: chain})
+        # Make chain 1 different to catch chain propagation.
+        state = state + xr.DataArray(np.asarray([0.0, 1000.0]), dims=(chain_dim,))
+
+    return state
+
+
+# --------------------------------------------------------------------------------------
+# DataTree roundtrip tests for FluxWeightedBasis/BasisFunctions wrapper
+# --------------------------------------------------------------------------------------
+def test_basisfunctions_roundtrip_datatree_single_source():
+    basis = make_basis_flat_from_blocks([[1, 1], [2, 2]])
+    flux = xr.ones_like(basis, dtype=float).rename("flux")
+
+    bf = BasisFunctions.from_basis_flat(basis_flat=basis, flux=flux, operator_kwargs={"state_dim": "region"})
+
+    dt = bf.to_datatree()
+    bf2 = BasisFunctions.from_datatree(dt)
+
+    assert isinstance(bf2.operator, BucketBasisOperator)
+    xr.testing.assert_identical(bf2.flux, bf.flux)
+    xr.testing.assert_identical(bf2.operator.basis_flat, bf.operator.basis_flat)
+    xr.testing.assert_identical(bf2.operator.basis_matrix, bf.operator.basis_matrix)
+
+
+def test_basisfunctions_roundtrip_datatree_multisource_flux_mapping():
+    basis_a = make_basis_flat_from_blocks([[1, 1], [2, 2]])
+    basis_b = make_basis_flat_from_blocks([[1, 2], [1, 2]])
+    basis = {"A": basis_a, "B": basis_b}
+
+    # Exercise the mapping->concat codepath
+    flux_a = xr.ones_like(basis_a, dtype=float) * 1.0
+    flux_b = xr.ones_like(basis_b, dtype=float) * 2.0
+    flux = {"A": flux_a.rename("flux"), "B": flux_b.rename("flux")}
+
+    bf = BasisFunctions.from_multi_source_basis_flat(
+        basis_flat=basis, flux=flux, operator_kwargs={"state_dim": "region"}
+    )
+    assert "source" in bf.flux.dims
+    xr.testing.assert_allclose(bf.flux.sel(source="A", drop=True), flux_a)
+    xr.testing.assert_allclose(bf.flux.sel(source="B", drop=True), flux_b)
+
+    dt = bf.to_datatree()
+    bf2 = BasisFunctions.from_datatree(dt)
+
+    assert isinstance(bf2.operator, MultiSourceBucketBasisOperator)
+    assert set(bf2.operator.basis_flat.keys()) == {"A", "B"}
+    xr.testing.assert_identical(bf2.flux, bf.flux)
+    xr.testing.assert_identical(bf2.operator.basis_matrix, bf.operator.basis_matrix)
+    for k in bf.operator.basis_flat:
+        xr.testing.assert_identical(bf2.operator.basis_flat[k], bf.operator.basis_flat[k])
+
+
+# --------------------------------------------------------------------------------------
+# Interpolate tests (wrapper-level): intended PyMC-like state traces
+# --------------------------------------------------------------------------------------
+def test_basisfunctions_interpolate_no_flux_weights_trace_dims_propagate():
+    # Basis: top row region 0, bottom row region 1 (labels 1/2 -> regions 0/1)
+    basis = make_basis_flat_from_blocks([[1, 1], [2, 2]])
+    flux = xr.ones_like(basis, dtype=float)
+
+    bf = BasisFunctions.from_basis_flat(basis_flat=basis, flux=flux, operator_kwargs={"state_dim": "region"})
+
+    state = _make_simple_state_trace(region_dim="region", draw_dim="draw", chain_dim=None)
+
+    out = bf.interpolate(state, flux=False)
+    assert set(out.dims) == {"lat", "lon", "draw"}
+
+    # Expected: top row gets region 0 value, bottom row gets region 1 value
+    # region 0 base=10, region 1 base=100, plus draw offset
+    expected_top = xr.DataArray(np.asarray([10.0, 11.0, 12.0]), dims=("draw",), coords={"draw": state.draw})
+    expected_bottom = xr.DataArray(
+        np.asarray([100.0, 101.0, 102.0]), dims=("draw",), coords={"draw": state.draw}
+    )
+
+    xr.testing.assert_allclose(out.sel(lat=0, lon=0, drop=True), expected_top)
+    xr.testing.assert_allclose(out.sel(lat=0, lon=1, drop=True), expected_top)
+    xr.testing.assert_allclose(out.sel(lat=1, lon=0, drop=True), expected_bottom)
+    xr.testing.assert_allclose(out.sel(lat=1, lon=1, drop=True), expected_bottom)
+
+
+def test_basisfunctions_interpolate_with_flux_weights_trace_dims_propagate():
+    basis = make_basis_flat_from_blocks([[1, 1], [2, 2]])
+
+    # Make flux non-uniform on the grid so we verify weighting actually occurs
+    flux_values = np.asarray([[1.0, 2.0], [3.0, 4.0]])
+    flux = xr.DataArray(flux_values, coords=basis.coords, dims=basis.dims, name="flux")
+
+    bf = BasisFunctions.from_basis_flat(basis_flat=basis, flux=flux, operator_kwargs={"state_dim": "region"})
+
+    state = _make_simple_state_trace(region_dim="region", draw_dim="draw", chain_dim=None)
+
+    out = bf.interpolate(state, flux=True)
+    assert set(out.dims) == {"lat", "lon", "draw"}
+
+    # Expected: out(lat,lon,draw) = state(region,draw) * flux(lat,lon) for the region covering that cell
+    # Top row uses region 0, bottom row uses region 1.
+    region0 = xr.DataArray(np.asarray([10.0, 11.0, 12.0]), dims=("draw",), coords={"draw": state.draw})
+    region1 = xr.DataArray(np.asarray([100.0, 101.0, 102.0]), dims=("draw",), coords={"draw": state.draw})
+
+    xr.testing.assert_allclose(out.sel(lat=0, lon=0, drop=True), region0 * 1.0)
+    xr.testing.assert_allclose(out.sel(lat=0, lon=1, drop=True), region0 * 2.0)
+    xr.testing.assert_allclose(out.sel(lat=1, lon=0, drop=True), region1 * 3.0)
+    xr.testing.assert_allclose(out.sel(lat=1, lon=1, drop=True), region1 * 4.0)
+
+
+def test_basisfunctions_interpolate_trace_with_chain_dim():
+    basis = make_basis_flat_from_blocks([[1, 1], [2, 2]])
+    flux = xr.ones_like(basis, dtype=float)
+
+    bf = BasisFunctions.from_basis_flat(basis_flat=basis, flux=flux, operator_kwargs={"state_dim": "region"})
+
+    state = _make_simple_state_trace(region_dim="region", draw_dim="draw", chain_dim="chain")
+
+    out = bf.interpolate(state, flux=False)
+    assert set(out.dims) == {"lat", "lon", "draw", "chain"}
+
+    # Spot-check one cell per region, both chains.
+    # chain=0: region0=10+draw, region1=100+draw
+    # chain=1: +1000
+    expected_region0_chain0 = xr.DataArray(
+        np.asarray([10.0, 11.0, 12.0]), dims=("draw",), coords={"draw": state.draw}
+    )
+    expected_region0_chain1 = expected_region0_chain0 + 1000.0
+
+    xr.testing.assert_allclose(out.sel(lat=0, lon=0, chain=0, drop=True), expected_region0_chain0)
+    xr.testing.assert_allclose(out.sel(lat=0, lon=0, chain=1, drop=True), expected_region0_chain1)
+
+
+# --------------------------------------------------------------------------------------
+# Multi-source equivalence: gathered MultiIndex vs legacy padded H conversion
+# --------------------------------------------------------------------------------------
+def test_multisource_sensitivity_matches_legacy_padded_conversion_smoke():
+    # Use small deterministic basis and footprints; simplest: same basis per source but different scaling.
+    sources = ["A", "B"]
+    basis = make_basis_flat_from_blocks([[1, 1], [2, 2]])
+    basis_by_source = {s: basis for s in sources}
+
+    fp_x_flux_sectoral = make_fp_x_flux_sectoral(sources=sources, nlat=2, nlon=2, ntime=3)
+    flux = xr.ones_like(basis, dtype=float)
+
+    # New gathered H: MultiSourceBucketBasisOperator under the wrapper
+    bf = BasisFunctions.from_multi_source_basis_flat(
+        basis_flat=basis_by_source, flux=flux, operator_kwargs={"state_dim": "region"}
+    )
+    H_new = bf.sensitivity(fp_x_flux_sectoral)
+
+    # Construct a legacy-like padded H_old(region=max_regions, time, source) by computing each source separately
+    # with the single-source basis and then padding to the maximum region count (here identical counts).
+    H_pieces = []
+    for s in sources:
+        Hs = expected_H_from_basis_sum(
+            fp_x_flux_sectoral.sel(source=s), basis, region_dim="region"
+        )  # (region,time)
+        H_pieces.append(Hs.expand_dims(source=[s]))
+    H_old = xr.concat(H_pieces, dim="source").transpose("region", "time", "source")
+
+    # Convert legacy padded -> gathered MultiIndex and compare (up to ordering)
+    H_old_gathered = convert_old_multisector_H_to_gathered(
+        H_old,
+        source_dim="source",
+        region_dim="region",
+        gathered_dim="region",
+        source_region_dim="region_in_source",
+    )
+
+    # The new operator returns region as a MultiIndex; order should match source-major stacking.
+    # Ensure both are in a comparable order.
+    H_new = H_new.transpose("region", "time")
+    H_old_gathered = H_old_gathered.transpose("region", "time")
+
+    xr.testing.assert_allclose(H_new, H_old_gathered)

--- a/tests/test_basis_operators.py
+++ b/tests/test_basis_operators.py
@@ -1,0 +1,49 @@
+import pytest
+import xarray as xr
+
+from openghg_inversions.basis.operators import (
+    BucketBasisOperator,
+    MultiSourceBucketBasisOperator,
+    BasisOperator,
+)
+
+from helpers import basis_function
+
+
+@pytest.fixture
+def basis_func():
+    nlat, nlon = 10, 12
+    nbasis = 3
+    return basis_function(nlat, nlon, nbasis)
+
+
+@pytest.fixture
+def basis_func2():
+    nlat, nlon = 10, 12
+    nbasis = 7
+    return basis_function(nlat, nlon, nbasis)
+
+
+def test_bucket_basis_operator_roundtrip_datatree(basis_func):
+    op = BucketBasisOperator(basis_func, state_dim="state")
+    dt = op.to_datatree()
+    op2 = BasisOperator.decode_datatree(dt)
+
+    assert isinstance(op2, BucketBasisOperator)
+    xr.testing.assert_identical(op2.basis_flat, op.basis_flat)
+    xr.testing.assert_identical(op2.basis_matrix, op.basis_matrix)
+
+
+def test_multisource_basis_operator_roundtrip_datatree(basis_func, basis_func2):
+    basis = {"a": basis_func, "b": basis_func2}
+    op = MultiSourceBucketBasisOperator(basis, state_dim="state")
+    dt = op.to_datatree()
+    op2 = BasisOperator.decode_datatree(dt)
+
+    assert isinstance(op2, MultiSourceBucketBasisOperator)
+    assert set(op2.basis_flat) == set(op.basis_flat)
+
+    xr.testing.assert_identical(op2.basis_matrix, op.basis_matrix)
+
+    for k in op.basis_flat:
+        xr.testing.assert_identical(op2.basis_flat[k], op.basis_flat[k])

--- a/tests/test_basis_operators.py
+++ b/tests/test_basis_operators.py
@@ -47,3 +47,16 @@ def test_multisource_basis_operator_roundtrip_datatree(basis_func, basis_func2):
 
     for k in op.basis_flat:
         xr.testing.assert_identical(op2.basis_flat[k], op.basis_flat[k])
+
+
+# --------------------------------------------------------------------------------------
+# Canonical dim name test: do not bake in "region"
+# --------------------------------------------------------------------------------------
+def test_bucket_basis_operator_roundtrip_preserves_default_state_dim():
+    basis = basis_function(6, 5, 3)
+    op = BucketBasisOperator(basis, state_dim="state")
+    dt = op.to_datatree()
+    op2 = BasisOperator.decode_datatree(dt)
+
+    assert op2.meta.state_dim == "state"
+    assert "state" in op2.basis_matrix.dims

--- a/tests/test_basis_operators.py
+++ b/tests/test_basis_operators.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 import xarray as xr
 
@@ -60,3 +61,105 @@ def test_bucket_basis_operator_roundtrip_preserves_default_state_dim():
 
     assert op2.meta.state_dim == "state"
     assert "state" in op2.basis_matrix.dims
+
+
+# --------------------------------------------------------------------------------------
+# Test interpolation for MultiSourceBucketBasisOperator
+# --------------------------------------------------------------------------------------
+
+def _make_multisource_operator_for_broadcast_tests(state_dim: str = "state") -> MultiSourceBucketBasisOperator:
+    """Create a tiny multisource operator with ragged per-source region counts.
+
+    Source A has 2 regions; source B has 1 region.
+    """
+    basis_a = xr.DataArray(
+        np.array([[1, 2], [1, 2]], dtype=int),
+        dims=("lat", "lon"),
+        coords={"lat": [0, 1], "lon": [0, 1]},
+        name="basis_flat",
+    )
+    basis_b = xr.DataArray(
+        np.array([[1, 1], [1, 1]], dtype=int),
+        dims=("lat", "lon"),
+        coords={"lat": [0, 1], "lon": [0, 1]},
+        name="basis_flat",
+    )
+    return MultiSourceBucketBasisOperator({"A": basis_a, "B": basis_b}, state_dim=state_dim)
+
+
+def _state_for_operator(op: MultiSourceBucketBasisOperator, values: list[float], name: str = "state") -> xr.DataArray:
+    """Create a state(state) vector matching the operator's gathered MultiIndex order."""
+    state_index = op.basis_matrix[op.meta.state_dim]
+    if len(values) != state_index.size:
+        raise ValueError("values must match gathered state size")
+
+    return xr.DataArray(
+        np.asarray(values, dtype=float),
+        dims=(op.meta.state_dim,),
+        coords={op.meta.state_dim: state_index},
+        name=name,
+    )
+
+
+def test_multisource_interpolate_broadcasts_weights_source_to_state():
+    """weights(source, lat, lon) should broadcast onto gathered state(source, region_in_source)."""
+    op = _make_multisource_operator_for_broadcast_tests(state_dim="state")
+
+    # State order is source-major: (A, r1), (A, r2), (B, r1)
+    # For basis defined above:
+    # - A r1 covers left column, A r2 covers right column, B r1 covers entire grid.
+    state = _state_for_operator(op, [10.0, 100.0, 1000.0], name="x")
+
+    # weights differ by source, so broadcasting/alignment matters
+    weights = xr.DataArray(
+        np.stack([np.ones((2, 2), dtype=float) * 2.0, np.ones((2, 2), dtype=float) * 3.0], axis=0),
+        dims=("source", "lat", "lon"),
+        coords={"source": ["A", "B"], "lat": [0, 1], "lon": [0, 1]},
+        name="weights",
+    )
+
+    out = op.interpolate(state, weights=weights)
+    assert set(out.dims) == {"lat", "lon"}
+
+    expected = xr.DataArray(
+        np.array([[10.0 * 2.0 + 1000.0 * 3.0, 100.0 * 2.0 + 1000.0 * 3.0],
+                  [10.0 * 2.0 + 1000.0 * 3.0, 100.0 * 2.0 + 1000.0 * 3.0]], dtype=float),
+        dims=("lat", "lon"),
+        coords={"lat": [0, 1], "lon": [0, 1]},
+        name=out.name,
+    )
+
+    xr.testing.assert_allclose(out, expected)
+
+
+def test_multisource_interpolate_broadcasts_weights_source_with_nontrivial_values():
+    """Second check: per-source weights and per-region states combine correctly."""
+    op = _make_multisource_operator_for_broadcast_tests(state_dim="state")
+
+    # Make A regions different, B different, to ensure ordering is respected.
+    state_array = _state_for_operator(op, [1.0, 10.0, 100.0], name="x")
+
+    # A weights=5, B weights=7
+    weights = xr.DataArray(
+        np.stack([np.ones((2, 2), dtype=float) * 5.0, np.ones((2, 2), dtype=float) * 7.0], axis=0),
+        dims=("source", "lat", "lon"),
+        coords={"source": ["A", "B"], "lat": [0, 1], "lon": [0, 1]},
+        name="weights",
+    )
+
+    out = op.interpolate(state_array, weights=weights)
+
+    expected = xr.DataArray(
+        np.array(
+            [
+                [1.0 * 5.0 + 100.0 * 7.0, 10.0 * 5.0 + 100.0 * 7.0],
+                [1.0 * 5.0 + 100.0 * 7.0, 10.0 * 5.0 + 100.0 * 7.0],
+            ],
+            dtype=float,
+        ),
+        dims=("lat", "lon"),
+        coords={"lat": [0, 1], "lon": [0, 1]},
+        name=out.name,
+    )
+
+    xr.testing.assert_allclose(out, expected)


### PR DESCRIPTION
* **Summary of changes**

This PR adds a `BasisFunctions` object, which packages the code for converting flat basis functions into "dummy matrices" that are used to compute sensitivities. The idea here is that we can have many different types of basis functions, and the corresponding class just needs to provide a `.sensitivity` method for computing the H matrix from `fp_x_flux`.

This will make it easier to add the multi-sector code with minimal differences in the basis functions workflow.

Notes: 
- this PR doesn't change any existing functionality, it just adds some new classes and functions, and checks that the new `BasisFunctions.sensitivity` method matches the output of the helpers currently used to apply basis functions to create H matrices.
- some helper functions have been moved from `inversion_inputs.py` to `array_ops.py`
- the `BasisOperator` subclasses in `basis/operators.py` contain the logic for creating basis matrices out of the flat basis arrays produced by the quadtree and bucket basis algorithms. For `MultiSourceBucketBasisOperator`, you can supply a dictionary of flat basis arrays, and these will be converted into a suitable basis matrix. This is the main reason for introducing this `BasisOperator` class: to allow the logic for single flux and multi-source/sector inversions to be separate.
- the `BasisFunctions` class in `basis/basis_fuctions.py` adds extra methods like plotting and "interpolating" back from the regions where we solve for scaling factors to the original lat/lon grid. Eventually, I will add methods to adjust prior covariances with the basis functions, and to output aggregation error.
- The `BasisFunctions` class is just an alias of a class called `FluxWeightedBasis`; the latter name is more precise, but I think `BasisFunctions` is more user-friendly.
- The `BasisFunctions` and `BasisOperator` classes have `to_datatree` and `from_datatree` methods that can be used to save the operator or basis functions, or combine them with other xarray data. The `xr.DataTree` format makes it possible to store multiple flat basis function arrays, needed for the multi-sector case.

* **Please check if the PR fulfills these requirements**

- Closes #xxxx (Replace xxxx with the Github issue number)
- [x] Tests added and passing
- [x] Documentation and tutorials updated/added (docstrings for all functions/modules added)
- [x] Added an entry to the `CHANGELOG.md` file
- Added any new requirements to `requirements.txt`
