### PR TITLE
Basis refactor 1: create `BasisFunctions` object in `basis_functions_wrapper`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Added new `inversion_inputs.py` with helper functions for creating the inputs to the PyMC code. Tests added to check compatibility with older `inversionsetup.py` helpers. [PR #356](https://github.com/openghg/openghg_inversions/pull/356)
 - Added `BasisFunctions` object (backed by `BasisOperator` objects) and tests to confirm that these preserve existing behaviour when computing H matrices. These classes will be used to refactor the basis functions wrapper in a future PR. [PR #358](https://github.com/openghg/openghg_inversions/pull/358)
 - Fixed issue that raised `IndexError` in `inferpymc` when a monthly of data was missing an `sigam_freq` is "monthly". (Code accidentally merged into devel instea of PR, so this is a placeholder PR)[PR #365](https://github.com/openghg/openghg_inversions/pull/365)
-- Added opt-in `basis_functions_wrapper` support for returning `BasisFunctions` objects and saving basis artifacts in DataTree format while keeping legacy flat-basis output as the default. [#367](https://github.com/openghg/openghg_inversions/issues/367)
+- Added opt-in `basis_functions_wrapper` support for returning `BasisFunctions` objects and saving basis artifacts in DataTree format while keeping legacy flat-basis output as the default. [PR #367](https://github.com/openghg/openghg_inversions/pull/367)
 
 # Version 0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Added new `inversion_inputs.py` with helper functions for creating the inputs to the PyMC code. Tests added to check compatibility with older `inversionsetup.py` helpers. [PR #356](https://github.com/openghg/openghg_inversions/pull/356)
 - Added `BasisFunctions` object (backed by `BasisOperator` objects) and tests to confirm that these preserve existing behaviour when computing H matrices. These classes will be used to refactor the basis functions wrapper in a future PR. [PR #358](https://github.com/openghg/openghg_inversions/pull/358)
 - Fixed issue that raised `IndexError` in `inferpymc` when a monthly of data was missing an `sigam_freq` is "monthly". (Code accidentally merged into devel instea of PR, so this is a placeholder PR)[PR #365](https://github.com/openghg/openghg_inversions/pull/365)
-- Added opt-in `basis_functions_wrapper` support for returning `BasisFunctions` objects and saving basis artifacts in DataTree format while keeping legacy flat-basis output as the default. [#362](https://github.com/openghg/openghg_inversions/issues/362)
+- Added opt-in `basis_functions_wrapper` support for returning `BasisFunctions` objects and saving basis artifacts in DataTree format while keeping legacy flat-basis output as the default. [#367](https://github.com/openghg/openghg_inversions/issues/367)
 
 # Version 0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixed bug introduced by PR 327, which caused "prior factor" variables filled with None values to be passed to post-processing. [PR #353](https://github.com/openghg/openghg_inversions/pull/353)
 - Added new `inversion_inputs.py` with helper functions for creating the inputs to the PyMC code. Tests added to check compatibility with older `inversionsetup.py` helpers. [PR #356](https://github.com/openghg/openghg_inversions/pull/356)
 - Added `BasisFunctions` object (backed by `BasisOperator` objects) and tests to confirm that these preserve existing behaviour when computing H matrices. These classes will be used to refactor the basis functions wrapper in a future PR. [PR #358](https://github.com/openghg/openghg_inversions/pull/358)
+- Added opt-in `basis_functions_wrapper` support for returning `BasisFunctions` objects and saving basis artifacts in DataTree format while keeping legacy flat-basis output as the default. [#362](https://github.com/openghg/openghg_inversions/issues/362)
 
 # Version 0.6.0
 

--- a/docs/basisfunctions_refactor_plan.md
+++ b/docs/basisfunctions_refactor_plan.md
@@ -1,0 +1,174 @@
+# BasisFunctions PR review and refactor sketch (revised)
+
+## What this revision adds
+
+This revision focuses on the practical concerns raised in review:
+
+- temporary support for **legacy basis save format** and **new DataTree format**,
+- how the migration stages map to reviewable PRs,
+- what to test at each stage,
+- and where a cleanup of `fixedbasisMCMC` output wiring should sit before deeper postprocessing migration.
+
+## Updated architectural stance
+
+### 1) Retain BasisFunctions object at runtime
+
+After `basis_functions_wrapper` executes, retain a `BasisFunctions` object in memory (e.g. under a side-channel
+entry on the run context) so downstream code can access:
+
+- `operator.sensitivity(...)` for H construction parity,
+- `operator.basis_matrix` for flux/country trace calculations,
+- `operator.interpolate(...)` for state->grid reconstruction.
+
+### 2) Basis save/read compatibility policy (temporary dual format)
+
+Because `basis_functions_wrapper` can save basis functions today, and the new operator serialization is DataTree,
+the migration should explicitly support both for a deprecation window.
+
+Recommended temporary contract:
+
+- **Legacy write (default)**: keep existing flat dataset save behavior unchanged.
+- **New write (opt-in)**: add a new option to save DataTree serialization (for operator-aware experiments).
+- **Read path**:
+  - if DataTree metadata is present, use it to reconstruct `BasisFunctions`/`BasisOperator`;
+  - else fall back to legacy flat basis dataset loader.
+
+This gives reproducibility for experiments that reuse fixed basis functions across model variants without forcing
+an immediate format switch.
+
+---
+
+## PR slicing plan (review-friendly)
+
+### PR-1: Wrapper plumbing + dual-format IO scaffold (no fixedbasisMCMC behavior change)
+
+Scope:
+
+- Add opt-in return/payload from `basis_functions_wrapper` (non-breaking default).
+- Attach basis objects in-memory on `fp_data` side channel.
+- Introduce temporary dual write/read support:
+  - legacy flat format remains default,
+  - DataTree write/read added behind explicit option/flag.
+
+Why this as a standalone PR:
+
+- It is self-contained and low-risk.
+- It can be validated with focused unit tests even if broader fixedbasisMCMC reviews are light.
+
+Tests:
+
+- wrapper return contract tests (`legacy` vs `with_basis_object` mode),
+- serialization roundtrip tests (legacy and DataTree),
+- compatibility tests proving both formats load to equivalent basis partition / basis_matrix.
+
+### PR-2: fixedbasisMCMC output cleanup (structural, minimal logic change)
+
+Scope:
+
+- Refactor/untangle output writing code paths in `fixedbasisMCMC`.
+- Separate concerns clearly:
+  1. inversion solve outputs,
+  2. basis artifact persistence,
+  3. postprocessing trigger/output wiring.
+
+Why before postprocessing migration:
+
+- It reduces coupling and makes PR-3/4 easier to review.
+- It addresses the “output code is a mess” concern directly.
+
+Tests:
+
+- regression tests on output variables/attrs presence,
+- smoke test that current run still writes expected legacy outputs,
+- no expected numerical behavior change.
+
+### PR-3: New postprocessing output mode matching legacy `inferpymc_postprocessouts`
+
+Scope:
+
+- Add a postprocessing output mode using the **new postprocessing submodule** but emitting a dataset that matches
+  legacy output structure/variables as closely as practical.
+- Keep legacy rule differences explicit (e.g. modeled prior obs definition) and configurable if needed.
+
+Notes:
+
+- This PR is about output harmonization, not full operator migration.
+- This step enables side-by-side comparison and easier reviewer confidence.
+
+Tests:
+
+- schema/variable parity checks against legacy-like expected outputs,
+- numerical parity tests for quantities expected to match,
+- explicit tests documenting known/intentional differences.
+
+### PR-4: Postprocessing phase 1 integration with retained BasisFunctions (fallback-first)
+
+Scope:
+
+- Where postprocessing currently rebuilds dummy matrices from flat basis fields, prefer retained
+  `BasisFunctions.operator.basis_matrix` when available.
+- Keep legacy reconstruction as fallback.
+
+Tests:
+
+- path-selection tests (`basis object present` vs `absent`),
+- equality tests for flux/country totals between fallback and operator-backed paths on same inputs.
+
+### PR-5: Postprocessing phase 2 primary operator path + deprecation plan
+
+Scope:
+
+- Make operator-backed basis handling primary.
+- Keep legacy path behind feature flag for one release cycle.
+- Publish deprecation timeline for legacy basis reconstruction and (optionally) legacy save format.
+
+Tests:
+
+- end-to-end regression suite (legacy vs new mode),
+- multisource/ragged basis tests for country and flux traces,
+- performance smoke checks on representative runs.
+
+---
+
+## Test strategy summary by layer
+
+1. **Unit tests** (fast)
+   - `BasisFunctions` construction from legacy-loaded and DataTree-loaded inputs,
+   - basis_matrix equivalence across formats,
+   - wrapper API contract / defaults.
+
+2. **Integration tests** (moderate)
+   - wrapper -> fixedbasisMCMC (or equivalent pipeline slice) retains basis objects,
+   - output writer preserves required legacy fields while adding optional operator metadata.
+
+3. **Parity tests** (heavier)
+   - postprocessing outputs: legacy vs new code path comparison,
+   - country and flux traces agree within tolerance where definitions match,
+   - documented expected differences are asserted explicitly.
+
+4. **Backward-compatibility tests**
+   - old saved basis artifacts still load and run,
+   - new DataTree artifacts load and run,
+   - mixed-run environments do not break rerun workflows.
+
+---
+
+## Practical defaults for transition
+
+To reduce disruption while enabling new workflows:
+
+- Keep all new behavior opt-in at first.
+- Keep legacy file format as default writer until parity confidence is high.
+- Add clear metadata tags to saved basis artifacts indicating format and loader path.
+- Add concise logging at load time: "loaded legacy flat basis" vs "loaded DataTree basis".
+
+---
+
+## Exit criteria before full migration
+
+Before removing ad-hoc postprocessing basis reconstruction:
+
+- PR-1..PR-4 merged,
+- parity tests stable across representative domains/species,
+- at least one experiment workflow confirmed to reuse basis artifacts in both formats,
+- reviewer sign-off that output cleanup in fixedbasisMCMC is sufficient for maintainability.

--- a/openghg_inversions/basis/_helpers.py
+++ b/openghg_inversions/basis/_helpers.py
@@ -34,8 +34,9 @@ def fp_sensitivity(fp_and_data: dict, basis_func: xr.DataArray | dict[str, xr.Da
     sites = [key for key in list(fp_and_data.keys()) if key[0] != "."]
 
     flux_sources = list(fp_and_data[".flux"].keys())
+    split_by_sectors = bool(fp_and_data.get(".split_by_sectors", len(flux_sources) > 1))
 
-    if len(flux_sources) == 1:
+    if not split_by_sectors:
         if not isinstance(basis_func, xr.DataArray):
             basis_func = next(iter(basis_func.values()))
 

--- a/openghg_inversions/basis/_wrapper.py
+++ b/openghg_inversions/basis/_wrapper.py
@@ -5,7 +5,9 @@ from time import time
 from typing import Literal
 
 import xarray as xr
+from openghg.analyse._utils import match_dataset_dims, stack_datasets
 
+from openghg_inversions.array_ops import force_align
 from .basis_functions import BasisFunctions
 from ._functions import basis_functions, fixed_outer_regions_basis, basis
 from ._helpers import fp_sensitivity, bc_sensitivity
@@ -198,9 +200,10 @@ def basis_functions_wrapper(
 def _make_basis_functions_object(fp_all: dict, basis: xr.DataArray) -> BasisFunctions:
     """Construct a BasisFunctions object from wrapper inputs.
 
-    The current wrapper only computes a single emissions basis array, so this helper
-    builds a single-source ``BasisFunctions`` with ``state_dim='region'`` for
-    compatibility with legacy naming conventions.
+    The current wrapper computes a single emissions basis array. For non-sector
+    workflows, this helper combines all flux sources into one representative flux
+    using the same alignment/summing behavior as ``ModelScenario.combine_flux_sources``.
+    For sector-split workflows, fluxes are preserved along a ``source`` dimension.
     """
     if ".flux" not in fp_all or not fp_all[".flux"]:
         raise ValueError("Cannot construct BasisFunctions object: fp_all['.flux'] is missing or empty.")
@@ -212,17 +215,9 @@ def _make_basis_functions_object(fp_all: dict, basis: xr.DataArray) -> BasisFunc
     # - single-source workflows combine fluxes by summing over flux entries
     # - multi-source/sector workflows keep per-source fluxes keyed by source
     if _is_multi_source_workflow(fp_all):
-        flux = xr.concat(
-            [arr.expand_dims({"source": [key]}) for key, arr in flux_arrays.items()],
-            dim="source",
-            join="outer",
-        )
+        flux = _stack_flux_sources_with_alignment(flux_arrays)
     else:
-        flux = xr.concat(
-            [arr.expand_dims({"_flux_source": [key]}) for key, arr in flux_arrays.items()],
-            dim="_flux_source",
-            join="outer",
-        ).sum(dim="_flux_source", skipna=True)
+        flux = _combine_flux_sources_like_modelscenario(flux_arrays)
 
     return BasisFunctions.from_basis_flat(
         basis_flat=basis,
@@ -232,11 +227,11 @@ def _make_basis_functions_object(fp_all: dict, basis: xr.DataArray) -> BasisFunc
 
 
 def _is_multi_source_workflow(fp_all: dict) -> bool:
-    """Infer whether this fp_all payload represents a multi-source/sector workflow."""
-    site_keys = [key for key in fp_all if not str(key).startswith(".")]
-    return any(
-        isinstance(fp_all[site], xr.Dataset) and "fp_x_flux_sectoral" in fp_all[site].data_vars for site in site_keys
-    )
+    """Determine multi-source/sector mode from explicit fp_all metadata."""
+    split_by_sectors = fp_all.get(".split_by_sectors")
+    if split_by_sectors is None:
+        return False
+    return bool(split_by_sectors)
 
 
 def _extract_flux_dataarray(flux_entry: object, flux_key: str) -> xr.DataArray:
@@ -251,6 +246,43 @@ def _extract_flux_dataarray(flux_entry: object, flux_key: str) -> xr.DataArray:
     raise TypeError(
         "Could not extract a flux DataArray from fp_all['.flux']. "
         f"Got type {type(flux_entry)!r} for flux entry {flux_key!r}."
+    )
+
+
+def _combine_flux_sources_like_modelscenario(flux_arrays: dict[str, xr.DataArray]) -> xr.DataArray:
+    """Combine fluxes as in ModelScenario.combine_flux_sources."""
+    flux_datasets = [
+        arr.rename("flux").to_dataset() if arr.name != "flux" else arr.to_dataset()
+        for arr in flux_arrays.values()
+    ]
+
+    if len(flux_datasets) == 1:
+        return flux_datasets[0]["flux"]
+
+    dims = [dim for dim in flux_datasets[0].dims if dim != "time"]
+    flux_datasets = match_dataset_dims(flux_datasets, dims=dims)
+    if "time" in flux_datasets[0].dims:
+        flux_stacked = stack_datasets(flux_datasets, dim="time", method="ffill")
+    else:
+        flux_stacked = sum(flux_datasets)
+
+    return flux_stacked["flux"]
+
+
+def _stack_flux_sources_with_alignment(flux_arrays: dict[str, xr.DataArray]) -> xr.DataArray:
+    """Stack fluxes along `source`, validating structural coordinate alignment."""
+    first_key = next(iter(flux_arrays))
+    reference = flux_arrays[first_key]
+    dims_to_align = [dim for dim in reference.dims if dim != "time"]
+
+    aligned_flux = {}
+    for key, arr in flux_arrays.items():
+        aligned_flux[key] = force_align(arr, reference=reference, dims=dims_to_align)
+
+    return xr.concat(
+        [arr.expand_dims({"source": [key]}) for key, arr in aligned_flux.items()],
+        dim="source",
+        join="outer",
     )
 
 

--- a/openghg_inversions/basis/_wrapper.py
+++ b/openghg_inversions/basis/_wrapper.py
@@ -227,11 +227,18 @@ def _make_basis_functions_object(fp_all: dict, basis: xr.DataArray) -> BasisFunc
 
 
 def _is_multi_source_workflow(fp_all: dict) -> bool:
-    """Determine multi-source/sector mode from explicit fp_all metadata."""
+    """Determine multi-source/sector mode from fp_all metadata.
+
+    Prefer explicit ``.split_by_sectors`` when present. For legacy/hand-constructed
+    ``fp_all`` without this flag, fall back to inferring sectoral behavior when
+    multiple flux entries are present.
+    """
     split_by_sectors = fp_all.get(".split_by_sectors")
-    if split_by_sectors is None:
-        return False
-    return bool(split_by_sectors)
+    if split_by_sectors is not None:
+        return bool(split_by_sectors)
+
+    flux_entries = fp_all.get(".flux")
+    return isinstance(flux_entries, dict) and len(flux_entries) > 1
 
 
 def _extract_flux_dataarray(flux_entry: object, flux_key: str) -> xr.DataArray:

--- a/openghg_inversions/basis/_wrapper.py
+++ b/openghg_inversions/basis/_wrapper.py
@@ -91,7 +91,7 @@ def basis_functions_wrapper(
         Default "legacy"
 
     Returns:
-      fp_data (dict) or tuple[dict, dict]:
+      fp_data (dict) or tuple[dict, dict[str, BasisFunctions]]:
         By default, returns a dictionary object similar to fp_all but with information
         on basis functions and sensitivities.
 
@@ -205,25 +205,52 @@ def _make_basis_functions_object(fp_all: dict, basis: xr.DataArray) -> BasisFunc
     if ".flux" not in fp_all or not fp_all[".flux"]:
         raise ValueError("Cannot construct BasisFunctions object: fp_all['.flux'] is missing or empty.")
 
-    first_flux = next(iter(fp_all[".flux"].values()))
+    flux_entries = fp_all[".flux"]
+    flux_arrays = {key: _extract_flux_dataarray(value, flux_key=key) for key, value in flux_entries.items()}
 
-    flux: xr.DataArray
-    if hasattr(first_flux, "data") and isinstance(first_flux.data, xr.Dataset) and "flux" in first_flux.data:
-        flux = first_flux.data["flux"]
-    elif isinstance(first_flux, xr.Dataset) and "flux" in first_flux:
-        flux = first_flux["flux"]
-    elif isinstance(first_flux, xr.DataArray):
-        flux = first_flux
-    else:
-        raise TypeError(
-            "Could not extract a flux DataArray from fp_all['.flux']. "
-            f"Got type {type(first_flux)!r} for first flux entry."
+    # Follow existing ModelScenario behavior:
+    # - single-source workflows combine fluxes by summing over flux entries
+    # - multi-source/sector workflows keep per-source fluxes keyed by source
+    if _is_multi_source_workflow(fp_all):
+        flux = xr.concat(
+            [arr.expand_dims({"source": [key]}) for key, arr in flux_arrays.items()],
+            dim="source",
+            join="outer",
         )
+    else:
+        flux = xr.concat(
+            [arr.expand_dims({"_flux_source": [key]}) for key, arr in flux_arrays.items()],
+            dim="_flux_source",
+            join="outer",
+        ).sum(dim="_flux_source", skipna=True)
 
     return BasisFunctions.from_basis_flat(
         basis_flat=basis,
         flux=flux,
         operator_kwargs={"state_dim": "region"},
+    )
+
+
+def _is_multi_source_workflow(fp_all: dict) -> bool:
+    """Infer whether this fp_all payload represents a multi-source/sector workflow."""
+    site_keys = [key for key in fp_all if not str(key).startswith(".")]
+    return any(
+        isinstance(fp_all[site], xr.Dataset) and "fp_x_flux_sectoral" in fp_all[site].data_vars for site in site_keys
+    )
+
+
+def _extract_flux_dataarray(flux_entry: object, flux_key: str) -> xr.DataArray:
+    """Extract a DataArray named ``flux`` from supported flux entry containers."""
+    if hasattr(flux_entry, "data") and isinstance(flux_entry.data, xr.Dataset) and "flux" in flux_entry.data:
+        return flux_entry.data["flux"]
+    if isinstance(flux_entry, xr.Dataset) and "flux" in flux_entry:
+        return flux_entry["flux"]
+    if isinstance(flux_entry, xr.DataArray):
+        return flux_entry
+
+    raise TypeError(
+        "Could not extract a flux DataArray from fp_all['.flux']. "
+        f"Got type {type(flux_entry)!r} for flux entry {flux_key!r}."
     )
 
 

--- a/openghg_inversions/basis/_wrapper.py
+++ b/openghg_inversions/basis/_wrapper.py
@@ -2,9 +2,11 @@
 
 from pathlib import Path
 from time import time
+from typing import Literal
 
 import xarray as xr
 
+from .basis_functions import BasisFunctions
 from ._functions import basis_functions, fixed_outer_regions_basis, basis
 from ._helpers import fp_sensitivity, bc_sensitivity
 
@@ -26,6 +28,8 @@ def basis_functions_wrapper(
     country_directory: str | None = None,
     outputname: str | None = None,
     output_path: str | None = None,
+    return_basis_objects: bool = False,
+    basis_output_format: Literal["legacy", "datatree"] = "legacy",
 ):
     """Wrapper function for selecting basis function
     algorithm.
@@ -75,11 +79,25 @@ def basis_functions_wrapper(
       output_path (str, optional):
         Passed to `outputdir` argument of `quadtreebasisfunction`. Used for testing.
         Default None
+      return_basis_objects (bool, optional):
+        If True, return a tuple ``(fp_data, basis_objects)`` where
+        ``basis_objects["emissions"]`` is a ``BasisFunctions`` object constructed
+        from the basis used in this wrapper.
+        Default False
+      basis_output_format (str, optional):
+        Format to use when saving basis output with ``output_path``:
+        - ``"legacy"``: save legacy flat basis netCDF (default)
+        - ``"datatree"``: save BasisFunctions DataTree netCDF
+        Default "legacy"
 
     Returns:
-      fp_data (dict):
-        Dictionary object similar to fp_all but with information
-        on basis functions and sensitivities
+      fp_data (dict) or tuple[dict, dict]:
+        By default, returns a dictionary object similar to fp_all but with information
+        on basis functions and sensitivities.
+
+        If ``return_basis_objects=True``, returns ``(fp_data, basis_objects)`` where
+        ``basis_objects`` contains an ``"emissions"`` key with a ``BasisFunctions``
+        object that wraps the basis operator and representative flux.
     """
     if use_bc is True and bc_basis_case is None:
         raise ValueError("If `use_bc` is True, you must specify `bc_basis_case`.")
@@ -126,6 +144,15 @@ def basis_functions_wrapper(
     fp_data = fp_sensitivity(fp_all, basis_func=basis_data_array)
     print(f"Computing fp sensitivity took {time() - fp_sens_start}s.")
 
+    basis_objects: dict[str, BasisFunctions] = {}
+    needs_basis_object = return_basis_objects or (output_path is not None and basis_output_format == "datatree")
+
+    if needs_basis_object:
+        basis_objects["emissions"] = _make_basis_functions_object(
+            fp_all=fp_all,
+            basis=basis_data_array,
+        )
+
     if use_bc is True:
         bc_sens_start = time()
         fp_data = bc_sensitivity(
@@ -137,16 +164,67 @@ def basis_functions_wrapper(
         print(f"Computing bc sensitivity took {time() - bc_sens_start}s.")
 
     if output_path is not None and basis_algorithm is not None and fp_basis_case is None:
-        _save_basis(
-            basis=basis_data_array,
-            basis_algorithm=basis_algorithm,
-            output_dir=output_path,
-            domain=domain,
-            species=species,
-            output_name=outputname,
-        )
+        if basis_output_format == "legacy":
+            _save_basis(
+                basis=basis_data_array,
+                basis_algorithm=basis_algorithm,
+                output_dir=output_path,
+                domain=domain,
+                species=species,
+                output_name=outputname,
+            )
+        elif basis_output_format == "datatree":
+            _save_basis_datatree(
+                basis_functions=basis_objects["emissions"],
+                basis=basis_data_array,
+                basis_algorithm=basis_algorithm,
+                output_dir=output_path,
+                domain=domain,
+                species=species,
+                output_name=outputname,
+            )
+        else:
+            raise ValueError(
+                f"Unknown basis_output_format '{basis_output_format}'. "
+                "Expected one of: 'legacy', 'datatree'."
+            )
+
+    if return_basis_objects:
+        return fp_data, basis_objects
 
     return fp_data
+
+
+def _make_basis_functions_object(fp_all: dict, basis: xr.DataArray) -> BasisFunctions:
+    """Construct a BasisFunctions object from wrapper inputs.
+
+    The current wrapper only computes a single emissions basis array, so this helper
+    builds a single-source ``BasisFunctions`` with ``state_dim='region'`` for
+    compatibility with legacy naming conventions.
+    """
+    if ".flux" not in fp_all or not fp_all[".flux"]:
+        raise ValueError("Cannot construct BasisFunctions object: fp_all['.flux'] is missing or empty.")
+
+    first_flux = next(iter(fp_all[".flux"].values()))
+
+    flux: xr.DataArray
+    if hasattr(first_flux, "data") and isinstance(first_flux.data, xr.Dataset) and "flux" in first_flux.data:
+        flux = first_flux.data["flux"]
+    elif isinstance(first_flux, xr.Dataset) and "flux" in first_flux:
+        flux = first_flux["flux"]
+    elif isinstance(first_flux, xr.DataArray):
+        flux = first_flux
+    else:
+        raise TypeError(
+            "Could not extract a flux DataArray from fp_all['.flux']. "
+            f"Got type {type(first_flux)!r} for first flux entry."
+        )
+
+    return BasisFunctions.from_basis_flat(
+        basis_flat=basis,
+        flux=flux,
+        operator_kwargs={"state_dim": "region"},
+    )
 
 
 def _save_basis(
@@ -190,3 +268,33 @@ def _save_basis(
         output_name = f"{basis_algorithm}_{species}-{output_name}_{domain}_{start_date}.nc"
 
     basis.to_netcdf(basis_out_path / output_name, mode="w")
+
+
+def _save_basis_datatree(
+    basis_functions: BasisFunctions,
+    basis: xr.DataArray,
+    basis_algorithm: str,
+    output_dir: str,
+    domain: str,
+    species: str,
+    output_name: str | None = None,
+) -> None:
+    """Save BasisFunctions object to netCDF DataTree.
+
+    This is an opt-in serialization path. The legacy flat basis writer remains the
+    default to preserve backwards compatibility.
+    """
+    basis_out_path = Path(output_dir, domain.upper())
+
+    if not basis_out_path.exists():
+        basis_out_path.mkdir(parents=True)
+
+    start_date = str(basis.time.min().values)[:7]  # year and month
+
+    if output_name is None:
+        output_name = f"{basis_algorithm}_{species}_{domain}_{start_date}_basis_datatree.nc"
+    else:
+        output_name = f"{basis_algorithm}_{species}-{output_name}_{domain}_{start_date}_basis_datatree.nc"
+
+    dt = basis_functions.to_datatree()
+    dt.to_netcdf(basis_out_path / output_name)

--- a/openghg_inversions/inversion_data/get_data.py
+++ b/openghg_inversions/inversion_data/get_data.py
@@ -176,6 +176,7 @@ def data_processing_surface_notracer(
     obs_store: str | list[str] | None = None,
     footprint_store: str | list[str] | None = None,
     emissions_store: str | None = None,
+    split_by_sectors: bool = False,
     averagingerror: bool = True,
     save_merged_data: bool = False,
     merged_data_name: str | None = None,
@@ -216,6 +217,8 @@ def data_processing_surface_notracer(
         obs_store: Name of object store to retrieve observations data from.
         footprint_store: Name of object store to retrieve footprints data from.
         emissions_store: Name of object store to retrieve emissions data from.
+        split_by_sectors: If True, calculate sector-resolved ``fp_x_flux_sectoral`` in ModelScenario.
+            If False (default), combine all flux sources into a single ``fp_x_flux`` pathway.
         averagingerror: Adds the variability in the averaging period to the measurement
             error if set to True.
         save_merged_data: Save forward simulations data and observations.
@@ -265,6 +268,7 @@ def data_processing_surface_notracer(
         store=emissions_store,
     )
     fp_all[".flux"] = flux_dict
+    fp_all[".split_by_sectors"] = split_by_sectors
 
     # Get BC data
     if use_bc is True:
@@ -350,7 +354,13 @@ def data_processing_surface_notracer(
             continue  # skip this site
 
         scenario_combined = merged_scenario_data(
-            site_data, footprint_data, flux_dict, bc_data, platform=platform[i], max_level=max_level
+            site_data,
+            footprint_data,
+            flux_dict,
+            bc_data,
+            platform=platform[i],
+            max_level=max_level,
+            split_by_sectors=split_by_sectors,
         )
         fp_all[site] = scenario_combined
 

--- a/openghg_inversions/inversion_data/get_data.py
+++ b/openghg_inversions/inversion_data/get_data.py
@@ -359,7 +359,7 @@ def data_processing_surface_notracer(
             flux_dict,
             bc_data,
             platform=platform[i],
-            max_level=max_level,
+            max_level=max_level[i],
             split_by_sectors=split_by_sectors,
         )
         fp_all[site] = scenario_combined

--- a/openghg_inversions/inversion_data/scenario.py
+++ b/openghg_inversions/inversion_data/scenario.py
@@ -10,7 +10,8 @@ def merged_scenario_data(
     flux_dict: dict[str, FluxData],
     bc_data: BoundaryConditionsData | None = None,
     platform: str | None = None,
-    max_level: int | None = None
+    max_level: int | None = None,
+    split_by_sectors: bool = False,
 ) -> xr.Dataset:
     """Create ModelScenario and get result of `footprint_data_merge`."""
     # Create ModelScenario object for all emissions_sectors
@@ -32,8 +33,6 @@ def merged_scenario_data(
             bc=bc_data,
         )
 
-    # TODO: should we make this option explicit? Multiple fluxes can be stacked and used as a single flux
-    split_by_sectors = len(flux_dict) > 1
     scenario_combined = model_scenario.footprints_data_merge(
         platform=platform,
         calc_fp_x_flux=True,

--- a/openghg_inversions/inversion_data/serialise.py
+++ b/openghg_inversions/inversion_data/serialise.py
@@ -11,6 +11,7 @@ import pickle
 from collections import defaultdict
 from pathlib import Path
 from typing import Any, cast, Literal
+import warnings
 
 from numcodecs import Blosc
 import numpy as np
@@ -413,7 +414,13 @@ def fp_all_from_dataset(ds: xr.Dataset) -> dict:
         # conversion to float failed
         fp_all[".units"] = 1.0
 
-    fp_all[".split_by_sectors"] = bool(ds.attrs.get("split_by_sectors", False))
+    if bool(ds.attrs.get("split_by_sectors", False)):
+        warnings.warn(
+            "Legacy `fp_all_from_dataset` drops scenario `source` dimensions, so sector-resolved "
+            "state cannot be reconstructed. Setting `fp_all['.split_by_sectors'] = False` on load.",
+            UserWarning,
+        )
+    fp_all[".split_by_sectors"] = False
 
     return fp_all
 

--- a/openghg_inversions/inversion_data/serialise.py
+++ b/openghg_inversions/inversion_data/serialise.py
@@ -327,6 +327,8 @@ def make_combined_scenario(fp_all: dict) -> xr.Dataset:
         bc = bc.reindex_like(combined_scenario, method="nearest")
         combined_scenario = combined_scenario.merge(bc)
 
+    combined_scenario.attrs["split_by_sectors"] = bool(fp_all.get(".split_by_sectors", False))
+
     return combined_scenario
 
 
@@ -410,6 +412,8 @@ def fp_all_from_dataset(ds: xr.Dataset) -> dict:
     except ValueError:
         # conversion to float failed
         fp_all[".units"] = 1.0
+
+    fp_all[".split_by_sectors"] = bool(ds.attrs.get("split_by_sectors", False))
 
     return fp_all
 

--- a/tests/test_basis_functions.py
+++ b/tests/test_basis_functions.py
@@ -469,6 +469,8 @@ def test_multisector_ragged_new_matches_old_after_conversion():
         ]
         v["fp_x_flux_sectoral"] = xr.concat(to_concat, dim="source")
 
+    fp_all_sectoral[".split_by_sectors"] = True
+
     # --- Build two different basis partitions (ragged region counts) ---
     weighted_basis_args_1 = {
         "domain": "EUROPE",

--- a/tests/test_basis_functions.py
+++ b/tests/test_basis_functions.py
@@ -15,6 +15,11 @@ from openghg_inversions.basis import (
     quadtreebasisfunction,
     fixed_outer_regions_basis,
 )
+from openghg_inversions.basis._wrapper import (
+    _make_basis_functions_object,
+    _save_basis,
+    _save_basis_datatree,
+)
 from openghg_inversions.basis.basis_functions import BasisFunctions
 from openghg_inversions.basis.operators import (
     BucketBasisOperator,
@@ -739,3 +744,103 @@ def test_multisource_sensitivity_matches_legacy_padded_conversion_smoke():
     H_old_gathered = H_old_gathered.transpose("region", "time")
 
     xr.testing.assert_allclose(H_new, H_old_gathered)
+
+
+def test_make_basis_functions_object_from_fp_all(tac_ch4_data_args):
+    """Construct BasisFunctions object from fp_all side-channel flux data."""
+    fp_all, *_ = data_processing_surface_notracer(**tac_ch4_data_args)
+    basis_name = next(iter(fp_all[".flux"].keys()))
+
+    flux = fp_all[".flux"][basis_name].data["flux"]
+    basis_flat = xr.ones_like(flux, dtype=int).rename("basis")
+
+    bf = _make_basis_functions_object(fp_all=fp_all, basis=basis_flat)
+
+    assert isinstance(bf, BasisFunctions)
+    assert bf.operator.meta.state_dim == "region"
+    assert bf.flux.dims == flux.dims
+
+
+def test_basis_functions_wrapper_return_basis_objects(tac_ch4_data_args):
+    """Wrapper can optionally return BasisFunctions payload without changing default path."""
+    fp_all, *_ = data_processing_surface_notracer(**tac_ch4_data_args)
+
+    basis_args = {
+        "species": "ch4",
+        "domain": "EUROPE",
+        "start_date": "2019-01-01",
+        "emissions_name": ["total-ukghg-edgar7"],
+        "nbasis": 8,
+        "use_bc": False,
+        "basis_algorithm": "weighted",
+        "return_basis_objects": True,
+    }
+
+    fp_data, basis_objects = basis_functions_wrapper(fp_all, **basis_args)
+
+    site_keys = [k for k in fp_data if not str(k).startswith(".")]
+    assert len(site_keys) >= 1
+    assert "emissions" in basis_objects
+    assert isinstance(basis_objects["emissions"], BasisFunctions)
+
+
+def test_save_basis_datatree_roundtrip(tmp_path):
+    """Saving DataTree basis output is readable via BasisFunctions.from_datatree."""
+    basis_flat = make_basis_flat_from_blocks([[1, 1], [2, 2]]).expand_dims(time=[np.datetime64("2019-01-01")])
+    flux = xr.ones_like(basis_flat.isel(time=0, drop=True), dtype=float).rename("flux")
+    bf = BasisFunctions.from_basis_flat(
+        basis_flat=basis_flat,
+        flux=flux,
+        operator_kwargs={"state_dim": "region"},
+    )
+
+    _save_basis_datatree(
+        basis_functions=bf,
+        basis=basis_flat,
+        basis_algorithm="weighted",
+        output_dir=str(tmp_path),
+        domain="EUROPE",
+        species="ch4",
+    )
+
+    saved = list((tmp_path / "EUROPE").glob("*_basis_datatree.nc"))
+    assert len(saved) == 1
+
+    dt = xr.open_datatree(saved[0])
+    bf2 = BasisFunctions.from_datatree(dt)
+
+    xr.testing.assert_identical(bf.operator.basis_matrix, bf2.operator.basis_matrix)
+    xr.testing.assert_identical(bf.flux, bf2.flux)
+
+
+def test_save_basis_legacy_and_datatree_filenames(tmp_path):
+    """Legacy and DataTree writers both produce expected output files."""
+    basis_flat = make_basis_flat_from_blocks([[1, 1], [2, 2]]).expand_dims(time=[np.datetime64("2019-01-01")])
+    flux = xr.ones_like(basis_flat.isel(time=0, drop=True), dtype=float).rename("flux")
+    bf = BasisFunctions.from_basis_flat(
+        basis_flat=basis_flat,
+        flux=flux,
+        operator_kwargs={"state_dim": "region"},
+    )
+
+    _save_basis(
+        basis=basis_flat,
+        basis_algorithm="weighted",
+        output_dir=str(tmp_path),
+        domain="EUROPE",
+        species="ch4",
+        output_name="legacy-check",
+    )
+    _save_basis_datatree(
+        basis_functions=bf,
+        basis=basis_flat,
+        basis_algorithm="weighted",
+        output_dir=str(tmp_path),
+        domain="EUROPE",
+        species="ch4",
+        output_name="datatree-check",
+    )
+
+    files = [p.name for p in (tmp_path / "EUROPE").iterdir()]
+    assert any("legacy-check" in name and name.endswith(".nc") for name in files)
+    assert any("datatree-check" in name and name.endswith("_basis_datatree.nc") for name in files)

--- a/tests/test_basis_functions.py
+++ b/tests/test_basis_functions.py
@@ -17,6 +17,7 @@ from openghg_inversions.basis import (
 )
 from openghg_inversions.basis._wrapper import (
     _make_basis_functions_object,
+    _is_multi_source_workflow,
     _save_basis,
     _save_basis_datatree,
 )
@@ -844,6 +845,14 @@ def test_make_basis_functions_object_stacks_fluxes_sectoral():
         dim="source",
     )
     xr.testing.assert_allclose(bf.flux, expected)
+
+
+def test_is_multi_source_workflow_legacy_fallback():
+    """If .split_by_sectors is missing, fallback inference uses number of flux entries."""
+    fp_all = {
+        ".flux": {"a": xr.DataArray([1.0], dims=("x",)), "b": xr.DataArray([2.0], dims=("x",))},
+    }
+    assert _is_multi_source_workflow(fp_all)
 
 
 def test_basis_functions_wrapper_return_basis_objects(tac_ch4_data_args):

--- a/tests/test_basis_functions.py
+++ b/tests/test_basis_functions.py
@@ -184,6 +184,24 @@ def test_fp_sensitivity_two_flux_sectors():
         np.testing.assert_allclose(2 * h.isel(time=0), h.isel(time=1))
 
 
+def test_fp_sensitivity_two_flux_sources_combined_mode():
+    """If split_by_sectors is False, use combined `fp_x_flux` even with multiple flux entries."""
+    nlat, nlon = 10, 12
+    nbasis = 3
+    basis_func = basis_function(nlat, nlon, nbasis)
+    fp = footprint(nlat, nlon, "2019-01-01", "2019-01-02", 2)
+
+    fp_and_data = {
+        "TAC": xr.Dataset({"fp_x_flux": fp}),
+        ".flux": {"a": 1, "b": 2},
+        ".split_by_sectors": False,
+    }
+
+    fp_and_data = fp_sensitivity(fp_and_data, basis_func)
+    h = fp_and_data["TAC"].H
+    np.testing.assert_allclose(2 * h.isel(time=0), h.isel(time=1))
+
+
 def test_fp_sensitivity_two_flux_sectors_two_basis_funcs():
     """Check that we can apply separate basis functions to separate sources."""
     nlat, nlon = 10, 12
@@ -776,10 +794,12 @@ def test_make_basis_functions_object_sums_fluxes_non_sectoral():
         coords={"lat": basis_flat.lat, "lon": basis_flat.lon},
         name="flux",
     )
-    fp_x_flux = make_fp_x_flux(nlat=2, nlon=2, ntime=2)
+    fp_x_flux_sectoral = make_fp_x_flux_sectoral(sources=["a", "b"], nlat=2, nlon=2, ntime=2)
     fp_all = {
-        "TAC": xr.Dataset({"fp_x_flux": fp_x_flux}),
+        # Even if sectoral variables are present, explicit mode flag should control behavior.
+        "TAC": xr.Dataset({"fp_x_flux_sectoral": fp_x_flux_sectoral}),
         ".flux": {"a": flux_a, "b": flux_b},
+        ".split_by_sectors": False,
     }
 
     bf = _make_basis_functions_object(fp_all=fp_all, basis=basis_flat)
@@ -808,6 +828,7 @@ def test_make_basis_functions_object_stacks_fluxes_sectoral():
     fp_all = {
         "TAC": xr.Dataset({"fp_x_flux_sectoral": fp_x_flux_sectoral}),
         ".flux": {"a": flux_a, "b": flux_b},
+        ".split_by_sectors": True,
     }
 
     bf = _make_basis_functions_object(fp_all=fp_all, basis=basis_flat)

--- a/tests/test_basis_functions.py
+++ b/tests/test_basis_functions.py
@@ -761,6 +761,68 @@ def test_make_basis_functions_object_from_fp_all(tac_ch4_data_args):
     assert bf.flux.dims == flux.dims
 
 
+def test_make_basis_functions_object_sums_fluxes_non_sectoral():
+    """Non-sectoral workflows should sum flux entries into one representative flux."""
+    basis_flat = make_basis_flat_from_blocks([[1, 1], [2, 2]])
+    flux_a = xr.DataArray(
+        np.array([[1.0, 1.0], [1.0, 1.0]]),
+        dims=("lat", "lon"),
+        coords={"lat": basis_flat.lat, "lon": basis_flat.lon},
+        name="flux",
+    )
+    flux_b = xr.DataArray(
+        np.array([[2.0, 2.0], [2.0, 2.0]]),
+        dims=("lat", "lon"),
+        coords={"lat": basis_flat.lat, "lon": basis_flat.lon},
+        name="flux",
+    )
+    fp_x_flux = make_fp_x_flux(nlat=2, nlon=2, ntime=2)
+    fp_all = {
+        "TAC": xr.Dataset({"fp_x_flux": fp_x_flux}),
+        ".flux": {"a": flux_a, "b": flux_b},
+    }
+
+    bf = _make_basis_functions_object(fp_all=fp_all, basis=basis_flat)
+
+    assert isinstance(bf, BasisFunctions)
+    assert "source" not in bf.flux.dims
+    xr.testing.assert_allclose(bf.flux, flux_a + flux_b)
+
+
+def test_make_basis_functions_object_stacks_fluxes_sectoral():
+    """Sectoral workflows should preserve source-resolved fluxes along `source`."""
+    basis_flat = make_basis_flat_from_blocks([[1, 1], [2, 2]])
+    flux_a = xr.DataArray(
+        np.array([[1.0, 1.0], [1.0, 1.0]]),
+        dims=("lat", "lon"),
+        coords={"lat": basis_flat.lat, "lon": basis_flat.lon},
+        name="flux",
+    )
+    flux_b = xr.DataArray(
+        np.array([[2.0, 2.0], [2.0, 2.0]]),
+        dims=("lat", "lon"),
+        coords={"lat": basis_flat.lat, "lon": basis_flat.lon},
+        name="flux",
+    )
+    fp_x_flux_sectoral = make_fp_x_flux_sectoral(sources=["a", "b"], nlat=2, nlon=2, ntime=2)
+    fp_all = {
+        "TAC": xr.Dataset({"fp_x_flux_sectoral": fp_x_flux_sectoral}),
+        ".flux": {"a": flux_a, "b": flux_b},
+    }
+
+    bf = _make_basis_functions_object(fp_all=fp_all, basis=basis_flat)
+
+    assert isinstance(bf, BasisFunctions)
+    assert "source" in bf.flux.dims
+    assert list(bf.flux.source.values) == ["a", "b"]
+
+    expected = xr.concat(
+        [flux_a.expand_dims({"source": ["a"]}), flux_b.expand_dims({"source": ["b"]})],
+        dim="source",
+    )
+    xr.testing.assert_allclose(bf.flux, expected)
+
+
 def test_basis_functions_wrapper_return_basis_objects(tac_ch4_data_args):
     """Wrapper can optionally return BasisFunctions payload without changing default path."""
     fp_all, *_ = data_processing_surface_notracer(**tac_ch4_data_args)
@@ -782,6 +844,29 @@ def test_basis_functions_wrapper_return_basis_objects(tac_ch4_data_args):
     assert len(site_keys) >= 1
     assert "emissions" in basis_objects
     assert isinstance(basis_objects["emissions"], BasisFunctions)
+
+
+def test_basis_functions_wrapper_invalid_basis_output_format(tac_ch4_data_args, tmp_path):
+    """Invalid basis_output_format should raise a clear ValueError."""
+    fp_all, *_ = data_processing_surface_notracer(**tac_ch4_data_args)
+
+    basis_args = {
+        "species": "ch4",
+        "domain": "EUROPE",
+        "start_date": "2019-01-01",
+        "emissions_name": ["total-ukghg-edgar7"],
+        "nbasis": 8,
+        "use_bc": False,
+        "basis_algorithm": "weighted",
+        "output_path": str(tmp_path),
+        "basis_output_format": "invalid",
+    }
+
+    with pytest.raises(
+        ValueError,
+        match="Unknown basis_output_format 'invalid'. Expected one of: 'legacy', 'datatree'.",
+    ):
+        basis_functions_wrapper(fp_all, **basis_args)
 
 
 def test_save_basis_datatree_roundtrip(tmp_path):

--- a/tests/test_get_data.py
+++ b/tests/test_get_data.py
@@ -35,7 +35,7 @@ def test_data_processing_surface_notracer(
     assert len(result) == 6
 
     # check keys of "fp_all"
-    assert list(result[0].keys()) == [".species", ".flux", ".bc", "TAC", ".scales", ".units"]
+    assert list(result[0].keys()) == [".species", ".flux", ".split_by_sectors", ".bc", "TAC", ".scales", ".units"]
 
     # variables to check (to avoid surprises from new variables added to data)
     check_vars = ["mf", "fp", "mf_mod", "bc_mod", "fp_x_flux", "bc_n"]


### PR DESCRIPTION
* **Summary of changes**

This is the first PR in a series of 5 that will close #360. It creates a `BasisFunctions` object in `basis_functions_wrapper` and implements options to save it, but it doesn't change how the "H matrix" is computed, or have any other effect. It just tests that we can create and return the `BasisFunctions` object if we opt-in with `return_basis_objects=True`.

- Implemented PR-1 plumbing in basis_functions_wrapper with two opt-in parameters:
  - return_basis_objects to optionally return (fp_data, basis_objects),
  - basis_output_format to choose "legacy" (default) or "datatree" for basis saving. This preserves existing behavior unless explicitly enabled.
- Added _make_basis_functions_object(...) so wrapper code can build a BasisFunctions object from fp_all[".flux"] and the computed basis, using state_dim="region" for compatibility with legacy naming assumptions.
- Added _save_basis_datatree(...) as an opt-in DataTree serialization save path, while keeping legacy _save_basis(...) untouched as default output behavior.
- Added tests covering:
  - helper object construction from fp_all,
  - wrapper opt-in return of basis objects,
  - DataTree save/load roundtrip,
  - coexistence of legacy + DataTree save outputs.

### Compatibility / behavior notes

- Fixed a pre-existing bug in `data_processing_surface_notracer`: `max_level` is normalized to a per-site list, and we now correctly pass `max_level[i]` into `merged_scenario_data` for each site.
- `basis._wrapper._is_multi_source_workflow` now prefers explicit `fp_all[".split_by_sectors"]` when present, but falls back to legacy inference (`len(fp_all[".flux"]) > 1`) when the flag is absent. This preserves compatibility for older / hand-constructed `fp_all` payloads.
- Added a guard for the legacy Dataset conversion path (`fp_all_from_dataset`): because this path drops scenario `source` dimensions, it cannot faithfully reconstruct sector-resolved state. We now emit a warning and set `fp_all[".split_by_sectors"] = False` on load in this path.
- Primary persisted formats (`zarr`, `zarr.zip`, `netcdf`) continue to use the DataTree serialization path.

* **Please check if the PR fulfills these requirements**

- [x] Closes #362 
- [x] Tests added and passing
- Documentation and tutorials updated/added
- [x] Added an entry to the `CHANGELOG.md` file
- Added any new requirements to `requirements.txt`
