### PR TITLE
Iss372 xarray inputs for inferpymc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Fixed issue that raised `IndexError` in `inferpymc` when a monthly of data was missing an `sigam_freq` is "monthly". (Code accidentally merged into devel instea of PR, so this is a placeholder PR)[PR #365](https://github.com/openghg/openghg_inversions/pull/365)
 - Added opt-in `basis_functions_wrapper` support for returning `BasisFunctions` objects and saving basis artifacts in DataTree format while keeping legacy flat-basis output as the default. [PR #367](https://github.com/openghg/openghg_inversions/pull/367)
 - Stage A of PyMC model refactor. Added regression tests for `inferpymc` and extracted function to build the PyMC model. [PR #378](https://github.com/openghg/openghg_inversions/pull/378)
-- Stage B of PyMC model refactor. Updated `inferpymc` to accept current/legacy inputs as well as xarray `Datatset`. [PR #380](https://github.com/openghg/openghg_inversions/pull/380)
+- Stage B of PyMC model refactor. Updated `inferpymc` to accept current/legacy inputs as well as xarray `Dataset`. [PR #380](https://github.com/openghg/openghg_inversions/pull/380)
 
 # Version 0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fixed issue that raised `IndexError` in `inferpymc` when a monthly of data was missing an `sigam_freq` is "monthly". (Code accidentally merged into devel instea of PR, so this is a placeholder PR)[PR #365](https://github.com/openghg/openghg_inversions/pull/365)
 - Added opt-in `basis_functions_wrapper` support for returning `BasisFunctions` objects and saving basis artifacts in DataTree format while keeping legacy flat-basis output as the default. [PR #367](https://github.com/openghg/openghg_inversions/pull/367)
 - Stage A of PyMC model refactor. Added regression tests for `inferpymc` and extracted function to build the PyMC model. [PR #378](https://github.com/openghg/openghg_inversions/pull/378)
+- Stage B of PyMC model refactor. Updated `inferpymc` to accept current/legacy inputs as well as xarray `Datatset`. [PR #380](https://github.com/openghg/openghg_inversions/pull/380)
 
 # Version 0.6.0
 

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -41,7 +41,7 @@ from openghg_inversions.basis import basis_functions_wrapper
 from openghg_inversions.inversion_data import data_processing_surface_notracer, load_merged_data
 from openghg_inversions.filters import filtering
 from openghg_inversions.postprocessing.inversion_output import make_inv_out_for_fixed_basis_mcmc
-from openghg_inversions.inversion_inputs import make_inv_inputs as _make_inv_inputs
+from openghg_inversions.inversion_inputs import make_inv_inputs
 
 
 def update_log_normal_prior(prior):
@@ -60,7 +60,12 @@ def update_log_normal_prior(prior):
     return prior
 
 
-def make_inv_inputs(
+# ----------------------------------------
+# Preparing inputs
+# ----------------------------------------
+
+
+def make_inv_inputs_legacy(
     *,
     fp_data,
     sites,
@@ -84,7 +89,7 @@ def make_inv_inputs(
 
     min_error_options = min_error_options or {}
 
-    ds = _make_inv_inputs(
+    ds = make_inv_inputs(
         fp_data,
         sites=sites,
         bc_freq=bc_freq,
@@ -93,27 +98,6 @@ def make_inv_inputs(
         min_error_per_site=min_error_options.get("by_site", False),
         start_date=start_date,
     )
-
-    drop_subset = ["H", "H_bc", "mf", "mf_error"]
-    drop_subset = [dv for dv in drop_subset if dv in ds]
-    ds = ds.dropna(dim="nmeasure", how="any", subset=drop_subset)
-
-    # Trigger dask computations
-    # we only compute the variables we need below
-    to_compute = [
-        "H",
-        "H_bc",
-        "mf",
-        "mf_error",
-        "mf_repeatability",
-        "mf_variability",
-        "mf_prior_factor",
-        "mf_prior_upper_level_factor",
-        "bc_mod",
-        "mf_mod",
-    ]
-    to_compute = [dv for dv in to_compute if dv in ds]
-    ds[to_compute] = ds[to_compute].compute()
 
     y = ds.mf.values
     y_time = ds.time.values
@@ -558,7 +542,7 @@ def fixedbasisMCMC(
     if use_bc:
         mcmc_config["bcprior"] = update_log_normal_prior(bcprior)
 
-    mcmc_args, post_process_args = make_inv_inputs(
+    mcmc_args, post_process_args = make_inv_inputs_legacy(
         fp_data=fp_data,
         sites=sites,
         start_date=start_date,

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -1,5 +1,12 @@
 """Functions for performing MCMC inversion.
 PyMC library used for Bayesian modelling.
+
+Notes:
+    Some internal helpers in this module are temporary compatibility code for
+    the Stage B refactor in issue #372, part of the model-building work tracked
+    in issue #370. They support both legacy ndarray inputs and direct xarray
+    inputs from ``make_inv_inputs``. These helpers should be simplified or
+    removed once the legacy path is retired in a later stage.
 """
 
 import re
@@ -43,6 +50,26 @@ class InferPyMCModelSetup:
     step1: pm.NUTS
     step2: pm.Slice
     sample_kwargs: dict[str, Any]
+
+
+@dataclass
+class InferPyMCInputs:
+    """Normalised inputs for PyMC model construction.
+
+    Temporary Stage B compatibility container for issue #372. This should be
+    simplified once the legacy ndarray input path is removed in a later stage.
+    """
+
+    hx: np.ndarray
+    y: np.ndarray
+    error: np.ndarray
+    site_indicator: np.ndarray
+    sigma_freq_index: np.ndarray
+    hbc: np.ndarray | None
+    min_error: np.ndarray | float
+    coords: dict[str, np.ndarray]
+    original_coords: dict[str, Any]
+    source: xr.Dataset | None
 
 
 def lognormal_mu_sigma(mean: float, stdev: float) -> tuple[float, float]:
@@ -125,25 +152,276 @@ def parse_prior(name: str, prior_params: PriorArgs, **kwargs) -> TensorVariable:
     return dist(name, **params, **kwargs)
 
 
-def _make_coords(
-    Y: np.ndarray,
-    Hx: np.ndarray,
-    site_indicator: np.ndarray,
-    sigma_freq_indices: np.ndarray,
-    Hbc: np.ndarray | None = None,
-    sites: list[str] | None = None,
-    sigma_per_site: bool = False,
-) -> dict:
-    result = {
-        "nmeasure": np.arange(len(Y)),
-        "nx": np.arange(Hx.shape[0]),
-        "sites": sites if sites is not None else np.unique(site_indicator),
-        "nsigma_time": np.unique(sigma_freq_indices),
-        "nsigma_site": np.unique(site_indicator) if sigma_per_site else [0],
+def _make_range_coords(
+    *,
+    nmeasure: int,
+    nx: int,
+    nbc: int | None,
+    nsigma_site: int | None,
+    nsigma_time: int,
+) -> dict[str, np.ndarray]:
+    """Create simple range coordinates for PyMC.
+
+    Temporary Stage B compatibility helper for issue #372. We intentionally use
+    only range coordinates in PyMC and preserve richer xarray coordinates
+    separately for potential restoration after sampling.
+    """
+    coords: dict[str, np.ndarray] = {
+        "nmeasure": np.arange(nmeasure),
+        "nx": np.arange(nx),
+        "nsigma_time": np.arange(nsigma_time),
+        "nsigma_site": np.arange(1 if nsigma_site is None else nsigma_site),
     }
-    if Hbc is not None:
-        result["nbc"] = np.arange(Hbc.shape[0])
-    return result
+    if nbc is not None:
+        coords["nbc"] = np.arange(nbc)
+    return coords
+
+
+def _extract_original_coords(ds: xr.Dataset) -> dict[str, Any]:
+    """Extract original dataset coordinates for possible later restoration.
+
+    Temporary Stage B compatibility helper for issue #372. This is not yet used
+    by inferpymc directly because post-processing still expects the current
+    outputs, but keeping it here lets us test coordinate restoration separately.
+    """
+    original_coords: dict[str, Any] = {}
+    for dim in ds.dims:
+        if dim in ds.indexes:
+            original_coords[dim] = ds.indexes[dim]
+        elif dim in ds.coords:
+            original_coords[dim] = ds.coords[dim].values
+    return original_coords
+
+
+def _validate_inferpymc_input_mode(
+    inv_inputs: xr.Dataset | None,
+    *,
+    Hx: np.ndarray | None,
+    Y: np.ndarray | None,
+    error: np.ndarray | None,
+    siteindicator: np.ndarray | None,
+    sigma_freq_index: np.ndarray | None,
+    Hbc: np.ndarray | None,
+) -> str:
+    """Validate whether dataset or legacy ndarray inputs are being used.
+
+    Temporary Stage B compatibility helper for issue #372.
+    """
+    legacy_args = {
+        "Hx": Hx,
+        "Y": Y,
+        "error": error,
+        "siteindicator": siteindicator,
+        "sigma_freq_index": sigma_freq_index,
+        "Hbc": Hbc,
+    }
+    provided_legacy = [name for name, value in legacy_args.items() if value is not None]
+
+    if inv_inputs is not None:
+        if provided_legacy:
+            raise ValueError(
+                "`inv_inputs` cannot be combined with legacy array arguments: "
+                + ", ".join(provided_legacy)
+            )
+        return "dataset"
+
+    required_legacy = ["Hx", "Y", "error", "siteindicator", "sigma_freq_index"]
+    missing = [name for name in required_legacy if legacy_args[name] is None]
+    if missing:
+        raise ValueError(
+            "Either provide `inv_inputs` or all required legacy arguments. Missing: "
+            + ", ".join(missing)
+        )
+    return "legacy"
+
+
+def _prepare_inferpymc_inputs_from_dataset(
+    ds: xr.Dataset,
+    *,
+    sigma_per_site: bool,
+    use_bc: bool,
+    state: str = "region",
+    bc_state: str = "bc_region",
+) -> InferPyMCInputs:
+    """Prepare normalised PyMC inputs from an xarray dataset.
+
+    Temporary Stage B compatibility helper for issue #372.
+
+    Args:
+        ds: xarray.Dataset containing inversion inputs created by make_inv_inputs.
+        sigma_per_site: whether sigma is per-site
+        use_bc: whether to use boundary conditions
+        state: name of the spatial state dimension in the dataset (e.g. "region").
+        bc_state: name of the BC state dimension in the dataset (e.g. "bc_region").
+    """
+    # Use the dataset-provided state dimension names when extracting H/H_bc.
+    hx = ds["H"].transpose("nmeasure", state).values
+    y = ds["mf"].values
+    error = ds["mf_error"].values
+    site_indicator = ds["site_indicator"].values.astype(int)
+    sigma_freq_index = ds["sigma_freq_index"].values.astype(int)
+
+    hbc: np.ndarray | None = None
+    if use_bc:
+        if "H_bc" not in ds:
+            raise ValueError("If `use_bc` is True, the dataset must contain `H_bc`.")
+        hbc = ds["H_bc"].transpose("nmeasure", bc_state).values
+
+    min_error: np.ndarray | float
+    min_error = ds["min_error"].values if "min_error" in ds else 0.0
+
+    sigma_freq_index_model = _contiguous_sigma_time_index(sigma_freq_index)
+
+    nmeasure, nx = hx.shape
+    nbc = None if hbc is None else hbc.shape[1]
+    nsigma_site = int(np.max(site_indicator)) + 1 if sigma_per_site else None
+    nsigma_time = int(np.max(sigma_freq_index_model)) + 1 if sigma_freq_index_model.size else 0
+
+    return InferPyMCInputs(
+        hx=hx,
+        y=y,
+        error=error,
+        site_indicator=site_indicator,
+        sigma_freq_index=sigma_freq_index_model,
+        hbc=hbc,
+        min_error=min_error,
+        coords=_make_range_coords(
+            nmeasure=nmeasure,
+            nx=nx,
+            nbc=nbc,
+            nsigma_site=nsigma_site,
+            nsigma_time=nsigma_time,
+        ),
+        original_coords=_extract_original_coords(ds),
+        source=ds,
+    )
+
+
+def _prepare_inferpymc_inputs_from_legacy(
+    *,
+    Hx: np.ndarray,
+    Y: np.ndarray,
+    error: np.ndarray,
+    siteindicator: np.ndarray,
+    sigma_freq_index: np.ndarray,
+    Hbc: np.ndarray | None,
+    min_error: np.ndarray | float | None,
+    sigma_per_site: bool,
+    use_bc: bool,
+) -> InferPyMCInputs:
+    """Prepare normalised PyMC inputs from legacy ndarray arguments.
+
+    Temporary Stage B compatibility helper for issue #372.
+    """
+    hx = Hx.T
+    hbc = Hbc.T if use_bc and Hbc is not None else None
+    site_indicator = siteindicator.astype(int)
+    sigma_freq_index_model = _contiguous_sigma_time_index(sigma_freq_index)
+
+    nmeasure, nx = hx.shape
+    nbc = None if hbc is None else hbc.shape[1]
+    nsigma_site = int(np.max(site_indicator)) + 1 if sigma_per_site else None
+    nsigma_time = int(np.max(sigma_freq_index_model)) + 1 if sigma_freq_index_model.size else 0
+
+    return InferPyMCInputs(
+        hx=hx,
+        y=Y,
+        error=error,
+        site_indicator=site_indicator,
+        sigma_freq_index=sigma_freq_index_model,
+        hbc=hbc,
+        min_error=0.0 if min_error is None else min_error,
+        coords=_make_range_coords(
+            nmeasure=nmeasure,
+            nx=nx,
+            nbc=nbc,
+            nsigma_site=nsigma_site,
+            nsigma_time=nsigma_time,
+        ),
+        original_coords={},
+        source=None,
+    )
+
+
+def _prepare_inferpymc_inputs(
+    inv_inputs: xr.Dataset | None = None,
+    *,
+    Hx: np.ndarray | None = None,
+    Y: np.ndarray | None = None,
+    error: np.ndarray | None = None,
+    siteindicator: np.ndarray | None = None,
+    sigma_freq_index: np.ndarray | None = None,
+    Hbc: np.ndarray | None = None,
+    min_error: np.ndarray | float | None = None,
+    sigma_per_site: bool = True,
+    use_bc: bool = True,
+    state: str = "region",
+    bc_state: str = "bc_region",
+) -> InferPyMCInputs:
+    """Normalise dataset or legacy inputs for PyMC model building.
+
+    Temporary Stage B compatibility helper for issue #372.
+    """
+    mode = _validate_inferpymc_input_mode(
+        inv_inputs,
+        Hx=Hx,
+        Y=Y,
+        error=error,
+        siteindicator=siteindicator,
+        sigma_freq_index=sigma_freq_index,
+        Hbc=Hbc,
+    )
+
+    if mode == "dataset":
+        assert inv_inputs is not None
+        return _prepare_inferpymc_inputs_from_dataset(
+            inv_inputs,
+            sigma_per_site=sigma_per_site,
+            use_bc=use_bc,
+            state=state,
+            bc_state=bc_state,
+        )
+
+    assert Hx is not None
+    assert Y is not None
+    assert error is not None
+    assert siteindicator is not None
+    assert sigma_freq_index is not None
+    return _prepare_inferpymc_inputs_from_legacy(
+        Hx=Hx,
+        Y=Y,
+        error=error,
+        siteindicator=siteindicator,
+        sigma_freq_index=sigma_freq_index,
+        Hbc=Hbc,
+        min_error=min_error,
+        sigma_per_site=sigma_per_site,
+        use_bc=use_bc,
+    )
+
+
+def _restore_inferencedata_coords(idata: az.InferenceData, original_coords: dict[str, Any]) -> az.InferenceData:
+    """Restore saved coordinates onto matching InferenceData groups.
+
+    Temporary Stage B helper for issue #372. This is intentionally not yet wired
+    into inferpymc because downstream post-processing still expects the current
+    outputs.
+    """
+    for group_name in idata.groups():
+        group = getattr(idata, group_name)
+        if not isinstance(group, xr.Dataset):
+            continue
+
+        for dim, coord in original_coords.items():
+            if dim not in group.dims:
+                continue
+            if len(coord) != group.sizes[dim]:
+                continue
+            group = group.assign_coords({dim: coord})
+
+        setattr(idata, group_name, group)
+
+    return idata
 
 
 def _contiguous_sigma_time_index(sigma_freq_index: np.ndarray) -> np.ndarray:
@@ -173,11 +451,11 @@ DEFAULT_OFFSETPRIOR: PriorArgs = {"pdf": "normal", "mu": 0, "sigma": 1}
 
 
 def build_inferpymc_model(
-    Hx: np.ndarray,
-    Y: np.ndarray,
-    error: np.ndarray,
-    siteindicator: np.ndarray,
-    sigma_freq_index: np.ndarray,
+    Hx: np.ndarray | None = None,
+    Y: np.ndarray | None = None,
+    error: np.ndarray | None = None,
+    siteindicator: np.ndarray | None = None,
+    sigma_freq_index: np.ndarray | None = None,
     Hbc: np.ndarray | None = None,
     xprior: dict | None = None,
     bcprior: dict | None = None,
@@ -193,10 +471,25 @@ def build_inferpymc_model(
     offset_args: dict | None = None,
     power: dict | float = 1.99,
     nuts_sampler: str = "pymc",
+    inv_inputs: xr.Dataset | None = None,
+    state: str = "region",
+    bc_state: str = "bc_region",
 ) -> InferPyMCModelSetup:
     """Build the PyMC model and sampler configuration used by inferpymc."""
-    if use_bc and Hbc is None:
-        raise ValueError("If `use_bc` is True, then `Hbc` must be provided.")
+    prepared = _prepare_inferpymc_inputs(
+        inv_inputs=inv_inputs,
+        Hx=Hx,
+        Y=Y,
+        error=error,
+        siteindicator=siteindicator,
+        sigma_freq_index=sigma_freq_index,
+        Hbc=Hbc,
+        min_error=min_error,
+        sigma_per_site=sigma_per_site,
+        use_bc=use_bc,
+        state=state,
+        bc_state=bc_state,
+    )
 
     # Assign defaults here to avoid sharing the same dict across calls.
     xprior = DEFAULT_XPRIOR.copy() if xprior is None else xprior
@@ -204,20 +497,20 @@ def build_inferpymc_model(
     sigprior = DEFAULT_SIGPRIOR.copy() if sigprior is None else sigprior
     offsetprior = DEFAULT_OFFSETPRIOR.copy() if offsetprior is None else offsetprior
 
-    hx = Hx.T
-    hbc = Hbc.T if use_bc and Hbc is not None else None
-
-    sites = siteindicator.astype(int) if sigma_per_site else np.zeros_like(siteindicator).astype(int)
-    sigma_freq_index_model = _contiguous_sigma_time_index(sigma_freq_index)
-
-    coords = _make_coords(
-        Y, Hx, siteindicator, sigma_freq_index_model, Hbc, sigma_per_site=sigma_per_site, sites=None
+    sites = (
+        prepared.site_indicator.astype(int)
+        if sigma_per_site
+        else np.zeros_like(prepared.site_indicator).astype(int)
     )
 
-    if isinstance(min_error, float) or (isinstance(min_error, np.ndarray) and min_error.ndim == 0):
-        min_error = min_error * np.ones_like(Y)
+    if isinstance(prepared.min_error, float) or (
+        isinstance(prepared.min_error, np.ndarray) and prepared.min_error.ndim == 0
+    ):
+        min_error_data = prepared.min_error * np.ones_like(prepared.y)
+    else:
+        min_error_data = prepared.min_error
 
-    with pm.Model(coords=coords) as model:
+    with pm.Model(coords=prepared.coords) as model:
         step1_vars = []
 
         if reparameterise_log_normal and xprior["pdf"] == "lognormal":
@@ -239,35 +532,35 @@ def build_inferpymc_model(
 
         sigma = parse_prior("sigma", sigprior, dims=("nsigma_site", "nsigma_time"))
 
-        hx_data = pm.Data("hx", hx, dims=("nmeasure", "nx"))
+        hx_data = pm.Data("hx", prepared.hx, dims=("nmeasure", "nx"))
         mu = pm.Deterministic("mu", pt.dot(hx_data, x), dims="nmeasure")
 
-        if use_bc and hbc is not None:
-            hbc_data = pm.Data("hbc", hbc, dims=("nmeasure", "nbc"))
+        if use_bc and prepared.hbc is not None:
+            hbc_data = pm.Data("hbc", prepared.hbc, dims=("nmeasure", "nbc"))
             mu_bc = pm.Deterministic("mu_bc", pt.dot(hbc_data, bc), dims="nmeasure")
             mu += mu_bc
 
         if add_offset:
             offset_args = offset_args or {}
-            offset = make_offset(siteindicator, offsetprior, **offset_args)
+            offset = make_offset(prepared.site_indicator, offsetprior, **offset_args)
             mu += offset
 
-        y_data = pm.Data("Y", Y, dims="nmeasure")  # type: ignore[arg-type]
-        error_data = pm.Data("error", error, dims="nmeasure")  # type: ignore[arg-type]
-        min_error_data = pm.Data("min_error", min_error, dims="nmeasure")  # type: ignore[arg-type]
+        y_data = pm.Data("Y", prepared.y, dims="nmeasure")  # type: ignore[arg-type]
+        error_data = pm.Data("error", prepared.error, dims="nmeasure")  # type: ignore[arg-type]
+        min_error_data = pm.Data("min_error", min_error_data, dims="nmeasure")  # type: ignore[arg-type]
 
         if pollution_events_from_obs is True:
-            if use_bc is True:
+            if use_bc is True and prepared.hbc is not None:
                 pollution_event = pt.abs(y_data - mu_bc)
             else:
                 pollution_event = pt.abs(y_data) + 1e-6 * pt.mean(y_data)
         else:
             pollution_event = pt.abs(pt.dot(hx_data, x))
 
-        pollution_event_scaled_error = pollution_event * sigma[sites, sigma_freq_index_model]
+        pollution_event_scaled_error = pollution_event * sigma[sites, prepared.sigma_freq_index]
 
         if no_model_error is True:
-            mean_obs = np.nanmean(Y)
+            mean_obs = np.nanmean(prepared.y)
             small_amount = 1e-12 * mean_obs
             eps = pt.maximum(pt.abs(error_data), small_amount)
         else:
@@ -294,22 +587,22 @@ def build_inferpymc_model(
 
 
 def inferpymc(
-    Hx: np.ndarray,
-    Y: np.ndarray,
-    error: np.ndarray,
-    siteindicator: np.ndarray,
-    sigma_freq_index: np.ndarray,
+    Hx: np.ndarray | None = None,
+    Y: np.ndarray | None = None,
+    error: np.ndarray | None = None,
+    siteindicator: np.ndarray | None = None,
+    sigma_freq_index: np.ndarray | None = None,
     Hbc: np.ndarray | None = None,
-    xprior: dict = {"pdf": "normal", "mu": 1.0, "sigma": 1.0},
-    bcprior: dict = {"pdf": "normal", "mu": 1.0, "sigma": 1.0},
-    sigprior: dict = {"pdf": "uniform", "lower": 0.1, "upper": 3.0},
+    xprior: dict | None = None,
+    bcprior: dict | None = None,
+    sigprior: dict | None = None,
     nuts_sampler: str = "pymc",
     nit: int = 20000,
     burn: int = 10000,
     tune: int = 10000,
     nchain: int = 4,
     sigma_per_site: bool = True,
-    offsetprior: dict = {"pdf": "normal", "mu": 0, "sigma": 1},
+    offsetprior: dict | None = None,
     add_offset: bool = False,
     verbose: bool = False,
     min_error: np.ndarray | float | None = 0.0,
@@ -320,6 +613,9 @@ def inferpymc(
     offset_args: dict | None = None,
     power: dict | float = 1.99,
     sampler_kwargs: dict | None = None,
+    inv_inputs: xr.Dataset | None = None,
+    state: str = "region",
+    bc_state: str = "bc_region",
 ) -> dict:
     """Uses PyMC module for Bayesian inference for emissions field, boundary
     conditions and (currently) a single model error value.
@@ -450,6 +746,9 @@ def inferpymc(
         offset_args=offset_args,
         power=power,
         nuts_sampler=nuts_sampler,
+        inv_inputs=inv_inputs,
+        state=state,
+        bc_state=bc_state,
     )
 
     sampler_kwargs = sampler_kwargs or {}

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -633,10 +633,10 @@ def inferpymc(
 
     This routine constructs and runs a PyMC model (by default using a Normal
     likelihood) to infer emissions, boundary conditions, and a single model-
-    error parameter (or per-site model-error if requested). The function can
-    accept either numpy-based inputs (Hx, Y, etc.) or an xarray.Dataset produced
-    by `make_inv_inputs`, which preserves dims and coordinates for cleaner model
-    construction.
+    error parameter (or may vary by site and/or over a given period, if requested).
+    The function can accept either numpy-based inputs (Hx, Y, etc.) or an xarray.Dataset
+    produced by `inversion_inputs.make_inv_inputs`, which preserves dims and coordinates for
+    cleaner model construction.
 
     Args:
         Hx: Transpose of the sensitivity matrix mapping emissions to measurements.

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -486,7 +486,7 @@ def build_inferpymc_model(
     bc_state: str = "bc_region",
 ) -> InferPyMCModelSetup:
     """Build the PyMC model and sampler configuration used by inferpymc."""
-    prepared_inferpymc_inputs = _prepare_inferpymc_inputs(
+    prepared_inputs = _prepare_inferpymc_inputs(
         inv_inputs=inv_inputs,
         Hx=Hx,
         Y=Y,
@@ -508,19 +508,19 @@ def build_inferpymc_model(
     offsetprior = DEFAULT_OFFSETPRIOR.copy() if offsetprior is None else offsetprior
 
     sites = (
-        prepared.site_indicator.astype(int)
+        prepared_inputs.site_indicator.astype(int)
         if sigma_per_site
-        else np.zeros_like(prepared.site_indicator).astype(int)
+        else np.zeros_like(prepared_inputs.site_indicator).astype(int)
     )
 
-    if isinstance(prepared.min_error, float) or (
-        isinstance(prepared.min_error, np.ndarray) and prepared.min_error.ndim == 0
+    if isinstance(prepared_inputs.min_error, float) or (
+        isinstance(prepared_inputs.min_error, np.ndarray) and prepared_inputs.min_error.ndim == 0
     ):
-        min_error_data = prepared.min_error * np.ones_like(prepared.y)
+        min_error_data = prepared_inputs.min_error * np.ones_like(prepared_inputs.y)
     else:
-        min_error_data = prepared.min_error
+        min_error_data = prepared_inputs.min_error
 
-    with pm.Model(coords=prepared.coords) as model:
+    with pm.Model(coords=prepared_inputs.coords) as model:
         step1_vars = []
 
         if reparameterise_log_normal and xprior["pdf"] == "lognormal":
@@ -542,35 +542,35 @@ def build_inferpymc_model(
 
         sigma = parse_prior("sigma", sigprior, dims=("nsigma_site", "nsigma_time"))
 
-        hx_data = pm.Data("hx", prepared.hx, dims=("nmeasure", "nx"))
+        hx_data = pm.Data("hx", prepared_inputs.hx, dims=("nmeasure", "nx"))
         mu = pm.Deterministic("mu", pt.dot(hx_data, x), dims="nmeasure")
 
-        if use_bc and prepared.hbc is not None:
-            hbc_data = pm.Data("hbc", prepared.hbc, dims=("nmeasure", "nbc"))
+        if use_bc and prepared_inputs.hbc is not None:
+            hbc_data = pm.Data("hbc", prepared_inputs.hbc, dims=("nmeasure", "nbc"))
             mu_bc = pm.Deterministic("mu_bc", pt.dot(hbc_data, bc), dims="nmeasure")
             mu += mu_bc
 
         if add_offset:
             offset_args = offset_args or {}
-            offset = make_offset(prepared.site_indicator, offsetprior, **offset_args)
+            offset = make_offset(prepared_inputs.site_indicator, offsetprior, **offset_args)
             mu += offset
 
-        y_data = pm.Data("Y", prepared.y, dims="nmeasure")  # type: ignore[arg-type]
-        error_data = pm.Data("error", prepared.error, dims="nmeasure")  # type: ignore[arg-type]
+        y_data = pm.Data("Y", prepared_inputs.y, dims="nmeasure")  # type: ignore[arg-type]
+        error_data = pm.Data("error", prepared_inputs.error, dims="nmeasure")  # type: ignore[arg-type]
         min_error_data = pm.Data("min_error", min_error_data, dims="nmeasure")  # type: ignore[arg-type]
 
         if pollution_events_from_obs is True:
-            if use_bc is True and prepared.hbc is not None:
+            if use_bc is True and prepared_inputs.hbc is not None:
                 pollution_event = pt.abs(y_data - mu_bc)
             else:
                 pollution_event = pt.abs(y_data) + 1e-6 * pt.mean(y_data)
         else:
             pollution_event = pt.abs(pt.dot(hx_data, x))
 
-        pollution_event_scaled_error = pollution_event * sigma[sites, prepared.sigma_freq_index]
+        pollution_event_scaled_error = pollution_event * sigma[sites, prepared_inputs.sigma_freq_index]
 
         if no_model_error is True:
-            mean_obs = np.nanmean(prepared.y)
+            mean_obs = np.nanmean(prepared_inputs.y)
             small_amount = 1e-12 * mean_obs
             eps = pt.maximum(pt.abs(error_data), small_amount)
         else:

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -312,6 +312,12 @@ def _prepare_inferpymc_inputs_from_legacy(
 
     Temporary Stage B compatibility helper for issue #372.
     """
+    if use_bc and Hbc is None:
+        raise ValueError(
+            "In legacy-array mode, `Hbc` must be provided when `use_bc` is True. "
+            "Either supply a non-None boundary-condition influence matrix `Hbc` "
+            "or disable BCs by setting `use_bc=False`."
+        )
     hx = Hx.T
     hbc = Hbc.T if use_bc and Hbc is not None else None
     site_indicator = siteindicator.astype(int)
@@ -671,19 +677,27 @@ def inferpymc(
     Returns:
         dict: Dictionary containing inference results, samples, and diagnostics.
 
-            Keys typically include:
-            - 'trace': Raw MCMC trace/samples produced by the sampler.
-            - 'posterior': Processed posterior summaries and diagnostics.
-            - 'model': The constructed PyMC model object (if returned).
-            - 'inputs': Processed inputs used for the run (Hx, Y, etc.), with coords/dims
-              preserved when inv_inputs was provided.
-            - 'metadata': Run metadata such as nit, burn, tune, nchain, sampler settings,
-              and any warnings about reparameterisation or dropped samples.
+            The returned dictionary uses the legacy key structure. Depending on
+            the options used (e.g. whether BCs or offsets are included, and which
+            priors are active), keys typically include:
+
+            - ``'xouts'``: Posterior samples or summaries for the state vector
+              (emissions / fluxes).
+            - ``'sigouts'``: Posterior samples or summaries for model–data
+              mismatch (sigma) parameters.
+            - ``'Ytrace'``: Trace of the modelled observations corresponding to
+              the data vector ``Y``.
+            - ``'bcouts'``: Posterior samples or summaries for boundary condition
+              state variables (if boundary conditions are used).
+            - ``'offset_trace'`` or similar keys: Traces for site- or
+              observation-specific offset terms when ``add_offset`` is enabled.
+            - Additional diagnostic arrays and traces needed for convergence
+              checking and postprocessing.
 
             The returned dict is intended to contain enough information for
             postprocessing and diagnostic checks (convergence, effective sample
             size, R-hat, and so on). Exact key names and contents may vary with
-            sampler and options used.
+            sampler settings and options used.
     """
     burn = int(burn)
     nit = int(nit)

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -486,7 +486,7 @@ def build_inferpymc_model(
     bc_state: str = "bc_region",
 ) -> InferPyMCModelSetup:
     """Build the PyMC model and sampler configuration used by inferpymc."""
-    prepared = _prepare_inferpymc_inputs(
+    prepared_inferpymc_inputs = _prepare_inferpymc_inputs(
         inv_inputs=inv_inputs,
         Hx=Hx,
         Y=Y,

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -203,6 +203,7 @@ def _validate_inferpymc_input_mode(
     siteindicator: np.ndarray | None,
     sigma_freq_index: np.ndarray | None,
     Hbc: np.ndarray | None,
+    min_error: np.ndarray | float | None,
 ) -> str:
     """Validate whether dataset or legacy ndarray inputs are being used.
 
@@ -215,6 +216,7 @@ def _validate_inferpymc_input_mode(
         "siteindicator": siteindicator,
         "sigma_freq_index": sigma_freq_index,
         "Hbc": Hbc,
+        "min_error": min_error,
     }
     provided_legacy = [name for name, value in legacy_args.items() if value is not None]
 
@@ -375,6 +377,7 @@ def _prepare_inferpymc_inputs(
         siteindicator=siteindicator,
         sigma_freq_index=sigma_freq_index,
         Hbc=Hbc,
+        min_error=min_error,
     )
 
     if mode == "dataset":
@@ -470,7 +473,7 @@ def build_inferpymc_model(
     sigma_per_site: bool = True,
     offsetprior: dict | None = None,
     add_offset: bool = False,
-    min_error: np.ndarray | float | None = 0.0,
+    min_error: np.ndarray | float | None = None,
     use_bc: bool = True,
     reparameterise_log_normal: bool = False,
     pollution_events_from_obs: bool = False,
@@ -614,7 +617,7 @@ def inferpymc(
     offsetprior: dict | None = None,
     add_offset: bool = False,
     verbose: bool = False,
-    min_error: np.ndarray | float | None = 0.0,
+    min_error: np.ndarray | float | None = None,
     use_bc: bool = True,
     reparameterise_log_normal: bool = False,
     pollution_events_from_obs: bool = False,

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -19,6 +19,7 @@ import numpy as np
 
 # import pytensor before pymc so we can set config values
 import pytensor
+
 pytensor.config.floatX = "float32"
 pytensor.config.warn_float64 = "warn"
 
@@ -220,8 +221,7 @@ def _validate_inferpymc_input_mode(
     if inv_inputs is not None:
         if provided_legacy:
             raise ValueError(
-                "`inv_inputs` cannot be combined with legacy array arguments: "
-                + ", ".join(provided_legacy)
+                "`inv_inputs` cannot be combined with legacy array arguments: " + ", ".join(provided_legacy)
             )
         return "dataset"
 
@@ -229,8 +229,7 @@ def _validate_inferpymc_input_mode(
     missing = [name for name in required_legacy if legacy_args[name] is None]
     if missing:
         raise ValueError(
-            "Either provide `inv_inputs` or all required legacy arguments. Missing: "
-            + ", ".join(missing)
+            "Either provide `inv_inputs` or all required legacy arguments. Missing: " + ", ".join(missing)
         )
     return "legacy"
 
@@ -400,7 +399,9 @@ def _prepare_inferpymc_inputs(
     )
 
 
-def _restore_inferencedata_coords(idata: az.InferenceData, original_coords: dict[str, Any]) -> az.InferenceData:
+def _restore_inferencedata_coords(
+    idata: az.InferenceData, original_coords: dict[str, Any]
+) -> az.InferenceData:
     """Restore saved coordinates onto matching InferenceData groups.
 
     Temporary Stage B helper for issue #372. This is intentionally not yet wired
@@ -565,7 +566,9 @@ def build_inferpymc_model(
             eps = pt.maximum(pt.abs(error_data), small_amount)
         else:
             power0 = parse_prior("power", power) if isinstance(power, dict) else power
-            eps = pt.maximum(pt.sqrt(error_data**2 + pt.pow(pollution_event_scaled_error, power0)), min_error_data)
+            eps = pt.maximum(
+                pt.sqrt(error_data**2 + pt.pow(pollution_event_scaled_error, power0)), min_error_data
+            )
 
         pm.Deterministic("epsilon", eps, dims="nmeasure")
         pm.Normal("y", mu=mu, sigma=eps, observed=y_data, dims="nmeasure")
@@ -581,9 +584,9 @@ def build_inferpymc_model(
     )
 
 
-#----------------------------------------
+# ----------------------------------------
 # Build/run model
-#----------------------------------------
+# ----------------------------------------
 
 
 def inferpymc(
@@ -617,110 +620,70 @@ def inferpymc(
     state: str = "region",
     bc_state: str = "bc_region",
 ) -> dict:
-    """Uses PyMC module for Bayesian inference for emissions field, boundary
-    conditions and (currently) a single model error value.
-    This uses a Normal likelihood but the (hyper)prior PDFs can be selected by user.
+    """Perform Bayesian inference with PyMC for emissions, boundary conditions, and model error.
+
+    This routine constructs and runs a PyMC model (by default using a Normal
+    likelihood) to infer emissions, boundary conditions, and a single model-
+    error parameter (or per-site model-error if requested). The function can
+    accept either numpy-based inputs (Hx, Y, etc.) or an xarray.Dataset produced
+    by `make_inv_inputs`, which preserves dims and coordinates for cleaner model
+    construction.
 
     Args:
-      Hx:
-        Transpose of the sensitivity matrix to map emissions to measurement.
-        This is the same as what is given from fp_data[site].H.values, where
-        fp_data is the output from e.g. footprint_data_merge, but where it
-        has been stacked for all sites.
-      Y:
-        Measurement vector containing all measurements
-      error:
-        Measurement error vector, containg a value for each element of Y.
-      siteindicator:
-        Array of indexing integers that relate each measurement to a site
-      sigma_freq_index:
-        Array of integer indexes that converts time into periods
-      Hbc:
-        Same as Hx but for boundary conditions. Only used if use_bc=True.
-      xprior:
-        Dictionary containing information about the prior PDF for emissions.
-        The entry "pdf" is the name of the analytical PDF used, see
-        https://docs.pymc.io/api/distributions/continuous.html for PDFs
-        built into pymc3, although they may have to be coded into the script.
-        The other entries in the dictionary should correspond to the shape
-        parameters describing that PDF as the online documentation,
-        e.g. N(1,1**2) would be: `xprior={pdf: "normal", "mu": 1.0, "sigma": 1.0}`.
-        Note that the standard deviation should be used rather than the
-        precision. Currently all variables are considered iid.
-      bcprior:
-        Same as xprior but for boundary conditions. Only used if use_bc=True.
-      sigprior:
-        Same as xprior but for model error.
-      nuts_sampler:
-        nuts_sampler use by pymc.sample. Options are "pymc" and "numpyro"?
-      nit:
-        number of samples to generate (per chain)
-      burn:
-        number of samples to discard (or "burn") from the beginning of each chain
-      tune:
-        number of tuning steps used by sampler
-      nchain:
-        number of chains use by sampler. You should use at least 2 chains for the convergence checks
-        to work; four chains is better. Chains run in parallel, so the number of chains doesn't affect
-        running time, provided the number of threads available is at least the number of chains.
-      sigma_per_site (bool):
-        Whether a model sigma value will be calculated for each site independantly (True) or all sites together (False).
-        Default: True
-      offsetprior (dict):
-        Same as above but for bias offset. Only used is addoffset=True.
-      add_offset (bool):
-        Add an offset (intercept) to all sites but the first in the site list. Default False.
-      verbose:
-        When True, prints progress bar
-      min_error:
-        Minimum error to use during inversion. Only used if no_model_error is False.
-      save_trace:
-        Path where to save the trace. If None, the trace is not saved.
-        Default None.
-      use_bc:
-        When True, use and infer boundary conditions.
-      reparameterise_log_normal:
-        If there are many divergences when using a log normal prior, setting this to True might help. It samples from a normal prior, then puts the normal samples through a function that converts them to log normal samples; this changes the space the sampler needs to explore.
-      pollution_events_from_obs:
-        When True, calculate the pollution events from obs; when false pollution events are set
-        to the modeled concentration.
-      no_model_error:
-        When True, only use observation error in likelihood function (omitting min. model error
-        and model error from scaling pollution events.)
-      offset_args: optional arguments to pass to `make_offset`.
-      power: power to raise pollution events to when using pollution events from obs. Default is 1.99.
-        Any value (strictly) between 1 and 2 will work. If a dictionary is passed, this is used to create
-        a prior for the power, making the power a hyper-parameter.
+        Hx: Transpose of the sensitivity matrix mapping emissions to measurements.
+            This is typically fp_data[site].H.values stacked for all sites.
+        Y: Measurement vector containing all observations.
+        error: Measurement error vector, containing a value for each element of Y.
+        siteindicator: Array of indexing integers that relate each measurement to a site.
+        sigma_freq_index: Array of integer indexes that converts time into periods.
+        Hbc: Transpose of the sensitivity matrix for boundary conditions. Only used if use_bc is True.
+        xprior: Dictionary describing the prior PDF for emissions. The entry "pdf"
+            is the name of the analytical PDF used; other entries are shape
+            parameters (e.g., {'pdf': 'lognormal', 'stdev': 1.0}).
+        bcprior: Prior specification for boundary conditions. Only used if use_bc is True.
+            A common choice is {'pdf': 'truncatednormal', 'lower': 0.0, 'mu': 1.0, 'sigma': 0.1}.
+        sigprior: Prior specification for the model-error parameter(s).
+        nuts_sampler: Name of the NUTS sampler used by pymc.sample (e.g., "pymc" or "numpyro").
+        nit: Total number of iterations (samples + tuning) to draw per chain.
+        burn: Number of samples to discard as burn-in.
+        tune: Number of tuning steps passed to the sampler.
+        nchain: Number of MCMC chains to run.
+        sigma_per_site: If True, estimate a separate sigma (model error) for each site.
+        offsetprior: Prior specification for offsets applied to sites or observations.
+        add_offset: If True, include an offset term in the model.
+        verbose: If True, print additional diagnostic information.
+        min_error: Minimum allowed measurement error. Can be a scalar or an array matching Y.
+        use_bc: If True, include boundary condition terms in the model.
+        reparameterise_log_normal: If True, reparameterise log-normal priors for numerical stability.
+        pollution_events_from_obs: If True, derive pollution event terms from observations.
+        no_model_error: If True, do not include an explicit model-error term.
+        offset_args: Additional arguments used when constructing offsets.
+        power: Exponent used in certain weighting or prior schemes; may be a dict or float.
+        sampler_kwargs: Extra keyword arguments passed to the sampler.
+        inv_inputs: xarray.Dataset produced by `make_inv_inputs`, providing xarray-native
+            inputs (e.g., sensitivity matrices, coordinates, and dims) so the function
+            can accept inversion inputs without reconstructing dims and coords.
+        state: Dimension name of the state variable for flux sensitivities ("H") in inv_inputs.
+            Defaults to "region".
+        bc_state: Dimension name of the state variable for BC sensitivities ("H_bc") in inv_inputs.
+            Defaults to "bc_region".
 
     Returns:
-      Dictionary containing:
-        xouts (array):
-          MCMC chain for emissions scaling factors for each basis function.
-        sigouts (array):
-          MCMC chain for model error.
-        Ytrace (array):
-          MCMC chain for modelled obs..
-        OFFSETtrace (array):
-          MCMC chain for the offset.
-        convergence (str):
-          Passed/Failed convergence test as to whether mutliple chains
-          have a Gelman-Rubin diagnostic value <1.05
-        step1 (str):
-          Type of MCMC sampler for emissions and boundary condition updates.
-          Currently it's hardwired to NUTS (probably wouldn't change this
-          unless you're doing something obscure).
-        step2 (str):
-          Type of MCMC sampler for model error updates.
-          Currently it's hardwired to a slice sampler. This parameter is low
-          dimensional and quite simple with a slice sampler, although could
-          easily be changed.
-        bcouts (array):
-          MCMC chain for boundary condition scaling factors. Only if use_bc is True.
-        YBCtrace (array):
-          MCMC chain for modelled boundary condition Only if use_bc is True.
+        dict: Dictionary containing inference results, samples, and diagnostics.
 
-    TO DO:
-       - Allow non-iid variables
+            Keys typically include:
+            - 'trace': Raw MCMC trace/samples produced by the sampler.
+            - 'posterior': Processed posterior summaries and diagnostics.
+            - 'model': The constructed PyMC model object (if returned).
+            - 'inputs': Processed inputs used for the run (Hx, Y, etc.), with coords/dims
+              preserved when inv_inputs was provided.
+            - 'metadata': Run metadata such as nit, burn, tune, nchain, sampler settings,
+              and any warnings about reparameterisation or dropped samples.
+
+            The returned dict is intended to contain enough information for
+            postprocessing and diagnostic checks (convergence, effective sample
+            size, R-hat, and so on). Exact key names and contents may vary with
+            sampler and options used.
     """
     burn = int(burn)
     nit = int(nit)
@@ -803,14 +766,11 @@ def inferpymc(
     else:
         Ytrace = posterior_burned.mu + OFFtrace
 
-
     # truncate trace and sample prior and predictive distributions
     trace = trace.isel(draw=slice(burn, None))
     ndraw = nit - burn
     trace.extend(pm.sample_prior_predictive(ndraw, model))
     trace.extend(pm.sample_posterior_predictive(trace, model=model, var_names=["y"]))
-
-
 
     result = {
         "xouts": xouts,
@@ -875,7 +835,7 @@ def inferpymc_postprocessouts(
     min_error: float | np.ndarray = 0.0,
 ) -> xr.Dataset:
     r"""Take the output from inferpymc function along with other input information.
-    
+
     Calculates statistics on them and places it all in a dataset.
     Also calculates statistics on posterior emissions for the countries in
     the inversion domain and saves all in netcdf.

--- a/openghg_inversions/inversion_inputs.py
+++ b/openghg_inversions/inversion_inputs.py
@@ -191,7 +191,7 @@ def _drop_nan_and_compute(ds: xr.Dataset, drop_nan_from: Iterable[str] = ("H", "
             will be used.
 
     Returns:
-        xarray.Dataset with NaNs dropped along `nmeasure` basied on selected variables,
+        xarray.Dataset with NaNs dropped along `nmeasure` based on selected variables,
             and with certain variables computed.
     """
     # Variables that must not contain NaNs along the nmeasure dim

--- a/openghg_inversions/inversion_inputs.py
+++ b/openghg_inversions/inversion_inputs.py
@@ -1,7 +1,7 @@
 """Functions for creating the inputs needed by PyMC."""
 
 import datetime as dt
-from typing import Any, Literal
+from typing import Any, Iterable, Literal
 
 import numpy as np
 import pandas as pd
@@ -176,6 +176,49 @@ def transform_bc(
 
 
 # INVERSION INPUTS PIPELINE
+def _drop_nan_and_compute(ds: xr.Dataset, drop_nan_from: Iterable[str] = ("H", "H_bc", "mf", "mf_error")) -> xr.Dataset:
+    """Drop NaNs in required inversion variables and materialize core variables.
+
+    This centralizes the dataset cleanup that was previously duplicated in
+    hbmcmc.make_inv_inputs. It:
+      - drops nmeasure rows with NaNs in required variables (H, H_bc, mf, mf_error)
+      - triggers computation for a selected set of variables so returned dataset
+        is ready for immediate consumption (avoids repeated dask computations)
+
+    Args:
+        ds: Input xarray.Dataset produced by make_inv_inputs logic.
+        drop_nan_from: data variables to drop NaNs from; only data variables present in `ds`
+            will be used.
+
+    Returns:
+        xarray.Dataset with NaNs dropped along `nmeasure` basied on selected variables,
+            and with certain variables computed.
+    """
+    # Variables that must not contain NaNs along the nmeasure dim
+    drop_subset: list[str] = [v for v in drop_nan_from if v in ds]
+    if drop_subset:
+        ds = ds.dropna(dim="nmeasure", how="any", subset=drop_subset)
+
+    # Variables we want to ensure are materialized (compute() only these)
+    to_compute: list[str] = [
+        "H",
+        "H_bc",
+        "mf",
+        "mf_error",
+        "mf_repeatability",
+        "mf_variability",
+        "mf_prior_factor",
+        "mf_prior_upper_level_factor",
+        "bc_mod",
+        "mf_mod",
+    ]
+    to_compute = [v for v in to_compute if v in ds]
+    if to_compute:
+        ds[to_compute] = ds[to_compute].compute()
+
+    return ds
+
+
 def make_inv_inputs(
     fp_data: dict[str, Any],
     sites: list[str] | None = None,
@@ -201,5 +244,7 @@ def make_inv_inputs(
     ds["sigma_freq_index"] = make_sigma_freq(ds.time, freq=sigma_freq, anchor_time=start_date)
 
     ds = add_min_error(ds, fp_data=fp_data, min_error=min_error, min_error_per_site=min_error_per_site)
+
+    ds = _drop_nan_and_compute(ds)
 
     return ds

--- a/tests/test_inferpymc.py
+++ b/tests/test_inferpymc.py
@@ -7,8 +7,8 @@ import pymc as pm
 import pytest
 import xarray as xr
 
-from openghg_inversions.hbmcmc.hbmcmc import make_inv_inputs
-from openghg_inversions.inversion_inputs import make_inv_inputs as make_inv_inputs_ds
+from openghg_inversions.hbmcmc.hbmcmc import make_inv_inputs_legacy
+from openghg_inversions.inversion_inputs import make_inv_inputs
 from openghg_inversions.hbmcmc.inversion_pymc import (
     InferPyMCModelSetup,
     _prepare_inferpymc_inputs,
@@ -28,7 +28,7 @@ def inferpymc_args(mhd_and_tac_fp_data) -> MappingProxyType:
 
     The result is wrapped in a MappingProxyType as a precaution.
     """
-    mcmc_args, _ = make_inv_inputs(
+    mcmc_args, _ = make_inv_inputs_legacy(
         fp_data=mhd_and_tac_fp_data,
         sites=["MHD", "TAC"],
         start_date="2019-01-01",
@@ -69,7 +69,7 @@ def inferpymc_args(mhd_and_tac_fp_data) -> MappingProxyType:
 @pytest.fixture(scope="module")
 def inferpymc_inputs_dataset(mhd_and_tac_fp_data) -> xr.Dataset:
     """Create xarray inversion inputs for the Stage B dataset path."""
-    ds = make_inv_inputs_ds(
+    ds = make_inv_inputs(
         mhd_and_tac_fp_data,
         sites=["MHD", "TAC"],
         bc_freq="3h",
@@ -78,28 +78,6 @@ def inferpymc_inputs_dataset(mhd_and_tac_fp_data) -> xr.Dataset:
         min_error_per_site=False,
         start_date="2019-01-01",
     )
-
-    drop_subset = ["H", "H_bc", "mf", "mf_error"]
-    drop_subset = [dv for dv in drop_subset if dv in ds]
-    ds = ds.dropna(dim="nmeasure", how="any", subset=drop_subset)
-
-    to_compute = [
-        "H",
-        "H_bc",
-        "mf",
-        "mf_error",
-        "mf_repeatability",
-        "mf_variability",
-        "mf_prior_factor",
-        "mf_prior_upper_level_factor",
-        "bc_mod",
-        "mf_mod",
-        "site_indicator",
-        "sigma_freq_index",
-        "min_error",
-    ]
-    to_compute = [dv for dv in to_compute if dv in ds]
-    ds[to_compute] = ds[to_compute].compute()
     return ds
 
 

--- a/tests/test_inferpymc.py
+++ b/tests/test_inferpymc.py
@@ -1,11 +1,21 @@
 from types import MappingProxyType
 
+import arviz as az
 import numpy as np
+import pandas as pd
 import pymc as pm
 import pytest
+import xarray as xr
 
 from openghg_inversions.hbmcmc.hbmcmc import make_inv_inputs
-from openghg_inversions.hbmcmc.inversion_pymc import InferPyMCModelSetup, build_inferpymc_model, inferpymc
+from openghg_inversions.inversion_inputs import make_inv_inputs as make_inv_inputs_ds
+from openghg_inversions.hbmcmc.inversion_pymc import (
+    InferPyMCModelSetup,
+    _prepare_inferpymc_inputs,
+    _restore_inferencedata_coords,
+    build_inferpymc_model,
+    inferpymc,
+)
 
 
 @pytest.fixture(scope="module")
@@ -54,6 +64,43 @@ def inferpymc_args(mhd_and_tac_fp_data) -> MappingProxyType:
         }
     )
     return MappingProxyType(mcmc_args)
+
+
+@pytest.fixture(scope="module")
+def inferpymc_inputs_dataset(mhd_and_tac_fp_data) -> xr.Dataset:
+    """Create xarray inversion inputs for the Stage B dataset path."""
+    ds = make_inv_inputs_ds(
+        mhd_and_tac_fp_data,
+        sites=["MHD", "TAC"],
+        bc_freq="3h",
+        sigma_freq="3h",
+        min_error="percentile",
+        min_error_per_site=False,
+        start_date="2019-01-01",
+    )
+
+    drop_subset = ["H", "H_bc", "mf", "mf_error"]
+    drop_subset = [dv for dv in drop_subset if dv in ds]
+    ds = ds.dropna(dim="nmeasure", how="any", subset=drop_subset)
+
+    to_compute = [
+        "H",
+        "H_bc",
+        "mf",
+        "mf_error",
+        "mf_repeatability",
+        "mf_variability",
+        "mf_prior_factor",
+        "mf_prior_upper_level_factor",
+        "bc_mod",
+        "mf_mod",
+        "site_indicator",
+        "sigma_freq_index",
+        "min_error",
+    ]
+    to_compute = [dv for dv in to_compute if dv in ds]
+    ds[to_compute] = ds[to_compute].compute()
+    return ds
 
 
 def test_build_inferpymc_model_returns_setup_for_pymc(inferpymc_args: dict) -> None:
@@ -205,6 +252,100 @@ def test_inferpymc_model_contains_expected_variables(inferpymc_args: dict, infer
     assert len(coords["nbc"]) == hbc.shape[0]
     assert len(coords["nsigma_site"]) == len(np.unique(siteindicator))
     assert len(coords["nsigma_time"]) == len(np.unique(sigma_freq_index))
+
+
+def test_prepare_inferpymc_inputs_dataset_matches_legacy(
+    inferpymc_args: dict, inferpymc_inputs_dataset: xr.Dataset
+) -> None:
+    """Check dataset and legacy preparation paths agree on core arrays."""
+    prepared_dataset = _prepare_inferpymc_inputs(
+        inv_inputs=inferpymc_inputs_dataset,
+        sigma_per_site=True,
+        use_bc=True,
+        state="region",
+        bc_state="bc_region",
+    )
+    prepared_legacy = _prepare_inferpymc_inputs(
+        Hx=inferpymc_args["Hx"],
+        Y=inferpymc_args["Y"],
+        error=inferpymc_args["error"],
+        siteindicator=inferpymc_args["siteindicator"],
+        sigma_freq_index=inferpymc_args["sigma_freq_index"],
+        Hbc=inferpymc_args["Hbc"],
+        min_error=inferpymc_args["min_error"],
+        sigma_per_site=True,
+        use_bc=True,
+    )
+
+    np.testing.assert_allclose(prepared_dataset.hx, prepared_legacy.hx)
+    np.testing.assert_allclose(prepared_dataset.y, prepared_legacy.y)
+    np.testing.assert_allclose(prepared_dataset.error, prepared_legacy.error)
+    np.testing.assert_array_equal(prepared_dataset.site_indicator, prepared_legacy.site_indicator)
+    np.testing.assert_array_equal(prepared_dataset.sigma_freq_index, prepared_legacy.sigma_freq_index)
+    assert prepared_dataset.hbc is not None
+    assert prepared_legacy.hbc is not None
+    np.testing.assert_allclose(prepared_dataset.hbc, prepared_legacy.hbc)
+    assert prepared_dataset.original_coords
+
+
+def test_build_inferpymc_model_accepts_dataset(
+    inferpymc_args: dict, inferpymc_inputs_dataset: xr.Dataset
+) -> None:
+    """Check model builder accepts direct xarray inversion inputs."""
+    setup = build_inferpymc_model(
+        inv_inputs=inferpymc_inputs_dataset,
+        xprior=inferpymc_args["xprior"],
+        bcprior=inferpymc_args["bcprior"],
+        sigprior=inferpymc_args["sigprior"],
+        sigma_per_site=inferpymc_args["sigma_per_site"],
+        offsetprior=inferpymc_args["offsetprior"],
+        add_offset=inferpymc_args["add_offset"],
+        use_bc=inferpymc_args["use_bc"],
+        reparameterise_log_normal=inferpymc_args["reparameterise_log_normal"],
+        pollution_events_from_obs=inferpymc_args["pollution_events_from_obs"],
+        no_model_error=inferpymc_args["no_model_error"],
+        offset_args=inferpymc_args["offset_args"],
+        power=inferpymc_args["power"],
+        nuts_sampler="pymc",
+    )
+
+    assert isinstance(setup, InferPyMCModelSetup)
+    assert isinstance(setup.model, pm.Model)
+    assert len(setup.model.coords["nmeasure"]) == inferpymc_inputs_dataset.sizes["nmeasure"]
+    assert len(setup.model.coords["nx"]) == inferpymc_inputs_dataset.sizes["region"]
+
+
+def test_build_inferpymc_model_rejects_mixed_input_modes(
+    inferpymc_args: dict, inferpymc_inputs_dataset: xr.Dataset
+) -> None:
+    """Check dataset and legacy input paths cannot be combined."""
+    with pytest.raises(ValueError, match="cannot be combined"):
+        build_inferpymc_model(
+            inv_inputs=inferpymc_inputs_dataset,
+            Hx=inferpymc_args["Hx"],
+            Y=inferpymc_args["Y"],
+            error=inferpymc_args["error"],
+            siteindicator=inferpymc_args["siteindicator"],
+            sigma_freq_index=inferpymc_args["sigma_freq_index"],
+        )
+
+
+def test_restore_inferencedata_coords_helper_restores_multiindex() -> None:
+    """Check restoration helper can re-attach a MultiIndex coordinate."""
+    multi_index = pd.MultiIndex.from_arrays(
+        [["MHD", "MHD", "TAC"], pd.to_datetime(["2019-01-01", "2019-01-02", "2019-01-01"])],
+        names=["site", "time"],
+    )
+    posterior = xr.Dataset(
+        data_vars={"x": (("chain", "draw", "nmeasure"), np.zeros((1, 1, 3)))},
+        coords={"chain": [0], "draw": [0], "nmeasure": np.arange(3)},
+    )
+    idata = az.InferenceData(posterior=posterior)
+
+    restored = _restore_inferencedata_coords(idata, {"nmeasure": multi_index})
+
+    assert "nmeasure" in restored.posterior.indexes
+    assert restored.posterior.indexes["nmeasure"].equals(multi_index)
 
 
 def test_inferpymc_runs_without_boundary_conditions(inferpymc_args: dict) -> None:

--- a/tests/test_inferpymc_month_gap.py
+++ b/tests/test_inferpymc_month_gap.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
-from openghg_inversions.hbmcmc.hbmcmc import make_inv_inputs
+from openghg_inversions.hbmcmc.hbmcmc import make_inv_inputs_legacy
 from openghg_inversions.hbmcmc.inversion_pymc import inferpymc
 
 
@@ -48,7 +48,7 @@ def _synthetic_fp_data_one_site_with_missing_month() -> dict[str, xr.Dataset]:
 def test_make_inv_inputs_month_gap_monthly_indices_are_non_contiguous():
     fp_data = _synthetic_fp_data_one_site_with_missing_month()
 
-    mcmc_args, _ = make_inv_inputs(
+    mcmc_args, _ = make_inv_inputs_legacy(
         fp_data=fp_data,
         sites=["AAA"],
         start_date="2019-01-01",
@@ -67,7 +67,7 @@ def test_make_inv_inputs_month_gap_monthly_indices_are_non_contiguous():
 def test_inferpymc_smoke_runs_for_month_gap():
     fp_data = _synthetic_fp_data_one_site_with_missing_month()
 
-    mcmc_args, _ = make_inv_inputs(
+    mcmc_args, _ = make_inv_inputs_legacy(
         fp_data=fp_data,
         sites=["AAA"],
         start_date="2019-01-01",

--- a/tests/test_inversion_inputs.py
+++ b/tests/test_inversion_inputs.py
@@ -7,7 +7,7 @@ from numpy.testing import assert_almost_equal
 import pytest
 import xarray as xr
 
-from openghg_inversions.hbmcmc.hbmcmc import make_inv_inputs
+from openghg_inversions.hbmcmc.hbmcmc import make_inv_inputs_legacy
 from openghg_inversions.inversion_inputs import add_site_indicator, concat_gather_datasets
 
 
@@ -92,7 +92,7 @@ def inv_inputs_args(mhd_and_tac_fp_data):
 @pytest.mark.create_frozen
 def test_inversion_input_create_frozen(raw_data_path, inv_inputs_args):
     """This 'test' just regenerates frozen data for use in other tests."""
-    mcmc_args, post_args = make_inv_inputs(**inv_inputs_args)
+    mcmc_args, post_args = make_inv_inputs_legacy(**inv_inputs_args)
 
     out_name = raw_data_path / "frozen_mhd_tac_make_inv_inputs_hbmcmc.npz"
     save_frozen_npz(out_name, mcmc_args=mcmc_args, post_process_args=post_args)
@@ -104,7 +104,7 @@ def test_inversion_input_hbmcmc_matches_frozen(raw_data_path, inv_inputs_args):
 
     frozen_mcmc, frozen_post = load_frozen_npz(frozen_path)
 
-    mcmc_args, post_args = make_inv_inputs(**inv_inputs_args)
+    mcmc_args, post_args = make_inv_inputs_legacy(**inv_inputs_args)
 
     _compare_with_frozen(mcmc_args, frozen_mcmc)
     _compare_with_frozen(post_args, frozen_post)


### PR DESCRIPTION
* **Summary of changes**

Updated build `inferpymcmodel` and inferpymc to accept the
xarray.Dataset produced by make `invinputs` as an alternative to
the existing NumPy-array inputs (Y, H, etc.). This change is part of
Stage B (Issue #372) for the broader refactor tracked in Issue #370
and is intended to prepare for Stage C (Issue #373).

### Motivation

- xarray inputs are ultimately simpler and more flexible for indexing,
  metadata, and future model components.
- Adding xarray input support now will inform how we implement "model
  components" in the next stage (Stage C).

### Main changes

- Introduced an `InferPyMCInputs` dataclass that serves as the canonical,
  internal representation of model inputs. It is instantiated from
  either:

  - the legacy NumPy-array inputs (Y, H, R, etc.), or
  - the xarray.Dataset produced by `make_inv_inputs`.

  The dataclass isolates downstream code from the two upstream input
  formats and ensures consistent behaviour regardless of input source.

- Modified `build_inferpymc_model` and inferpymc so they accept
  either:

  - legacy NumPy inputs (unchanged behavior), or
  - an xr.Dataset from `make_inv_inputs`, which is converted to
    InferPyMCInputs.

- Added helper functions and small adapters to convert between formats
  and to extract the required pieces from the xr.Dataset. These helpers
  are intentionally plentiful for now to preserve the legacy path and
  make the transition transparent; they will be simplified/removed in
  later stages.

- Minor change: switched the default value of min_error from 0.0 to None in `inferpymc` and `build_inferpymc_model`, but this doesn't affect behaviour overall (since `inferpymc` is called via `fixedbasisMCMC`, which still has 0.0 as the default).

### Tests

- Added tests that exercise the `xr.Dataset` / `make_inv_inputs`
  path to verify the new input option works end-to-end.
- Added parity tests that compare outputs from the legacy NumPy path and
  the new xr.Dataset path to guard against regressions.
- Updated existing tests and fixtures where necessary so current
  regression tests continue to pass; these changes are minimal and
  focused on exercising both input paths.

### Notes / future work

- The helper function proliferation is deliberate: keeping the legacy
  inputs supported lets us be confident inferpymc behaviour is
  unchanged. Once Stage B is stable, many of these helpers will be
  simplified or removed in Stage C.
- This PR should not change model behavior; it only adds an alternate,
  more expressive input option and the plumbing to convert it to a
  single canonical form (`InferPyMCInputs`).

* **Please check if the PR fulfills these requirements**

- [x] Closes #372 
- [x] Tests added and passing
- Documentation and tutorials updated/added
- [x] Added an entry to the `CHANGELOG.md` file
- Added any new requirements to `requirements.txt`
