### PR TITLE
Fix PyMC sigma indexing for missing monthly periods + add regression smoke test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Fixed bug introduced by PR 327, which caused "prior factor" variables filled with None values to be passed to post-processing. [PR #353](https://github.com/openghg/openghg_inversions/pull/353)
 - Added new `inversion_inputs.py` with helper functions for creating the inputs to the PyMC code. Tests added to check compatibility with older `inversionsetup.py` helpers. [PR #356](https://github.com/openghg/openghg_inversions/pull/356)
 - Added `BasisFunctions` object (backed by `BasisOperator` objects) and tests to confirm that these preserve existing behaviour when computing H matrices. These classes will be used to refactor the basis functions wrapper in a future PR. [PR #358](https://github.com/openghg/openghg_inversions/pull/358)
-- Fixed issue that raised `IndexError` in `inferpymc` when a monthly of data was missing an `sigam_freq` is "monthly". [PR #365](https://github.com/openghg/openghg_inversions/pull/365)
+- Fixed issue that raised `IndexError` in `inferpymc` when a monthly of data was missing an `sigam_freq` is "monthly". (Code accidentally merged into devel instea of PR, so this is a placeholder PR)[PR #365](https://github.com/openghg/openghg_inversions/pull/365)
 
 # Version 0.6.0
 


### PR DESCRIPTION
* **Summary of changes**

This PR fixes a PyMC indexing bug when `sigma_freq="monthly"` and one or more calendar months have no observations (for example Jan + Mar data, missing Feb). It also adds a synthetic regression test for this case.

Root cause:
- `make_inv_inputs` now produces monthly `sigma_freq_index` values based on actual observed months.
- With missing months, those indices can be non-contiguous (for example `[0, 2]`).
- In `inferpymc`, `sigma` is created with shape `(nsigma_site, nsigma_time)`, where `nsigma_time` is based on `np.unique(...)`, i.e. only two columns in this example.
- Advanced indexing then used the original non-contiguous labels (`2`) as positional indices: `sigma[sites, sigma_freq_index]`, causing out-of-bounds.

Why `Hbc` was different:
- Correct: this is not the same failure mode as BC setup.
- `Hbc` monthly changes affected matrix construction/alignment and whether empty months get explicit columns.
- The crash here is specifically from advanced tensor indexing into `sigma`; `Hbc` is used in dot-products, not indexed the same way.

Fix:
- In `inferpymc`, remap `sigma_freq_index` to contiguous positional indices (`0..N-1`) before using it in tensor indexing.
- Keep this as a minimal local fix in the sampler path.

Tests:
- Added synthetic one-site daily data covering 3 months with a full middle month missing.
- Assert `make_inv_inputs` yields non-contiguous monthly sigma indices.
- Updated regression from “expect IndexError” to a smoke test that `inferpymc` runs successfully for this case.

Behavioral impact:
- No change for contiguous indices.
- Missing-period monthly runs no longer fail during model initialization.

NOTE: the main changes were accidentally pushed directly to devel. This is a placeholder PR. The branch protections have been fixed to prevent this in the future.

* **Please check if the PR fulfills these requirements**

- [x] Closes #364  (Replace xxxx with the Github issue number)
- [x] Tests added and passing
- Documentation and tutorials updated/added
- [x] Added an entry to the `CHANGELOG.md` file
- Added any new requirements to `requirements.txt`
