### PR TITLE
Reproduce legacy hbmcmc output format with new post-processing

### DIFF
--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -229,7 +229,7 @@ def fixedbasisMCMC(
     calculate_min_error: Literal["percentile", "residual"] | None = None,
     min_error_options: dict | None = None,
     output_format: Literal[
-        "hbmcmc", "paris", "basic", "merged_data", "inv_out", "mcmc_args", "mcmc_results"
+        "hbmcmc", "hbmcmc_postprocessing", "paris", "basic", "merged_data", "inv_out", "mcmc_args", "mcmc_results"
     ] = "hbmcmc",
     paris_postprocessing: bool = False,
     paris_postprocessing_kwargs: dict | None = None,
@@ -347,6 +347,8 @@ def fixedbasisMCMC(
             error (as specified by `min_error`).
         output_format: Select what is returned/saved by inversion.
             - "hbmcmc": (default) return the results of `inferpymc_postprocessouts`, and save result as netCDF
+            - "hbmcmc_postprocessing": return legacy-style output format, computed using functions from the
+              `postprocessing` submodule
             - "merged_data": return `fp_all` dictionary, no further processing and inversion *not* run
             - "inv_out": return `InversionOutput` object
             - "basic": return basic output created by new `postprocessing` submodule
@@ -365,6 +367,7 @@ def fixedbasisMCMC(
     merged_data_only = False
     return_inv_out = False
     new_postprocessing = False
+    hbmcmc_postprocessing = False
     paris_postprocessing = False
     return_mcmc_args = False
     skip_postprocessing = False
@@ -383,6 +386,8 @@ def fixedbasisMCMC(
         return_inv_out = True
     elif output_format == "basic":
         new_postprocessing = True
+    elif output_format == "hbmcmc_postprocessing":
+        hbmcmc_postprocessing = True
     elif output_format == "paris":
         paris_postprocessing = True
     elif output_format == "mcmc_args":
@@ -669,6 +674,24 @@ def fixedbasisMCMC(
         inv_out = make_inv_out_for_fixed_basis_mcmc(**inv_out_args)
 
         outputs = basic_output(inv_out, country_file=country_file)
+        end_post = time.time()
+        print(f"Post processing Complete. Time taken = {end_post - start_post:.2f} seconds")
+
+        return outputs
+
+    if hbmcmc_postprocessing:
+        from ..postprocessing.make_outputs import make_legacy_hbmcmc_output_from_postprocessing
+
+        inv_out = make_inv_out_for_fixed_basis_mcmc(**inv_out_args)
+        outputs = make_legacy_hbmcmc_output_from_postprocessing(
+            inv_out=inv_out,
+            mcmc_results=mcmc_results,
+            sigma_freq_index=post_process_args["sigma_freq_index"],
+            Hx=post_process_args["Hx"],
+            Hbc=post_process_args.get("Hbc"),
+            country_file=country_file,
+            use_bc=use_bc,
+        )
         end_post = time.time()
         print(f"Post processing Complete. Time taken = {end_post - start_post:.2f} seconds")
 

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -352,7 +352,7 @@ def fixedbasisMCMC(
     return_inv_out = False
     new_postprocessing = False
     hbmcmc_postprocessing = False
-    paris_postprocessing = False
+    do_paris_postprocessing = False
     return_mcmc_args = False
     skip_postprocessing = False
 
@@ -373,7 +373,7 @@ def fixedbasisMCMC(
     elif output_format == "hbmcmc_postprocessing":
         hbmcmc_postprocessing = True
     elif output_format == "paris":
-        paris_postprocessing = True
+        do_paris_postprocessing = True
     elif output_format == "mcmc_args":
         return_mcmc_args = True
     elif output_format == "mcmc_results":
@@ -686,7 +686,7 @@ def fixedbasisMCMC(
 
         return outputs
 
-    if paris_postprocessing:
+    if do_paris_postprocessing:
         from openghg_inversions.hbmcmc.hbmcmc_output import define_output_filename
 
         from openghg_inversions.postprocessing.make_paris_outputs import make_paris_outputs

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -680,10 +680,10 @@ def fixedbasisMCMC(
         return outputs
 
     if hbmcmc_postprocessing:
-        from ..postprocessing.make_outputs import make_legacy_hbmcmc_output_from_postprocessing
+        from ..postprocessing.legacy_outputs import make_legacy_hbmcmc_output
 
         inv_out = make_inv_out_for_fixed_basis_mcmc(**inv_out_args)
-        outputs = make_legacy_hbmcmc_output_from_postprocessing(
+        outputs = make_legacy_hbmcmc_output(
             inv_out=inv_out,
             mcmc_results=mcmc_results,
             sigma_freq_index=post_process_args["sigma_freq_index"],

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -680,6 +680,8 @@ def fixedbasisMCMC(
         return outputs
 
     if hbmcmc_postprocessing:
+        from openghg_inversions.hbmcmc.hbmcmc_output import define_output_filename
+
         from ..postprocessing.legacy_outputs import make_legacy_hbmcmc_output
 
         inv_out = make_inv_out_for_fixed_basis_mcmc(**inv_out_args)
@@ -692,6 +694,9 @@ def fixedbasisMCMC(
             country_file=country_file,
             use_bc=use_bc,
         )
+        output_filename = define_output_filename(outputpath, species, domain, outputname, start_date, ext=".nc")
+        Path(outputpath).mkdir(parents=True, exist_ok=True)
+        outputs.to_netcdf(output_filename, encoding=ncdf_encoding(outputs), mode="w")
         end_post = time.time()
         print(f"Post processing Complete. Time taken = {end_post - start_post:.2f} seconds")
 

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -465,6 +465,22 @@ def _weighted_apriori_flux_for_months(flux_array_all: np.ndarray, month_index: n
     return apriori_flux
 
 
+def _map_times_to_available_month_positions(times: np.ndarray, available_times: np.ndarray) -> np.ndarray:
+    """Map timestamps onto contiguous month positions defined by available flux periods."""
+    time_periods = pd.to_datetime(times).to_period("M")
+    available_periods = pd.Index(pd.to_datetime(available_times).to_period("M").unique())
+
+    if len(time_periods) == 0:
+        return np.array([], dtype=int)
+
+    missing = pd.Index(time_periods).difference(available_periods)
+    if len(missing) > 0:
+        raise ValueError(f"Observation months {list(missing.astype(str))} are missing from available flux periods.")
+
+    period_positions = {period: idx for idx, period in enumerate(available_periods)}
+    return np.array([period_positions[period] for period in time_periods], dtype=int)
+
+
 # ----------------------------------------
 # Model building code
 # ----------------------------------------
@@ -1060,11 +1076,18 @@ def inferpymc_postprocessouts(
 
     if rerun_file is not None:
         flux_array_all = np.expand_dims(rerun_file.fluxapriori.values, 2)
+        flux_time_values = None
     elif emissions_name is None:
         raise ValueError("Emissions name not provided.")
     else:
         emds = fp_data[".flux"][emissions_name[0]]
         flux_array_all = emds.data.flux.values
+        if "time" in emds.data.flux.coords:
+            flux_time_values = emds.data.flux["time"].values
+        elif "flux_time" in emds.data.flux.coords:
+            flux_time_values = emds.data.flux["flux_time"].values
+        else:
+            flux_time_values = None
 
     # HACK: assume that smallest flux dim is time, then re-order flux so that
     # time is the last coordinate
@@ -1081,7 +1104,9 @@ def inferpymc_postprocessouts(
     else:
         print("\nAssuming flux prior is monthly.")
         print(f"Extracting weighted average flux prior from {start_date} to {end_date}")
-        month_index = pd.to_datetime(Ytime).month.values - 1
+        if flux_time_values is None:
+            raise ValueError("Monthly flux prior requires time coordinates on the flux data.")
+        month_index = _map_times_to_available_month_positions(Ytime, flux_time_values)
         apriori_flux = _weighted_apriori_flux_for_months(flux_array_all, month_index)
 
     flux = scalemap_mode * apriori_flux

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -434,6 +434,16 @@ def _restore_inferencedata_coords(
     return idata
 
 
+def _contiguous_index(index: np.ndarray) -> np.ndarray:
+    """Remap integer period indices to contiguous 0..N-1 values."""
+    index = np.asarray(index, dtype=int)
+    if index.size == 0:
+        return index
+
+    uniq = np.unique(index)
+    return np.searchsorted(uniq, index).astype(int)
+
+
 def _contiguous_sigma_time_index(sigma_freq_index: np.ndarray) -> np.ndarray:
     """Remap sigma period indices to contiguous 0..N-1 values.
 
@@ -441,12 +451,18 @@ def _contiguous_sigma_time_index(sigma_freq_index: np.ndarray) -> np.ndarray:
     data (e.g. Jan and Mar only => [0, 2]). PyMC array indexing is positional, so
     these values must be compacted before using `sigma[..., sigma_freq_index]`.
     """
-    sigma_freq_index = np.asarray(sigma_freq_index, dtype=int)
-    if sigma_freq_index.size == 0:
-        return sigma_freq_index
+    return _contiguous_index(sigma_freq_index)
 
-    uniq = np.unique(sigma_freq_index)
-    return np.searchsorted(uniq, sigma_freq_index).astype(int)
+
+def _weighted_apriori_flux_for_months(flux_array_all: np.ndarray, month_index: np.ndarray) -> np.ndarray:
+    """Compute a weighted prior flux average using compacted month positions."""
+    month_index = _contiguous_index(month_index)
+    apriori_flux = np.zeros_like(flux_array_all[:, :, 0])
+
+    for month_pos in np.unique(month_index):
+        apriori_flux += flux_array_all[:, :, month_pos] * np.sum(month_index == month_pos) / len(month_index)
+
+    return apriori_flux
 
 
 # ----------------------------------------
@@ -1065,14 +1081,8 @@ def inferpymc_postprocessouts(
     else:
         print("\nAssuming flux prior is monthly.")
         print(f"Extracting weighted average flux prior from {start_date} to {end_date}")
-        allmonths = pd.date_range(start_date, end_date).month[:-1].values
-        allmonths -= 1  # to align with zero indexed array
-
-        apriori_flux = np.zeros_like(flux_array_all[:, :, 0])
-
-        # calculate the weighted average flux across the whole inversion period
-        for m in np.unique(allmonths):
-            apriori_flux += flux_array_all[:, :, m] * np.sum(allmonths == m) / len(allmonths)
+        month_index = pd.to_datetime(Ytime).month.values - 1
+        apriori_flux = _weighted_apriori_flux_for_months(flux_array_all, month_index)
 
     flux = scalemap_mode * apriori_flux
 

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -465,22 +465,6 @@ def _weighted_apriori_flux_for_months(flux_array_all: np.ndarray, month_index: n
     return apriori_flux
 
 
-def _map_times_to_available_month_positions(times: np.ndarray, available_times: np.ndarray) -> np.ndarray:
-    """Map timestamps onto contiguous month positions defined by available flux periods."""
-    time_periods = pd.to_datetime(times).to_period("M")
-    available_periods = pd.Index(pd.to_datetime(available_times).to_period("M").unique())
-
-    if len(time_periods) == 0:
-        return np.array([], dtype=int)
-
-    missing = pd.Index(time_periods).difference(available_periods)
-    if len(missing) > 0:
-        raise ValueError(f"Observation months {list(missing.astype(str))} are missing from available flux periods.")
-
-    period_positions = {period: idx for idx, period in enumerate(available_periods)}
-    return np.array([period_positions[period] for period in time_periods], dtype=int)
-
-
 # ----------------------------------------
 # Model building code
 # ----------------------------------------
@@ -1102,11 +1086,15 @@ def inferpymc_postprocessouts(
         print("\nAssuming flux prior is annual and extracting first index of flux array.")
         apriori_flux = flux_array_all[:, :, 0]
     else:
-        print("\nAssuming flux prior is monthly.")
-        print(f"Extracting weighted average flux prior from {start_date} to {end_date}")
         if flux_time_values is None:
-            raise ValueError("Monthly flux prior requires time coordinates on the flux data.")
-        month_index = _map_times_to_available_month_positions(Ytime, flux_time_values)
+            raise ValueError("Time-varying flux prior requires time coordinates on the flux data.")
+        flux_period = utils._infer_flux_period(
+            flux_time_values,
+            getattr(emds.data.flux, "attrs", {}).get("time_period") if rerun_file is None else None,
+        )
+        print(f"\nAssuming flux prior is {flux_period}.")
+        print(f"Extracting weighted average flux prior from {start_date} to {end_date}")
+        month_index = utils._map_times_to_available_period_positions(Ytime, flux_time_values, flux_period)
         apriori_flux = _weighted_apriori_flux_for_months(flux_array_all, month_index)
 
     flux = scalemap_mode * apriori_flux

--- a/openghg_inversions/postprocessing/inversion_output.py
+++ b/openghg_inversions/postprocessing/inversion_output.py
@@ -605,8 +605,16 @@ class InversionOutput:
             InversionOutput loaded from saved file
 
         """
-        dt = xr.open_datatree(file_path)
-        return cls.from_datatree(dt)
+        open_errors: list[Exception] = []
+        for engine in ("h5netcdf", None):
+            try:
+                dt = xr.open_datatree(file_path, engine=engine) if engine is not None else xr.open_datatree(file_path)
+            except (OSError, RuntimeError, ValueError) as exc:
+                open_errors.append(exc)
+            else:
+                return cls.from_datatree(dt)
+
+        raise open_errors[-1]
 
 
 def make_inv_out_for_fixed_basis_mcmc(

--- a/openghg_inversions/postprocessing/legacy_outputs.py
+++ b/openghg_inversions/postprocessing/legacy_outputs.py
@@ -1,0 +1,235 @@
+"""Legacy-format output adapters built on top of postprocessing helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import xarray as xr
+
+from openghg_inversions import utils
+from openghg_inversions.postprocessing.inversion_output import InversionOutput
+from openghg_inversions.postprocessing.make_outputs import (
+    make_concentration_outputs,
+    make_country_outputs,
+    make_flux_outputs,
+)
+
+
+def _set_legacy_var_attrs(ds: xr.Dataset, obs_units: str, country_units: str, use_bc: bool) -> None:
+    """Set variable attrs to match legacy hbmcmc output style."""
+    units = {
+        "fluxmode": "mol/m2/s",
+        "fluxapriori": "mol/m2/s",
+        "Yobs": f"{obs_units} mol/mol",
+        "Yerror": f"{obs_units} mol/mol",
+        "Yerror_repeatability": f"{obs_units} mol/mol",
+        "Yerror_variability": f"{obs_units} mol/mol",
+        "Yapriori": f"{obs_units} mol/mol",
+        "Ymodmean": f"{obs_units} mol/mol",
+        "Ymodmedian": f"{obs_units} mol/mol",
+        "Ymodmode": f"{obs_units} mol/mol",
+        "Ymod95": f"{obs_units} mol/mol",
+        "Ymod68": f"{obs_units} mol/mol",
+        "Yoffmean": f"{obs_units} mol/mol",
+        "Yoffmedian": f"{obs_units} mol/mol",
+        "Yoffmode": f"{obs_units} mol/mol",
+        "Yoff95": f"{obs_units} mol/mol",
+        "Yoff68": f"{obs_units} mol/mol",
+        "countrymean": country_units,
+        "countrymedian": country_units,
+        "countrymode": country_units,
+        "country68": country_units,
+        "country95": country_units,
+        "countrysd": country_units,
+        "countryapriori": country_units,
+        "xsensitivity": f"{obs_units} mol/mol",
+        "sigtrace": f"{obs_units} mol/mol",
+    }
+
+    longname = {
+        "Yobs": "observations",
+        "Yerror": "measurement error",
+        "Ytime": "time of measurements",
+        "Yapriori": "a priori simulated measurements",
+        "Ymodmean": "mean of posterior simulated measurements",
+        "Ymodmedian": "median of posterior simulated measurements",
+        "Ymodmode": "mode of posterior simulated measurements",
+        "Ymod68": " 0.68 Bayesian credible interval of posterior simulated measurements",
+        "Ymod95": " 0.95 Bayesian credible interval of posterior simulated measurements",
+        "Yoffmean": "mean of posterior simulated offset between measurements",
+        "Yoffmedian": "median of posterior simulated offset between measurements",
+        "Yoffmode": "mode of posterior simulated offset between measurements",
+        "Yoff68": " 0.68 Bayesian credible interval of posterior simulated offset between measurements",
+        "Yoff95": " 0.95 Bayesian credible interval of posterior simulated offset between measurements",
+        "xtrace": "trace of unitless scaling factors for emissions parameters",
+        "sigtrace": "trace of model error parameters",
+        "siteindicator": "index of site of measurement corresponding to sitenames",
+        "sigmafreqindex": "perdiod over which the model error is estimated",
+        "sitenames": "site names",
+        "fluxapriori": "mean a priori flux over period",
+        "fluxmode": "mode posterior flux over period",
+        "scalingmean": "mean scaling factor field over period",
+        "scalingmode": "mode scaling factor field over period",
+        "basisfunctions": "basis function field",
+        "countrymean": "mean of ocean and country totals",
+        "countrymedian": "median of ocean and country totals",
+        "countrymode": "mode of ocean and country totals",
+        "country68": "0.68 Bayesian credible interval of ocean and country totals",
+        "country95": "0.95 Bayesian credible interval of ocean and country totals",
+        "countrysd": "standard deviation of ocean and country totals",
+        "countryapriori": "prior mean of ocean and country totals",
+        "countrydefinition": "grid definition of countries",
+        "xsensitivity": "emissions sensitivity timeseries",
+    }
+
+    if use_bc:
+        units.update(
+            {
+                "YmodmeanBC": f"{obs_units} mol/mol",
+                "YmodmedianBC": f"{obs_units} mol/mol",
+                "YmodmodeBC": f"{obs_units} mol/mol",
+                "Ymod95BC": f"{obs_units} mol/mol",
+                "Ymod68BC": f"{obs_units} mol/mol",
+                "YaprioriBC": f"{obs_units} mol/mol",
+                "bcsensitivity": f"{obs_units} mol/mol",
+            }
+        )
+        longname.update(
+            {
+                "YaprioriBC": "a priori simulated boundary conditions",
+                "YmodmeanBC": "mean of posterior simulated boundary conditions",
+                "YmodmedianBC": "median of posterior simulated boundary conditions",
+                "YmodmodeBC": "mode of posterior simulated boundary conditions",
+                "Ymod68BC": " 0.68 Bayesian credible interval of posterior simulated boundary conditions",
+                "Ymod95BC": " 0.95 Bayesian credible interval of posterior simulated boundary conditions",
+                "bctrace": "trace of unitless scaling factors for boundary condition parameters",
+                "bcsensitivity": "boundary conditions sensitivity timeseries",
+            }
+        )
+
+    for dv, unit in units.items():
+        if dv in ds:
+            ds[dv].attrs["units"] = unit
+
+    for dv, lname in longname.items():
+        if dv in ds:
+            ds[dv].attrs["longname"] = lname
+
+    for dv in ds.data_vars:
+        if "longname" not in ds[dv].attrs:
+            ds[dv].attrs["longname"] = str(dv).replace("_", " ")
+
+
+def make_legacy_hbmcmc_output(
+    inv_out: InversionOutput,
+    mcmc_results: dict,
+    sigma_freq_index,
+    Hx,
+    Hbc=None,
+    country_file: str | Path | None = None,
+    use_bc: bool = False,
+) -> xr.Dataset:
+    """Create a legacy-style hbmcmc dataset using postprocessing helpers."""
+    conc = make_concentration_outputs(
+        inv_out,
+        stats=["mean", "median", "mode_kde", "hdi"],
+        stats_args={
+            "hdi__hdi_prob": [0.68, 0.95],
+            "mode_kde__chunk_dim": "nmeasure",
+            "mode_kde__chunk_size": 1,
+        },
+    )
+    flux = make_flux_outputs(
+        inv_out,
+        stats=["mean", "mode_kde"],
+        stats_args={"mode_kde__chunk_dim": "nx", "mode_kde__chunk_size": 1},
+    )
+    country = make_country_outputs(
+        inv_out,
+        country_file=country_file,
+        stats=["mean", "median", "mode_kde", "stdev", "hdi"],
+        stats_args={"hdi__hdi_prob": [0.68, 0.95], "mode_kde__chunk_dim": "country", "mode_kde__chunk_size": 1},
+    )
+
+    country_obj = utils.get_country(inv_out.domain, country_file=country_file)
+    country_idx = country_obj.country
+
+    yapriori = Hx.sum(axis=0)
+    if use_bc and Hbc is not None:
+        yapriori = yapriori + Hbc.sum(axis=0)
+
+    data_vars = {
+        "Yobs": inv_out.obs,
+        "Yerror": inv_out.obs_err,
+        "Yerror_repeatability": inv_out.obs_repeatability,
+        "Yerror_variability": inv_out.obs_variability,
+        "Ytime": inv_out.times,
+        "Yapriori": ("nmeasure", yapriori),
+        "Ymodmean": conc["y_posterior_predictive_mean"],
+        "Ymodmedian": conc["y_posterior_predictive_median"],
+        "Ymodmode": conc["y_posterior_predictive_mode"],
+        "Ymod68": conc["y_posterior_predictive_hdi_68"],
+        "Ymod95": conc["y_posterior_predictive_hdi_95"],
+        "Yoffmean": conc.get("offset_posterior_mean", xr.zeros_like(inv_out.obs)),
+        "Yoffmedian": conc.get("offset_posterior_median", xr.zeros_like(inv_out.obs)),
+        "Yoffmode": conc.get("offset_posterior_mode", xr.zeros_like(inv_out.obs)),
+        "Yoff68": conc.get("offset_posterior_hdi_68", xr.zeros_like(conc["y_posterior_predictive_hdi_68"])),
+        "Yoff95": conc.get("offset_posterior_hdi_95", xr.zeros_like(conc["y_posterior_predictive_hdi_95"])),
+        "xtrace": (("steps", "nparam"), mcmc_results["xouts"].values),
+        "sigtrace": (("steps", "nsigma_site", "nsigma_time"), mcmc_results["sigouts"].values),
+        "siteindicator": inv_out.site_indicators,
+        "sigmafreqindex": ("nmeasure", sigma_freq_index),
+        "sitenames": inv_out.site_names,
+        "fluxapriori": flux["flux_prior_mode"],
+        "fluxmode": flux["flux_posterior_mode"],
+        "scalingmean": flux["scaling_posterior_mean"],
+        "scalingmode": flux["scaling_posterior_mode"],
+        "basisfunctions": inv_out.get_flat_basis(),
+        "countrymean": country["country_posterior_mean"],
+        "countrymedian": country["country_posterior_median"],
+        "countrymode": country["country_posterior_mode"],
+        "countrysd": country["country_posterior_stdev"],
+        "country68": country["country_posterior_hdi_68"],
+        "country95": country["country_posterior_hdi_95"],
+        "countryapriori": country["country_prior_mean"],
+        "countrydefinition": (("lat", "lon"), country_idx),
+        "xsensitivity": (("nmeasure", "nparam"), Hx.T),
+    }
+
+    if use_bc and Hbc is not None:
+        data_vars.update(
+            {
+                "YaprioriBC": ("nmeasure", Hbc.sum(axis=0)),
+                "YmodmeanBC": conc["mu_bc_posterior_mean"],
+                "YmodmedianBC": conc["mu_bc_posterior_median"],
+                "YmodmodeBC": conc["mu_bc_posterior_mode"],
+                "Ymod95BC": conc["mu_bc_posterior_hdi_95"],
+                "Ymod68BC": conc["mu_bc_posterior_hdi_68"],
+                "bctrace": (("steps", "nBC"), mcmc_results["bcouts"].values),
+                "bcsensitivity": (("nmeasure", "nBC"), Hbc.T),
+            }
+        )
+
+    out = xr.Dataset(data_vars)
+
+    obs_units = inv_out.obs.attrs.get("units", "")
+    if obs_units.endswith("mol/mol"):
+        obs_units = obs_units.split(" ")[0]
+    try:
+        obs_units = f"{float(obs_units):.0e}"
+    except (TypeError, ValueError):
+        pass
+    country_units = country["country_posterior_mean"].attrs.get("units", "g")
+    _set_legacy_var_attrs(out, obs_units=obs_units, country_units=country_units, use_bc=use_bc)
+
+    out.attrs["Start date"] = str(inv_out.start_date)
+    out.attrs["End date"] = str(inv_out.end_date)
+
+    if "convergence" in mcmc_results:
+        out.attrs["Convergence"] = mcmc_results["convergence"]
+
+    return out
+
+
+# backward-compatible alias
+make_legacy_hbmcmc_output_from_postprocessing = make_legacy_hbmcmc_output

--- a/openghg_inversions/postprocessing/legacy_outputs.py
+++ b/openghg_inversions/postprocessing/legacy_outputs.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 
 import numpy as np
-import pandas as pd
 import xarray as xr
 
 from openghg_inversions import utils
@@ -24,9 +23,9 @@ def _compute_apriori_flux(
 
     Args:
         flux: Prior flux with dimensions ``lat``, ``lon``, and optionally ``flux_time``.
-        start_date: Inversion start date (YYYY-mm-dd).
-        end_date: Inversion end date (YYYY-mm-dd).
-        times: Optional measurement times used to weight monthly periods.
+        start_date: Inversion start date (YYYY-mm-dd). Retained for call-site compatibility.
+        end_date: Inversion end date (YYYY-mm-dd). Retained for call-site compatibility.
+        times: Optional measurement times used to weight available flux periods.
 
     Returns:
         Two-dimensional prior flux map over ``lat`` and ``lon``.
@@ -52,6 +51,7 @@ def _compute_apriori_flux(
         )
 
     return apriori_flux
+
 
 def _set_legacy_var_attrs(ds: xr.Dataset, obs_units: str, country_units: str, use_bc: bool) -> None:
     """Set variable attributes to match legacy hbmcmc output style.
@@ -113,7 +113,7 @@ def _set_legacy_var_attrs(ds: xr.Dataset, obs_units: str, country_units: str, us
         "xtrace": "trace of unitless scaling factors for emissions parameters",
         "sigtrace": "trace of model error parameters",
         "siteindicator": "index of site of measurement corresponding to sitenames",
-        "sigmafreqindex": "perdiod over which the model error is estimated",
+        "sigmafreqindex": "period over which the model error is estimated",
         "sitenames": "site names",
         "fluxapriori": "mean a priori flux over period",
         "fluxmode": "mode posterior flux over period",
@@ -167,6 +167,52 @@ def _set_legacy_var_attrs(ds: xr.Dataset, obs_units: str, country_units: str, us
     for dv in ds.data_vars:
         if "longname" not in ds[dv].attrs:
             ds[dv].attrs["longname"] = str(dv).replace("_", " ")
+
+
+def _rename_hdi_for_legacy(ds: xr.Dataset) -> xr.Dataset:
+    """Rename postprocessing HDI metadata to legacy names."""
+    if "hdi" not in ds.dims and "hdi" not in ds.coords:
+        return ds
+
+    result = ds.rename(hdi="nUI")
+
+    # Legacy files carry a separate `UInum` coordinate rather than string labels on `nUI`.
+    if "nUI" in result.dims:
+        if "nUI" in result.coords:
+            result = result.drop_vars("nUI")
+        result = result.assign_coords(UInum=("nUI", np.arange(result.sizes["nUI"])))
+
+    return result
+
+
+def _rename_country_for_legacy(ds: xr.Dataset) -> xr.Dataset:
+    """Rename country metadata to legacy names."""
+    if "country" not in ds.dims and "country" not in ds.coords:
+        return ds
+
+    result = ds.rename(country="countrynames")
+    return result
+
+
+def _collapse_flux_time_for_legacy(
+    ds: xr.Dataset, times: xr.DataArray | np.ndarray, flux_time: xr.DataArray | np.ndarray, time_period: str | None = None
+) -> xr.Dataset:
+    """Collapse `flux_time` to a single legacy period using observation-weighted averaging."""
+    if "flux_time" not in ds.dims:
+        return ds
+
+    flux_period = utils._infer_flux_period(flux_time, time_period)
+    period_index = utils._map_times_to_available_period_positions(times, flux_time, flux_period)
+
+    if period_index.size == 0:
+        return ds.isel(flux_time=0, drop=True)
+
+    weights = np.zeros(len(flux_time), dtype=float)
+    for period_pos in np.unique(period_index):
+        weights[int(period_pos)] = np.sum(period_index == period_pos) / len(period_index)
+
+    weights_da = xr.DataArray(weights, dims=("flux_time",), coords={"flux_time": ds["flux_time"]})
+    return (ds * weights_da).sum("flux_time")
 
 
 def _flatten_nmeasure_for_legacy(data: xr.DataArray) -> xr.DataArray:
@@ -234,6 +280,14 @@ def make_legacy_hbmcmc_output(
         stats=["mean", "median", "mode_kde", "stdev", "hdi"],
         stats_args={"hdi__hdi_prob": [0.68, 0.95], "mode_kde__chunk_dim": "country", "mode_kde__chunk_size": 1},
     )
+    conc = _rename_hdi_for_legacy(conc)
+    country = _collapse_flux_time_for_legacy(
+        country,
+        inv_out.times,
+        inv_out.flux["flux_time"],
+        inv_out.flux.attrs.get("time_period"),
+    )
+    country = _rename_hdi_for_legacy(_rename_country_for_legacy(country))
 
     country_obj = utils.get_country(inv_out.domain, country_file=country_file)
     country_idx = country_obj.country
@@ -299,7 +353,24 @@ def make_legacy_hbmcmc_output(
         if isinstance(value, xr.DataArray):
             data_vars[name] = _flatten_nmeasure_for_legacy(value)
 
-    out = xr.Dataset(data_vars)
+    xouts_arr = np.asarray(mcmc_results["xouts"])
+    sigouts_arr = np.asarray(mcmc_results["sigouts"])
+    coords: dict[str, xr.DataArray | tuple[tuple[str, ...], np.ndarray]] = {
+        "stepnum": ("steps", np.arange(xouts_arr.shape[0])),
+        "paramnum": ("nparam", np.arange(Hx_arr.shape[0])),
+        "measurenum": ("nmeasure", np.arange(Hx_arr.shape[1])),
+        "nsigma_site": ("nsigma_site", np.arange(sigouts_arr.shape[1])),
+        "nsigma_time": ("nsigma_time", np.arange(sigouts_arr.shape[2])),
+        "countrynames": country["countrynames"],
+    }
+    if "nUI" in conc.dims or "nUI" in country.dims:
+        n_ui = conc.sizes.get("nUI", country.sizes.get("nUI"))
+        if n_ui is not None:
+            coords["UInum"] = ("nUI", np.arange(n_ui))
+    if use_bc and Hbc_arr is not None:
+        coords["numBC"] = ("nBC", np.arange(Hbc_arr.shape[0]))
+
+    out = xr.Dataset(data_vars, coords=coords)
 
     obs_units = inv_out.obs.attrs.get("units", "")
     if obs_units.endswith("mol/mol"):

--- a/openghg_inversions/postprocessing/legacy_outputs.py
+++ b/openghg_inversions/postprocessing/legacy_outputs.py
@@ -17,13 +17,16 @@ from openghg_inversions.postprocessing.make_outputs import (
 )
 
 
-def _compute_apriori_flux(flux: xr.DataArray, start_date: str, end_date: str) -> xr.DataArray:
+def _compute_apriori_flux(
+    flux: xr.DataArray, start_date: str, end_date: str, times: xr.DataArray | np.ndarray | None = None
+) -> xr.DataArray:
     """Compute the legacy-style prior flux map from a flux timeseries.
 
     Args:
         flux: Prior flux with dimensions ``lat``, ``lon``, and optionally ``flux_time``.
         start_date: Inversion start date (YYYY-mm-dd).
         end_date: Inversion end date (YYYY-mm-dd).
+        times: Optional measurement times used to weight monthly periods.
 
     Returns:
         Two-dimensional prior flux map over ``lat`` and ``lon``.
@@ -32,7 +35,12 @@ def _compute_apriori_flux(flux: xr.DataArray, start_date: str, end_date: str) ->
     if "flux_time" not in flux.dims or flux.sizes.get("flux_time", 1) == 1:
         return flux.isel(flux_time=0, drop=True) if "flux_time" in flux.dims else flux
 
-    allmonths = pd.date_range(start_date, end_date).month[:-1].values - 1
+    if times is None:
+        month_source = flux.flux_time.values
+    else:
+        month_source = times.values if isinstance(times, xr.DataArray) else times
+
+    allmonths = _contiguous_month_index(pd.to_datetime(month_source).month.values - 1)
     if len(allmonths) == 0:
         return flux.isel(flux_time=0, drop=True)
 
@@ -43,6 +51,16 @@ def _compute_apriori_flux(flux: xr.DataArray, start_date: str, end_date: str) ->
         )
 
     return apriori_flux
+
+
+def _contiguous_month_index(month_index: np.ndarray) -> np.ndarray:
+    """Remap month indices to contiguous 0..N-1 values for positional indexing."""
+    month_index = np.asarray(month_index, dtype=int)
+    if month_index.size == 0:
+        return month_index
+
+    uniq = np.unique(month_index)
+    return np.searchsorted(uniq, month_index).astype(int)
 
 
 def _set_legacy_var_attrs(ds: xr.Dataset, obs_units: str, country_units: str, use_bc: bool) -> None:
@@ -229,7 +247,7 @@ def make_legacy_hbmcmc_output(
 
     country_obj = utils.get_country(inv_out.domain, country_file=country_file)
     country_idx = country_obj.country
-    apriori_flux = _compute_apriori_flux(inv_out.flux, str(inv_out.start_date), str(inv_out.end_date))
+    apriori_flux = _compute_apriori_flux(inv_out.flux, str(inv_out.start_date), str(inv_out.end_date), inv_out.times)
 
     yapriori = Hx_arr.sum(axis=0)
     if use_bc and Hbc_arr is not None:

--- a/openghg_inversions/postprocessing/legacy_outputs.py
+++ b/openghg_inversions/postprocessing/legacy_outputs.py
@@ -36,11 +36,11 @@ def _compute_apriori_flux(
         return flux.isel(flux_time=0, drop=True) if "flux_time" in flux.dims else flux
 
     if times is None:
-        month_source = flux.flux_time.values
+        time_source = flux.flux_time.values
     else:
-        month_source = times.values if isinstance(times, xr.DataArray) else times
+        time_source = times.values if isinstance(times, xr.DataArray) else times
 
-    allmonths = _contiguous_month_index(pd.to_datetime(month_source).month.values - 1)
+    allmonths = _map_times_to_available_month_positions(time_source, flux.flux_time.values)
     if len(allmonths) == 0:
         return flux.isel(flux_time=0, drop=True)
 
@@ -53,14 +53,22 @@ def _compute_apriori_flux(
     return apriori_flux
 
 
-def _contiguous_month_index(month_index: np.ndarray) -> np.ndarray:
-    """Remap month indices to contiguous 0..N-1 values for positional indexing."""
-    month_index = np.asarray(month_index, dtype=int)
-    if month_index.size == 0:
-        return month_index
+def _map_times_to_available_month_positions(
+    times: xr.DataArray | np.ndarray, available_times: xr.DataArray | np.ndarray
+) -> np.ndarray:
+    """Map timestamps onto contiguous month positions defined by available flux periods."""
+    time_periods = pd.to_datetime(times).to_period("M")
+    available_periods = pd.Index(pd.to_datetime(available_times).to_period("M").unique())
 
-    uniq = np.unique(month_index)
-    return np.searchsorted(uniq, month_index).astype(int)
+    if len(time_periods) == 0:
+        return np.array([], dtype=int)
+
+    missing = pd.Index(time_periods).difference(available_periods)
+    if len(missing) > 0:
+        raise ValueError(f"Observation months {list(missing.astype(str))} are missing from available flux periods.")
+
+    period_positions = {period: idx for idx, period in enumerate(available_periods)}
+    return np.array([period_positions[period] for period in time_periods], dtype=int)
 
 
 def _set_legacy_var_attrs(ds: xr.Dataset, obs_units: str, country_units: str, use_bc: bool) -> None:

--- a/openghg_inversions/postprocessing/legacy_outputs.py
+++ b/openghg_inversions/postprocessing/legacy_outputs.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import numpy as np
+import pandas as pd
 import xarray as xr
 
 from openghg_inversions import utils
@@ -15,8 +17,47 @@ from openghg_inversions.postprocessing.make_outputs import (
 )
 
 
+def _compute_apriori_flux(flux: xr.DataArray, start_date: str, end_date: str) -> xr.DataArray:
+    """Compute the legacy-style prior flux map from a flux timeseries.
+
+    Args:
+        flux: Prior flux with dimensions ``lat``, ``lon``, and optionally ``flux_time``.
+        start_date: Inversion start date (YYYY-mm-dd).
+        end_date: Inversion end date (YYYY-mm-dd).
+
+    Returns:
+        Two-dimensional prior flux map over ``lat`` and ``lon``.
+
+    """
+    if "flux_time" not in flux.dims or flux.sizes.get("flux_time", 1) == 1:
+        return flux.isel(flux_time=0, drop=True) if "flux_time" in flux.dims else flux
+
+    allmonths = pd.date_range(start_date, end_date).month[:-1].values - 1
+    if len(allmonths) == 0:
+        return flux.isel(flux_time=0, drop=True)
+
+    apriori_flux = xr.zeros_like(flux.isel(flux_time=0, drop=True))
+    for month_idx in np.unique(allmonths):
+        apriori_flux = apriori_flux + flux.isel(flux_time=int(month_idx), drop=True) * (
+            np.sum(allmonths == month_idx) / len(allmonths)
+        )
+
+    return apriori_flux
+
+
 def _set_legacy_var_attrs(ds: xr.Dataset, obs_units: str, country_units: str, use_bc: bool) -> None:
-    """Set variable attrs to match legacy hbmcmc output style."""
+    """Set variable attributes to match legacy hbmcmc output style.
+
+    Args:
+        ds: Dataset to mutate.
+        obs_units: Observation scaling prefix used in legacy units (e.g. ``1e-09``).
+        country_units: Units used for country totals.
+        use_bc: Whether boundary-condition variables are present.
+
+    Returns:
+        None. Attributes are set in-place.
+
+    """
     units = {
         "fluxmode": "mol/m2/s",
         "fluxapriori": "mol/m2/s",
@@ -123,13 +164,32 @@ def _set_legacy_var_attrs(ds: xr.Dataset, obs_units: str, country_units: str, us
 def make_legacy_hbmcmc_output(
     inv_out: InversionOutput,
     mcmc_results: dict,
-    sigma_freq_index,
-    Hx,
-    Hbc=None,
+    sigma_freq_index: np.ndarray | xr.DataArray,
+    Hx: np.ndarray | xr.DataArray,
+    Hbc: np.ndarray | xr.DataArray | None = None,
     country_file: str | Path | None = None,
     use_bc: bool = False,
 ) -> xr.Dataset:
-    """Create a legacy-style hbmcmc dataset using postprocessing helpers."""
+    """Create a legacy-format hbmcmc output dataset from postprocessing products.
+
+    Args:
+        inv_out: Inversion outputs container.
+        mcmc_results: Raw dictionary returned by ``inferpymc``.
+        sigma_freq_index: Sigma frequency index per measurement.
+        Hx: Emissions sensitivity matrix with shape ``(nparam, nmeasure)``.
+        Hbc: Boundary-condition sensitivity matrix with shape ``(nBC, nmeasure)``.
+        country_file: Optional path to country definition file.
+        use_bc: Whether BC variables should be included.
+
+    Returns:
+        Legacy-style ``xr.Dataset`` matching key variable names/attrs from
+        ``inferpymc_postprocessouts``.
+
+    """
+    Hx_arr = np.asarray(Hx)
+    Hbc_arr = np.asarray(Hbc) if Hbc is not None else None
+    sigma_freq = np.asarray(sigma_freq_index)
+
     conc = make_concentration_outputs(
         inv_out,
         stats=["mean", "median", "mode_kde", "hdi"],
@@ -153,12 +213,13 @@ def make_legacy_hbmcmc_output(
 
     country_obj = utils.get_country(inv_out.domain, country_file=country_file)
     country_idx = country_obj.country
+    apriori_flux = _compute_apriori_flux(inv_out.flux, str(inv_out.start_date), str(inv_out.end_date))
 
-    yapriori = Hx.sum(axis=0)
-    if use_bc and Hbc is not None:
-        yapriori = yapriori + Hbc.sum(axis=0)
+    yapriori = Hx_arr.sum(axis=0)
+    if use_bc and Hbc_arr is not None:
+        yapriori = yapriori + Hbc_arr.sum(axis=0)
 
-    data_vars = {
+    data_vars: dict[str, xr.DataArray | tuple[tuple[str, ...], np.ndarray]] = {
         "Yobs": inv_out.obs,
         "Yerror": inv_out.obs_err,
         "Yerror_repeatability": inv_out.obs_repeatability,
@@ -178,9 +239,9 @@ def make_legacy_hbmcmc_output(
         "xtrace": (("steps", "nparam"), mcmc_results["xouts"].values),
         "sigtrace": (("steps", "nsigma_site", "nsigma_time"), mcmc_results["sigouts"].values),
         "siteindicator": inv_out.site_indicators,
-        "sigmafreqindex": ("nmeasure", sigma_freq_index),
+        "sigmafreqindex": ("nmeasure", sigma_freq),
         "sitenames": inv_out.site_names,
-        "fluxapriori": flux["flux_prior_mode"],
+        "fluxapriori": apriori_flux,
         "fluxmode": flux["flux_posterior_mode"],
         "scalingmean": flux["scaling_posterior_mean"],
         "scalingmode": flux["scaling_posterior_mode"],
@@ -193,20 +254,20 @@ def make_legacy_hbmcmc_output(
         "country95": country["country_posterior_hdi_95"],
         "countryapriori": country["country_prior_mean"],
         "countrydefinition": (("lat", "lon"), country_idx),
-        "xsensitivity": (("nmeasure", "nparam"), Hx.T),
+        "xsensitivity": (("nmeasure", "nparam"), Hx_arr.T),
     }
 
-    if use_bc and Hbc is not None:
+    if use_bc and Hbc_arr is not None:
         data_vars.update(
             {
-                "YaprioriBC": ("nmeasure", Hbc.sum(axis=0)),
+                "YaprioriBC": ("nmeasure", Hbc_arr.sum(axis=0)),
                 "YmodmeanBC": conc["mu_bc_posterior_mean"],
                 "YmodmedianBC": conc["mu_bc_posterior_median"],
                 "YmodmodeBC": conc["mu_bc_posterior_mode"],
                 "Ymod95BC": conc["mu_bc_posterior_hdi_95"],
                 "Ymod68BC": conc["mu_bc_posterior_hdi_68"],
                 "bctrace": (("steps", "nBC"), mcmc_results["bcouts"].values),
-                "bcsensitivity": (("nmeasure", "nBC"), Hbc.T),
+                "bcsensitivity": (("nmeasure", "nBC"), Hbc_arr.T),
             }
         )
 
@@ -219,17 +280,13 @@ def make_legacy_hbmcmc_output(
         obs_units = f"{float(obs_units):.0e}"
     except (TypeError, ValueError):
         pass
+
     country_units = country["country_posterior_mean"].attrs.get("units", "g")
     _set_legacy_var_attrs(out, obs_units=obs_units, country_units=country_units, use_bc=use_bc)
 
     out.attrs["Start date"] = str(inv_out.start_date)
     out.attrs["End date"] = str(inv_out.end_date)
-
     if "convergence" in mcmc_results:
         out.attrs["Convergence"] = mcmc_results["convergence"]
 
     return out
-
-
-# backward-compatible alias
-make_legacy_hbmcmc_output_from_postprocessing = make_legacy_hbmcmc_output

--- a/openghg_inversions/postprocessing/legacy_outputs.py
+++ b/openghg_inversions/postprocessing/legacy_outputs.py
@@ -40,7 +40,8 @@ def _compute_apriori_flux(
     else:
         time_source = times.values if isinstance(times, xr.DataArray) else times
 
-    allmonths = _map_times_to_available_month_positions(time_source, flux.flux_time.values)
+    flux_period = utils._infer_flux_period(flux.flux_time.values, flux.attrs.get("time_period"))
+    allmonths = utils._map_times_to_available_period_positions(time_source, flux.flux_time.values, flux_period)
     if len(allmonths) == 0:
         return flux.isel(flux_time=0, drop=True)
 
@@ -51,25 +52,6 @@ def _compute_apriori_flux(
         )
 
     return apriori_flux
-
-
-def _map_times_to_available_month_positions(
-    times: xr.DataArray | np.ndarray, available_times: xr.DataArray | np.ndarray
-) -> np.ndarray:
-    """Map timestamps onto contiguous month positions defined by available flux periods."""
-    time_periods = pd.to_datetime(times).to_period("M")
-    available_periods = pd.Index(pd.to_datetime(available_times).to_period("M").unique())
-
-    if len(time_periods) == 0:
-        return np.array([], dtype=int)
-
-    missing = pd.Index(time_periods).difference(available_periods)
-    if len(missing) > 0:
-        raise ValueError(f"Observation months {list(missing.astype(str))} are missing from available flux periods.")
-
-    period_positions = {period: idx for idx, period in enumerate(available_periods)}
-    return np.array([period_positions[period] for period in time_periods], dtype=int)
-
 
 def _set_legacy_var_attrs(ds: xr.Dataset, obs_units: str, country_units: str, use_bc: bool) -> None:
     """Set variable attributes to match legacy hbmcmc output style.

--- a/openghg_inversions/postprocessing/legacy_outputs.py
+++ b/openghg_inversions/postprocessing/legacy_outputs.py
@@ -161,6 +161,22 @@ def _set_legacy_var_attrs(ds: xr.Dataset, obs_units: str, country_units: str, us
             ds[dv].attrs["longname"] = str(dv).replace("_", " ")
 
 
+def _flatten_nmeasure_for_legacy(data: xr.DataArray) -> xr.DataArray:
+    """Convert any stacked `nmeasure` coordinate back to the legacy flat form."""
+    if "nmeasure" not in data.dims:
+        return data
+
+    result = data
+    if "nmeasure" in result.indexes:
+        result = result.reset_index("nmeasure", drop=True)
+
+    drop_coords = [coord for coord in ("site", "time") if coord in result.coords and "nmeasure" in result[coord].dims]
+    if drop_coords:
+        result = result.drop_vars(drop_coords)
+
+    return result.assign_coords(nmeasure=np.arange(result.sizes["nmeasure"]))
+
+
 def make_legacy_hbmcmc_output(
     inv_out: InversionOutput,
     mcmc_results: dict,
@@ -270,6 +286,10 @@ def make_legacy_hbmcmc_output(
                 "bcsensitivity": (("nmeasure", "nBC"), Hbc_arr.T),
             }
         )
+
+    for name, value in list(data_vars.items()):
+        if isinstance(value, xr.DataArray):
+            data_vars[name] = _flatten_nmeasure_for_legacy(value)
 
     out = xr.Dataset(data_vars)
 

--- a/openghg_inversions/postprocessing/make_outputs.py
+++ b/openghg_inversions/postprocessing/make_outputs.py
@@ -3,6 +3,7 @@ from typing import Literal
 
 import xarray as xr
 
+from openghg_inversions import utils
 from openghg_inversions.array_ops import sparse_xr_dot
 from openghg_inversions.postprocessing.countries import Countries, paris_regions_dict
 from openghg_inversions.postprocessing.inversion_output import InversionOutput
@@ -316,3 +317,87 @@ def basic_output(
     result.attrs["description"] = "RHIME inversion outputs."
 
     return result
+
+
+def make_legacy_hbmcmc_output_from_postprocessing(
+    inv_out: InversionOutput,
+    mcmc_results: dict,
+    sigma_freq_index,
+    Hx,
+    Hbc=None,
+    country_file: str | Path | None = None,
+    use_bc: bool = False,
+) -> xr.Dataset:
+    """Create a legacy-style hbmcmc dataset using postprocessing helpers.
+
+    This is intended as a compatibility bridge while moving away from
+    ``inferpymc_postprocessouts``.
+    """
+    conc = make_concentration_outputs(
+        inv_out,
+        stats=["mean", "median", "mode_kde", "hdi"],
+        stats_args={"hdi__hdi_prob": [0.68, 0.95], "mode_kde__chunk_dim": "nmeasure", "mode_kde__chunk_size": 1},
+    )
+    flux = make_flux_outputs(inv_out, stats=["mean", "mode_kde"], stats_args={"mode_kde__chunk_dim": "nx", "mode_kde__chunk_size": 1})
+    country = make_country_outputs(
+        inv_out,
+        country_file=country_file,
+        stats=["mean", "median", "mode_kde", "stdev", "hdi"],
+        stats_args={"hdi__hdi_prob": [0.68, 0.95], "mode_kde__chunk_dim": "country", "mode_kde__chunk_size": 1},
+    )
+
+    country_idx = utils.get_country(inv_out.domain, country_file=country_file).country
+
+    data_vars = {
+        "Yobs": inv_out.obs,
+        "Yerror": inv_out.obs_err,
+        "Yerror_repeatability": inv_out.obs_repeatability,
+        "Yerror_variability": inv_out.obs_variability,
+        "Ytime": inv_out.times,
+        "Yapriori": ("nmeasure", Hx.sum(axis=0)),
+        "Ymodmean": conc["y_posterior_predictive_mean"],
+        "Ymodmedian": conc["y_posterior_predictive_median"],
+        "Ymodmode": conc["y_posterior_predictive_mode"],
+        "Ymod68": conc["y_posterior_predictive_hdi_68"],
+        "Ymod95": conc["y_posterior_predictive_hdi_95"],
+        "Yoffmean": conc.get("offset_posterior_mean", xr.zeros_like(inv_out.obs)),
+        "Yoffmedian": conc.get("offset_posterior_median", xr.zeros_like(inv_out.obs)),
+        "Yoffmode": conc.get("offset_posterior_mode", xr.zeros_like(inv_out.obs)),
+        "Yoff68": conc.get("offset_posterior_hdi_68", xr.zeros_like(conc["y_posterior_predictive_hdi_68"])),
+        "Yoff95": conc.get("offset_posterior_hdi_95", xr.zeros_like(conc["y_posterior_predictive_hdi_95"])),
+        "xtrace": (("steps", "nparam"), mcmc_results["xouts"].values),
+        "sigtrace": (("steps", "nsigma_site", "nsigma_time"), mcmc_results["sigouts"].values),
+        "siteindicator": inv_out.site_indicators,
+        "sigmafreqindex": ("nmeasure", sigma_freq_index),
+        "sitenames": inv_out.site_names,
+        "fluxapriori": flux["flux_prior_mode"],
+        "fluxmode": flux["flux_posterior_mode"],
+        "scalingmean": flux["scaling_posterior_mean"],
+        "scalingmode": flux["scaling_posterior_mode"],
+        "basisfunctions": inv_out.get_flat_basis(),
+        "countrymean": country["country_posterior_mean"],
+        "countrymedian": country["country_posterior_median"],
+        "countrymode": country["country_posterior_mode"],
+        "countrysd": country["country_posterior_stdev"],
+        "country68": country["country_posterior_hdi_68"],
+        "country95": country["country_posterior_hdi_95"],
+        "countryapriori": country["country_prior_mean"],
+        "countrydefinition": (("lat", "lon"), country_idx),
+        "xsensitivity": (("nmeasure", "nparam"), Hx.T),
+    }
+
+    if use_bc and Hbc is not None:
+        data_vars.update(
+            {
+                "YaprioriBC": ("nmeasure", Hbc.sum(axis=0)),
+                "YmodmeanBC": conc["mu_bc_posterior_mean"],
+                "YmodmedianBC": conc["mu_bc_posterior_median"],
+                "YmodmodeBC": conc["mu_bc_posterior_mode"],
+                "Ymod95BC": conc["mu_bc_posterior_hdi_95"],
+                "Ymod68BC": conc["mu_bc_posterior_hdi_68"],
+                "bctrace": (("steps", "nBC"), mcmc_results["bcouts"].values),
+                "bcsensitivity": (("nmeasure", "nBC"), Hbc.T),
+            }
+        )
+
+    return xr.Dataset(data_vars)

--- a/openghg_inversions/postprocessing/make_outputs.py
+++ b/openghg_inversions/postprocessing/make_outputs.py
@@ -348,13 +348,17 @@ def make_legacy_hbmcmc_output_from_postprocessing(
 
     country_idx = utils.get_country(inv_out.domain, country_file=country_file).country
 
+    yapriori = Hx.sum(axis=0)
+    if use_bc and Hbc is not None:
+        yapriori = yapriori + Hbc.sum(axis=0)
+
     data_vars = {
         "Yobs": inv_out.obs,
         "Yerror": inv_out.obs_err,
         "Yerror_repeatability": inv_out.obs_repeatability,
         "Yerror_variability": inv_out.obs_variability,
         "Ytime": inv_out.times,
-        "Yapriori": ("nmeasure", Hx.sum(axis=0)),
+        "Yapriori": ("nmeasure", yapriori),
         "Ymodmean": conc["y_posterior_predictive_mean"],
         "Ymodmedian": conc["y_posterior_predictive_median"],
         "Ymodmode": conc["y_posterior_predictive_mode"],

--- a/openghg_inversions/postprocessing/make_outputs.py
+++ b/openghg_inversions/postprocessing/make_outputs.py
@@ -3,7 +3,6 @@ from typing import Literal
 
 import xarray as xr
 
-from openghg_inversions import utils
 from openghg_inversions.array_ops import sparse_xr_dot
 from openghg_inversions.postprocessing.countries import Countries, paris_regions_dict
 from openghg_inversions.postprocessing.inversion_output import InversionOutput
@@ -317,91 +316,3 @@ def basic_output(
     result.attrs["description"] = "RHIME inversion outputs."
 
     return result
-
-
-def make_legacy_hbmcmc_output_from_postprocessing(
-    inv_out: InversionOutput,
-    mcmc_results: dict,
-    sigma_freq_index,
-    Hx,
-    Hbc=None,
-    country_file: str | Path | None = None,
-    use_bc: bool = False,
-) -> xr.Dataset:
-    """Create a legacy-style hbmcmc dataset using postprocessing helpers.
-
-    This is intended as a compatibility bridge while moving away from
-    ``inferpymc_postprocessouts``.
-    """
-    conc = make_concentration_outputs(
-        inv_out,
-        stats=["mean", "median", "mode_kde", "hdi"],
-        stats_args={"hdi__hdi_prob": [0.68, 0.95], "mode_kde__chunk_dim": "nmeasure", "mode_kde__chunk_size": 1},
-    )
-    flux = make_flux_outputs(inv_out, stats=["mean", "mode_kde"], stats_args={"mode_kde__chunk_dim": "nx", "mode_kde__chunk_size": 1})
-    country = make_country_outputs(
-        inv_out,
-        country_file=country_file,
-        stats=["mean", "median", "mode_kde", "stdev", "hdi"],
-        stats_args={"hdi__hdi_prob": [0.68, 0.95], "mode_kde__chunk_dim": "country", "mode_kde__chunk_size": 1},
-    )
-
-    country_idx = utils.get_country(inv_out.domain, country_file=country_file).country
-
-    yapriori = Hx.sum(axis=0)
-    if use_bc and Hbc is not None:
-        yapriori = yapriori + Hbc.sum(axis=0)
-
-    data_vars = {
-        "Yobs": inv_out.obs,
-        "Yerror": inv_out.obs_err,
-        "Yerror_repeatability": inv_out.obs_repeatability,
-        "Yerror_variability": inv_out.obs_variability,
-        "Ytime": inv_out.times,
-        "Yapriori": ("nmeasure", yapriori),
-        "Ymodmean": conc["y_posterior_predictive_mean"],
-        "Ymodmedian": conc["y_posterior_predictive_median"],
-        "Ymodmode": conc["y_posterior_predictive_mode"],
-        "Ymod68": conc["y_posterior_predictive_hdi_68"],
-        "Ymod95": conc["y_posterior_predictive_hdi_95"],
-        "Yoffmean": conc.get("offset_posterior_mean", xr.zeros_like(inv_out.obs)),
-        "Yoffmedian": conc.get("offset_posterior_median", xr.zeros_like(inv_out.obs)),
-        "Yoffmode": conc.get("offset_posterior_mode", xr.zeros_like(inv_out.obs)),
-        "Yoff68": conc.get("offset_posterior_hdi_68", xr.zeros_like(conc["y_posterior_predictive_hdi_68"])),
-        "Yoff95": conc.get("offset_posterior_hdi_95", xr.zeros_like(conc["y_posterior_predictive_hdi_95"])),
-        "xtrace": (("steps", "nparam"), mcmc_results["xouts"].values),
-        "sigtrace": (("steps", "nsigma_site", "nsigma_time"), mcmc_results["sigouts"].values),
-        "siteindicator": inv_out.site_indicators,
-        "sigmafreqindex": ("nmeasure", sigma_freq_index),
-        "sitenames": inv_out.site_names,
-        "fluxapriori": flux["flux_prior_mode"],
-        "fluxmode": flux["flux_posterior_mode"],
-        "scalingmean": flux["scaling_posterior_mean"],
-        "scalingmode": flux["scaling_posterior_mode"],
-        "basisfunctions": inv_out.get_flat_basis(),
-        "countrymean": country["country_posterior_mean"],
-        "countrymedian": country["country_posterior_median"],
-        "countrymode": country["country_posterior_mode"],
-        "countrysd": country["country_posterior_stdev"],
-        "country68": country["country_posterior_hdi_68"],
-        "country95": country["country_posterior_hdi_95"],
-        "countryapriori": country["country_prior_mean"],
-        "countrydefinition": (("lat", "lon"), country_idx),
-        "xsensitivity": (("nmeasure", "nparam"), Hx.T),
-    }
-
-    if use_bc and Hbc is not None:
-        data_vars.update(
-            {
-                "YaprioriBC": ("nmeasure", Hbc.sum(axis=0)),
-                "YmodmeanBC": conc["mu_bc_posterior_mean"],
-                "YmodmedianBC": conc["mu_bc_posterior_median"],
-                "YmodmodeBC": conc["mu_bc_posterior_mode"],
-                "Ymod95BC": conc["mu_bc_posterior_hdi_95"],
-                "Ymod68BC": conc["mu_bc_posterior_hdi_68"],
-                "bctrace": (("steps", "nBC"), mcmc_results["bcouts"].values),
-                "bcsensitivity": (("nmeasure", "nBC"), Hbc.T),
-            }
-        )
-
-    return xr.Dataset(data_vars)

--- a/openghg_inversions/utils.py
+++ b/openghg_inversions/utils.py
@@ -13,6 +13,7 @@ from types import SimpleNamespace
 from typing import Literal
 
 import numpy as np
+import pandas as pd
 import xarray as xr
 
 from openghg.analyse import combine_datasets as openghg_combine_datasets
@@ -262,3 +263,48 @@ def areagrid(lat: np.ndarray, lon: np.ndarray) -> np.ndarray:
             area[latI, :] = (rad_earth**2) * (np.cos(lat1) - np.cos(lat2)) * dlon
 
     return area
+
+
+# ---------------------------------------------------------------------
+# Flux period helpers used by legacy and PyMC post-processing code paths.
+# These stay private because they are implementation details for mapping
+# observation times onto available time-varying flux slices.
+# ---------------------------------------------------------------------
+def _infer_flux_period(times: xr.DataArray | np.ndarray, time_period: str | None = None) -> str:
+    """Infer whether flux slices are yearly or monthly."""
+    if time_period is not None:
+        time_period = str(time_period).lower()
+        if "year" in time_period:
+            return "yearly"
+        if "month" in time_period:
+            return "monthly"
+
+    time_values = pd.to_datetime(times)
+    if len(time_values) <= 1:
+        return "yearly"
+
+    deltas = pd.Series(time_values).sort_values().diff().dropna()
+    if deltas.empty:
+        return "yearly"
+
+    delta = deltas.mode().iloc[0]
+    return "yearly" if delta >= pd.Timedelta(days=330) else "monthly"
+
+
+def _map_times_to_available_period_positions(
+    times: xr.DataArray | np.ndarray, available_times: xr.DataArray | np.ndarray, period: str
+) -> np.ndarray:
+    """Map timestamps onto contiguous period positions defined by available flux periods."""
+    period_code = "Y" if period == "yearly" else "M"
+    time_periods = pd.to_datetime(times).to_period(period_code)
+    available_periods = pd.Index(pd.to_datetime(available_times).to_period(period_code).unique())
+
+    if len(time_periods) == 0:
+        return np.array([], dtype=int)
+
+    missing = pd.Index(time_periods).difference(available_periods)
+    if len(missing) > 0:
+        raise ValueError(f"Observation months {list(missing.astype(str))} are missing from available flux periods.")
+
+    period_positions = {period_value: idx for idx, period_value in enumerate(available_periods)}
+    return np.array([period_positions[period_value] for period_value in time_periods], dtype=int)

--- a/openghg_inversions/utils.py
+++ b/openghg_inversions/utils.py
@@ -304,7 +304,8 @@ def _map_times_to_available_period_positions(
 
     missing = pd.Index(time_periods).difference(available_periods)
     if len(missing) > 0:
-        raise ValueError(f"Observation months {list(missing.astype(str))} are missing from available flux periods.")
+        period_label = "years" if period == "yearly" else "months"
+        raise ValueError(f"Observation {period_label} {list(missing.astype(str))} are missing from available flux periods.")
 
     period_positions = {period_value: idx for idx, period_value in enumerate(available_periods)}
     return np.array([period_positions[period_value] for period_value in time_periods], dtype=int)

--- a/tests/postprocessing/test_legacy_outputs.py
+++ b/tests/postprocessing/test_legacy_outputs.py
@@ -1,8 +1,9 @@
 import numpy as np
+import pandas as pd
 import xarray as xr
 
 from openghg_inversions.postprocessing.inversion_output import InversionOutput
-from openghg_inversions.postprocessing.legacy_outputs import make_legacy_hbmcmc_output
+from openghg_inversions.postprocessing.legacy_outputs import _compute_apriori_flux, make_legacy_hbmcmc_output
 
 
 def test_make_legacy_hbmcmc_output_handles_mixed_nmeasure_indexes(raw_data_path, europe_country_file):
@@ -39,3 +40,23 @@ def test_make_legacy_hbmcmc_output_handles_mixed_nmeasure_indexes(raw_data_path,
     assert "site" not in compat["Ytime"].coords
     assert "time" not in compat["Ytime"].coords
     assert compat["Ymod68"].dims[0] == "nmeasure"
+
+
+def test_compute_apriori_flux_handles_missing_month():
+    flux = xr.DataArray(
+        np.array([[[1.0, 3.0]]]),
+        dims=["lat", "lon", "flux_time"],
+        coords={
+            "lat": [0.0],
+            "lon": [0.0],
+            "flux_time": pd.to_datetime(["2019-01-01", "2019-03-01"]),
+        },
+    )
+    times = xr.DataArray(
+        pd.to_datetime(["2019-01-15", "2019-01-20", "2019-03-10", "2019-03-20"]),
+        dims=["nmeasure"],
+    )
+
+    apriori_flux = _compute_apriori_flux(flux, "2019-01-01", "2019-04-01", times)
+
+    xr.testing.assert_allclose(apriori_flux, xr.DataArray([[2.0]], dims=["lat", "lon"], coords={"lat": [0.0], "lon": [0.0]}))

--- a/tests/postprocessing/test_legacy_outputs.py
+++ b/tests/postprocessing/test_legacy_outputs.py
@@ -3,7 +3,11 @@ import pandas as pd
 import xarray as xr
 
 from openghg_inversions.postprocessing.inversion_output import InversionOutput
-from openghg_inversions.postprocessing.legacy_outputs import _compute_apriori_flux, make_legacy_hbmcmc_output
+from openghg_inversions.postprocessing.legacy_outputs import (
+    _compute_apriori_flux,
+    _map_times_to_available_month_positions,
+    make_legacy_hbmcmc_output,
+)
 
 
 def test_make_legacy_hbmcmc_output_handles_mixed_nmeasure_indexes(raw_data_path, europe_country_file):
@@ -60,3 +64,12 @@ def test_compute_apriori_flux_handles_missing_month():
     apriori_flux = _compute_apriori_flux(flux, "2019-01-01", "2019-04-01", times)
 
     xr.testing.assert_allclose(apriori_flux, xr.DataArray([[2.0]], dims=["lat", "lon"], coords={"lat": [0.0], "lon": [0.0]}))
+
+
+def test_map_times_to_available_month_positions_handles_gappy_flux_months():
+    times = pd.to_datetime(["2019-01-15", "2019-01-20", "2019-03-10", "2019-04-20"])
+    flux_times = pd.to_datetime(["2019-01-01", "2019-03-01", "2019-04-01"])
+
+    positions = _map_times_to_available_month_positions(times, flux_times)
+
+    np.testing.assert_array_equal(positions, np.array([0, 0, 1, 2]))

--- a/tests/postprocessing/test_legacy_outputs.py
+++ b/tests/postprocessing/test_legacy_outputs.py
@@ -2,10 +2,10 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
+from openghg_inversions import utils
 from openghg_inversions.postprocessing.inversion_output import InversionOutput
 from openghg_inversions.postprocessing.legacy_outputs import (
     _compute_apriori_flux,
-    _map_times_to_available_month_positions,
     make_legacy_hbmcmc_output,
 )
 
@@ -66,11 +66,11 @@ def test_compute_apriori_flux_handles_missing_month():
     xr.testing.assert_allclose(apriori_flux, xr.DataArray([[2.0]], dims=["lat", "lon"], coords={"lat": [0.0], "lon": [0.0]}))
 
 
-def test_map_times_to_available_month_positions_handles_gappy_flux_months():
+def test_map_times_to_available_period_positions_handles_gappy_flux_months():
     times = pd.to_datetime(["2019-01-15", "2019-01-20", "2019-03-10", "2019-04-20"])
     flux_times = pd.to_datetime(["2019-01-01", "2019-03-01", "2019-04-01"])
 
-    positions = _map_times_to_available_month_positions(times, flux_times)
+    positions = utils._map_times_to_available_period_positions(times, flux_times, "monthly")
 
     np.testing.assert_array_equal(positions, np.array([0, 0, 1, 2]))
 
@@ -92,4 +92,7 @@ def test_compute_apriori_flux_handles_multi_year_flux_time():
 
     apriori_flux = _compute_apriori_flux(flux, "2023-01-01", "2025-05-01", times)
 
-    xr.testing.assert_allclose(apriori_flux, xr.DataArray([[2.0]], dims=["lat", "lon"], coords={"lat": [0.0], "lon": [0.0]}))
+    xr.testing.assert_allclose(
+        apriori_flux,
+        xr.DataArray([[1.75]], dims=["lat", "lon"], coords={"lat": [0.0], "lon": [0.0]}),
+    )

--- a/tests/postprocessing/test_legacy_outputs.py
+++ b/tests/postprocessing/test_legacy_outputs.py
@@ -1,0 +1,41 @@
+import numpy as np
+import xarray as xr
+
+from openghg_inversions.postprocessing.inversion_output import InversionOutput
+from openghg_inversions.postprocessing.legacy_outputs import make_legacy_hbmcmc_output
+
+
+def test_make_legacy_hbmcmc_output_handles_mixed_nmeasure_indexes(raw_data_path, europe_country_file):
+    legacy = xr.open_dataset(raw_data_path / "standard_rhime_outs.nc")
+    inv_out = InversionOutput.load(raw_data_path / "inversion_output.nc")
+    inv_out.times = xr.DataArray(
+        inv_out.times.values,
+        dims=["nmeasure"],
+        coords={"nmeasure": np.arange(inv_out.obs.sizes["nmeasure"])},
+        attrs=inv_out.times.attrs,
+        name=inv_out.times.name,
+    )
+
+    compat = make_legacy_hbmcmc_output(
+        inv_out=inv_out,
+        mcmc_results={
+            "xouts": legacy["xtrace"],
+            "sigouts": legacy["sigtrace"],
+            "bcouts": legacy["bctrace"],
+        },
+        sigma_freq_index=legacy["sigmafreqindex"].values,
+        Hx=legacy["xsensitivity"].values.T,
+        Hbc=legacy["bcsensitivity"].values.T,
+        country_file=europe_country_file,
+        use_bc=True,
+    )
+
+    assert (compat["nmeasure"].values == legacy["nmeasure"].values).all()
+    assert compat["Yobs"].dims == ("nmeasure",)
+    assert compat["Ytime"].dims == ("nmeasure",)
+    assert compat["Ymodmean"].dims == ("nmeasure",)
+    assert "site" not in compat["Yobs"].coords
+    assert "time" not in compat["Yobs"].coords
+    assert "site" not in compat["Ytime"].coords
+    assert "time" not in compat["Ytime"].coords
+    assert compat["Ymod68"].dims[0] == "nmeasure"

--- a/tests/postprocessing/test_legacy_outputs.py
+++ b/tests/postprocessing/test_legacy_outputs.py
@@ -73,3 +73,23 @@ def test_map_times_to_available_month_positions_handles_gappy_flux_months():
     positions = _map_times_to_available_month_positions(times, flux_times)
 
     np.testing.assert_array_equal(positions, np.array([0, 0, 1, 2]))
+
+
+def test_compute_apriori_flux_handles_multi_year_flux_time():
+    flux = xr.DataArray(
+        np.array([[[1.0, 2.0, 3.0]]]),
+        dims=["lat", "lon", "flux_time"],
+        coords={
+            "lat": [0.0],
+            "lon": [0.0],
+            "flux_time": pd.to_datetime(["2023-01-01", "2024-01-01", "2025-01-01"]),
+        },
+    )
+    times = xr.DataArray(
+        pd.to_datetime(["2023-03-15", "2023-11-20", "2024-07-10", "2025-04-20"]),
+        dims=["nmeasure"],
+    )
+
+    apriori_flux = _compute_apriori_flux(flux, "2023-01-01", "2025-05-01", times)
+
+    xr.testing.assert_allclose(apriori_flux, xr.DataArray([[2.0]], dims=["lat", "lon"], coords={"lat": [0.0], "lon": [0.0]}))

--- a/tests/test_inferpymc_month_gap.py
+++ b/tests/test_inferpymc_month_gap.py
@@ -5,7 +5,7 @@ import pandas as pd
 import xarray as xr
 
 from openghg_inversions.hbmcmc.hbmcmc import make_inv_inputs_legacy
-from openghg_inversions.hbmcmc.inversion_pymc import inferpymc
+from openghg_inversions.hbmcmc.inversion_pymc import _weighted_apriori_flux_for_months, inferpymc
 
 
 def _synthetic_fp_data_one_site_with_missing_month() -> dict[str, xr.Dataset]:
@@ -97,3 +97,12 @@ def test_inferpymc_smoke_runs_for_month_gap():
 
     assert "sigouts" in result
     assert "trace" in result
+
+
+def test_weighted_apriori_flux_handles_missing_month():
+    flux_array_all = np.array([[[1.0, 3.0]]], dtype=np.float32)
+    month_index = np.array([0, 0, 2, 2], dtype=int)
+
+    apriori_flux = _weighted_apriori_flux_for_months(flux_array_all, month_index)
+
+    np.testing.assert_allclose(apriori_flux, np.array([[2.0]], dtype=np.float32))

--- a/tests/test_inferpymc_month_gap.py
+++ b/tests/test_inferpymc_month_gap.py
@@ -4,9 +4,9 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
+from openghg_inversions import utils
 from openghg_inversions.hbmcmc.hbmcmc import make_inv_inputs_legacy
 from openghg_inversions.hbmcmc.inversion_pymc import (
-    _map_times_to_available_month_positions,
     _weighted_apriori_flux_for_months,
     inferpymc,
 )
@@ -112,19 +112,19 @@ def test_weighted_apriori_flux_handles_missing_month():
     np.testing.assert_allclose(apriori_flux, np.array([[2.0]], dtype=np.float32))
 
 
-def test_map_times_to_available_month_positions_handles_gappy_flux_months():
+def test_map_times_to_available_period_positions_handles_gappy_flux_months():
     times = pd.to_datetime(["2019-01-15", "2019-01-20", "2019-03-10", "2019-04-20"])
     flux_times = pd.to_datetime(["2019-01-01", "2019-03-01", "2019-04-01"])
 
-    positions = _map_times_to_available_month_positions(times, flux_times)
+    positions = utils._map_times_to_available_period_positions(times, flux_times, "monthly")
 
     np.testing.assert_array_equal(positions, np.array([0, 0, 1, 2]))
 
 
-def test_map_times_to_available_month_positions_handles_multi_year_flux_time():
+def test_map_times_to_available_period_positions_handles_multi_year_flux_time():
     times = pd.to_datetime(["2023-03-15", "2023-11-20", "2024-07-10", "2025-04-20"])
     flux_times = pd.to_datetime(["2023-01-01", "2024-01-01", "2025-01-01"])
 
-    positions = _map_times_to_available_month_positions(times, flux_times)
+    positions = utils._map_times_to_available_period_positions(times, flux_times, "yearly")
 
     np.testing.assert_array_equal(positions, np.array([0, 0, 1, 2]))

--- a/tests/test_inferpymc_month_gap.py
+++ b/tests/test_inferpymc_month_gap.py
@@ -119,3 +119,12 @@ def test_map_times_to_available_month_positions_handles_gappy_flux_months():
     positions = _map_times_to_available_month_positions(times, flux_times)
 
     np.testing.assert_array_equal(positions, np.array([0, 0, 1, 2]))
+
+
+def test_map_times_to_available_month_positions_handles_multi_year_flux_time():
+    times = pd.to_datetime(["2023-03-15", "2023-11-20", "2024-07-10", "2025-04-20"])
+    flux_times = pd.to_datetime(["2023-01-01", "2024-01-01", "2025-01-01"])
+
+    positions = _map_times_to_available_month_positions(times, flux_times)
+
+    np.testing.assert_array_equal(positions, np.array([0, 0, 1, 2]))

--- a/tests/test_inferpymc_month_gap.py
+++ b/tests/test_inferpymc_month_gap.py
@@ -5,7 +5,11 @@ import pandas as pd
 import xarray as xr
 
 from openghg_inversions.hbmcmc.hbmcmc import make_inv_inputs_legacy
-from openghg_inversions.hbmcmc.inversion_pymc import _weighted_apriori_flux_for_months, inferpymc
+from openghg_inversions.hbmcmc.inversion_pymc import (
+    _map_times_to_available_month_positions,
+    _weighted_apriori_flux_for_months,
+    inferpymc,
+)
 
 
 def _synthetic_fp_data_one_site_with_missing_month() -> dict[str, xr.Dataset]:
@@ -106,3 +110,12 @@ def test_weighted_apriori_flux_handles_missing_month():
     apriori_flux = _weighted_apriori_flux_for_months(flux_array_all, month_index)
 
     np.testing.assert_allclose(apriori_flux, np.array([[2.0]], dtype=np.float32))
+
+
+def test_map_times_to_available_month_positions_handles_gappy_flux_months():
+    times = pd.to_datetime(["2019-01-15", "2019-01-20", "2019-03-10", "2019-04-20"])
+    flux_times = pd.to_datetime(["2019-01-01", "2019-03-01", "2019-04-01"])
+
+    positions = _map_times_to_available_month_positions(times, flux_times)
+
+    np.testing.assert_array_equal(positions, np.array([0, 0, 1, 2]))

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -3,7 +3,8 @@ import xarray as xr
 
 from openghg_inversions.hbmcmc.hbmcmc import fixedbasisMCMC
 from openghg_inversions.postprocessing.inversion_output import InversionOutput
-from openghg_inversions.postprocessing.make_outputs import basic_output, make_legacy_hbmcmc_output_from_postprocessing
+from openghg_inversions.postprocessing.legacy_outputs import make_legacy_hbmcmc_output
+from openghg_inversions.postprocessing.make_outputs import basic_output
 from openghg_inversions.postprocessing.make_paris_outputs import (
     make_paris_flux_outputs_from_rhime,
     make_paris_outputs,
@@ -139,7 +140,7 @@ def test_hbmcmc_postprocessing_output_matches_legacy_core_fields(raw_data_path, 
     """Regression test for deterministic prior concentration terms in legacy-compatible output."""
     legacy = xr.open_dataset(raw_data_path / "standard_rhime_outs.nc")
     inv_out = InversionOutput.load(raw_data_path / "inversion_output.nc")
-    compat = make_legacy_hbmcmc_output_from_postprocessing(
+    compat = make_legacy_hbmcmc_output(
         inv_out=inv_out,
         mcmc_results={
             "xouts": legacy["xtrace"],
@@ -162,3 +163,9 @@ def test_hbmcmc_postprocessing_output_matches_legacy_core_fields(raw_data_path, 
     assert compat["Yobs"].dims == legacy["Yobs"].dims == ("nmeasure",)
     assert compat.sizes["nmeasure"] == legacy.sizes["nmeasure"]
     assert compat["Yobs"].sizes["nmeasure"] == compat["Yapriori"].sizes["nmeasure"]
+    assert compat["Yapriori"].attrs["units"] == legacy["Yapriori"].attrs["units"]
+    assert compat["YaprioriBC"].attrs["units"] == legacy["YaprioriBC"].attrs["units"]
+    assert compat["Yobs"].attrs["units"] == legacy["Yobs"].attrs["units"]
+
+    for dv in compat.data_vars:
+        assert "longname" in compat[dv].attrs

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -158,6 +158,8 @@ def test_hbmcmc_postprocessing_output_matches_legacy_core_fields(raw_data_path, 
     assert (compat["YaprioriBC"].values == legacy["YaprioriBC"].values).all()
     assert (compat["Yobs"].values == legacy["Yobs"].values).all()
 
+    xr.testing.assert_allclose(compat["fluxapriori"], legacy["fluxapriori"], rtol=1e-6, atol=1e-9)
+
     assert compat["Yapriori"].dims == legacy["Yapriori"].dims == ("nmeasure",)
     assert compat["YaprioriBC"].dims == legacy["YaprioriBC"].dims == ("nmeasure",)
     assert compat["Yobs"].dims == legacy["Yobs"].dims == ("nmeasure",)

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -159,36 +159,41 @@ def test_hbmcmc_postprocessing_saves_legacy_output(mcmc_args, tmpdir):
 
 def test_hbmcmc_postprocessing_output_matches_legacy_core_fields(raw_data_path, europe_country_file):
     """Regression test for deterministic prior concentration terms in legacy-compatible output."""
-    legacy = xr.open_dataset(raw_data_path / "standard_rhime_outs.nc")
-    inv_out = InversionOutput.load(raw_data_path / "inversion_output.nc")
-    compat = make_legacy_hbmcmc_output(
-        inv_out=inv_out,
-        mcmc_results={
-            "xouts": legacy["xtrace"],
-            "sigouts": legacy["sigtrace"],
-            "bcouts": legacy["bctrace"],
-        },
-        sigma_freq_index=legacy["sigmafreqindex"].values,
-        Hx=legacy["xsensitivity"].values.T,
-        Hbc=legacy["bcsensitivity"].values.T,
-        country_file=europe_country_file,
-        use_bc=True,
-    )
+    with xr.open_dataset(raw_data_path / "standard_rhime_outs.nc") as legacy:
+        inv_out = InversionOutput.load(raw_data_path / "inversion_output.nc")
+        compat = make_legacy_hbmcmc_output(
+            inv_out=inv_out,
+            mcmc_results={
+                "xouts": legacy["xtrace"],
+                "sigouts": legacy["sigtrace"],
+                "bcouts": legacy["bctrace"],
+            },
+            sigma_freq_index=legacy["sigmafreqindex"].values,
+            Hx=legacy["xsensitivity"].values.T,
+            Hbc=legacy["bcsensitivity"].values.T,
+            country_file=europe_country_file,
+            use_bc=True,
+        )
 
-    assert (compat["Yapriori"].values == legacy["Yapriori"].values).all()
-    assert (compat["YaprioriBC"].values == legacy["YaprioriBC"].values).all()
-    assert (compat["Yobs"].values == legacy["Yobs"].values).all()
+        assert (compat["Yapriori"].values == legacy["Yapriori"].values).all()
+        assert (compat["YaprioriBC"].values == legacy["YaprioriBC"].values).all()
+        assert (compat["Yobs"].values == legacy["Yobs"].values).all()
 
-    xr.testing.assert_allclose(compat["fluxapriori"], legacy["fluxapriori"], rtol=1e-6, atol=1e-9)
+        xr.testing.assert_allclose(compat["fluxapriori"], legacy["fluxapriori"], rtol=1e-6, atol=1e-9)
 
-    assert compat["Yapriori"].dims == legacy["Yapriori"].dims == ("nmeasure",)
-    assert compat["YaprioriBC"].dims == legacy["YaprioriBC"].dims == ("nmeasure",)
-    assert compat["Yobs"].dims == legacy["Yobs"].dims == ("nmeasure",)
-    assert compat.sizes["nmeasure"] == legacy.sizes["nmeasure"]
-    assert compat["Yobs"].sizes["nmeasure"] == compat["Yapriori"].sizes["nmeasure"]
-    assert compat["Yapriori"].attrs["units"] == legacy["Yapriori"].attrs["units"]
-    assert compat["YaprioriBC"].attrs["units"] == legacy["YaprioriBC"].attrs["units"]
-    assert compat["Yobs"].attrs["units"] == legacy["Yobs"].attrs["units"]
+        assert compat["Yapriori"].dims == legacy["Yapriori"].dims == ("nmeasure",)
+        assert compat["YaprioriBC"].dims == legacy["YaprioriBC"].dims == ("nmeasure",)
+        assert compat["Yobs"].dims == legacy["Yobs"].dims == ("nmeasure",)
+        assert compat["Ymod68"].dims == legacy["Ymod68"].dims == ("nmeasure", "nUI")
+        assert compat["country68"].dims == legacy["country68"].dims == ("countrynames", "nUI")
+        assert compat["countrymean"].dims == legacy["countrymean"].dims == ("countrynames",)
+        assert compat.sizes["nmeasure"] == legacy.sizes["nmeasure"]
+        assert compat["Yobs"].sizes["nmeasure"] == compat["Yapriori"].sizes["nmeasure"]
+        assert compat["Yapriori"].attrs["units"] == legacy["Yapriori"].attrs["units"]
+        assert compat["YaprioriBC"].attrs["units"] == legacy["YaprioriBC"].attrs["units"]
+        assert compat["Yobs"].attrs["units"] == legacy["Yobs"].attrs["units"]
+        assert "UInum" in compat.coords
+        assert "countrynames" in compat.coords
 
-    for dv in compat.data_vars:
-        assert "longname" in compat[dv].attrs
+        for dv in compat.data_vars:
+            assert "longname" in compat[dv].attrs

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -1,7 +1,9 @@
 import pytest
 import xarray as xr
+from pathlib import Path
 
 from openghg_inversions.hbmcmc.hbmcmc import fixedbasisMCMC
+from openghg_inversions.hbmcmc.hbmcmc_output import define_output_filename
 from openghg_inversions.postprocessing.inversion_output import InversionOutput
 from openghg_inversions.postprocessing.legacy_outputs import make_legacy_hbmcmc_output
 from openghg_inversions.postprocessing.make_outputs import basic_output
@@ -34,11 +36,11 @@ def mcmc_args(tmp_path, tac_ch4_data_args, merged_data_dir, merged_data_file_nam
     return mcmc_args
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def inv_out(raw_data_path):
     return InversionOutput.load(raw_data_path / "inversion_output.nc")
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def inv_out_eastasia(raw_data_path):
     return InversionOutput.load(raw_data_path / "inversion_output_EASTASIA.nc")
 
@@ -134,6 +136,25 @@ def test_save_inversion_output(mcmc_args, tmpdir):
     inv_out_reloaded = InversionOutput.load(tmpdir / "inv_out.nc")
 
     assert inv_out == inv_out_reloaded
+
+
+def test_hbmcmc_postprocessing_saves_legacy_output(mcmc_args, tmpdir):
+    mcmc_args["output_format"] = "hbmcmc_postprocessing"
+    mcmc_args["outputpath"] = str(tmpdir)
+
+    outputs = fixedbasisMCMC(**mcmc_args)
+    output_file = define_output_filename(
+        outputpath=str(tmpdir),
+        species=mcmc_args["species"],
+        domain=mcmc_args["domain"],
+        outputname=mcmc_args["outputname"],
+        start_date=mcmc_args["start_date"],
+        ext=".nc",
+    )
+
+    assert Path(output_file).exists()
+    reloaded = xr.open_dataset(output_file)
+    assert reloaded.sizes["nmeasure"] == outputs.sizes["nmeasure"]
 
 
 def test_hbmcmc_postprocessing_output_matches_legacy_core_fields(raw_data_path, europe_country_file):

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -153,5 +153,12 @@ def test_hbmcmc_postprocessing_output_matches_legacy_core_fields(raw_data_path, 
         use_bc=True,
     )
 
-    assert ((compat["Yapriori"].values - legacy["xsensitivity"].sum("nparam").values) == 0).all()
-    assert ((compat["YaprioriBC"].values - legacy["bcsensitivity"].sum("nBC").values) == 0).all()
+    assert (compat["Yapriori"].values == legacy["Yapriori"].values).all()
+    assert (compat["YaprioriBC"].values == legacy["YaprioriBC"].values).all()
+    assert (compat["Yobs"].values == legacy["Yobs"].values).all()
+
+    assert compat["Yapriori"].dims == legacy["Yapriori"].dims == ("nmeasure",)
+    assert compat["YaprioriBC"].dims == legacy["YaprioriBC"].dims == ("nmeasure",)
+    assert compat["Yobs"].dims == legacy["Yobs"].dims == ("nmeasure",)
+    assert compat.sizes["nmeasure"] == legacy.sizes["nmeasure"]
+    assert compat["Yobs"].sizes["nmeasure"] == compat["Yapriori"].sizes["nmeasure"]

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -3,7 +3,7 @@ import xarray as xr
 
 from openghg_inversions.hbmcmc.hbmcmc import fixedbasisMCMC
 from openghg_inversions.postprocessing.inversion_output import InversionOutput
-from openghg_inversions.postprocessing.make_outputs import basic_output
+from openghg_inversions.postprocessing.make_outputs import basic_output, make_legacy_hbmcmc_output_from_postprocessing
 from openghg_inversions.postprocessing.make_paris_outputs import (
     make_paris_flux_outputs_from_rhime,
     make_paris_outputs,
@@ -133,3 +133,25 @@ def test_save_inversion_output(mcmc_args, tmpdir):
     inv_out_reloaded = InversionOutput.load(tmpdir / "inv_out.nc")
 
     assert inv_out == inv_out_reloaded
+
+
+def test_hbmcmc_postprocessing_output_matches_legacy_core_fields(raw_data_path, europe_country_file):
+    """Regression test for deterministic prior concentration terms in legacy-compatible output."""
+    legacy = xr.open_dataset(raw_data_path / "standard_rhime_outs.nc")
+    inv_out = InversionOutput.load(raw_data_path / "inversion_output.nc")
+    compat = make_legacy_hbmcmc_output_from_postprocessing(
+        inv_out=inv_out,
+        mcmc_results={
+            "xouts": legacy["xtrace"],
+            "sigouts": legacy["sigtrace"],
+            "bcouts": legacy["bctrace"],
+        },
+        sigma_freq_index=legacy["sigmafreqindex"].values,
+        Hx=legacy["xsensitivity"].values.T,
+        Hbc=legacy["bcsensitivity"].values.T,
+        country_file=europe_country_file,
+        use_bc=True,
+    )
+
+    assert ((compat["Yapriori"].values - legacy["xsensitivity"].sum("nparam").values) == 0).all()
+    assert ((compat["YaprioriBC"].values - legacy["bcsensitivity"].sum("nBC").values) == 0).all()


### PR DESCRIPTION
This PR adds an option to create outputs that look like the legacy outputs from `inferpymc_postprocessouts`, but using the new code in the `postprocessing` submodule. This should allow us to remove `inferpymc_postprocessouts` eventually (I'm not sure if anyone is still using it).

### Motivation
- Provide a compatibility bridge so outputs produced by the new `postprocessing` pipeline can reproduce the legacy `inferpymc_postprocessouts` HBMCMC output format (from `hbmcmc/inversion_pymc.py`). 
- Preserve the legacy behaviour that a priori observed `y` values are deterministic sums of forward-model sensitivity columns (`Hx` / `Hbc`) while using the richer stats available from the new pipeline. 

### Description
- Added `make_legacy_hbmcmc_output_from_postprocessing` in `openghg_inversions/postprocessing/make_outputs.py`, which uses `make_concentration_outputs`, `make_flux_outputs`, and `make_country_outputs` to assemble a legacy-style `xr.Dataset` and explicitly sets deterministic `Yapriori` / `YaprioriBC` from provided `Hx` / `Hbc`. 
- Updated `openghg_inversions/hbmcmc/hbmcmc.py` to accept a new `output_format` value `"hbmcmc_postprocessing"` and route post-processing to the new compatibility function when requested. 
- Added a regression test `test_hbmcmc_postprocessing_output_matches_legacy_core_fields` in `tests/test_postprocessing.py` that constructs the legacy RHIME dataset and validates deterministic prior concentration fields (`Yapriori` and `YaprioriBC`) generated by the new compatibility function match the legacy sums of sensitivities. 
- Small supporting changes: import `utils` in `make_outputs.py`, use `inv_out.get_flat_basis()` for basis output, and ensure the compatibility function accepts the MCMC traces and sensitivity matrices required to recreate legacy fields. 

### Testing
- Ran the focused pytest: `PYTHONPATH=. pytest -q tests/test_postprocessing.py::test_hbmcmc_postprocessing_output_matches_legacy_core_fields`, and it passed (1 passed, 0 failed). 
- Performed a syntax/byte-compile check with `PYTHONPATH=. python -m py_compile openghg_inversions/hbmcmc/hbmcmc.py openghg_inversions/postprocessing/make_outputs.py tests/test_postprocessing.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a94d673c1883229c27d5c5015ef17b)


----

- [x] Closes #381 
- [x] Tests added and passing
- [ ] Updated CHANGELOG.md