### PR TITLE
fix country code alignment issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Code changes
 
+- Fix small bug where postprocessing was failing if country codes in file didn't match exactly those in `paris_regions_dict`. [#PR 377](https://github.com/openghg/openghg_inversions/pull/377)
 - More flexibility for new inversion domains. [#PR 333](https://github.com/openghg/openghg_inversions/pull/333)
 - More flexibility for types of boundary condition basis functions. [#PR 333](https://github.com/openghg/openghg_inversions/pull/333)
 - Bug fix for quadtree algorithm. [#PR 333](https://github.com/openghg/openghg_inversions/pull/333)

--- a/openghg_inversions/postprocessing/countries.py
+++ b/openghg_inversions/postprocessing/countries.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import warnings
 from collections import defaultdict
 from pathlib import Path
 from typing import cast, Literal, TypeVar
@@ -167,7 +168,12 @@ class CountryRegions:
 
         return missing
 
-    def align(self, country_list: CountryInfoList, drop_missing: bool = False) -> Self:
+    def align(
+        self,
+        country_list: CountryInfoList,
+        drop_missing: bool = False,
+        warn_on_drop: bool = True,
+    ) -> Self:
         """Return CountryRegions with values aligned to a given list of countries.
 
         This is used to make sure that the region definitions have the same "input names"
@@ -177,15 +183,37 @@ class CountryRegions:
             country_list: list to align countries against.
             drop_missing: if True, skip any region for which one or more countries are
               missing from `country_list`.
+            warn_on_drop: if True and `drop_missing` is True, emit a warning listing
+              dropped regions and missing countries.
         """
+        missing_by_region = self.region_countries_missing_from(country_list)
+
+        if missing_by_region and not drop_missing:
+            msg = "\n".join(
+                f"{region}: {list(missing_countries)}"
+                for region, missing_countries in missing_by_region.items()
+                if missing_countries
+            )
+            raise ValueError(f"Could not find the following countries needed for regions:\n{msg}")
+
+        if missing_by_region and drop_missing and warn_on_drop:
+            msg = "; ".join(
+                f"{region} (missing: {list(missing_countries)})"
+                for region, missing_countries in missing_by_region.items()
+                if missing_countries
+            )
+            warnings.warn(
+                "Dropping country regions with unmatched countries in `country_regions`: " + msg,
+                UserWarning,
+            )
+
         aligned_country_regions = {}
 
         for region, region_countries in self._regions.items():
-            try:
-                aligned_country_regions[region] = country_list.select_by_country_info(region_countries)
-            except ValueError:
-                if not drop_missing:
-                    raise
+            if region in missing_by_region:
+                continue
+
+            aligned_country_regions[region] = country_list.select_by_country_info(region_countries)
 
         return type(self)(aligned_country_regions)
 
@@ -212,6 +240,7 @@ class Countries:
         country_selections: list[str] | None = None,
         country_code: Literal["alpha2", "alpha3"] | None = None,
         country_regions: dict[str, list[str]] | str | Path | None = None,
+        drop_missing_regions: bool = False,
     ) -> None:
         """Create Countries object given country map Dataset and optional list of countries to select.
 
@@ -224,6 +253,9 @@ class Countries:
               list of (country codes) of the countries comprising that regions (e.g.
               `["BEL", "NLD", "LUX"]`). Alternatively, a path (or string representing a path)
               to a JSON file with a similar specification can be passed.
+            drop_missing_regions: if True, region definitions containing countries not
+                found in the country file are dropped with a warning. If False, missing
+                countries in region definitions raise a ValueError.
 
         """
         self.country_code = country_code
@@ -235,7 +267,9 @@ class Countries:
         else:
             self.country_regions = CountryRegions(country_regions)
 
-        self.country_regions = self.country_regions.align(self.country_labels, drop_missing=True)
+        self.country_regions = self.country_regions.align(
+            self.country_labels, drop_missing=drop_missing_regions
+        )
 
         # check that country regions are specified in correct country code
         missing_countries = self.country_regions.region_countries_missing_from(self.country_labels)
@@ -302,6 +336,7 @@ class Countries:
         country_selections: list[str] | None = None,
         country_code: Literal["alpha2", "alpha3"] | None = None,
         country_regions: dict[str, list[str]] | str | Path | None = None,
+        drop_missing_regions: bool = False,
     ) -> Self:
         """Create Countries object given country map Dataset and optional list of countries to select.
 
@@ -315,6 +350,9 @@ class Countries:
               list of (country codes) of the countries comprising that regions (e.g.
               `["BEL", "NLD", "LUX"]`). Alternatively, a path (or string representing a path)
               to a JSON file with a similar specification can be passed.
+            drop_missing_regions: if True, region definitions containing countries not
+                found in the country file are dropped with a warning. If False, missing
+                countries in region definitions raise a ValueError.
 
         """
         country_file_path = get_country_file_path(country_file=country_file, domain=domain)
@@ -323,6 +361,7 @@ class Countries:
             country_code=country_code,
             country_selections=country_selections,
             country_regions=country_regions,
+            drop_missing_regions=drop_missing_regions,
         )
 
     def get_x_to_country_mat(

--- a/openghg_inversions/postprocessing/countries.py
+++ b/openghg_inversions/postprocessing/countries.py
@@ -167,16 +167,26 @@ class CountryRegions:
 
         return missing
 
-    def align(self, country_list: CountryInfoList) -> Self:
+    def align(self, country_list: CountryInfoList, drop_missing: bool = False) -> Self:
         """Return CountryRegions with values aligned to a given list of countries.
 
         This is used to make sure that the region definitions have the same "input names"
         as the given country list, which is necessary if country codes are not being used.
+
+        Args:
+            country_list: list to align countries against.
+            drop_missing: if True, skip any region for which one or more countries are
+              missing from `country_list`.
         """
-        aligned_country_regions = {
-            region: country_list.select_by_country_info(region_countries)
-            for region, region_countries in self._regions.items()
-        }
+        aligned_country_regions = {}
+
+        for region, region_countries in self._regions.items():
+            try:
+                aligned_country_regions[region] = country_list.select_by_country_info(region_countries)
+            except ValueError:
+                if not drop_missing:
+                    raise
+
         return type(self)(aligned_country_regions)
 
     def all_region_countries_present_in(self, country_list: CountryInfoList) -> bool:
@@ -225,7 +235,7 @@ class Countries:
         else:
             self.country_regions = CountryRegions(country_regions)
 
-        self.country_regions = self.country_regions.align(self.country_labels)
+        self.country_regions = self.country_regions.align(self.country_labels, drop_missing=True)
 
         # check that country regions are specified in correct country code
         missing_countries = self.country_regions.region_countries_missing_from(self.country_labels)

--- a/openghg_inversions/postprocessing/make_outputs.py
+++ b/openghg_inversions/postprocessing/make_outputs.py
@@ -244,13 +244,20 @@ def make_country_outputs(
         xr.Dataset containing statistics for the specified countries and regions.
 
     """
+    drop_missing_regions = False
+
     if country_regions == "paris":
         country_regions = paris_regions_dict.get(inv_out.domain.lower())
+        drop_missing_regions = True
     elif isinstance(country_regions, str):
         country_regions = Path(country_regions)
 
     countries = Countries.from_file(
-        country_file=country_file, country_code=country_code, country_regions=country_regions, domain=inv_out.domain
+        country_file=country_file,
+        country_code=country_code,
+        country_regions=country_regions,
+        domain=inv_out.domain,
+        drop_missing_regions=drop_missing_regions,
     )
     country_traces = countries.get_country_trace(inv_out=inv_out)
 

--- a/tests/postprocessing/test_countries.py
+++ b/tests/postprocessing/test_countries.py
@@ -83,6 +83,42 @@ def test_countries_matrix_skips_regions_with_missing_country_codes(country_code,
         country_regions=country_regions,
         country_code=country_code,
         country_file=eastasia_country_file,
+        drop_missing_regions=True,
     )
 
     assert "EASTERN_ASIA" not in countries.country_selections
+
+
+@pytest.mark.parametrize("country_code", ["alpha2", "alpha3", None])
+def test_countries_matrix_warns_when_regions_dropped(country_code, eastasia_country_file):
+    """Check that dropping regions due to missing country names/codes emits a warning."""
+    country_regions = {
+        "EASTERN_ASIA": ["NOT_A_COUNTRY", "PRK", "KOR", "JPN"],
+    }
+
+    with pytest.warns(UserWarning, match="Dropping country regions with unmatched countries"):
+        countries = Countries.from_file(
+            domain="EASTASIA",
+            country_regions=country_regions,
+            country_code=country_code,
+            country_file=eastasia_country_file,
+            drop_missing_regions=True,
+        )
+
+    assert "EASTERN_ASIA" not in countries.country_selections
+
+
+@pytest.mark.parametrize("country_code", ["alpha2", "alpha3", None])
+def test_countries_matrix_raises_on_missing_regions_by_default(country_code, eastasia_country_file):
+    """Check that missing countries in region definitions raise by default."""
+    country_regions = {
+        "EASTERN_ASIA": ["NOT_A_COUNTRY", "PRK", "KOR", "JPN"],
+    }
+
+    with pytest.raises(ValueError, match="Could not find the following countries needed for regions"):
+        Countries.from_file(
+            domain="EASTASIA",
+            country_regions=country_regions,
+            country_code=country_code,
+            country_file=eastasia_country_file,
+        )

--- a/tests/postprocessing/test_countries.py
+++ b/tests/postprocessing/test_countries.py
@@ -69,3 +69,20 @@ def test_countries_matrix_with_regions_EASTASIA(country_code, country_ds_eastasi
     )
 
     assert len(countries.country_selections) == len(country_ds_eastasia.name) + len(paris_regions_dict.get('eastasia', []))
+
+
+@pytest.mark.parametrize("country_code", ["alpha2", "alpha3", None])
+def test_countries_matrix_skips_regions_with_missing_country_codes(country_code, eastasia_country_file):
+    """Check that regions with missing country names/codes are skipped instead of raising."""
+    country_regions = {
+        "EASTERN_ASIA": ["NOT_A_COUNTRY", "PRK", "KOR", "JPN"],
+    }
+
+    countries = Countries.from_file(
+        domain="EASTASIA",
+        country_regions=country_regions,
+        country_code=country_code,
+        country_file=eastasia_country_file,
+    )
+
+    assert "EASTERN_ASIA" not in countries.country_selections


### PR DESCRIPTION
Fix issue where, if the country codes in the country file didn't align with those in the `paris_region_dict`, postprocessing would fail. Now, the expected behaviour is to skip that composite region. 


* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [x] Tests added and passing
- [ ] Documentation and tutorials updated/added
- [x] Added an entry to the `CHANGELOG.md` file
- [ ] Added any new requirements to `requirements.txt`
