### PR TITLE
Iss371: inferpymc regression tests and model function extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added `BasisFunctions` object (backed by `BasisOperator` objects) and tests to confirm that these preserve existing behaviour when computing H matrices. These classes will be used to refactor the basis functions wrapper in a future PR. [PR #358](https://github.com/openghg/openghg_inversions/pull/358)
 - Fixed issue that raised `IndexError` in `inferpymc` when a monthly of data was missing an `sigam_freq` is "monthly". (Code accidentally merged into devel instea of PR, so this is a placeholder PR)[PR #365](https://github.com/openghg/openghg_inversions/pull/365)
 - Added opt-in `basis_functions_wrapper` support for returning `BasisFunctions` objects and saving basis artifacts in DataTree format while keeping legacy flat-basis output as the default. [PR #367](https://github.com/openghg/openghg_inversions/pull/367)
+- Stage A of PyMC model refactor. Added regression tests for `inferpymc` and extracted function to build the PyMC model. [PR #378](https://github.com/openghg/openghg_inversions/pull/378)
 
 # Version 0.6.0
 

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -161,6 +161,17 @@ def _contiguous_sigma_time_index(sigma_freq_index: np.ndarray) -> np.ndarray:
     return np.searchsorted(uniq, sigma_freq_index).astype(int)
 
 
+#----------------------------------------
+# Model building code
+#----------------------------------------
+
+# Defaults to avoid mutable default arguments in model building functions.
+DEFAULT_XPRIOR: PriorArgs = {"pdf": "normal", "mu": 1.0, "sigma": 1.0}
+DEFAULT_BCPRIOR: PriorArgs = {"pdf": "normal", "mu": 1.0, "sigma": 1.0}
+DEFAULT_SIGPRIOR: PriorArgs = {"pdf": "uniform", "lower": 0.1, "upper": 3.0}
+DEFAULT_OFFSETPRIOR: PriorArgs = {"pdf": "normal", "mu": 0, "sigma": 1}
+
+
 def build_inferpymc_model(
     Hx: np.ndarray,
     Y: np.ndarray,
@@ -168,11 +179,11 @@ def build_inferpymc_model(
     siteindicator: np.ndarray,
     sigma_freq_index: np.ndarray,
     Hbc: np.ndarray | None = None,
-    xprior: dict = {"pdf": "normal", "mu": 1.0, "sigma": 1.0},
-    bcprior: dict = {"pdf": "normal", "mu": 1.0, "sigma": 1.0},
-    sigprior: dict = {"pdf": "uniform", "lower": 0.1, "upper": 3.0},
+    xprior: dict | None = None,
+    bcprior: dict | None = None,
+    sigprior: dict | None= None,
     sigma_per_site: bool = True,
-    offsetprior: dict = {"pdf": "normal", "mu": 0, "sigma": 1},
+    offsetprior: dict | None = None,
     add_offset: bool = False,
     min_error: np.ndarray | float | None = 0.0,
     use_bc: bool = True,
@@ -186,6 +197,12 @@ def build_inferpymc_model(
     """Build the PyMC model and sampler configuration used by inferpymc."""
     if use_bc and Hbc is None:
         raise ValueError("If `use_bc` is True, then `Hbc` must be provided.")
+
+    # Assign defaults here to avoid sharing the same dict across calls.
+    xprior = DEFAULT_XPRIOR.copy() if xprior is None else xprior
+    bcprior = DEFAULT_BCPRIOR.copy() if bcprior is None else bcprior
+    sigprior = DEFAULT_SIGPRIOR.copy() if sigprior is None else sigprior
+    offsetprior = DEFAULT_OFFSETPRIOR.copy() if offsetprior is None else offsetprior
 
     hx = Hx.T
     hbc = Hbc.T if use_bc and Hbc is not None else None
@@ -269,6 +286,11 @@ def build_inferpymc_model(
         step2=step2,
         sample_kwargs={"step": [step1, step2] if nuts_sampler == "pymc" else None},
     )
+
+
+#----------------------------------------
+# Build/run model
+#----------------------------------------
 
 
 def inferpymc(

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -4,7 +4,9 @@ PyMC library used for Bayesian modelling.
 
 import re
 import getpass
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 
@@ -31,6 +33,16 @@ from openghg_inversions.config.version import code_version
 
 # type alias for prior args
 PriorArgs = dict[str, str | float]
+
+
+@dataclass
+class InferPyMCModelSetup:
+    """Container for the PyMC model and sampler configuration used by inferpymc."""
+
+    model: pm.Model
+    step1: pm.NUTS
+    step2: pm.Slice
+    sample_kwargs: dict[str, Any]
 
 
 def lognormal_mu_sigma(mean: float, stdev: float) -> tuple[float, float]:
@@ -147,6 +159,116 @@ def _contiguous_sigma_time_index(sigma_freq_index: np.ndarray) -> np.ndarray:
 
     uniq = np.unique(sigma_freq_index)
     return np.searchsorted(uniq, sigma_freq_index).astype(int)
+
+
+def build_inferpymc_model(
+    Hx: np.ndarray,
+    Y: np.ndarray,
+    error: np.ndarray,
+    siteindicator: np.ndarray,
+    sigma_freq_index: np.ndarray,
+    Hbc: np.ndarray | None = None,
+    xprior: dict = {"pdf": "normal", "mu": 1.0, "sigma": 1.0},
+    bcprior: dict = {"pdf": "normal", "mu": 1.0, "sigma": 1.0},
+    sigprior: dict = {"pdf": "uniform", "lower": 0.1, "upper": 3.0},
+    sigma_per_site: bool = True,
+    offsetprior: dict = {"pdf": "normal", "mu": 0, "sigma": 1},
+    add_offset: bool = False,
+    min_error: np.ndarray | float | None = 0.0,
+    use_bc: bool = True,
+    reparameterise_log_normal: bool = False,
+    pollution_events_from_obs: bool = False,
+    no_model_error: bool = False,
+    offset_args: dict | None = None,
+    power: dict | float = 1.99,
+    nuts_sampler: str = "pymc",
+) -> InferPyMCModelSetup:
+    """Build the PyMC model and sampler configuration used by inferpymc."""
+    if use_bc and Hbc is None:
+        raise ValueError("If `use_bc` is True, then `Hbc` must be provided.")
+
+    hx = Hx.T
+    hbc = Hbc.T if use_bc and Hbc is not None else None
+
+    sites = siteindicator.astype(int) if sigma_per_site else np.zeros_like(siteindicator).astype(int)
+    sigma_freq_index_model = _contiguous_sigma_time_index(sigma_freq_index)
+
+    coords = _make_coords(
+        Y, Hx, siteindicator, sigma_freq_index_model, Hbc, sigma_per_site=sigma_per_site, sites=None
+    )
+
+    if isinstance(min_error, float) or (isinstance(min_error, np.ndarray) and min_error.ndim == 0):
+        min_error = min_error * np.ones_like(Y)
+
+    with pm.Model(coords=coords) as model:
+        step1_vars = []
+
+        if reparameterise_log_normal and xprior["pdf"] == "lognormal":
+            x0 = pm.Normal("x0", 0, 1, dims="nx")
+            x = pm.Deterministic("x", pt.exp(xprior["mu"] + xprior["sigma"] * x0), dims="nx")
+            step1_vars.append(x0)
+        else:
+            x = parse_prior("x", xprior, dims="nx")
+            step1_vars.append(x)
+
+        if use_bc:
+            if reparameterise_log_normal and bcprior["pdf"] == "lognormal":
+                bc0 = pm.Normal("bc0", 0, 1, dims="nbc")
+                bc = pm.Deterministic("bc", pt.exp(bcprior["mu"] + bcprior["sigma"] * bc0), dims="nbc")
+                step1_vars.append(bc0)
+            else:
+                bc = parse_prior("bc", bcprior, dims="nbc")
+                step1_vars.append(bc)
+
+        sigma = parse_prior("sigma", sigprior, dims=("nsigma_site", "nsigma_time"))
+
+        hx_data = pm.Data("hx", hx, dims=("nmeasure", "nx"))
+        mu = pm.Deterministic("mu", pt.dot(hx_data, x), dims="nmeasure")
+
+        if use_bc and hbc is not None:
+            hbc_data = pm.Data("hbc", hbc, dims=("nmeasure", "nbc"))
+            mu_bc = pm.Deterministic("mu_bc", pt.dot(hbc_data, bc), dims="nmeasure")
+            mu += mu_bc
+
+        if add_offset:
+            offset_args = offset_args or {}
+            offset = make_offset(siteindicator, offsetprior, **offset_args)
+            mu += offset
+
+        y_data = pm.Data("Y", Y, dims="nmeasure")  # type: ignore[arg-type]
+        error_data = pm.Data("error", error, dims="nmeasure")  # type: ignore[arg-type]
+        min_error_data = pm.Data("min_error", min_error, dims="nmeasure")  # type: ignore[arg-type]
+
+        if pollution_events_from_obs is True:
+            if use_bc is True:
+                pollution_event = pt.abs(y_data - mu_bc)
+            else:
+                pollution_event = pt.abs(y_data) + 1e-6 * pt.mean(y_data)
+        else:
+            pollution_event = pt.abs(pt.dot(hx_data, x))
+
+        pollution_event_scaled_error = pollution_event * sigma[sites, sigma_freq_index_model]
+
+        if no_model_error is True:
+            mean_obs = np.nanmean(Y)
+            small_amount = 1e-12 * mean_obs
+            eps = pt.maximum(pt.abs(error_data), small_amount)
+        else:
+            power0 = parse_prior("power", power) if isinstance(power, dict) else power
+            eps = pt.maximum(pt.sqrt(error_data**2 + pt.pow(pollution_event_scaled_error, power0)), min_error_data)
+
+        pm.Deterministic("epsilon", eps, dims="nmeasure")
+        pm.Normal("y", mu=mu, sigma=eps, observed=y_data, dims="nmeasure")
+
+        step1 = pm.NUTS(vars=step1_vars)
+        step2 = pm.Slice(vars=[sigma])
+
+    return InferPyMCModelSetup(
+        model=model,
+        step1=step1,
+        step2=step2,
+        sample_kwargs={"step": [step1, step2] if nuts_sampler == "pymc" else None},
+    )
 
 
 def inferpymc(
@@ -282,107 +404,39 @@ def inferpymc(
     TO DO:
        - Allow non-iid variables
     """
-    if use_bc and Hbc is None:
-        raise ValueError("If `use_bc` is True, then `Hbc` must be provided.")
-
     burn = int(burn)
-
-    hx = Hx.T
-    nx = hx.shape[1]
-
-    if use_bc:
-        hbc = Hbc.T
-        nbc = hbc.shape[1]
-
-    ny = len(Y)
-
     nit = int(nit)
 
-    # convert siteindicator into a site indexer
-    sites = siteindicator.astype(int) if sigma_per_site else np.zeros_like(siteindicator).astype(int)
-
-    # sigma_freq_index may be non-contiguous (e.g. missing calendar month).
-    # Compact to positional indices for safe tensor indexing.
-    sigma_freq_index_model = _contiguous_sigma_time_index(sigma_freq_index)
-
-    coords = _make_coords(
-        Y, Hx, siteindicator, sigma_freq_index_model, Hbc, sigma_per_site=sigma_per_site, sites=None
+    setup = build_inferpymc_model(
+        Hx=Hx,
+        Y=Y,
+        error=error,
+        siteindicator=siteindicator,
+        sigma_freq_index=sigma_freq_index,
+        Hbc=Hbc,
+        xprior=xprior,
+        bcprior=bcprior,
+        sigprior=sigprior,
+        sigma_per_site=sigma_per_site,
+        offsetprior=offsetprior,
+        add_offset=add_offset,
+        min_error=min_error,
+        use_bc=use_bc,
+        reparameterise_log_normal=reparameterise_log_normal,
+        pollution_events_from_obs=pollution_events_from_obs,
+        no_model_error=no_model_error,
+        offset_args=offset_args,
+        power=power,
+        nuts_sampler=nuts_sampler,
     )
 
-    if isinstance(min_error, float) or (isinstance(min_error, np.ndarray) and min_error.ndim == 0):
-        min_error = min_error * np.ones_like(Y)
-
-    with pm.Model(coords=coords) as model:
-        step1_vars = []
-
-        if reparameterise_log_normal and xprior["pdf"] == "lognormal":
-            x0 = pm.Normal("x0", 0, 1, dims="nx")
-            x = pm.Deterministic("x", pt.exp(xprior["mu"] + xprior["sigma"] * x0), dims="nx")
-            step1_vars.append(x0)
-        else:
-            x = parse_prior("x", xprior, dims="nx")
-            step1_vars.append(x)
-
-        if use_bc:
-            if reparameterise_log_normal and bcprior["pdf"] == "lognormal":
-                bc0 = pm.Normal("bc0", 0, 1, dims="nbc")
-                bc = pm.Deterministic("bc", pt.exp(bcprior["mu"] + bcprior["sigma"] * bc0), dims="nbc")
-                step1_vars.append(bc0)
-            else:
-                bc = parse_prior("bc", bcprior, dims="nbc")
-                step1_vars.append(bc)
-
-        sigma = parse_prior("sigma", sigprior, dims=("nsigma_site", "nsigma_time"))
-
-        hx = pm.Data("hx", hx, dims=("nmeasure", "nx"))
-        mu = pm.Deterministic("mu", pt.dot(hx, x), dims="nmeasure")
-
-        if use_bc:
-            hbc = pm.Data("hbc", hbc, dims=("nmeasure", "nbc"))
-            mu_bc = pm.Deterministic("mu_bc", pt.dot(hbc, bc), dims="nmeasure")
-            mu += mu_bc
-
-        if add_offset:
-            offset_args = offset_args or {}
-            offset = make_offset(siteindicator, offsetprior, **offset_args)
-            mu += offset
-
-        Y = pm.Data("Y", Y, dims="nmeasure")  # type: ignore
-        error = pm.Data("error", error, dims="nmeasure")  # type: ignore
-        min_error = pm.Data("min_error", min_error, dims="nmeasure")  # type: ignore
-
-        if pollution_events_from_obs is True:
-            if use_bc is True:
-                pollution_event = pt.abs(Y - mu_bc)
-            else:
-                pollution_event = pt.abs(Y) + 1e-6 * pt.mean(Y)  # small non-zero term to prevent NaNs
-        else:
-            pollution_event = pt.abs(pt.dot(hx, x))
-
-        pollution_event_scaled_error = pollution_event * sigma[sites, sigma_freq_index_model]
-
-        if no_model_error is True:
-            # need some small non-zero value to avoid sampling problems
-            mean_obs = np.nanmean(Y)
-            small_amount = 1e-12 * mean_obs
-            eps = pt.maximum(pt.abs(error), small_amount)  # type: ignore
-        else:
-            power0 = parse_prior("power", power) if isinstance(power, dict) else power
-            eps = pt.maximum(pt.sqrt(error**2 + pt.pow(pollution_event_scaled_error, power0)), min_error)  # type: ignore
-
-        epsilon = pm.Deterministic("epsilon", eps, dims="nmeasure")
-
-        pm.Normal("y", mu=mu, sigma=epsilon, observed=Y, dims="nmeasure")
-
-        step1 = pm.NUTS(vars=step1_vars)
-        step2 = pm.Slice(vars=[sigma])
-        step = [step1, step2] if nuts_sampler == "pymc" else None
-        sampler_kwargs = sampler_kwargs or {}
+    sampler_kwargs = sampler_kwargs or {}
+    with setup.model:
         trace = pm.sample(
             nit,
             tune=int(tune),
             chains=nchain,
-            step=step,
+            step=setup.sample_kwargs["step"],
             # progressbar=verbose,
             progressbar=False,
             cores=nchain,
@@ -390,6 +444,10 @@ def inferpymc(
             idata_kwargs={"log_likelihood": True},
             **sampler_kwargs,
         )
+
+    model = setup.model
+    step1 = setup.step1
+    step2 = setup.step2
 
     posterior_burned = trace.posterior.isel(chain=0, draw=slice(burn, nit)).drop_vars("chain")
 

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -161,9 +161,9 @@ def _contiguous_sigma_time_index(sigma_freq_index: np.ndarray) -> np.ndarray:
     return np.searchsorted(uniq, sigma_freq_index).astype(int)
 
 
-#----------------------------------------
+# ----------------------------------------
 # Model building code
-#----------------------------------------
+# ----------------------------------------
 
 # Defaults to avoid mutable default arguments in model building functions.
 DEFAULT_XPRIOR: PriorArgs = {"pdf": "normal", "mu": 1.0, "sigma": 1.0}
@@ -181,7 +181,7 @@ def build_inferpymc_model(
     Hbc: np.ndarray | None = None,
     xprior: dict | None = None,
     bcprior: dict | None = None,
-    sigprior: dict | None= None,
+    sigprior: dict | None = None,
     sigma_per_site: bool = True,
     offsetprior: dict | None = None,
     add_offset: bool = False,

--- a/tests/test_inferpymc.py
+++ b/tests/test_inferpymc.py
@@ -1,8 +1,9 @@
 import numpy as np
+import pymc as pm
 import pytest
 
 from openghg_inversions.hbmcmc.hbmcmc import make_inv_inputs
-from openghg_inversions.hbmcmc.inversion_pymc import inferpymc
+from openghg_inversions.hbmcmc.inversion_pymc import InferPyMCModelSetup, build_inferpymc_model, inferpymc
 
 
 @pytest.fixture
@@ -26,11 +27,88 @@ def inferpymc_args(mhd_and_tac_fp_data) -> dict:
             "burn": 0,
             "tune": 0,
             "nchain": 1,
+            "xprior": {"pdf": "normal", "mu": 1.0, "sigma": 1.0},
+            "bcprior": {"pdf": "normal", "mu": 1.0, "sigma": 1.0},
+            "sigprior": {"pdf": "uniform", "lower": 0.1, "upper": 10.0},
+            "sigma_per_site": True,
+            "offsetprior": {"pdf": "normal", "mu": 0, "sigma": 1},
+            "add_offset": False,
+            "min_error": 0.0,
+            "use_bc": True,
+            "reparameterise_log_normal": False,
+            "pollution_events_from_obs": True,
+            "no_model_error": False,
+            "offset_args": {"drop_first": False, "offset_freq": "D"},
+            "power": 1.99,
             "verbose": False,
             "sampler_kwargs": {"random_seed": 123},
         }
     )
     return mcmc_args
+
+
+def test_build_inferpymc_model_returns_setup_for_pymc(inferpymc_args: dict) -> None:
+    """Check extracted model builder returns PyMC step methods for the pymc sampler."""
+    setup = build_inferpymc_model(
+        Hx=inferpymc_args["Hx"],
+        Y=inferpymc_args["Y"],
+        error=inferpymc_args["error"],
+        siteindicator=inferpymc_args["siteindicator"],
+        sigma_freq_index=inferpymc_args["sigma_freq_index"],
+        Hbc=inferpymc_args["Hbc"],
+        xprior=inferpymc_args["xprior"],
+        bcprior=inferpymc_args["bcprior"],
+        sigprior=inferpymc_args["sigprior"],
+        sigma_per_site=inferpymc_args["sigma_per_site"],
+        offsetprior=inferpymc_args["offsetprior"],
+        add_offset=inferpymc_args["add_offset"],
+        min_error=inferpymc_args["min_error"],
+        use_bc=inferpymc_args["use_bc"],
+        reparameterise_log_normal=inferpymc_args["reparameterise_log_normal"],
+        pollution_events_from_obs=inferpymc_args["pollution_events_from_obs"],
+        no_model_error=inferpymc_args["no_model_error"],
+        offset_args=inferpymc_args["offset_args"],
+        power=inferpymc_args["power"],
+        nuts_sampler="pymc",
+    )
+
+    assert isinstance(setup, InferPyMCModelSetup)
+    assert isinstance(setup.model, pm.Model)
+    assert isinstance(setup.step1, pm.NUTS)
+    assert isinstance(setup.step2, pm.Slice)
+    assert setup.sample_kwargs["step"] == [setup.step1, setup.step2]
+
+
+def test_build_inferpymc_model_returns_no_steps_for_numpyro(inferpymc_args: dict) -> None:
+    """Check extracted model builder omits explicit steps for the numpyro sampler."""
+    setup = build_inferpymc_model(
+        Hx=inferpymc_args["Hx"],
+        Y=inferpymc_args["Y"],
+        error=inferpymc_args["error"],
+        siteindicator=inferpymc_args["siteindicator"],
+        sigma_freq_index=inferpymc_args["sigma_freq_index"],
+        Hbc=inferpymc_args["Hbc"],
+        xprior=inferpymc_args["xprior"],
+        bcprior=inferpymc_args["bcprior"],
+        sigprior=inferpymc_args["sigprior"],
+        sigma_per_site=inferpymc_args["sigma_per_site"],
+        offsetprior=inferpymc_args["offsetprior"],
+        add_offset=inferpymc_args["add_offset"],
+        min_error=inferpymc_args["min_error"],
+        use_bc=inferpymc_args["use_bc"],
+        reparameterise_log_normal=inferpymc_args["reparameterise_log_normal"],
+        pollution_events_from_obs=inferpymc_args["pollution_events_from_obs"],
+        no_model_error=inferpymc_args["no_model_error"],
+        offset_args=inferpymc_args["offset_args"],
+        power=inferpymc_args["power"],
+        nuts_sampler="numpyro",
+    )
+
+    assert isinstance(setup, InferPyMCModelSetup)
+    assert isinstance(setup.model, pm.Model)
+    assert isinstance(setup.step1, pm.NUTS)
+    assert isinstance(setup.step2, pm.Slice)
+    assert setup.sample_kwargs["step"] is None
 
 
 def test_inferpymc_runs_on_inversion_inputs(inferpymc_args: dict) -> None:

--- a/tests/test_inferpymc.py
+++ b/tests/test_inferpymc.py
@@ -209,7 +209,7 @@ def test_inferpymc_model_contains_expected_variables(inferpymc_args: dict, infer
 
 def test_inferpymc_runs_without_boundary_conditions(inferpymc_args: dict) -> None:
     """Check inferpymc direct call when boundary conditions are disabled."""
-    inferpymc_args = dict(inferpymc_args.copy())
+    inferpymc_args = dict(inferpymc_args)
     inferpymc_args["use_bc"] = False
     inferpymc_args["Hbc"] = None
 

--- a/tests/test_inferpymc.py
+++ b/tests/test_inferpymc.py
@@ -1,3 +1,5 @@
+from types import MappingProxyType
+
 import numpy as np
 import pymc as pm
 import pytest
@@ -6,9 +8,16 @@ from openghg_inversions.hbmcmc.hbmcmc import make_inv_inputs
 from openghg_inversions.hbmcmc.inversion_pymc import InferPyMCModelSetup, build_inferpymc_model, inferpymc
 
 
-@pytest.fixture
-def inferpymc_args(mhd_and_tac_fp_data) -> dict:
-    """Create direct inputs for inferpymc using existing inversion input machinery."""
+@pytest.fixture(scope="module")
+def inferpymc_args(mhd_and_tac_fp_data) -> MappingProxyType:
+    """Create direct inputs for inferpymc using existing inversion input machinery.
+
+    NOTE: the module level scope allows us to define other module scoped fixtures
+    using this fixture, but it means we need to be careful about not mutating the
+    return of the fixture.
+
+    The result is wrapped in a MappingProxyType as a precaution.
+    """
     mcmc_args, _ = make_inv_inputs(
         fp_data=mhd_and_tac_fp_data,
         sites=["MHD", "TAC"],
@@ -41,10 +50,10 @@ def inferpymc_args(mhd_and_tac_fp_data) -> dict:
             "offset_args": {"drop_first": False, "offset_freq": "D"},
             "power": 1.99,
             "verbose": False,
-            "sampler_kwargs": {"random_seed": 123},
+            "sampler_kwargs": {"random_seed": 123, "compute_convergence_checks": False},
         }
     )
-    return mcmc_args
+    return MappingProxyType(mcmc_args)
 
 
 def test_build_inferpymc_model_returns_setup_for_pymc(inferpymc_args: dict) -> None:
@@ -80,7 +89,11 @@ def test_build_inferpymc_model_returns_setup_for_pymc(inferpymc_args: dict) -> N
 
 
 def test_build_inferpymc_model_returns_no_steps_for_numpyro(inferpymc_args: dict) -> None:
-    """Check extracted model builder omits explicit steps for the numpyro sampler."""
+    """Check model setup does not pass steps them via sample_kwargs['step'] for the numpyro sampler.
+
+    The steps are still created by build_inferpymc_model and stored in the dataclass. This matches
+    the pre-existing behaviour, but perhaps should be changed.
+    """
     setup = build_inferpymc_model(
         Hx=inferpymc_args["Hx"],
         Y=inferpymc_args["Y"],
@@ -111,9 +124,19 @@ def test_build_inferpymc_model_returns_no_steps_for_numpyro(inferpymc_args: dict
     assert setup.sample_kwargs["step"] is None
 
 
-def test_inferpymc_runs_on_inversion_inputs(inferpymc_args: dict) -> None:
+@pytest.fixture(scope="module")
+def inferpymc_with_bc_result(inferpymc_args: dict):
+    """Run inferpymc with inferpymc_args, including use_bc=True.
+
+    The results from `inferpymc(**inferpymc_args)` are used at least
+    twice in the tests, so this fixture saves some computation.
+    """
+    return inferpymc(**inferpymc_args)
+
+
+def test_inferpymc_runs_on_inversion_inputs(inferpymc_args: dict, inferpymc_with_bc_result) -> None:
     """Smoke test inferpymc directly on prepared inversion inputs."""
-    result = inferpymc(**inferpymc_args)
+    result = inferpymc_with_bc_result
 
     expected_keys = {
         "xouts",
@@ -148,9 +171,9 @@ def test_inferpymc_runs_on_inversion_inputs(inferpymc_args: dict) -> None:
     assert np.isfinite(result["YBCtrace"]).all()
 
 
-def test_inferpymc_model_contains_expected_variables(inferpymc_args: dict) -> None:
+def test_inferpymc_model_contains_expected_variables(inferpymc_args: dict, inferpymc_with_bc_result) -> None:
     """Check that inferpymc builds the expected PyMC model structure."""
-    result = inferpymc(**inferpymc_args)
+    result = inferpymc_with_bc_result
     model = result["model"]
 
     expected_named_vars = {
@@ -186,7 +209,7 @@ def test_inferpymc_model_contains_expected_variables(inferpymc_args: dict) -> No
 
 def test_inferpymc_runs_without_boundary_conditions(inferpymc_args: dict) -> None:
     """Check inferpymc direct call when boundary conditions are disabled."""
-    inferpymc_args = inferpymc_args.copy()
+    inferpymc_args = dict(inferpymc_args.copy())
     inferpymc_args["use_bc"] = False
     inferpymc_args["Hbc"] = None
 

--- a/tests/test_inferpymc.py
+++ b/tests/test_inferpymc.py
@@ -1,0 +1,123 @@
+import numpy as np
+import pytest
+
+from openghg_inversions.hbmcmc.hbmcmc import make_inv_inputs
+from openghg_inversions.hbmcmc.inversion_pymc import inferpymc
+
+
+@pytest.fixture
+def inferpymc_args(mhd_and_tac_fp_data) -> dict:
+    """Create direct inputs for inferpymc using existing inversion input machinery."""
+    mcmc_args, _ = make_inv_inputs(
+        fp_data=mhd_and_tac_fp_data,
+        sites=["MHD", "TAC"],
+        start_date="2019-01-01",
+        use_bc=True,
+        bc_freq="3h",
+        sigma_freq="3h",
+        min_error="percentile",
+        calculate_min_error=None,
+        min_error_options={},
+    )
+
+    mcmc_args.update(
+        {
+            "nit": 1,
+            "burn": 0,
+            "tune": 0,
+            "nchain": 1,
+            "verbose": False,
+            "sampler_kwargs": {"random_seed": 123},
+        }
+    )
+    return mcmc_args
+
+
+def test_inferpymc_runs_on_inversion_inputs(inferpymc_args: dict) -> None:
+    """Smoke test inferpymc directly on prepared inversion inputs."""
+    result = inferpymc(**inferpymc_args)
+
+    expected_keys = {
+        "xouts",
+        "sigouts",
+        "Ytrace",
+        "OFFSETtrace",
+        "convergence",
+        "step1",
+        "step2",
+        "model",
+        "trace",
+        "bcouts",
+        "YBCtrace",
+    }
+    assert expected_keys.issubset(result.keys())
+
+    y = np.asarray(inferpymc_args["Y"])
+    hx = np.asarray(inferpymc_args["Hx"])
+    siteindicator = np.asarray(inferpymc_args["siteindicator"])
+    sigma_freq_index = np.asarray(inferpymc_args["sigma_freq_index"])
+
+    assert result["xouts"].sizes["nx"] == hx.shape[0]
+    assert result["sigouts"].sizes["nsigma_time"] == len(np.unique(sigma_freq_index))
+    assert result["sigouts"].sizes["nsigma_site"] == len(np.unique(siteindicator))
+
+    assert y.size in result["Ytrace"].shape
+    assert result["OFFSETtrace"].shape == result["Ytrace"].shape
+    assert result["YBCtrace"].shape == result["Ytrace"].shape
+
+    assert np.isfinite(result["Ytrace"]).all()
+    assert np.isfinite(result["OFFSETtrace"]).all()
+    assert np.isfinite(result["YBCtrace"]).all()
+
+
+def test_inferpymc_model_contains_expected_variables(inferpymc_args: dict) -> None:
+    """Check that inferpymc builds the expected PyMC model structure."""
+    result = inferpymc(**inferpymc_args)
+    model = result["model"]
+
+    expected_named_vars = {
+        "x",
+        "bc",
+        "sigma",
+        "hx",
+        "hbc",
+        "Y",
+        "error",
+        "min_error",
+        "mu",
+        "mu_bc",
+        "epsilon",
+        "y",
+    }
+
+    assert expected_named_vars.issubset(model.named_vars)
+
+    coords = model.coords
+    y = np.asarray(inferpymc_args["Y"])
+    hx = np.asarray(inferpymc_args["Hx"])
+    hbc = np.asarray(inferpymc_args["Hbc"])
+    siteindicator = np.asarray(inferpymc_args["siteindicator"])
+    sigma_freq_index = np.asarray(inferpymc_args["sigma_freq_index"])
+
+    assert len(coords["nmeasure"]) == y.size
+    assert len(coords["nx"]) == hx.shape[0]
+    assert len(coords["nbc"]) == hbc.shape[0]
+    assert len(coords["nsigma_site"]) == len(np.unique(siteindicator))
+    assert len(coords["nsigma_time"]) == len(np.unique(sigma_freq_index))
+
+
+def test_inferpymc_runs_without_boundary_conditions(inferpymc_args: dict) -> None:
+    """Check inferpymc direct call when boundary conditions are disabled."""
+    inferpymc_args = inferpymc_args.copy()
+    inferpymc_args["use_bc"] = False
+    inferpymc_args["Hbc"] = None
+
+    result = inferpymc(**inferpymc_args)
+
+    assert "bcouts" not in result
+    assert "YBCtrace" not in result
+
+    model = result["model"]
+    assert "bc" not in model.named_vars
+    assert "hbc" not in model.named_vars
+    assert "mu_bc" not in model.named_vars


### PR DESCRIPTION
* **Summary of changes**

This is the first stage in refactoring the PyMC code into a more "modular" framework; see #370 for the full plan.

This PR is a completely neutral change:
1. it adds "regression" tests to check that `inferpymc` continues to work as expected; we test that the outputs have the expected variables (like `xouts`, `Ytrace`, etc.), and that the PyMC model has the expected coordinates and variables.
2. it extracts a function `build_inferpymc_model` from `inferpymc`; this function builds the PyMC model and returns the model plus any other arguments needed for sampling and post-processing. It doesn't change behaviour.


* **Please check if the PR fulfills these requirements**

- [x] Closes #371 
- [x] Tests added and passing
- Documentation and tutorials updated/added
- [x] Added an entry to the `CHANGELOG.md` file
- Added any new requirements to `requirements.txt`
