### PR TITLE
Issue 373 add model components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Added opt-in `basis_functions_wrapper` support for returning `BasisFunctions` objects and saving basis artifacts in DataTree format while keeping legacy flat-basis output as the default. [PR #367](https://github.com/openghg/openghg_inversions/pull/367)
 - Stage A of PyMC model refactor. Added regression tests for `inferpymc` and extracted function to build the PyMC model. [PR #378](https://github.com/openghg/openghg_inversions/pull/378)
 - Stage B of PyMC model refactor. Updated `inferpymc` to accept current/legacy inputs as well as xarray `Dataset`. [PR #380](https://github.com/openghg/openghg_inversions/pull/380)
+- Stage C of PyMC model refactor. Added function for building PyMC "model components". The model building code from Stage B is still used by default, but the new code can be selected by adding `model_builder="components"` to the .ini file. [PR #382](https://github.com/openghg/openghg_inversions/pull/382)
 
 # Version 0.6.0
 

--- a/openghg_inversions/hbmcmc/components.py
+++ b/openghg_inversions/hbmcmc/components.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import numpy as np
 import xarray as xr
-from pytensor.tensor import TensorVariable
+from pytensor.tensor.variable import TensorVariable
 
 from openghg_inversions.models.components import add_offset_component
 

--- a/openghg_inversions/hbmcmc/components.py
+++ b/openghg_inversions/hbmcmc/components.py
@@ -24,6 +24,12 @@ def make_offset(
     to the new shared component implementation.
     """
     site_indicator_da = xr.DataArray(site_indicator, dims=(output_dim,), name="site_indicator")
+
+    # Previously `offset_freq` was ignored, and without adding another argument to this function,
+    # we cannot make use of it
+    if offset_freq_indicator is None:
+        offset_freq = None
+
     return add_offset_component(
         site_indicator_da,
         prior_args=prior_args,

--- a/openghg_inversions/hbmcmc/components.py
+++ b/openghg_inversions/hbmcmc/components.py
@@ -1,52 +1,36 @@
-"""Classes and functions to making self-contained parts of the RHIME model."""
+"""Compatibility wrappers for HBMCMC model components."""
+
+from __future__ import annotations
+
 import numpy as np
-import pandas as pd
-import pymc as pm
-import pytensor.tensor as pt
+import xarray as xr
 from pytensor.tensor import TensorVariable
 
+from openghg_inversions.models.components import add_offset_component
 
-def make_offset(site_indicator: np.ndarray, 
-                prior_args: dict, 
-                name: str = "offset", 
-                output_dim: str = "nmeasure", 
-                drop_first: bool = False,
-                offset_freq: str | None = None,
-                offset_freq_indicator: str | None = None ) -> TensorVariable:
+
+def make_offset(
+    site_indicator: np.ndarray,
+    prior_args: dict,
+    name: str = "offset",
+    output_dim: str = "nmeasure",
+    drop_first: bool = False,
+    offset_freq: str | None = None,
+    offset_freq_indicator: xr.DataArray | np.ndarray | None = None,
+) -> TensorVariable:
     """Create an offset inside a PyMC model.
 
-    Note: this *must* be called from inside a PyMC `model` context.
-
-    Args:
-        site_indicator: array with same length as obs, with integers to indicator which site
-          an observation belongs to
-        prior_args: dict of prior args for offset prior
-        name: name for offset in PyMC model
-        output_dim: name of dimension for output
-        drop_first: if True, set first site's offset to zero
-
-        offset_freq: frequency for which to solve for the offset (e.g. "M"). Not used.
-        offset_freq_indicator: array of period indicators for each measurement
-
-    Returns:
-        TensorVariable containing offset vector (to add to modelled observations).
+    This compatibility wrapper keeps the historical import path while delegating
+    to the new shared component implementation.
     """
-    from .inversion_pymc import parse_prior  # TODO move parse_prior into this file?
-
-    sites = np.unique(site_indicator)
-
-    n_sites = len(sites) - 1 if drop_first else len(sites)
-
-    matrix = pd.get_dummies(site_indicator, drop_first=drop_first, dtype=int).values
-    if offset_freq_indicator is not None:
-        offset_freq_matrix = pd.get_dummies(offset_freq_indicator, dtype=int).values
-        # Combine using cartesian product
-        # matrix: [n_obs, n_sites], offset_freq_matrix: [n_obs, n_periods]
-        combined_matrix = np.einsum('ij,ik->ijk', matrix, offset_freq_matrix).reshape(matrix.shape[0], -1)
-        n_offsets = combined_matrix.shape[1]
-        offset_x = parse_prior(name + "0", prior_args, shape=n_offsets)
-        matrix = combined_matrix
-    else:
-        offset_x = parse_prior(name + "0", prior_args, shape=n_sites)
-
-    return pm.Deterministic(name, pt.dot(matrix, offset_x), dims=output_dim)
+    site_indicator_da = xr.DataArray(site_indicator, dims=(output_dim,), name="site_indicator")
+    return add_offset_component(
+        site_indicator_da,
+        prior_args=prior_args,
+        offset_freq_indicator=offset_freq_indicator,
+        offset_freq=offset_freq,
+        var_name=f"{name}_latent",
+        output_name=name,
+        output_dim=output_dim,
+        drop_first=drop_first,
+    )

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -36,6 +36,7 @@ import xarray as xr
 from openghg.util import split_function_inputs
 
 import openghg_inversions.hbmcmc.inversion_pymc as mcmc
+from openghg_inversions.models.priors import lognormal_mu_sigma
 from openghg_inversions.utils import ncdf_encoding
 from openghg_inversions.basis import basis_functions_wrapper
 from openghg_inversions.inversion_data import data_processing_surface_notracer, load_merged_data
@@ -50,7 +51,7 @@ def update_log_normal_prior(prior):
         stdev = float(prior["stdev"])
         mean = float(prior.get("mean", 1.0))
 
-        mu, sigma = mcmc.lognormal_mu_sigma(mean, stdev)
+        mu, sigma = lognormal_mu_sigma(mean, stdev)
         prior["mu"] = mu
         prior["sigma"] = sigma
 

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -29,18 +29,22 @@ import xarray as xr
 import pytensor.tensor as pt
 import arviz as az
 from scipy import stats
-from pymc.distributions import continuous
-from pytensor.tensor import TensorVariable
 
 from openghg_inversions import convert
 from openghg_inversions import utils
-from openghg_inversions.hbmcmc.components import make_offset
 from openghg_inversions.hbmcmc.hbmcmc_output import define_output_filename
 from openghg_inversions.config.version import code_version
-
-
-# type alias for prior args
-PriorArgs = dict[str, str | float]
+from openghg_inversions.models.components import (
+    add_inferpymc_likelihood_component,
+    add_linear_component,
+    add_offset_component,
+)
+from openghg_inversions.models.coords import (
+    CoordRegistry,
+    attach_coord_registry,
+    restore_inferencedata_coords,
+)
+from openghg_inversions.models.priors import PriorArgs, lognormal_mu_sigma, parse_prior
 
 
 @dataclass
@@ -72,85 +76,6 @@ class InferPyMCInputs:
     original_coords: dict[str, Any]
     source: xr.Dataset | None
 
-
-def lognormal_mu_sigma(mean: float, stdev: float) -> tuple[float, float]:
-    """Return the pymc `mu` and `sigma` parameters that give a log normal distribution
-    with the given mean and stdev.
-
-    Args:
-        mean: desired mean of log normal
-        stdev: desired standard deviation of log normal
-
-    Returns:
-        tuple (mu, sigma), where `pymc.LogNormal(mu, sigma)` has the given mean and stdev.
-
-    Formulas for log normal mean and variance:
-
-    mean = exp(mu + 0.5 * sigma ** 2)
-    stdev ** 2 = var = exp(2*mu + sigma ** 2) * (exp(sigma ** 2) - 1)
-
-    This gives linear equations for `mu` and `sigma ** 2`:
-
-    mu + 0.5 * sigma ** 2 = log(mean)
-    sigma ** 2 = log(1 + (stdev / mean)**2)
-
-    So
-
-    mu = log(mean) - 0.5 * log(1 + (stdev/mean)**2)
-    sigma = sqrt(log(1 + (stdev / mean)**2))
-    """
-    var = np.log(1 + (stdev / mean) ** 2)
-    mu = np.log(mean) - 0.5 * var
-    sigma = np.sqrt(var)
-    return mu, sigma
-
-
-def parse_prior(name: str, prior_params: PriorArgs, **kwargs) -> TensorVariable:
-    """Parses all PyMC continuous distributions:
-    https://docs.pymc.io/api/distributions/continuous.html.
-
-    Args:
-        name:
-          name of variable in the pymc model
-        prior_params:
-          dict of parameters for the distribution, including 'pdf' for the distribution to use.
-          The value of `prior_params["pdf"]` must match the name of a PyMC continuous
-          distribution: https://docs.pymc.io/api/distributions/continuous.html
-        **kwargs: for instance, `shape` or `dims`
-    Returns:
-        continuous PyMC distribution
-
-    For example:
-    ```
-    params = {"pdf": "uniform", "lower": 0.0, "upper": 1.0}
-    parse_prior("x", params, shape=(20, 20))
-    ```
-    will create a 20 x 20 array of uniform random variables.
-    Alternatively,
-    ```
-    params = {"pdf": "uniform", "lower": 0.0, "upper": 1.0}
-    parse_prior("x", params, dims="nmeasure"))
-    ```
-    will create an array of uniform random variables with the same shape
-    as the dimension coordinate `nmeasure`. This can be used if `pm.Model`
-    is provided with coordinates.
-
-    Note: `parse_prior` must be called inside a `pm.Model` context (i.e. after `with pm.Model()`)
-    has an important side-effect of registering the random variable with the model.
-    """
-    # create dict to lookup continuous PyMC distributions by name, ignoring case
-    pdf_dict = {cd.lower(): cd for cd in continuous.__all__}
-
-    params = prior_params.copy()
-    pdf = str(params.pop("pdf")).lower()  # str is just for typing...
-    try:
-        dist = getattr(continuous, pdf_dict[pdf])
-    except AttributeError:
-        raise ValueError(
-            f"The distribution '{pdf}' doesn't appear to be a continuous distribution defined by PyMC."
-        )
-
-    return dist(name, **params, **kwargs)
 
 
 def _make_range_coords(
@@ -411,27 +336,8 @@ def _prepare_inferpymc_inputs(
 def _restore_inferencedata_coords(
     idata: az.InferenceData, original_coords: dict[str, Any]
 ) -> az.InferenceData:
-    """Restore saved coordinates onto matching InferenceData groups.
-
-    Temporary Stage B helper for issue #372. This is intentionally not yet wired
-    into inferpymc because downstream post-processing still expects the current
-    outputs.
-    """
-    for group_name in idata.groups():
-        group = getattr(idata, group_name)
-        if not isinstance(group, xr.Dataset):
-            continue
-
-        for dim, coord in original_coords.items():
-            if dim not in group.dims:
-                continue
-            if len(coord) != group.sizes[dim]:
-                continue
-            group = group.assign_coords({dim: coord})
-
-        setattr(idata, group_name, group)
-
-    return idata
+    """Restore saved coordinates onto matching InferenceData groups."""
+    return restore_inferencedata_coords(idata, original_coords)
 
 
 def _contiguous_sigma_time_index(sigma_freq_index: np.ndarray) -> np.ndarray:
@@ -458,6 +364,78 @@ DEFAULT_XPRIOR: PriorArgs = {"pdf": "normal", "mu": 1.0, "sigma": 1.0}
 DEFAULT_BCPRIOR: PriorArgs = {"pdf": "normal", "mu": 1.0, "sigma": 1.0}
 DEFAULT_SIGPRIOR: PriorArgs = {"pdf": "uniform", "lower": 0.1, "upper": 3.0}
 DEFAULT_OFFSETPRIOR: PriorArgs = {"pdf": "normal", "mu": 0, "sigma": 1}
+
+
+def _canonicalise_inferpymc_dataset(
+    prepared: InferPyMCInputs,
+    /,
+    sigma_per_site: bool,
+    use_bc: bool,
+    obs_dim: str = "nmeasure",
+    state_dim: str = "nx",
+    bc_state_dim: str = "nbc",
+) -> xr.Dataset:
+    """Convert normalized Stage B inputs into canonical xarray model inputs."""
+    nmeasure = prepared.hx.shape[0]
+    obs_coord = (
+        prepared.source.indexes[obs_dim]
+        if prepared.source is not None and obs_dim in prepared.source.indexes
+        else np.arange(nmeasure)
+    )
+    coords: dict[str, Any] = {obs_dim: obs_coord, state_dim: np.arange(prepared.hx.shape[1])}
+
+    if use_bc and prepared.hbc is not None:
+        coords[bc_state_dim] = np.arange(prepared.hbc.shape[1])
+
+    min_error = prepared.min_error
+    if np.isscalar(min_error) or (isinstance(min_error, np.ndarray) and np.ndim(min_error) == 0):
+        min_error_values = np.full(nmeasure, min_error)
+    else:
+        min_error_values = np.asarray(min_error)
+
+    data_vars: dict[str, xr.DataArray] = {
+        "H": xr.DataArray(
+            prepared.hx,
+            dims=(obs_dim, state_dim),
+            coords={obs_dim: obs_coord, state_dim: coords[state_dim]},
+            name="H",
+        ),
+        "mf": xr.DataArray(prepared.y, dims=(obs_dim,), coords={obs_dim: coords[obs_dim]}, name="mf"),
+        "mf_error": xr.DataArray(
+            prepared.error,
+            dims=(obs_dim,),
+            coords={obs_dim: coords[obs_dim]},
+            name="mf_error",
+        ),
+        "site_indicator": xr.DataArray(
+            prepared.site_indicator,
+            dims=(obs_dim,),
+            coords={obs_dim: coords[obs_dim]},
+            name="site_indicator",
+        ),
+        "sigma_freq_index": xr.DataArray(
+            prepared.sigma_freq_index,
+            dims=(obs_dim,),
+            coords={obs_dim: coords[obs_dim]},
+            name="sigma_freq_index",
+        ),
+        "min_error": xr.DataArray(
+            min_error_values,
+            dims=(obs_dim,),
+            coords={obs_dim: coords[obs_dim]},
+            name="min_error",
+        ),
+    }
+
+    if use_bc and prepared.hbc is not None:
+        data_vars["H_bc"] = xr.DataArray(
+            prepared.hbc,
+            dims=(obs_dim, bc_state_dim),
+            coords={obs_dim: coords[obs_dim], bc_state_dim: coords[bc_state_dim]},
+            name="H_bc",
+        )
+
+    return xr.Dataset(data_vars=data_vars, coords=coords)
 
 
 def build_inferpymc_model(
@@ -500,88 +478,83 @@ def build_inferpymc_model(
         state=state,
         bc_state=bc_state,
     )
-
-    # Assign defaults here to avoid sharing the same dict across calls.
-    xprior = DEFAULT_XPRIOR.copy() if xprior is None else xprior
-    bcprior = DEFAULT_BCPRIOR.copy() if bcprior is None else bcprior
-    sigprior = DEFAULT_SIGPRIOR.copy() if sigprior is None else sigprior
-    offsetprior = DEFAULT_OFFSETPRIOR.copy() if offsetprior is None else offsetprior
-
-    sites = (
-        prepared_inputs.site_indicator.astype(int)
-        if sigma_per_site
-        else np.zeros_like(prepared_inputs.site_indicator).astype(int)
+    canonical_ds = _canonicalise_inferpymc_dataset(
+        prepared_inputs,
+        sigma_per_site=sigma_per_site,
+        use_bc=use_bc,
     )
 
-    if isinstance(prepared_inputs.min_error, float) or (
-        isinstance(prepared_inputs.min_error, np.ndarray) and prepared_inputs.min_error.ndim == 0
-    ):
-        min_error_data = prepared_inputs.min_error * np.ones_like(prepared_inputs.y)
-    else:
-        min_error_data = prepared_inputs.min_error
+    # Assign defaults here to avoid sharing the same dict across calls.
+    xprior = DEFAULT_XPRIOR.copy() if xprior is None else xprior.copy()
+    bcprior = DEFAULT_BCPRIOR.copy() if bcprior is None else bcprior.copy()
+    sigprior = DEFAULT_SIGPRIOR.copy() if sigprior is None else sigprior.copy()
+    offsetprior = DEFAULT_OFFSETPRIOR.copy() if offsetprior is None else offsetprior.copy()
+
+    if reparameterise_log_normal:
+        # TODO: later prefer prior-native `reparameterise=True` over this separate public flag.
+        if str(xprior.get("pdf", "")).lower() == "lognormal":
+            xprior["reparameterise"] = True
+        if str(bcprior.get("pdf", "")).lower() == "lognormal":
+            bcprior["reparameterise"] = True
 
     with pm.Model(coords=prepared_inputs.coords) as model:
+        attach_coord_registry(model, CoordRegistry())
         step1_vars = []
 
-        if reparameterise_log_normal and xprior["pdf"] == "lognormal":
-            x0 = pm.Normal("x0", 0, 1, dims="nx")
-            x = pm.Deterministic("x", pt.exp(xprior["mu"] + xprior["sigma"] * x0), dims="nx")
-            step1_vars.append(x0)
-        else:
-            x = parse_prior("x", xprior, dims="nx")
-            step1_vars.append(x)
+        mu = add_linear_component(
+            canonical_ds["H"],
+            data_name="hx",
+            prior_args=xprior,
+            var_name="x",
+            output_name="mu",
+            output_dim="nmeasure",
+            compute_deterministic=True,
+        )
+        step1_vars.append(model.named_vars["x_latent"] if "x_latent" in model.named_vars else model.named_vars["x"])
 
+        mu_bc = None
         if use_bc:
-            if reparameterise_log_normal and bcprior["pdf"] == "lognormal":
-                bc0 = pm.Normal("bc0", 0, 1, dims="nbc")
-                bc = pm.Deterministic("bc", pt.exp(bcprior["mu"] + bcprior["sigma"] * bc0), dims="nbc")
-                step1_vars.append(bc0)
-            else:
-                bc = parse_prior("bc", bcprior, dims="nbc")
-                step1_vars.append(bc)
-
-        sigma = parse_prior("sigma", sigprior, dims=("nsigma_site", "nsigma_time"))
-
-        hx_data = pm.Data("hx", prepared_inputs.hx, dims=("nmeasure", "nx"))
-        mu = pm.Deterministic("mu", pt.dot(hx_data, x), dims="nmeasure")
-
-        if use_bc and prepared_inputs.hbc is not None:
-            hbc_data = pm.Data("hbc", prepared_inputs.hbc, dims=("nmeasure", "nbc"))
-            mu_bc = pm.Deterministic("mu_bc", pt.dot(hbc_data, bc), dims="nmeasure")
-            mu += mu_bc
-
-        if add_offset:
-            offset_args = offset_args or {}
-            offset = make_offset(prepared_inputs.site_indicator, offsetprior, **offset_args)
-            mu += offset
-
-        y_data = pm.Data("Y", prepared_inputs.y, dims="nmeasure")  # type: ignore[arg-type]
-        error_data = pm.Data("error", prepared_inputs.error, dims="nmeasure")  # type: ignore[arg-type]
-        min_error_data = pm.Data("min_error", min_error_data, dims="nmeasure")  # type: ignore[arg-type]
-
-        if pollution_events_from_obs is True:
-            if use_bc is True and prepared_inputs.hbc is not None:
-                pollution_event = pt.abs(y_data - mu_bc)
-            else:
-                pollution_event = pt.abs(y_data) + 1e-6 * pt.mean(y_data)
-        else:
-            pollution_event = pt.abs(pt.dot(hx_data, x))
-
-        pollution_event_scaled_error = pollution_event * sigma[sites, prepared_inputs.sigma_freq_index]
-
-        if no_model_error is True:
-            mean_obs = np.nanmean(prepared_inputs.y)
-            small_amount = 1e-12 * mean_obs
-            eps = pt.maximum(pt.abs(error_data), small_amount)
-        else:
-            power0 = parse_prior("power", power) if isinstance(power, dict) else power
-            eps = pt.maximum(
-                pt.sqrt(error_data**2 + pt.pow(pollution_event_scaled_error, power0)), min_error_data
+            assert prepared_inputs.hbc is not None
+            mu_bc = add_linear_component(
+                canonical_ds["H_bc"],
+                data_name="hbc",
+                prior_args=bcprior,
+                var_name="bc",
+                output_name="mu_bc",
+                output_dim="nmeasure",
+                compute_deterministic=True,
+            )
+            step1_vars.append(
+                model.named_vars["bc_latent"] if "bc_latent" in model.named_vars else model.named_vars["bc"]
             )
 
-        pm.Deterministic("epsilon", eps, dims="nmeasure")
-        pm.Normal("y", mu=mu, sigma=eps, observed=y_data, dims="nmeasure")
+        offset = None
+        if add_offset:
+            offset_args = offset_args or {}
+            # TODO: once component-side derivation is used consistently, some
+            # explicit frequency-indicator plumbing in make_inv_inputs(...) may be removable.
+            offset = add_offset_component(
+                canonical_ds["site_indicator"],
+                prior_args=offsetprior,
+                output_name="offset",
+                output_dim="nmeasure",
+                **offset_args,
+            )
 
+        add_inferpymc_likelihood_component(
+            canonical_ds,
+            mu=mu,
+            mu_bc=mu_bc,
+            offset=offset,
+            sigprior=sigprior,
+            power=power,
+            pollution_events_from_obs=pollution_events_from_obs,
+            no_model_error=no_model_error,
+            sigma_per_site=sigma_per_site,
+            output_dim="nmeasure",
+        )
+
+        sigma = model.named_vars["sigma"]
         step1 = pm.NUTS(vars=step1_vars)
         step2 = pm.Slice(vars=[sigma])
 

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -391,7 +391,20 @@ def _prepare_builder_priors(
     offsetprior: dict | None,
     reparameterise_log_normal: bool,
 ) -> tuple[dict, dict, dict, dict]:
-    """Copy builder priors and apply temporary compatibility flags."""
+    """Copy builder priors and apply temporary compatibility flags.
+
+    Args:
+        xprior: Optional emissions prior overrides.
+        bcprior: Optional boundary-condition prior overrides.
+        sigprior: Optional sigma prior overrides.
+        offsetprior: Optional offset prior overrides.
+        reparameterise_log_normal: Temporary public compatibility flag used to
+            request lognormal reparameterisation.
+
+    Returns:
+        Copies of the prior dictionaries with defaults filled in and temporary
+        compatibility flags applied.
+    """
     prepared_xprior = DEFAULT_XPRIOR.copy() if xprior is None else xprior.copy()
     prepared_bcprior = DEFAULT_BCPRIOR.copy() if bcprior is None else bcprior.copy()
     prepared_sigprior = DEFAULT_SIGPRIOR.copy() if sigprior is None else sigprior.copy()
@@ -408,32 +421,51 @@ def _prepare_builder_priors(
 
 
 def _validate_model_builder(model_builder: str) -> str:
+    """Validate the temporary Stage C model-builder selector."""
     if model_builder not in {"legacy", "components"}:
         raise ValueError(f"Unsupported model_builder {model_builder!r}. Expected 'legacy' or 'components'.")
     return model_builder
 
 
 def _canonicalise_inferpymc_dataset(
-    prepared: InferPyMCInputs,
+    prepared_inputs: InferPyMCInputs,
     /,
     use_bc: bool,
     obs_dim: str = "nmeasure",
     state_dim: str = "nx",
     bc_state_dim: str = "nbc",
 ) -> xr.Dataset:
-    """Convert normalized Stage B inputs into canonical xarray model inputs."""
-    nmeasure = prepared.hx.shape[0]
+    """Convert normalized Stage B inputs into canonical xarray model inputs.
+
+    Args:
+        prepared_inputs: Temporary Stage B compatibility container holding the
+            normalized inversion inputs.
+        use_bc: Whether the canonical dataset should include boundary-condition
+            sensitivities.
+        obs_dim: Observation dimension name used by the model components.
+        state_dim: State dimension name used for emissions sensitivities.
+        bc_state_dim: State dimension name used for boundary-condition
+            sensitivities.
+
+    Returns:
+        An xarray dataset containing the canonical Stage C model inputs.
+
+    This helper is temporary transition code. It exists to keep the Stage B
+    input-normalization path separate from the Stage C component builder until
+    the legacy path is removed in Stage D.
+    """
+    nmeasure = prepared_inputs.hx.shape[0]
     obs_coord = (
-        prepared.source.indexes[obs_dim]
-        if prepared.source is not None and obs_dim in prepared.source.indexes
+        prepared_inputs.source.indexes[obs_dim]
+        if prepared_inputs.source is not None and obs_dim in prepared_inputs.source.indexes
         else np.arange(nmeasure)
     )
-    coords: dict[str, Any] = {obs_dim: obs_coord, state_dim: np.arange(prepared.hx.shape[1])}
+    coords: dict[str, Any] = {obs_dim: obs_coord, state_dim: np.arange(prepared_inputs.hx.shape[1])}
 
-    if use_bc and prepared.hbc is not None:
-        coords[bc_state_dim] = np.arange(prepared.hbc.shape[1])
+    if use_bc and prepared_inputs.hbc is not None:
+        coords[bc_state_dim] = np.arange(prepared_inputs.hbc.shape[1])
 
-    min_error = prepared.min_error
+    min_error = prepared_inputs.min_error
     if np.isscalar(min_error) or (isinstance(min_error, np.ndarray) and np.ndim(min_error) == 0):
         min_error_values = np.full(nmeasure, min_error)
     else:
@@ -441,26 +473,26 @@ def _canonicalise_inferpymc_dataset(
 
     data_vars: dict[str, xr.DataArray] = {
         "H": xr.DataArray(
-            prepared.hx,
+            prepared_inputs.hx,
             dims=(obs_dim, state_dim),
             coords={obs_dim: obs_coord, state_dim: coords[state_dim]},
             name="H",
         ),
-        "mf": xr.DataArray(prepared.y, dims=(obs_dim,), coords={obs_dim: coords[obs_dim]}, name="mf"),
+        "mf": xr.DataArray(prepared_inputs.y, dims=(obs_dim,), coords={obs_dim: coords[obs_dim]}, name="mf"),
         "mf_error": xr.DataArray(
-            prepared.error,
+            prepared_inputs.error,
             dims=(obs_dim,),
             coords={obs_dim: coords[obs_dim]},
             name="mf_error",
         ),
         "site_indicator": xr.DataArray(
-            prepared.site_indicator,
+            prepared_inputs.site_indicator,
             dims=(obs_dim,),
             coords={obs_dim: coords[obs_dim]},
             name="site_indicator",
         ),
         "sigma_freq_index": xr.DataArray(
-            prepared.sigma_freq_index,
+            prepared_inputs.sigma_freq_index,
             dims=(obs_dim,),
             coords={obs_dim: coords[obs_dim]},
             name="sigma_freq_index",
@@ -473,9 +505,9 @@ def _canonicalise_inferpymc_dataset(
         ),
     }
 
-    if use_bc and prepared.hbc is not None:
+    if use_bc and prepared_inputs.hbc is not None:
         data_vars["H_bc"] = xr.DataArray(
-            prepared.hbc,
+            prepared_inputs.hbc,
             dims=(obs_dim, bc_state_dim),
             coords={obs_dim: coords[obs_dim], bc_state_dim: coords[bc_state_dim]},
             name="H_bc",
@@ -509,13 +541,11 @@ def build_inferpymc_model_legacy(
     state: str = "region",
     bc_state: str = "bc_region",
 ) -> InferPyMCModelSetup:
-    """Build the PyMC model and sampler configuration used by inferpymc.
+    """Build the temporary legacy inferpymc model path kept for Stage C parity.
 
-    This is the "legacy" version introduced in PR #380. It was tested to
-    ensure the existing behaviour of `inferpymc` was preserved.
-
-    It is used here to make sure the new model component based model builder
-    is still doing what `inferpymc` used to do.
+    This transitional builder preserves the pre-Stage-C runtime behavior so the
+    new component-based builder can be compared against it during the Stage C
+    to Stage D migration.
     """
     prepared_inputs = _prepare_inferpymc_inputs(
         inv_inputs=inv_inputs,
@@ -649,7 +679,12 @@ def build_inferpymc_model_components(
     state: str = "region",
     bc_state: str = "bc_region",
 ) -> InferPyMCModelSetup:
-    """Build the Stage C component-based model path intended to become the Stage D default."""
+    """Build the Stage C component-based model path.
+
+    This builder represents the intended future architecture introduced in
+    Stage C. It is expected to become the default inferpymc runtime path in
+    Stage D after parity with the temporary legacy builder is established.
+    """
     prepared_inputs = _prepare_inferpymc_inputs(
         inv_inputs=inv_inputs,
         Hx=Hx,

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -497,11 +497,11 @@ def build_inferpymc_model(
         if str(bcprior.get("pdf", "")).lower() == "lognormal":
             bcprior["reparameterise"] = True
 
-    with pm.Model(coords=prepared_inputs.coords) as model:
+    with pm.Model() as model:
         attach_coord_registry(model, CoordRegistry())
         step1_vars = []
 
-        mu = add_linear_component(
+        flux_component = add_linear_component(
             canonical_ds["H"],
             data_name="hx",
             prior_args=xprior,
@@ -510,12 +510,11 @@ def build_inferpymc_model(
             output_dim="nmeasure",
             compute_deterministic=True,
         )
-        step1_vars.append(model.named_vars["x_latent"] if "x_latent" in model.named_vars else model.named_vars["x"])
+        step1_vars.append(flux_component.latent)
 
         mu_bc = None
-        if use_bc:
-            assert prepared_inputs.hbc is not None
-            mu_bc = add_linear_component(
+        if use_bc and "H_bc" in canonical_ds:
+            bc_component = add_linear_component(
                 canonical_ds["H_bc"],
                 data_name="hbc",
                 prior_args=bcprior,
@@ -524,9 +523,8 @@ def build_inferpymc_model(
                 output_dim="nmeasure",
                 compute_deterministic=True,
             )
-            step1_vars.append(
-                model.named_vars["bc_latent"] if "bc_latent" in model.named_vars else model.named_vars["bc"]
-            )
+            mu_bc = bc_component.output
+            step1_vars.append(bc_component.latent)
 
         offset = None
         if add_offset:
@@ -543,7 +541,7 @@ def build_inferpymc_model(
 
         add_inferpymc_likelihood_component(
             canonical_ds,
-            mu=mu,
+            mu=flux_component.output,
             mu_bc=mu_bc,
             offset=offset,
             sigprior=sigprior,

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -32,15 +32,18 @@ from scipy import stats
 
 from openghg_inversions import convert
 from openghg_inversions import utils
+from openghg_inversions.hbmcmc.components import make_offset
 from openghg_inversions.hbmcmc.hbmcmc_output import define_output_filename
 from openghg_inversions.config.version import code_version
 from openghg_inversions.models.components import (
     add_inferpymc_likelihood_component,
     add_linear_component,
     add_offset_component,
+    get_model_latent,
 )
 from openghg_inversions.models.coords import (
     CoordRegistry,
+    add_coords,
     attach_coord_registry,
     restore_inferencedata_coords,
 )
@@ -366,6 +369,36 @@ DEFAULT_SIGPRIOR: PriorArgs = {"pdf": "uniform", "lower": 0.1, "upper": 3.0}
 DEFAULT_OFFSETPRIOR: PriorArgs = {"pdf": "normal", "mu": 0, "sigma": 1}
 
 
+def _prepare_builder_priors(
+    *,
+    xprior: dict | None,
+    bcprior: dict | None,
+    sigprior: dict | None,
+    offsetprior: dict | None,
+    reparameterise_log_normal: bool,
+) -> tuple[dict, dict, dict, dict]:
+    """Copy builder priors and apply temporary compatibility flags."""
+    prepared_xprior = DEFAULT_XPRIOR.copy() if xprior is None else xprior.copy()
+    prepared_bcprior = DEFAULT_BCPRIOR.copy() if bcprior is None else bcprior.copy()
+    prepared_sigprior = DEFAULT_SIGPRIOR.copy() if sigprior is None else sigprior.copy()
+    prepared_offsetprior = DEFAULT_OFFSETPRIOR.copy() if offsetprior is None else offsetprior.copy()
+
+    if reparameterise_log_normal:
+        # TODO: later prefer prior-native `reparameterise=True` over this separate public flag.
+        if str(prepared_xprior.get("pdf", "")).lower() == "lognormal":
+            prepared_xprior["reparameterise"] = True
+        if str(prepared_bcprior.get("pdf", "")).lower() == "lognormal":
+            prepared_bcprior["reparameterise"] = True
+
+    return prepared_xprior, prepared_bcprior, prepared_sigprior, prepared_offsetprior
+
+
+def _validate_model_builder(model_builder: str) -> str:
+    if model_builder not in {"legacy", "components"}:
+        raise ValueError(f"Unsupported model_builder {model_builder!r}. Expected 'legacy' or 'components'.")
+    return model_builder
+
+
 def _canonicalise_inferpymc_dataset(
     prepared: InferPyMCInputs,
     /,
@@ -438,7 +471,14 @@ def _canonicalise_inferpymc_dataset(
     return xr.Dataset(data_vars=data_vars, coords=coords)
 
 
-def build_inferpymc_model(
+# Defaults to avoid mutable default arguments in model building functions.
+DEFAULT_XPRIOR: PriorArgs = {"pdf": "normal", "mu": 1.0, "sigma": 1.0}
+DEFAULT_BCPRIOR: PriorArgs = {"pdf": "normal", "mu": 1.0, "sigma": 1.0}
+DEFAULT_SIGPRIOR: PriorArgs = {"pdf": "uniform", "lower": 0.1, "upper": 3.0}
+DEFAULT_OFFSETPRIOR: PriorArgs = {"pdf": "normal", "mu": 0, "sigma": 1}
+
+
+def build_inferpymc_model_legacy(
     Hx: np.ndarray | None = None,
     Y: np.ndarray | None = None,
     error: np.ndarray | None = None,
@@ -463,7 +503,147 @@ def build_inferpymc_model(
     state: str = "region",
     bc_state: str = "bc_region",
 ) -> InferPyMCModelSetup:
-    """Build the PyMC model and sampler configuration used by inferpymc."""
+    """Build the PyMC model and sampler configuration used by inferpymc.
+
+    This is the "legacy" version introduced in PR #380. It was tested to
+    ensure the existing behaviour of `inferpymc` was preserved.
+
+    It is used here to make sure the new model component based model builder
+    is still doing what `inferpymc` used to do.
+    """
+    prepared_inputs = _prepare_inferpymc_inputs(
+        inv_inputs=inv_inputs,
+        Hx=Hx,
+        Y=Y,
+        error=error,
+        siteindicator=siteindicator,
+        sigma_freq_index=sigma_freq_index,
+        Hbc=Hbc,
+        min_error=min_error,
+        sigma_per_site=sigma_per_site,
+        use_bc=use_bc,
+        state=state,
+        bc_state=bc_state,
+    )
+
+    # Assign defaults here to avoid sharing the same dict across calls.
+    xprior = DEFAULT_XPRIOR.copy() if xprior is None else xprior
+    bcprior = DEFAULT_BCPRIOR.copy() if bcprior is None else bcprior
+    sigprior = DEFAULT_SIGPRIOR.copy() if sigprior is None else sigprior
+    offsetprior = DEFAULT_OFFSETPRIOR.copy() if offsetprior is None else offsetprior
+
+    sites = (
+        prepared_inputs.site_indicator.astype(int)
+        if sigma_per_site
+        else np.zeros_like(prepared_inputs.site_indicator).astype(int)
+    )
+
+    if isinstance(prepared_inputs.min_error, float) or (
+        isinstance(prepared_inputs.min_error, np.ndarray) and prepared_inputs.min_error.ndim == 0
+    ):
+        min_error_data = prepared_inputs.min_error * np.ones_like(prepared_inputs.y)
+    else:
+        min_error_data = prepared_inputs.min_error
+
+    with pm.Model(coords=prepared_inputs.coords) as model:
+        step1_vars = []
+
+        if reparameterise_log_normal and xprior["pdf"] == "lognormal":
+            x0 = pm.Normal("x0", 0, 1, dims="nx")
+            x = pm.Deterministic("x", pt.exp(xprior["mu"] + xprior["sigma"] * x0), dims="nx")
+            step1_vars.append(x0)
+        else:
+            x = parse_prior("x", xprior, dims="nx")
+            step1_vars.append(x)
+
+        if use_bc:
+            if reparameterise_log_normal and bcprior["pdf"] == "lognormal":
+                bc0 = pm.Normal("bc0", 0, 1, dims="nbc")
+                bc = pm.Deterministic("bc", pt.exp(bcprior["mu"] + bcprior["sigma"] * bc0), dims="nbc")
+                step1_vars.append(bc0)
+            else:
+                bc = parse_prior("bc", bcprior, dims="nbc")
+                step1_vars.append(bc)
+
+        sigma = parse_prior("sigma", sigprior, dims=("nsigma_site", "nsigma_time"))
+
+        hx_data = pm.Data("hx", prepared_inputs.hx, dims=("nmeasure", "nx"))
+        mu = pm.Deterministic("mu", pt.dot(hx_data, x), dims="nmeasure")
+
+        if use_bc and prepared_inputs.hbc is not None:
+            hbc_data = pm.Data("hbc", prepared_inputs.hbc, dims=("nmeasure", "nbc"))
+            mu_bc = pm.Deterministic("mu_bc", pt.dot(hbc_data, bc), dims="nmeasure")
+            mu += mu_bc
+
+        if add_offset:
+            offset_args = offset_args or {}
+            offset = make_offset(prepared_inputs.site_indicator, offsetprior, **offset_args)
+            mu += offset
+
+        y_data = pm.Data("Y", prepared_inputs.y, dims="nmeasure")  # type: ignore[arg-type]
+        error_data = pm.Data("error", prepared_inputs.error, dims="nmeasure")  # type: ignore[arg-type]
+        min_error_data = pm.Data("min_error", min_error_data, dims="nmeasure")  # type: ignore[arg-type]
+
+        if pollution_events_from_obs is True:
+            if use_bc is True and prepared_inputs.hbc is not None:
+                pollution_event = pt.abs(y_data - mu_bc)
+            else:
+                pollution_event = pt.abs(y_data) + 1e-6 * pt.mean(y_data)
+        else:
+            pollution_event = pt.abs(pt.dot(hx_data, x))
+
+        pollution_event_scaled_error = pollution_event * sigma[sites, prepared_inputs.sigma_freq_index]
+
+        if no_model_error is True:
+            mean_obs = np.nanmean(prepared_inputs.y)
+            small_amount = 1e-12 * mean_obs
+            eps = pt.maximum(pt.abs(error_data), small_amount)
+        else:
+            power0 = parse_prior("power", power) if isinstance(power, dict) else power
+            eps = pt.maximum(
+                pt.sqrt(error_data**2 + pt.pow(pollution_event_scaled_error, power0)), min_error_data
+            )
+
+        pm.Deterministic("epsilon", eps, dims="nmeasure")
+        pm.Normal("y", mu=mu, sigma=eps, observed=y_data, dims="nmeasure")
+
+        step1 = pm.NUTS(vars=step1_vars)
+        step2 = pm.Slice(vars=[sigma])
+
+    return InferPyMCModelSetup(
+        model=model,
+        step1=step1,
+        step2=step2,
+        sample_kwargs={"step": [step1, step2] if nuts_sampler == "pymc" else None},
+    )
+
+
+def build_inferpymc_model_components(
+    Hx: np.ndarray | None = None,
+    Y: np.ndarray | None = None,
+    error: np.ndarray | None = None,
+    siteindicator: np.ndarray | None = None,
+    sigma_freq_index: np.ndarray | None = None,
+    Hbc: np.ndarray | None = None,
+    xprior: dict | None = None,
+    bcprior: dict | None = None,
+    sigprior: dict | None = None,
+    sigma_per_site: bool = True,
+    offsetprior: dict | None = None,
+    add_offset: bool = False,
+    min_error: np.ndarray | float | None = None,
+    use_bc: bool = True,
+    reparameterise_log_normal: bool = False,
+    pollution_events_from_obs: bool = False,
+    no_model_error: bool = False,
+    offset_args: dict | None = None,
+    power: dict | float = 1.99,
+    nuts_sampler: str = "pymc",
+    inv_inputs: xr.Dataset | None = None,
+    state: str = "region",
+    bc_state: str = "bc_region",
+) -> InferPyMCModelSetup:
+    """Build the Stage C component-based model path intended to become the Stage D default."""
     prepared_inputs = _prepare_inferpymc_inputs(
         inv_inputs=inv_inputs,
         Hx=Hx,
@@ -483,19 +663,13 @@ def build_inferpymc_model(
         sigma_per_site=sigma_per_site,
         use_bc=use_bc,
     )
-
-    # Assign defaults here to avoid sharing the same dict across calls.
-    xprior = DEFAULT_XPRIOR.copy() if xprior is None else xprior.copy()
-    bcprior = DEFAULT_BCPRIOR.copy() if bcprior is None else bcprior.copy()
-    sigprior = DEFAULT_SIGPRIOR.copy() if sigprior is None else sigprior.copy()
-    offsetprior = DEFAULT_OFFSETPRIOR.copy() if offsetprior is None else offsetprior.copy()
-
-    if reparameterise_log_normal:
-        # TODO: later prefer prior-native `reparameterise=True` over this separate public flag.
-        if str(xprior.get("pdf", "")).lower() == "lognormal":
-            xprior["reparameterise"] = True
-        if str(bcprior.get("pdf", "")).lower() == "lognormal":
-            bcprior["reparameterise"] = True
+    xprior, bcprior, sigprior, offsetprior = _prepare_builder_priors(
+        xprior=xprior,
+        bcprior=bcprior,
+        sigprior=sigprior,
+        offsetprior=offsetprior,
+        reparameterise_log_normal=reparameterise_log_normal,
+    )
 
     with pm.Model() as model:
         attach_coord_registry(model, CoordRegistry())
@@ -529,8 +703,6 @@ def build_inferpymc_model(
         offset = None
         if add_offset:
             offset_args = offset_args or {}
-            # TODO: once component-side derivation is used consistently, some
-            # explicit frequency-indicator plumbing in make_inv_inputs(...) may be removable.
             offset = add_offset_component(
                 canonical_ds["site_indicator"],
                 prior_args=offsetprior,
@@ -561,6 +733,69 @@ def build_inferpymc_model(
         step1=step1,
         step2=step2,
         sample_kwargs={"step": [step1, step2] if nuts_sampler == "pymc" else None},
+    )
+
+
+def build_inferpymc_model(
+    Hx: np.ndarray | None = None,
+    Y: np.ndarray | None = None,
+    error: np.ndarray | None = None,
+    siteindicator: np.ndarray | None = None,
+    sigma_freq_index: np.ndarray | None = None,
+    Hbc: np.ndarray | None = None,
+    xprior: dict | None = None,
+    bcprior: dict | None = None,
+    sigprior: dict | None = None,
+    sigma_per_site: bool = True,
+    offsetprior: dict | None = None,
+    add_offset: bool = False,
+    min_error: np.ndarray | float | None = None,
+    use_bc: bool = True,
+    reparameterise_log_normal: bool = False,
+    pollution_events_from_obs: bool = False,
+    no_model_error: bool = False,
+    offset_args: dict | None = None,
+    power: dict | float = 1.99,
+    nuts_sampler: str = "pymc",
+    inv_inputs: xr.Dataset | None = None,
+    state: str = "region",
+    bc_state: str = "bc_region",
+    model_builder: str = "legacy",
+) -> InferPyMCModelSetup:
+    """Dispatch temporarily between the Stage C legacy and component builders.
+
+    Stage C keeps the legacy runtime path as the default while exposing the new
+    component-based builder for parity testing. Stage D is expected to switch
+    the default to the component builder once parity is established.
+    """
+    model_builder = _validate_model_builder(model_builder)
+    builder = (
+        build_inferpymc_model_legacy if model_builder == "legacy" else build_inferpymc_model_components
+    )
+    return builder(
+        Hx=Hx,
+        Y=Y,
+        error=error,
+        siteindicator=siteindicator,
+        sigma_freq_index=sigma_freq_index,
+        Hbc=Hbc,
+        xprior=xprior,
+        bcprior=bcprior,
+        sigprior=sigprior,
+        sigma_per_site=sigma_per_site,
+        offsetprior=offsetprior,
+        add_offset=add_offset,
+        min_error=min_error,
+        use_bc=use_bc,
+        reparameterise_log_normal=reparameterise_log_normal,
+        pollution_events_from_obs=pollution_events_from_obs,
+        no_model_error=no_model_error,
+        offset_args=offset_args,
+        power=power,
+        nuts_sampler=nuts_sampler,
+        inv_inputs=inv_inputs,
+        state=state,
+        bc_state=bc_state,
     )
 
 
@@ -599,6 +834,7 @@ def inferpymc(
     inv_inputs: xr.Dataset | None = None,
     state: str = "region",
     bc_state: str = "bc_region",
+    model_builder: str = "legacy",
 ) -> dict:
     """Perform Bayesian inference with PyMC for emissions, boundary conditions, and model error.
 
@@ -647,6 +883,8 @@ def inferpymc(
             Defaults to "region".
         bc_state: Dimension name of the state variable for BC sensitivities ("H_bc") in inv_inputs.
             Defaults to "bc_region".
+        model_builder: Temporary builder selector used during the Stage C to Stage D
+            transition. Accepted values are ``"legacy"`` and ``"components"``.
 
     Returns:
         dict: Dictionary containing inference results, samples, and diagnostics.
@@ -700,6 +938,7 @@ def inferpymc(
         inv_inputs=inv_inputs,
         state=state,
         bc_state=bc_state,
+        model_builder=model_builder,
     )
 
     sampler_kwargs = sampler_kwargs or {}

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -468,13 +468,6 @@ def _canonicalise_inferpymc_dataset(
     return xr.Dataset(data_vars=data_vars, coords=coords)
 
 
-# Defaults to avoid mutable default arguments in model building functions.
-DEFAULT_XPRIOR: PriorArgs = {"pdf": "normal", "mu": 1.0, "sigma": 1.0}
-DEFAULT_BCPRIOR: PriorArgs = {"pdf": "normal", "mu": 1.0, "sigma": 1.0}
-DEFAULT_SIGPRIOR: PriorArgs = {"pdf": "uniform", "lower": 0.1, "upper": 3.0}
-DEFAULT_OFFSETPRIOR: PriorArgs = {"pdf": "normal", "mu": 0, "sigma": 1}
-
-
 def build_inferpymc_model_legacy(
     Hx: np.ndarray | None = None,
     Y: np.ndarray | None = None,

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -39,15 +39,13 @@ from openghg_inversions.models.components import (
     add_inferpymc_likelihood_component,
     add_linear_component,
     add_offset_component,
-    get_model_latent,
 )
 from openghg_inversions.models.coords import (
     CoordRegistry,
-    add_coords,
     attach_coord_registry,
     restore_inferencedata_coords,
 )
-from openghg_inversions.models.priors import PriorArgs, lognormal_mu_sigma, parse_prior
+from openghg_inversions.models.priors import PriorArgs, parse_prior
 
 
 @dataclass
@@ -55,8 +53,8 @@ class InferPyMCModelSetup:
     """Container for the PyMC model and sampler configuration used by inferpymc."""
 
     model: pm.Model
-    step1: pm.NUTS
-    step2: pm.Slice
+    step1: Any
+    step2: Any
     sample_kwargs: dict[str, Any]
 
 
@@ -402,7 +400,6 @@ def _validate_model_builder(model_builder: str) -> str:
 def _canonicalise_inferpymc_dataset(
     prepared: InferPyMCInputs,
     /,
-    sigma_per_site: bool,
     use_bc: bool,
     obs_dim: str = "nmeasure",
     state_dim: str = "nx",
@@ -660,7 +657,6 @@ def build_inferpymc_model_components(
     )
     canonical_ds = _canonicalise_inferpymc_dataset(
         prepared_inputs,
-        sigma_per_site=sigma_per_site,
         use_bc=use_bc,
     )
     xprior, bcprior, sigprior, offsetprior = _prepare_builder_priors(

--- a/openghg_inversions/models/__init__.py
+++ b/openghg_inversions/models/__init__.py
@@ -1,0 +1,31 @@
+"""Reusable model-building helpers for OpenGHG inversions."""
+
+from openghg_inversions.models.components import (
+    add_inferpymc_likelihood_component,
+    add_linear_component,
+    add_model_data,
+    add_offset_component,
+    add_sigma_component,
+)
+from openghg_inversions.models.coords import (
+    CoordRegistry,
+    add_coords,
+    attach_coord_registry,
+    get_coord_registry,
+    restore_inferencedata_coords,
+)
+from openghg_inversions.models.priors import parse_prior
+
+__all__ = [
+    "CoordRegistry",
+    "add_coords",
+    "attach_coord_registry",
+    "get_coord_registry",
+    "restore_inferencedata_coords",
+    "parse_prior",
+    "add_model_data",
+    "add_linear_component",
+    "add_sigma_component",
+    "add_offset_component",
+    "add_inferpymc_likelihood_component",
+]

--- a/openghg_inversions/models/__init__.py
+++ b/openghg_inversions/models/__init__.py
@@ -1,6 +1,7 @@
 """Reusable model-building helpers for OpenGHG inversions."""
 
 from openghg_inversions.models.components import (
+    LinearComponentResult,
     add_inferpymc_likelihood_component,
     add_linear_component,
     add_model_data,
@@ -23,6 +24,7 @@ __all__ = [
     "get_coord_registry",
     "restore_inferencedata_coords",
     "parse_prior",
+    "LinearComponentResult",
     "add_model_data",
     "add_linear_component",
     "add_sigma_component",

--- a/openghg_inversions/models/components.py
+++ b/openghg_inversions/models/components.py
@@ -48,8 +48,14 @@ class LinearComponentResult:
 def get_model_latent(variable: TensorVariable, base_name: str) -> TensorVariable:
     """Return the effective latent variable for a named model component.
 
-    If a reparameterized latent variable named ``{base_name}_latent`` exists in
-    the active model, return it. Otherwise return the supplied variable.
+    Args:
+        variable: User-facing variable returned by ``parse_prior``.
+        base_name: Base model variable name used to look up a reparameterized
+            latent variable.
+
+    Returns:
+        The reparameterized latent variable ``{base_name}_latent`` when it is
+        present on the active model, otherwise ``variable``.
     """
     model = pm.modelcontext(None)
     latent_name = f"{base_name}_latent"
@@ -59,6 +65,7 @@ def get_model_latent(variable: TensorVariable, base_name: str) -> TensorVariable
 
 
 def _extract_time_coord(data: xr.DataArray, output_dim: str) -> xr.DataArray | None:
+    """Extract a time coordinate aligned to the observation dimension."""
     if "time" in data.coords:
         coord = data.coords["time"]
         if output_dim in coord.dims:
@@ -85,6 +92,7 @@ def _resolve_freq_indicator(
     output_dim: str,
     fallback_name: str,
 ) -> xr.DataArray | None:
+    """Return an explicit or derived observation-aligned frequency indicator."""
     if explicit_indicator is not None:
         if isinstance(explicit_indicator, xr.DataArray):
             return explicit_indicator.rename(explicit_indicator.name or fallback_name)
@@ -108,7 +116,18 @@ def _resolve_freq_indicator(
 
 
 def add_model_data(data: xr.DataArray, name: str | None = None) -> TensorVariable:
-    """Add labelled xarray data to the active PyMC model."""
+    """Add labelled xarray data to the active PyMC model.
+
+    Args:
+        data: Xarray data to register as ``pm.Data``.
+        name: Optional PyMC variable name. If omitted, ``data.name`` is used.
+
+    Returns:
+        The registered ``pm.Data`` tensor for ``data``.
+
+    Raises:
+        ValueError: If no name can be determined for the data variable.
+    """
     name = name or (str(data.name) if data.name is not None else None)
     if name is None:
         raise ValueError("Data must have a name if a name is not provided.")
@@ -132,7 +151,22 @@ def add_linear_component(
     output_dim: str = "nmeasure",
     compute_deterministic: bool = True,
 ) -> LinearComponentResult:
-    """Add a linear latent component and its aligned forward-model contribution."""
+    """Add a linear latent component and its aligned forward-model contribution.
+
+    Args:
+        data: Sensitivity matrix or other linear data term.
+        data_name: Name used when registering the data as ``pm.Data``.
+        prior_args: Prior specification for the latent random variable.
+        var_name: Name for the latent random variable.
+        output_name: Name for the aligned deterministic output.
+        output_dim: Observation/output dimension name.
+        compute_deterministic: Whether to wrap the aligned output in
+            ``pm.Deterministic``.
+
+    Returns:
+        A ``LinearComponentResult`` containing the registered data tensor, the
+        effective latent variable, and the aligned output tensor.
+    """
     output_dim = str(output_dim)
     data = data.transpose(output_dim, ...)
     h = add_model_data(data, data_name)
@@ -157,7 +191,29 @@ def add_sigma_component(
     output_dim: str = "nmeasure",
     compute_deterministic: bool = False,
 ) -> TensorVariable:
-    """Add inferpymc-compatible sigma terms and align them to observations."""
+    """Add inferpymc-compatible sigma terms and align them to observations.
+
+    Args:
+        site_indicator: Observation-aligned site indicator.
+        prior_args: Prior specification for the sigma random variable.
+        sigma_freq_index: Optional explicit observation-aligned frequency
+            indicator.
+        sigma_freq: Optional frequency string used to derive an indicator when
+            ``sigma_freq_index`` is not provided.
+        var_name: Name for the latent sigma random variable.
+        output_name: Optional name for an observation-aligned deterministic
+            output.
+        per_site: Whether sigma varies by site.
+        output_dim: Observation/output dimension name.
+        compute_deterministic: Whether to register the aligned sigma term as a
+            deterministic variable.
+
+    Returns:
+        The observation-aligned sigma tensor or deterministic variable.
+
+    Raises:
+        ValueError: If no frequency information is available.
+    """
     output_dim = str(output_dim)
     site_indicator = site_indicator.rename("site_indicator").transpose(output_dim)
     freq_index = _resolve_freq_indicator(
@@ -202,7 +258,23 @@ def add_offset_component(
     output_dim: str = "nmeasure",
     drop_first: bool = False,
 ) -> TensorVariable:
-    """Add a site-only or site-by-period offset component."""
+    """Add a site-only or site-by-period offset component.
+
+    Args:
+        site_indicator: Observation-aligned site indicator.
+        prior_args: Prior specification for the offset latent variable.
+        offset_freq_indicator: Optional explicit observation-aligned offset
+            frequency indicator.
+        offset_freq: Optional frequency string used to derive an indicator when
+            ``offset_freq_indicator`` is not provided.
+        var_name: Name for the latent offset variable.
+        output_name: Name for the aligned deterministic offset output.
+        output_dim: Observation/output dimension name.
+        drop_first: Whether to omit the first site indicator column.
+
+    Returns:
+        The aligned offset deterministic variable.
+    """
     output_dim = str(output_dim)
     site_indicator = site_indicator.rename("site_indicator").transpose(output_dim)
     add_model_data(site_indicator, "site_indicator")
@@ -259,6 +331,23 @@ def add_inferpymc_likelihood_component(
 
     ``mu`` is the non-baseline forward-model contribution. ``mu_bc`` is the
     baseline contribution, usually ``H_bc @ bc``, plus offset if applicable.
+
+    Args:
+        data: Canonical inferpymc input dataset.
+        mu: Non-baseline forward-model contribution.
+        mu_bc: Baseline contribution, if present.
+        sigprior: Prior specification for sigma.
+        offset: Optional aligned offset term.
+        power: Scalar or prior specification controlling pollution-event
+            scaling.
+        pollution_events_from_obs: Whether to derive pollution events from the
+            observations instead of ``mu``.
+        no_model_error: Whether to bypass the model-error term.
+        sigma_per_site: Whether sigma varies by site.
+        output_dim: Observation/output dimension name.
+
+    Returns:
+        The ``epsilon`` deterministic variable used by the observation model.
     """
     y_data = add_model_data(data["mf"].transpose(output_dim), "Y")
     error_data = add_model_data(data["mf_error"].transpose(output_dim), "error")

--- a/openghg_inversions/models/components.py
+++ b/openghg_inversions/models/components.py
@@ -19,7 +19,7 @@ coordinates using shared helper logic based on
 
 from __future__ import annotations
 
-from typing import Any
+from dataclasses import dataclass
 
 import numpy as np
 import pandas as pd
@@ -31,6 +31,15 @@ from pytensor.tensor import TensorVariable
 from openghg_inversions.inversion_inputs import make_freq_indicator
 from openghg_inversions.models.coords import add_coords
 from openghg_inversions.models.priors import parse_prior
+
+
+@dataclass
+class LinearComponentResult:
+    """Objects created by ``add_linear_component``."""
+
+    data: TensorVariable
+    latent: TensorVariable
+    output: TensorVariable
 
 
 def _extract_time_coord(data: xr.DataArray, output_dim: str) -> xr.DataArray | None:
@@ -92,8 +101,7 @@ def add_model_data(data: xr.DataArray, name: str | None = None) -> TensorVariabl
     if name in model:
         return model[name]
 
-    dim_coords = {dim: data.coords[dim] for dim in data.dims if dim in data.coords}
-    add_coords(dim_coords)
+    add_coords(data.coords, model_dims=data.dims)
     return pm.Data(name, data.values, dims=data.dims)
 
 
@@ -106,7 +114,7 @@ def add_linear_component(
     output_name: str,
     output_dim: str = "nmeasure",
     compute_deterministic: bool = True,
-) -> TensorVariable:
+) -> LinearComponentResult:
     """Add a linear latent component and its aligned forward-model contribution."""
     data = data.transpose(output_dim, ...)
     h = add_model_data(data, data_name)
@@ -114,8 +122,8 @@ def add_linear_component(
     latent = parse_prior(var_name, prior_args, dims=input_dims)
     output = pt.dot(h, latent)
     if compute_deterministic:
-        return pm.Deterministic(output_name, output, dims=output_dim)
-    return output
+        output = pm.Deterministic(output_name, output, dims=output_dim)
+    return LinearComponentResult(data=h, latent=latent, output=output)
 
 
 def add_sigma_component(
@@ -143,7 +151,7 @@ def add_sigma_component(
         raise ValueError("Sigma frequency information must be provided via `sigma_freq_index` or `sigma_freq`.")
 
     site_data = site_indicator if per_site else xr.zeros_like(site_indicator)
-    add_model_data(site_data, "site_indicator")
+    site_data_var = add_model_data(site_data, "site_indicator")
     freq_data = add_model_data(freq_index.transpose(output_dim), freq_index.name)
 
     nsigma_site = int(site_data.max().item()) + 1 if per_site else 1
@@ -156,7 +164,7 @@ def add_sigma_component(
     )
 
     sigma = parse_prior(var_name, prior_args, dims=("nsigma_site", "nsigma_time"))
-    aligned = sigma[site_data.values.astype(int), freq_data]
+    aligned = sigma[site_data_var, freq_data]
     if compute_deterministic:
         deterministic_name = output_name or f"{var_name}_aligned"
         return pm.Deterministic(deterministic_name, aligned, dims=output_dim)
@@ -176,6 +184,7 @@ def add_offset_component(
 ) -> TensorVariable:
     """Add a site-only or site-by-period offset component."""
     site_indicator = site_indicator.rename("site_indicator").transpose(output_dim)
+    add_model_data(site_indicator, "site_indicator")
     indicator = _resolve_freq_indicator(
         explicit_indicator=offset_freq_indicator,
         freq=offset_freq,
@@ -183,6 +192,8 @@ def add_offset_component(
         output_dim=output_dim,
         fallback_name="offset_freq_indicator",
     )
+    if indicator is not None:
+        add_model_data(indicator.transpose(output_dim), indicator.name)
 
     site_codes = np.asarray(site_indicator.values, dtype=int)
     site_matrix = pd.get_dummies(site_codes, drop_first=drop_first, dtype=int).values
@@ -196,8 +207,18 @@ def add_offset_component(
     else:
         design_matrix = site_matrix
 
+    design_name = f"{output_name}_design"
+    design_data = add_model_data(
+        xr.DataArray(
+            design_matrix,
+            dims=(output_dim, "noffset_term"),
+            coords={output_dim: site_indicator.coords[output_dim], "noffset_term": np.arange(design_matrix.shape[1])},
+            name=design_name,
+        ),
+        design_name,
+    )
     latent = parse_prior(var_name, prior_args, shape=design_matrix.shape[1])
-    return pm.Deterministic(output_name, pt.dot(np.asarray(design_matrix), latent), dims=output_dim)
+    return pm.Deterministic(output_name, pt.dot(design_data, latent), dims=output_dim)
 
 
 def add_inferpymc_likelihood_component(
@@ -252,6 +273,8 @@ def add_inferpymc_likelihood_component(
             min_error_data,
         )
 
+    # TODO: this calculation should probably happen separately
+    # e.g. using a add_linear_component_sum function.
     total_mu = mu
     if mu_bc is not None:
         total_mu = total_mu + mu_bc

--- a/openghg_inversions/models/components.py
+++ b/openghg_inversions/models/components.py
@@ -5,6 +5,8 @@ xarray-first. They return PyTensor/PyMC tensors and should not implement their
 own coordinate sanitization policy; coordinate handling lives in
 ``openghg_inversions.models.coords``.
 
+All component helpers operate inside an active PyMC model context.
+
 Naming conventions:
 - ``data_name``: name for registered ``pm.Data``
 - ``var_name``: name for the latent random variable
@@ -40,6 +42,19 @@ class LinearComponentResult:
     data: TensorVariable
     latent: TensorVariable
     output: TensorVariable
+
+
+def get_model_latent(variable: TensorVariable, base_name: str) -> TensorVariable:
+    """Return the effective latent variable for a named model component.
+
+    If a reparameterized latent variable named ``{base_name}_latent`` exists in
+    the active model, return it. Otherwise return the supplied variable.
+    """
+    model = pm.modelcontext(None)
+    latent_name = f"{base_name}_latent"
+    if latent_name in model.named_vars:
+        return model.named_vars[latent_name]
+    return variable
 
 
 def _extract_time_coord(data: xr.DataArray, output_dim: str) -> xr.DataArray | None:
@@ -119,8 +134,9 @@ def add_linear_component(
     data = data.transpose(output_dim, ...)
     h = add_model_data(data, data_name)
     input_dims = tuple(dim for dim in data.dims if dim != output_dim)
-    latent = parse_prior(var_name, prior_args, dims=input_dims)
-    output = pt.dot(h, latent)
+    user_facing = parse_prior(var_name, prior_args, dims=input_dims)
+    latent = get_model_latent(user_facing, var_name)
+    output = pt.dot(h, user_facing)
     if compute_deterministic:
         output = pm.Deterministic(output_name, output, dims=output_dim)
     return LinearComponentResult(data=h, latent=latent, output=output)

--- a/openghg_inversions/models/components.py
+++ b/openghg_inversions/models/components.py
@@ -1,0 +1,263 @@
+"""Reusable PyMC model graph helpers.
+
+These helpers operate on the active PyMC model context and are designed to be
+xarray-first. They return PyTensor/PyMC tensors and should not implement their
+own coordinate sanitization policy; coordinate handling lives in
+``openghg_inversions.models.coords``.
+
+Naming conventions:
+- ``data_name``: name for registered ``pm.Data``
+- ``var_name``: name for the latent random variable
+- ``output_name``: name for the aligned deterministic output
+- plain ``name`` is reserved for helpers that truly create only one semantic
+  object or where a base name is the clearest API
+
+Frequency indicators may be supplied explicitly or derived from observation
+coordinates using shared helper logic based on
+``openghg_inversions.inversion_inputs.make_freq_indicator``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pymc as pm
+import pytensor.tensor as pt
+import xarray as xr
+from pytensor.tensor import TensorVariable
+
+from openghg_inversions.inversion_inputs import make_freq_indicator
+from openghg_inversions.models.coords import add_coords
+from openghg_inversions.models.priors import parse_prior
+
+
+def _extract_time_coord(data: xr.DataArray, output_dim: str) -> xr.DataArray | None:
+    if "time" in data.coords:
+        coord = data.coords["time"]
+        if output_dim in coord.dims:
+            return coord
+
+    if output_dim in data.indexes:
+        index = data.indexes[output_dim]
+        if isinstance(index, pd.MultiIndex) and "time" in index.names:
+            return xr.DataArray(
+                index.get_level_values("time").to_numpy(),
+                dims=(output_dim,),
+                coords={output_dim: data.coords[output_dim]},
+                name="time",
+            )
+
+    return None
+
+
+def _resolve_freq_indicator(
+    *,
+    explicit_indicator: xr.DataArray | np.ndarray | None,
+    freq: str | None,
+    data: xr.DataArray,
+    output_dim: str,
+    fallback_name: str,
+) -> xr.DataArray | None:
+    if explicit_indicator is not None:
+        if isinstance(explicit_indicator, xr.DataArray):
+            return explicit_indicator.rename(explicit_indicator.name or fallback_name)
+        return xr.DataArray(
+            np.asarray(explicit_indicator, dtype=int),
+            dims=(output_dim,),
+            coords={output_dim: data.coords[output_dim]},
+            name=fallback_name,
+        )
+
+    if freq is None:
+        return None
+
+    time_coord = _extract_time_coord(data, output_dim=output_dim)
+    if time_coord is None:
+        raise ValueError(f"Cannot derive frequency indicator for {fallback_name!r}: no time coordinate found.")
+
+    # TODO: once component-side derivation is relied on consistently, some
+    # explicit frequency-indicator plumbing in make_inv_inputs(...) may be removable.
+    return make_freq_indicator(time_coord, freq).rename(fallback_name)
+
+
+def add_model_data(data: xr.DataArray, name: str | None = None) -> TensorVariable:
+    """Add labelled xarray data to the active PyMC model."""
+    name = name or data.name
+    if name is None:
+        raise ValueError("Data must have a name if a name is not provided.")
+
+    model = pm.modelcontext(None)
+    if name in model:
+        return model[name]
+
+    dim_coords = {dim: data.coords[dim] for dim in data.dims if dim in data.coords}
+    add_coords(dim_coords)
+    return pm.Data(name, data.values, dims=data.dims)
+
+
+def add_linear_component(
+    data: xr.DataArray,
+    /,
+    data_name: str,
+    prior_args: dict,
+    var_name: str,
+    output_name: str,
+    output_dim: str = "nmeasure",
+    compute_deterministic: bool = True,
+) -> TensorVariable:
+    """Add a linear latent component and its aligned forward-model contribution."""
+    data = data.transpose(output_dim, ...)
+    h = add_model_data(data, data_name)
+    input_dims = tuple(dim for dim in data.dims if dim != output_dim)
+    latent = parse_prior(var_name, prior_args, dims=input_dims)
+    output = pt.dot(h, latent)
+    if compute_deterministic:
+        return pm.Deterministic(output_name, output, dims=output_dim)
+    return output
+
+
+def add_sigma_component(
+    site_indicator: xr.DataArray,
+    /,
+    prior_args: dict,
+    sigma_freq_index: xr.DataArray | None = None,
+    sigma_freq: str | None = None,
+    var_name: str = "sigma",
+    output_name: str | None = None,
+    per_site: bool = True,
+    output_dim: str = "nmeasure",
+    compute_deterministic: bool = False,
+) -> TensorVariable:
+    """Add inferpymc-compatible sigma terms and align them to observations."""
+    site_indicator = site_indicator.rename("site_indicator").transpose(output_dim)
+    freq_index = _resolve_freq_indicator(
+        explicit_indicator=sigma_freq_index,
+        freq=sigma_freq,
+        data=site_indicator,
+        output_dim=output_dim,
+        fallback_name="sigma_freq_index" if var_name == "sigma" else f"{var_name}_freq_indicator",
+    )
+    if freq_index is None:
+        raise ValueError("Sigma frequency information must be provided via `sigma_freq_index` or `sigma_freq`.")
+
+    site_data = site_indicator if per_site else xr.zeros_like(site_indicator)
+    add_model_data(site_data, "site_indicator")
+    freq_data = add_model_data(freq_index.transpose(output_dim), freq_index.name)
+
+    nsigma_site = int(site_data.max().item()) + 1 if per_site else 1
+    nsigma_time = int(freq_index.max().item()) + 1 if freq_index.size else 0
+    add_coords(
+        {
+            "nsigma_site": np.arange(nsigma_site),
+            "nsigma_time": np.arange(nsigma_time),
+        }
+    )
+
+    sigma = parse_prior(var_name, prior_args, dims=("nsigma_site", "nsigma_time"))
+    aligned = sigma[site_data.values.astype(int), freq_data]
+    if compute_deterministic:
+        deterministic_name = output_name or f"{var_name}_aligned"
+        return pm.Deterministic(deterministic_name, aligned, dims=output_dim)
+    return aligned
+
+
+def add_offset_component(
+    site_indicator: xr.DataArray,
+    /,
+    prior_args: dict,
+    offset_freq_indicator: xr.DataArray | np.ndarray | None = None,
+    offset_freq: str | None = None,
+    var_name: str = "offset_latent",
+    output_name: str = "offset",
+    output_dim: str = "nmeasure",
+    drop_first: bool = False,
+) -> TensorVariable:
+    """Add a site-only or site-by-period offset component."""
+    site_indicator = site_indicator.rename("site_indicator").transpose(output_dim)
+    indicator = _resolve_freq_indicator(
+        explicit_indicator=offset_freq_indicator,
+        freq=offset_freq,
+        data=site_indicator,
+        output_dim=output_dim,
+        fallback_name="offset_freq_indicator",
+    )
+
+    site_codes = np.asarray(site_indicator.values, dtype=int)
+    site_matrix = pd.get_dummies(site_codes, drop_first=drop_first, dtype=int).values
+
+    if indicator is not None:
+        period_codes = np.asarray(indicator.values, dtype=int)
+        period_matrix = pd.get_dummies(period_codes, dtype=int).values
+        design_matrix = (
+            site_matrix[:, :, None] * period_matrix[:, None, :]
+        ).reshape(site_matrix.shape[0], -1)
+    else:
+        design_matrix = site_matrix
+
+    latent = parse_prior(var_name, prior_args, shape=design_matrix.shape[1])
+    return pm.Deterministic(output_name, pt.dot(np.asarray(design_matrix), latent), dims=output_dim)
+
+
+def add_inferpymc_likelihood_component(
+    data: xr.Dataset,
+    /,
+    mu: TensorVariable,
+    mu_bc: TensorVariable | None,
+    sigprior: dict,
+    offset: TensorVariable | None = None,
+    power: dict | float = 1.99,
+    pollution_events_from_obs: bool = False,
+    no_model_error: bool = False,
+    sigma_per_site: bool = True,
+    output_dim: str = "nmeasure",
+) -> TensorVariable:
+    """Add the inferpymc observation model.
+
+    ``mu`` is the non-baseline forward-model contribution. ``mu_bc`` is the
+    baseline contribution, usually ``H_bc @ bc``, plus offset if applicable.
+    """
+    y_data = add_model_data(data["mf"].transpose(output_dim), "Y")
+    error_data = add_model_data(data["mf_error"].transpose(output_dim), "error")
+    min_error_data = add_model_data(data["min_error"].transpose(output_dim), "min_error")
+
+    sigma = add_sigma_component(
+        data["site_indicator"].transpose(output_dim),
+        prior_args=sigprior,
+        sigma_freq_index=data["sigma_freq_index"].transpose(output_dim),
+        var_name="sigma",
+        per_site=sigma_per_site,
+        output_dim=output_dim,
+    )
+
+    if pollution_events_from_obs is True:
+        if mu_bc is not None:
+            pollution_event = pt.abs(y_data - mu_bc)
+        else:
+            pollution_event = pt.abs(y_data) + 1e-6 * pt.mean(y_data)
+    else:
+        pollution_event = pt.abs(mu)
+
+    pollution_event_scaled_error = pollution_event * sigma
+
+    if no_model_error is True:
+        mean_obs = np.nanmean(data["mf"].values)
+        small_amount = 1e-12 * mean_obs
+        eps = pt.maximum(pt.abs(error_data), small_amount)
+    else:
+        power0 = parse_prior("power", power) if isinstance(power, dict) else power
+        eps = pt.maximum(
+            pt.sqrt(error_data**2 + pt.pow(pollution_event_scaled_error, power0)),
+            min_error_data,
+        )
+
+    total_mu = mu
+    if mu_bc is not None:
+        total_mu = total_mu + mu_bc
+    if offset is not None:
+        total_mu = total_mu + offset
+
+    epsilon = pm.Deterministic("epsilon", eps, dims=output_dim)
+    pm.Normal("y", mu=total_mu, sigma=epsilon, observed=y_data, dims=output_dim)
+    return epsilon

--- a/openghg_inversions/models/components.py
+++ b/openghg_inversions/models/components.py
@@ -22,13 +22,14 @@ coordinates using shared helper logic based on
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import cast
 
 import numpy as np
 import pandas as pd
 import pymc as pm
 import pytensor.tensor as pt
 import xarray as xr
-from pytensor.tensor import TensorVariable
+from pytensor.tensor.variable import TensorVariable
 
 from openghg_inversions.inversion_inputs import make_freq_indicator
 from openghg_inversions.models.coords import add_coords
@@ -108,7 +109,7 @@ def _resolve_freq_indicator(
 
 def add_model_data(data: xr.DataArray, name: str | None = None) -> TensorVariable:
     """Add labelled xarray data to the active PyMC model."""
-    name = name or data.name
+    name = name or (str(data.name) if data.name is not None else None)
     if name is None:
         raise ValueError("Data must have a name if a name is not provided.")
 
@@ -116,8 +117,9 @@ def add_model_data(data: xr.DataArray, name: str | None = None) -> TensorVariabl
     if name in model:
         return model[name]
 
-    add_coords(data.coords, model_dims=data.dims)
-    return pm.Data(name, data.values, dims=data.dims)
+    dims = tuple(str(dim) for dim in data.dims)
+    add_coords(data.coords, model_dims=dims)
+    return cast(TensorVariable, pm.Data(name, data.values, dims=dims))
 
 
 def add_linear_component(
@@ -131,9 +133,10 @@ def add_linear_component(
     compute_deterministic: bool = True,
 ) -> LinearComponentResult:
     """Add a linear latent component and its aligned forward-model contribution."""
+    output_dim = str(output_dim)
     data = data.transpose(output_dim, ...)
     h = add_model_data(data, data_name)
-    input_dims = tuple(dim for dim in data.dims if dim != output_dim)
+    input_dims = tuple(str(dim) for dim in data.dims if dim != output_dim)
     user_facing = parse_prior(var_name, prior_args, dims=input_dims)
     latent = get_model_latent(user_facing, var_name)
     output = pt.dot(h, user_facing)
@@ -155,6 +158,7 @@ def add_sigma_component(
     compute_deterministic: bool = False,
 ) -> TensorVariable:
     """Add inferpymc-compatible sigma terms and align them to observations."""
+    output_dim = str(output_dim)
     site_indicator = site_indicator.rename("site_indicator").transpose(output_dim)
     freq_index = _resolve_freq_indicator(
         explicit_indicator=sigma_freq_index,
@@ -168,7 +172,7 @@ def add_sigma_component(
 
     site_data = site_indicator if per_site else xr.zeros_like(site_indicator)
     site_data_var = add_model_data(site_data, "site_indicator")
-    freq_data = add_model_data(freq_index.transpose(output_dim), freq_index.name)
+    freq_data = add_model_data(freq_index.transpose(output_dim), str(freq_index.name))
 
     nsigma_site = int(site_data.max().item()) + 1 if per_site else 1
     nsigma_time = int(freq_index.max().item()) + 1 if freq_index.size else 0
@@ -199,6 +203,7 @@ def add_offset_component(
     drop_first: bool = False,
 ) -> TensorVariable:
     """Add a site-only or site-by-period offset component."""
+    output_dim = str(output_dim)
     site_indicator = site_indicator.rename("site_indicator").transpose(output_dim)
     add_model_data(site_indicator, "site_indicator")
     indicator = _resolve_freq_indicator(
@@ -209,7 +214,7 @@ def add_offset_component(
         fallback_name="offset_freq_indicator",
     )
     if indicator is not None:
-        add_model_data(indicator.transpose(output_dim), indicator.name)
+        add_model_data(indicator.transpose(output_dim), str(indicator.name))
 
     site_codes = np.asarray(site_indicator.values, dtype=int)
     site_matrix = pd.get_dummies(site_codes, drop_first=drop_first, dtype=int).values

--- a/openghg_inversions/models/coords.py
+++ b/openghg_inversions/models/coords.py
@@ -59,13 +59,18 @@ def _coords_equal(left: Any, right: Any) -> bool:
 
 def sanitize_coords_for_pymc(
     coords: dict[str, Any] | xr.core.coordinates.Coordinates | object,
+    *,
+    model_dims: tuple[str, ...] | list[str] | set[str] | None = None,
 ) -> dict[str, np.ndarray]:
     """Return PyMC-safe coordinates for the provided dimensions."""
     if not isinstance(coords, (dict, xr.core.coordinates.Coordinates)):
         return {}
 
+    dims_to_register = set(model_dims) if model_dims is not None else None
     result: dict[str, np.ndarray] = {}
     for name, coord in _coords_to_mapping(coords).items():
+        if dims_to_register is not None and name not in dims_to_register:
+            continue
         try:
             size = _coord_length(coord)
         except Exception:
@@ -82,40 +87,81 @@ class CoordRegistry:
     original_coords: dict[str, Any] = field(default_factory=dict)
     auxiliary_coords: dict[str, xr.DataArray] = field(default_factory=dict)
 
-    def add(self, coords: dict[str, Any] | xr.core.coordinates.Coordinates) -> None:
+    def _store_original_coord(self, name: str, coord: Any) -> None:
+        if name in self.original_coords:
+            existing = self.original_coords[name]
+            if len(existing) != len(coord):
+                raise ValueError(f"Conflicting coord registration for {name!r}: length mismatch.")
+            if not _coords_equal(existing, coord):
+                raise ValueError(f"Conflicting coord registration for {name!r}: values differ.")
+            return
+
+        self.original_coords[name] = coord
+
+    def _store_auxiliary_coord(self, name: str, coord: xr.DataArray) -> None:
+        if name in self.auxiliary_coords:
+            existing = self.auxiliary_coords[name]
+            if existing.dims != coord.dims or existing.shape != coord.shape:
+                raise ValueError(f"Conflicting coord registration for {name!r}: shape mismatch.")
+            if not _coords_equal(existing.values, coord.values):
+                raise ValueError(f"Conflicting coord registration for {name!r}: values differ.")
+            return
+
+        self.auxiliary_coords[name] = coord
+
+    def add(
+        self,
+        coords: dict[str, Any] | xr.core.coordinates.Coordinates,
+        *,
+        model_dims: tuple[str, ...] | list[str] | set[str] | None = None,
+    ) -> None:
         """Register coordinates, storing scientific coords and PyMC-safe coords."""
         mapping = _coords_to_mapping(coords)
-        pymc_coords = sanitize_coords_for_pymc(coords)
+        dims_to_register = tuple(model_dims) if model_dims is not None else tuple(mapping)
+        dim_set = set(dims_to_register)
+        pymc_coords = sanitize_coords_for_pymc(coords, model_dims=dims_to_register)
 
         for dim, safe_coord in pymc_coords.items():
             if dim in self.pymc_coords and len(self.pymc_coords[dim]) != len(safe_coord):
                 raise ValueError(f"Conflicting coord registration for {dim!r}: length mismatch.")
             self.pymc_coords[dim] = safe_coord
 
-        for dim, coord in mapping.items():
-            original = _coord_values(coord)
-            if dim in self.original_coords:
-                existing = self.original_coords[dim]
-                if len(existing) != len(original):
-                    raise ValueError(f"Conflicting coord registration for {dim!r}: length mismatch.")
-                if not _coords_equal(existing, original):
-                    raise ValueError(f"Conflicting coord registration for {dim!r}: values differ.")
+        for dim in dims_to_register:
+            if dim not in mapping:
                 continue
-
-            self.original_coords[dim] = original
+            coord = mapping[dim]
+            original = _coord_values(coord)
+            self._store_original_coord(dim, original)
 
             if isinstance(original, pd.MultiIndex):
-                dim_name = dim
                 for level_name in original.names:
                     if level_name is None:
                         continue
                     level_values = original.get_level_values(level_name)
-                    self.auxiliary_coords[f"{dim_name}_{level_name}"] = xr.DataArray(
-                        level_values.to_numpy(),
-                        dims=(dim_name,),
-                        coords={dim_name: np.arange(len(original))},
-                        name=f"{dim_name}_{level_name}",
+                    self._store_auxiliary_coord(
+                        level_name,
+                        xr.DataArray(
+                            level_values.to_numpy(),
+                            dims=(dim,),
+                            coords={dim: np.arange(len(original))},
+                            name=level_name,
+                        ),
                     )
+
+        for name, coord in mapping.items():
+            if name in dim_set or not isinstance(coord, xr.DataArray):
+                continue
+            if not set(coord.dims).issubset(dim_set):
+                continue
+            self._store_auxiliary_coord(
+                name,
+                xr.DataArray(
+                    coord.values,
+                    dims=coord.dims,
+                    coords={dim: np.arange(coord.sizes[dim]) for dim in coord.dims},
+                    name=name,
+                ),
+            )
 
 
 def attach_coord_registry(model: pm.Model, registry: CoordRegistry) -> None:
@@ -128,16 +174,20 @@ def get_coord_registry(model: pm.Model) -> CoordRegistry | None:
     return getattr(model, "_openghg_coord_registry", None)
 
 
-def add_coords(coords: dict[str, np.ndarray] | xr.core.coordinates.Coordinates) -> None:
+def add_coords(
+    coords: dict[str, np.ndarray] | xr.core.coordinates.Coordinates,
+    *,
+    model_dims: tuple[str, ...] | list[str] | set[str] | None = None,
+) -> None:
     """Register coords on the active model and store originals when possible."""
-    pymc_coords = sanitize_coords_for_pymc(coords)
+    pymc_coords = sanitize_coords_for_pymc(coords, model_dims=model_dims)
 
     with pm.modelcontext(None) as model:
         model.add_coords(pymc_coords)
 
         registry = get_coord_registry(model)
         if registry is not None:
-            registry.add(coords)
+            registry.add(coords, model_dims=model_dims)
 
 
 def restore_inferencedata_coords(
@@ -156,12 +206,27 @@ def restore_inferencedata_coords(
         if not isinstance(group, xr.Dataset):
             continue
 
+        restored_multiindex_dims: set[str] = set()
         for dim, coord in original_coords.items():
             if dim not in group.dims:
                 continue
             if len(coord) != group.sizes[dim]:
                 continue
-            group = group.assign_coords({dim: coord})
+            if isinstance(coord, pd.MultiIndex):
+                group = group.assign_coords(xr.Coordinates.from_pandas_multiindex(coord, dim))
+                restored_multiindex_dims.add(dim)
+            else:
+                group = group.assign_coords({dim: coord})
+
+        if isinstance(coords_or_registry, CoordRegistry):
+            for name, coord in coords_or_registry.auxiliary_coords.items():
+                if not set(coord.dims).issubset(set(group.dims)):
+                    continue
+                if any(group.sizes[dim] != coord.sizes[dim] for dim in coord.dims):
+                    continue
+                if any(dim in restored_multiindex_dims for dim in coord.dims):
+                    continue
+                group = group.assign_coords({name: coord})
 
         setattr(idata, group_name, group)
 

--- a/openghg_inversions/models/coords.py
+++ b/openghg_inversions/models/coords.py
@@ -23,12 +23,14 @@ import xarray as xr
 
 
 def _coords_to_mapping(coords: dict[str, Any] | xr.Coordinates) -> dict[str, Any]:
+    """Convert supported coordinate containers to a plain mapping."""
     if isinstance(coords, xr.Coordinates):
-        return {name: coords[name] for name in coords}
+        return {str(name): coords[name] for name in coords}
     return dict(coords)
 
 
 def _coord_values(coord: Any) -> Any:
+    """Extract comparable coordinate values from xarray coordinate objects."""
     if isinstance(coord, xr.DataArray):
         return coord.to_index() if coord.ndim == 1 and coord.name in coord.indexes else coord.values
     if isinstance(coord, xr.IndexVariable):
@@ -37,6 +39,7 @@ def _coord_values(coord: Any) -> Any:
 
 
 def _coord_length(coord: Any) -> int:
+    """Return the logical length of a coordinate-like object."""
     if isinstance(coord, xr.DataArray):
         return coord.sizes[coord.dims[0]]
     if isinstance(coord, xr.IndexVariable):
@@ -45,6 +48,7 @@ def _coord_length(coord: Any) -> int:
 
 
 def _coords_equal(left: Any, right: Any) -> bool:
+    """Compare coordinate values while tolerating pandas and NumPy types."""
     if isinstance(left, pd.Index) or isinstance(right, pd.Index):
         try:
             return pd.Index(left).equals(pd.Index(right))
@@ -62,7 +66,20 @@ def sanitize_coords_for_pymc(
     *,
     model_dims: tuple[str, ...] | list[str] | set[str] | None = None,
 ) -> dict[str, np.ndarray]:
-    """Return PyMC-safe coordinates for the provided dimensions."""
+    """Convert coordinate metadata into the range-based format to use with PyMC.
+
+    PyMC accepts fewer coordinate types than Xarray, so for simplicity, we convert
+    all coordinates to range coordinates, and use the range coordinates with PyMC.
+
+    Args:
+        coords: Coordinate mapping or xarray coordinate container.
+        model_dims: Optional subset of dimensions to sanitize. When omitted,
+            all dimensions found in ``coords`` are considered.
+
+    Returns:
+        A mapping from model dimension name to a simple ``np.arange`` index of
+        the corresponding length.
+    """
     if not isinstance(coords, (dict, xr.Coordinates)):
         return {}
 
@@ -81,13 +98,23 @@ def sanitize_coords_for_pymc(
 
 @dataclass
 class CoordRegistry:
-    """Track scientific and PyMC-safe coordinates for a model."""
+    """Track scientific and PyMC-safe coordinates for a model.
+
+    Attributes:
+        pymc_coords: Sanitized coordinates actually registered with PyMC.
+        original_coords: Original scientific coordinates keyed by model
+            dimension name.
+        auxiliary_coords: Additional non-dimension coordinates attached to
+            model dimensions, such as exploded ``time`` or ``site`` coordinates
+            derived from a stacked ``nmeasure`` MultiIndex.
+    """
 
     pymc_coords: dict[str, np.ndarray] = field(default_factory=dict)
     original_coords: dict[str, Any] = field(default_factory=dict)
     auxiliary_coords: dict[str, xr.DataArray] = field(default_factory=dict)
 
     def _store_original_coord(self, name: str, coord: Any) -> None:
+        """Store an original coordinate, rejecting conflicting re-registrations."""
         if name in self.original_coords:
             existing = self.original_coords[name]
             if len(existing) != len(coord):
@@ -99,6 +126,7 @@ class CoordRegistry:
         self.original_coords[name] = coord
 
     def _store_auxiliary_coord(self, name: str, coord: xr.DataArray) -> None:
+        """Store an auxiliary coordinate, rejecting conflicting re-registrations."""
         if name in self.auxiliary_coords:
             existing = self.auxiliary_coords[name]
             if existing.dims != coord.dims or existing.shape != coord.shape:
@@ -115,7 +143,19 @@ class CoordRegistry:
         *,
         model_dims: tuple[str, ...] | list[str] | set[str] | None = None,
     ) -> None:
-        """Register coordinates, storing scientific coords and PyMC-safe coords."""
+        """Register model and auxiliary coordinates with consistency checks.
+
+        Args:
+            coords: Coordinate mapping or xarray coordinate container to
+                register.
+            model_dims: Optional subset of model dimensions represented by the
+                current data variable. Auxiliary coordinates attached to these
+                dimensions are also preserved when possible.
+
+        Raises:
+            ValueError: If the same coordinate name is registered more than once
+                with conflicting lengths, shapes, or values.
+        """
         mapping = _coords_to_mapping(coords)
         dims_to_register = tuple(model_dims) if model_dims is not None else tuple(mapping)
         dim_set = set(dims_to_register)
@@ -133,6 +173,8 @@ class CoordRegistry:
             original = _coord_values(coord)
             self._store_original_coord(dim, original)
 
+            # Preserve exploded MultiIndex levels so users can recover useful
+            # scientific coordinates even though PyMC only sees range indices.
             if isinstance(original, pd.MultiIndex):
                 for level_name in original.names:
                     if level_name is None:
@@ -153,6 +195,8 @@ class CoordRegistry:
                 continue
             if not set(coord.dims).issubset(dim_set):
                 continue
+            # Only keep auxiliary coords that are actually attached to the
+            # registered model dims; unrelated coords are not useful to restore.
             self._store_auxiliary_coord(
                 name,
                 xr.DataArray(
@@ -179,7 +223,16 @@ def add_coords(
     *,
     model_dims: tuple[str, ...] | list[str] | set[str] | None = None,
 ) -> None:
-    """Register coords on the active model and store originals when possible."""
+    """Register coordinates on the active model and capture scientific metadata.
+
+    Args:
+        coords: Coordinate mapping or xarray coordinate container to register.
+        model_dims: Optional subset of model dimensions represented by the
+            current data variable. When provided, auxiliary coordinates attached
+            to those dimensions are also stored in the registry.
+
+    This helper must be called inside an active ``pm.Model`` context.
+    """
     pymc_coords = sanitize_coords_for_pymc(coords, model_dims=model_dims)
     pymc_coords_list = {name: coord.tolist() for name, coord in pymc_coords.items()}
 
@@ -195,7 +248,17 @@ def restore_inferencedata_coords(
     idata: az.InferenceData,
     coords_or_registry: CoordRegistry | dict[str, Any],
 ) -> az.InferenceData:
-    """Restore saved coordinates onto matching InferenceData groups."""
+    """Restore saved scientific coordinates onto matching ``InferenceData`` groups.
+
+    Args:
+        idata: Inference data object returned by sampling.
+        coords_or_registry: Either a ``CoordRegistry`` or a legacy mapping of
+            original coordinates keyed by dimension name.
+
+    Returns:
+        The same ``InferenceData`` object with compatible original coordinates
+        and auxiliary coordinates restored onto its xarray groups.
+    """
     original_coords = (
         coords_or_registry.original_coords
         if isinstance(coords_or_registry, CoordRegistry)
@@ -213,6 +276,8 @@ def restore_inferencedata_coords(
                 continue
             if len(coord) != group.sizes[dim]:
                 continue
+            # Restore true dimension coords first so downstream auxiliary coords
+            # can be validated against the final dimension layout.
             if isinstance(coord, pd.MultiIndex):
                 group = group.assign_coords(xr.Coordinates.from_pandas_multiindex(coord, dim))
                 restored_multiindex_dims.add(dim)
@@ -225,6 +290,8 @@ def restore_inferencedata_coords(
                     continue
                 if any(group.sizes[dim] != coord.sizes[dim] for dim in coord.dims):
                     continue
+                # Skip auxiliaries on restored MultiIndex dims because xarray
+                # has already recreated those level coords from the index itself.
                 if any(dim in restored_multiindex_dims for dim in coord.dims):
                     continue
                 group = group.assign_coords({name: coord})

--- a/openghg_inversions/models/coords.py
+++ b/openghg_inversions/models/coords.py
@@ -1,0 +1,168 @@
+"""Helpers for managing xarray and PyMC coordinate mismatches.
+
+Xarray coordinates can contain rich objects, including MultiIndex coordinates
+from stacked or ragged dimensions such as ``nmeasure`` representing stacked
+``(site, time)`` observations. PyMC does not reliably accept all such objects as
+model coordinates, so model construction should use sanitized, PyMC-safe coords.
+
+For Stage C, the sanitization policy is intentionally simple: convert each known
+dimension coordinate to a range index. The original scientific coordinates are
+stored separately so they can later be restored onto ArviZ ``InferenceData``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import arviz as az
+import numpy as np
+import pandas as pd
+import pymc as pm
+import xarray as xr
+
+
+def _coords_to_mapping(coords: dict[str, Any] | xr.core.coordinates.Coordinates) -> dict[str, Any]:
+    if isinstance(coords, xr.core.coordinates.Coordinates):
+        return {name: coords[name] for name in coords}
+    return dict(coords)
+
+
+def _coord_values(coord: Any) -> Any:
+    if isinstance(coord, xr.DataArray):
+        return coord.to_index() if coord.ndim == 1 and coord.name in coord.indexes else coord.values
+    if isinstance(coord, xr.IndexVariable):
+        return coord.to_index()
+    return coord
+
+
+def _coord_length(coord: Any) -> int:
+    if isinstance(coord, xr.DataArray):
+        return coord.sizes[coord.dims[0]]
+    if isinstance(coord, xr.IndexVariable):
+        return coord.sizes[coord.dims[0]]
+    return len(coord)
+
+
+def _coords_equal(left: Any, right: Any) -> bool:
+    if isinstance(left, pd.Index) or isinstance(right, pd.Index):
+        try:
+            return pd.Index(left).equals(pd.Index(right))
+        except Exception:
+            return False
+
+    try:
+        return np.array_equal(np.asarray(left), np.asarray(right))
+    except Exception:
+        return False
+
+
+def sanitize_coords_for_pymc(
+    coords: dict[str, Any] | xr.core.coordinates.Coordinates | object,
+) -> dict[str, np.ndarray]:
+    """Return PyMC-safe coordinates for the provided dimensions."""
+    if not isinstance(coords, (dict, xr.core.coordinates.Coordinates)):
+        return {}
+
+    result: dict[str, np.ndarray] = {}
+    for name, coord in _coords_to_mapping(coords).items():
+        try:
+            size = _coord_length(coord)
+        except Exception:
+            continue
+        result[name] = np.arange(size)
+    return result
+
+
+@dataclass
+class CoordRegistry:
+    """Track scientific and PyMC-safe coordinates for a model."""
+
+    pymc_coords: dict[str, np.ndarray] = field(default_factory=dict)
+    original_coords: dict[str, Any] = field(default_factory=dict)
+    auxiliary_coords: dict[str, xr.DataArray] = field(default_factory=dict)
+
+    def add(self, coords: dict[str, Any] | xr.core.coordinates.Coordinates) -> None:
+        """Register coordinates, storing scientific coords and PyMC-safe coords."""
+        mapping = _coords_to_mapping(coords)
+        pymc_coords = sanitize_coords_for_pymc(coords)
+
+        for dim, safe_coord in pymc_coords.items():
+            if dim in self.pymc_coords and len(self.pymc_coords[dim]) != len(safe_coord):
+                raise ValueError(f"Conflicting coord registration for {dim!r}: length mismatch.")
+            self.pymc_coords[dim] = safe_coord
+
+        for dim, coord in mapping.items():
+            original = _coord_values(coord)
+            if dim in self.original_coords:
+                existing = self.original_coords[dim]
+                if len(existing) != len(original):
+                    raise ValueError(f"Conflicting coord registration for {dim!r}: length mismatch.")
+                if not _coords_equal(existing, original):
+                    raise ValueError(f"Conflicting coord registration for {dim!r}: values differ.")
+                continue
+
+            self.original_coords[dim] = original
+
+            if isinstance(original, pd.MultiIndex):
+                dim_name = dim
+                for level_name in original.names:
+                    if level_name is None:
+                        continue
+                    level_values = original.get_level_values(level_name)
+                    self.auxiliary_coords[f"{dim_name}_{level_name}"] = xr.DataArray(
+                        level_values.to_numpy(),
+                        dims=(dim_name,),
+                        coords={dim_name: np.arange(len(original))},
+                        name=f"{dim_name}_{level_name}",
+                    )
+
+
+def attach_coord_registry(model: pm.Model, registry: CoordRegistry) -> None:
+    """Attach a coordinate registry to a PyMC model."""
+    setattr(model, "_openghg_coord_registry", registry)
+
+
+def get_coord_registry(model: pm.Model) -> CoordRegistry | None:
+    """Return the coordinate registry attached to a PyMC model, if any."""
+    return getattr(model, "_openghg_coord_registry", None)
+
+
+def add_coords(coords: dict[str, np.ndarray] | xr.core.coordinates.Coordinates) -> None:
+    """Register coords on the active model and store originals when possible."""
+    pymc_coords = sanitize_coords_for_pymc(coords)
+
+    with pm.modelcontext(None) as model:
+        model.add_coords(pymc_coords)
+
+        registry = get_coord_registry(model)
+        if registry is not None:
+            registry.add(coords)
+
+
+def restore_inferencedata_coords(
+    idata: az.InferenceData,
+    coords_or_registry: CoordRegistry | dict[str, Any],
+) -> az.InferenceData:
+    """Restore saved coordinates onto matching InferenceData groups."""
+    original_coords = (
+        coords_or_registry.original_coords
+        if isinstance(coords_or_registry, CoordRegistry)
+        else coords_or_registry
+    )
+
+    for group_name in idata.groups():
+        group = getattr(idata, group_name)
+        if not isinstance(group, xr.Dataset):
+            continue
+
+        for dim, coord in original_coords.items():
+            if dim not in group.dims:
+                continue
+            if len(coord) != group.sizes[dim]:
+                continue
+            group = group.assign_coords({dim: coord})
+
+        setattr(idata, group_name, group)
+
+    return idata

--- a/openghg_inversions/models/coords.py
+++ b/openghg_inversions/models/coords.py
@@ -22,8 +22,8 @@ import pymc as pm
 import xarray as xr
 
 
-def _coords_to_mapping(coords: dict[str, Any] | xr.core.coordinates.Coordinates) -> dict[str, Any]:
-    if isinstance(coords, xr.core.coordinates.Coordinates):
+def _coords_to_mapping(coords: dict[str, Any] | xr.Coordinates) -> dict[str, Any]:
+    if isinstance(coords, xr.Coordinates):
         return {name: coords[name] for name in coords}
     return dict(coords)
 
@@ -58,12 +58,12 @@ def _coords_equal(left: Any, right: Any) -> bool:
 
 
 def sanitize_coords_for_pymc(
-    coords: dict[str, Any] | xr.core.coordinates.Coordinates | object,
+    coords: dict[str, Any] | xr.Coordinates | object,
     *,
     model_dims: tuple[str, ...] | list[str] | set[str] | None = None,
 ) -> dict[str, np.ndarray]:
     """Return PyMC-safe coordinates for the provided dimensions."""
-    if not isinstance(coords, (dict, xr.core.coordinates.Coordinates)):
+    if not isinstance(coords, (dict, xr.Coordinates)):
         return {}
 
     dims_to_register = set(model_dims) if model_dims is not None else None
@@ -111,7 +111,7 @@ class CoordRegistry:
 
     def add(
         self,
-        coords: dict[str, Any] | xr.core.coordinates.Coordinates,
+        coords: dict[str, Any] | xr.Coordinates,
         *,
         model_dims: tuple[str, ...] | list[str] | set[str] | None = None,
     ) -> None:
@@ -175,15 +175,16 @@ def get_coord_registry(model: pm.Model) -> CoordRegistry | None:
 
 
 def add_coords(
-    coords: dict[str, np.ndarray] | xr.core.coordinates.Coordinates,
+    coords: dict[str, np.ndarray] | xr.Coordinates,
     *,
     model_dims: tuple[str, ...] | list[str] | set[str] | None = None,
 ) -> None:
     """Register coords on the active model and store originals when possible."""
     pymc_coords = sanitize_coords_for_pymc(coords, model_dims=model_dims)
+    pymc_coords_list = {name: coord.tolist() for name, coord in pymc_coords.items()}
 
     with pm.modelcontext(None) as model:
-        model.add_coords(pymc_coords)
+        model.add_coords(pymc_coords_list)
 
         registry = get_coord_registry(model)
         if registry is not None:

--- a/openghg_inversions/models/priors.py
+++ b/openghg_inversions/models/priors.py
@@ -14,7 +14,15 @@ PriorArgs: TypeAlias = dict[str, str | float | bool]
 
 
 def lognormal_mu_sigma(mean: float, stdev: float) -> tuple[float, float]:
-    """Return lognormal ``mu`` and ``sigma`` for the requested mean and stdev."""
+    """Convert lognormal mean and stdev into PyMC's ``mu`` and ``sigma``.
+
+    Args:
+        mean: Requested mean of the lognormal distribution.
+        stdev: Requested standard deviation of the lognormal distribution.
+
+    Returns:
+        A ``(mu, sigma)`` tuple suitable for ``pm.Lognormal``.
+    """
     var = np.log(1 + (stdev / mean) ** 2)
     mu = np.log(mean) - 0.5 * var
     sigma = np.sqrt(var)
@@ -22,6 +30,7 @@ def lognormal_mu_sigma(mean: float, stdev: float) -> tuple[float, float]:
 
 
 def _update_log_normal_prior(prior_params: PriorArgs) -> None:
+    """Rewrite lognormal prior arguments in-place to use ``mu`` and ``sigma``."""
     if "stdev" not in prior_params:
         return
 
@@ -36,7 +45,21 @@ def _update_log_normal_prior(prior_params: PriorArgs) -> None:
 
 
 def parse_prior(name: str, prior_params: PriorArgs, **kwargs) -> TensorVariable:
-    """Create a PyMC continuous prior from a prior parameter dictionary.
+    """Create a continuous PyMC prior from a prior-parameter dictionary.
+
+    Args:
+        name: Name of the user-facing PyMC variable to create.
+        prior_params: Prior specification including ``pdf`` and any distribution
+            parameters accepted by the chosen PyMC distribution.
+        **kwargs: Additional keyword arguments forwarded to the created PyMC
+            variable, such as ``dims``.
+
+    Returns:
+        The created PyMC random variable or deterministic transform.
+
+    Raises:
+        ValueError: If ``prior_params["pdf"]`` does not name a supported PyMC
+            continuous distribution.
 
     This helper must be called inside an active ``pm.Model`` context because it
     registers the created variable with the current model.

--- a/openghg_inversions/models/priors.py
+++ b/openghg_inversions/models/priors.py
@@ -1,0 +1,61 @@
+"""Reusable prior helpers for PyMC model construction."""
+
+from __future__ import annotations
+
+from typing import TypeAlias
+
+import numpy as np
+import pymc as pm
+import pytensor.tensor as pt
+from pymc.distributions import continuous
+from pytensor.tensor import TensorVariable
+
+PriorArgs: TypeAlias = dict[str, str | float | bool]
+
+
+def lognormal_mu_sigma(mean: float, stdev: float) -> tuple[float, float]:
+    """Return lognormal ``mu`` and ``sigma`` for the requested mean and stdev."""
+    var = np.log(1 + (stdev / mean) ** 2)
+    mu = np.log(mean) - 0.5 * var
+    sigma = np.sqrt(var)
+    return mu, sigma
+
+
+def _update_log_normal_prior(prior_params: PriorArgs) -> None:
+    if "stdev" not in prior_params:
+        return
+
+    stdev = float(prior_params["stdev"])
+    mean = float(prior_params.get("mean", 1.0))
+    mu, sigma = lognormal_mu_sigma(mean, stdev)
+    prior_params["mu"] = mu
+    prior_params["sigma"] = sigma
+    del prior_params["stdev"]
+    if "mean" in prior_params:
+        del prior_params["mean"]
+
+
+def parse_prior(name: str, prior_params: PriorArgs, **kwargs) -> TensorVariable:
+    """Create a PyMC continuous prior from a prior parameter dictionary."""
+    pdf_dict = {cd.lower(): cd for cd in continuous.__all__}
+
+    params = prior_params.copy()
+    pdf = str(params.pop("pdf")).lower()
+
+    if pdf == "lognormal":
+        _update_log_normal_prior(params)
+
+        if params.get("reparameterise", False):
+            latent = pm.Normal(f"{name}_latent", 0, 1, **kwargs)
+            return pm.Deterministic(name, pt.exp(params["mu"] + params["sigma"] * latent), **kwargs)
+
+    params.pop("reparameterise", None)
+
+    try:
+        dist = getattr(continuous, pdf_dict[pdf])
+    except (AttributeError, KeyError) as exc:
+        raise ValueError(
+            f"The distribution '{pdf}' doesn't appear to be a continuous distribution defined by PyMC."
+        ) from exc
+
+    return dist(name, **params, **kwargs)

--- a/openghg_inversions/models/priors.py
+++ b/openghg_inversions/models/priors.py
@@ -36,7 +36,11 @@ def _update_log_normal_prior(prior_params: PriorArgs) -> None:
 
 
 def parse_prior(name: str, prior_params: PriorArgs, **kwargs) -> TensorVariable:
-    """Create a PyMC continuous prior from a prior parameter dictionary."""
+    """Create a PyMC continuous prior from a prior parameter dictionary.
+
+    This helper must be called inside an active ``pm.Model`` context because it
+    registers the created variable with the current model.
+    """
     pdf_dict = {cd.lower(): cd for cd in continuous.__all__}
 
     params = prior_params.copy()

--- a/openghg_inversions/postprocessing/inversion_output.py
+++ b/openghg_inversions/postprocessing/inversion_output.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing_extensions import Self
 import warnings
 from dataclasses import dataclass
-from typing import Any, Literal, TypeVar
+from typing import Any, Hashable, Literal, TypeVar
 
 import arviz as az
 import numpy as np
@@ -42,6 +42,37 @@ def filter_data_vars_by_prefix(
                 data_vars.append(dv)
 
     return ds[data_vars]
+
+
+def _filter_trace_data_vars_by_name(ds: xr.Dataset, var_names: str | list[str]) -> xr.Dataset:
+    """Select trace variables by exact base variable name.
+
+    Trace datasets use names like ``x_prior`` or ``mu_bc_posterior``. This
+    helper matches the full base variable name before the trace-group suffix so
+    ``var_names="x"`` does not also select ``x_latent_prior``.
+    """
+    if isinstance(var_names, str):
+        var_names = [var_names]
+
+    group_suffixes = (
+        "_prior_predictive",
+        "_posterior_predictive",
+        "_prior",
+        "_posterior",
+    )
+    selected: list[Hashable] = []
+    wanted = set(var_names)
+
+    for dv in ds.data_vars:
+        name = str(dv)
+        for suffix in group_suffixes:
+            if name.endswith(suffix):
+                base_name = name.removesuffix(suffix)
+                if base_name in wanted:
+                    selected.append(dv)
+                break
+
+    return ds[selected]
 
 
 def convert_idata_to_dataset(
@@ -341,7 +372,7 @@ class InversionOutput:
         result = self.trace_ds
 
         if var_names is not None:
-            result = filter_data_vars_by_prefix(result, var_names)
+            result = _filter_trace_data_vars_by_name(result, var_names)
 
         return result
 

--- a/tests/models/test_components.py
+++ b/tests/models/test_components.py
@@ -15,6 +15,7 @@ from openghg_inversions.models.coords import CoordRegistry, attach_coord_registr
 
 
 def _obs_index() -> pd.MultiIndex:
+    """Create a stacked observation index used by component tests."""
     return pd.MultiIndex.from_arrays(
         [["MHD", "MHD", "TAC", "TAC"], pd.to_datetime(["2019-01-01", "2019-01-02", "2019-02-01", "2019-02-02"])],
         names=["site", "time"],
@@ -22,6 +23,7 @@ def _obs_index() -> pd.MultiIndex:
 
 
 def _site_indicator() -> xr.DataArray:
+    """Create a simple site-indicator DataArray aligned to the test index."""
     index = _obs_index()
     return xr.DataArray(
         np.array([0, 0, 1, 1]),
@@ -32,6 +34,7 @@ def _site_indicator() -> xr.DataArray:
 
 
 def _likelihood_dataset() -> xr.Dataset:
+    """Create a minimal canonical-style dataset for likelihood tests."""
     index = _obs_index()
     return xr.Dataset(
         data_vars={
@@ -48,6 +51,7 @@ def _likelihood_dataset() -> xr.Dataset:
 
 
 def test_add_model_data_uses_add_coords() -> None:
+    """Check add_model_data registers model coords through the shared coord helper."""
     data = xr.DataArray([1.0, 2.0], dims=("nmeasure",), coords={"nmeasure": [10, 11]}, name="Y")
 
     with pm.Model() as model:
@@ -59,6 +63,7 @@ def test_add_model_data_uses_add_coords() -> None:
 
 
 def test_add_linear_component_creates_expected_named_vars() -> None:
+    """Check add_linear_component returns the created PyMC objects explicitly."""
     data = xr.DataArray(
         np.ones((4, 2)),
         dims=("nmeasure", "nx"),
@@ -84,6 +89,12 @@ def test_add_linear_component_creates_expected_named_vars() -> None:
 
 
 def test_add_linear_component_returns_effective_reparameterised_latent() -> None:
+    """Check the component result exposes the true reparameterized latent variable.
+
+    This is a temporary refactor-support test. It protects the Stage C
+    component API while the legacy and component builders coexist and ensures
+    the builder does not need to inspect model internals to find ``x_latent``.
+    """
     data = xr.DataArray(
         np.ones((4, 2)),
         dims=("nmeasure", "nx"),
@@ -107,6 +118,7 @@ def test_add_linear_component_returns_effective_reparameterised_latent() -> None
 
 
 def test_add_sigma_component_supports_explicit_and_derived_freq() -> None:
+    """Check sigma accepts explicit or internally derived frequency indicators."""
     site_indicator = _site_indicator()
     sigma_freq_index = xr.DataArray([0, 0, 1, 1], dims=("nmeasure",), coords=site_indicator.coords)
 
@@ -129,6 +141,7 @@ def test_add_sigma_component_supports_explicit_and_derived_freq() -> None:
 
 
 def test_add_offset_component_supports_manual_and_derived_freq() -> None:
+    """Check offsets accept explicit or internally derived frequency indicators."""
     site_indicator = _site_indicator()
     manual_freq = xr.DataArray([0, 0, 1, 1], dims=("nmeasure",), coords=site_indicator.coords)
 
@@ -156,6 +169,7 @@ def test_add_offset_component_supports_manual_and_derived_freq() -> None:
 
 
 def test_add_inferpymc_likelihood_component_adds_epsilon_and_y() -> None:
+    """Check the likelihood helper adds epsilon, y, and sigma variables."""
     ds = _likelihood_dataset()
 
     with pm.Model(coords={"nmeasure": np.arange(4)}) as model:

--- a/tests/models/test_components.py
+++ b/tests/models/test_components.py
@@ -83,6 +83,29 @@ def test_add_linear_component_creates_expected_named_vars() -> None:
     assert result.output is model.named_vars["mu"]
 
 
+def test_add_linear_component_returns_effective_reparameterised_latent() -> None:
+    data = xr.DataArray(
+        np.ones((4, 2)),
+        dims=("nmeasure", "nx"),
+        coords={"nmeasure": np.arange(4), "nx": np.arange(2)},
+        name="H",
+    )
+
+    with pm.Model() as model:
+        attach_coord_registry(model, CoordRegistry())
+        result = add_linear_component(
+            data,
+            data_name="hx",
+            prior_args={"pdf": "lognormal", "mean": 1.5, "stdev": 0.2, "reparameterise": True},
+            var_name="x",
+            output_name="mu",
+        )
+
+    assert "x_latent" in model.named_vars
+    assert "x" in model.named_vars
+    assert result.latent is model.named_vars["x_latent"]
+
+
 def test_add_sigma_component_supports_explicit_and_derived_freq() -> None:
     site_indicator = _site_indicator()
     sigma_freq_index = xr.DataArray([0, 0, 1, 1], dims=("nmeasure",), coords=site_indicator.coords)

--- a/tests/models/test_components.py
+++ b/tests/models/test_components.py
@@ -1,0 +1,141 @@
+import numpy as np
+import pandas as pd
+import pymc as pm
+import xarray as xr
+
+from openghg_inversions.models.components import (
+    add_inferpymc_likelihood_component,
+    add_linear_component,
+    add_model_data,
+    add_offset_component,
+    add_sigma_component,
+)
+from openghg_inversions.models.coords import CoordRegistry, attach_coord_registry
+
+
+def _obs_index() -> pd.MultiIndex:
+    return pd.MultiIndex.from_arrays(
+        [["MHD", "MHD", "TAC", "TAC"], pd.to_datetime(["2019-01-01", "2019-01-02", "2019-02-01", "2019-02-02"])],
+        names=["site", "time"],
+    )
+
+
+def _site_indicator() -> xr.DataArray:
+    index = _obs_index()
+    return xr.DataArray(
+        np.array([0, 0, 1, 1]),
+        dims=("nmeasure",),
+        coords={"nmeasure": index},
+        name="site_indicator",
+    )
+
+
+def _likelihood_dataset() -> xr.Dataset:
+    index = _obs_index()
+    return xr.Dataset(
+        data_vars={
+            "mf": ("nmeasure", np.array([1.0, 2.0, 3.0, 4.0])),
+            "mf_error": ("nmeasure", np.full(4, 0.1)),
+            "site_indicator": ("nmeasure", np.array([0, 0, 1, 1])),
+            "sigma_freq_index": ("nmeasure", np.array([0, 0, 1, 1])),
+            "min_error": ("nmeasure", np.full(4, 0.01)),
+        },
+        coords={
+            "nmeasure": index,
+        },
+    )
+
+
+def test_add_model_data_uses_add_coords() -> None:
+    data = xr.DataArray([1.0, 2.0], dims=("nmeasure",), coords={"nmeasure": [10, 11]}, name="Y")
+
+    with pm.Model() as model:
+        attach_coord_registry(model, CoordRegistry())
+        add_model_data(data)
+
+    assert "Y" in model.named_vars
+    assert "nmeasure" in model.coords
+
+
+def test_add_linear_component_creates_expected_named_vars() -> None:
+    data = xr.DataArray(
+        np.ones((4, 2)),
+        dims=("nmeasure", "nx"),
+        coords={"nmeasure": np.arange(4), "nx": np.arange(2)},
+        name="H",
+    )
+
+    with pm.Model(coords={"nmeasure": np.arange(4), "nx": np.arange(2)}) as model:
+        attach_coord_registry(model, CoordRegistry())
+        add_linear_component(
+            data,
+            data_name="hx",
+            prior_args={"pdf": "normal", "mu": 1.0, "sigma": 1.0},
+            var_name="x",
+            output_name="mu",
+        )
+
+    assert {"hx", "x", "mu"}.issubset(model.named_vars)
+
+
+def test_add_sigma_component_supports_explicit_and_derived_freq() -> None:
+    site_indicator = _site_indicator()
+    sigma_freq_index = xr.DataArray([0, 0, 1, 1], dims=("nmeasure",), coords=site_indicator.coords)
+
+    with pm.Model(coords={"nmeasure": np.arange(4)}) as model:
+        attach_coord_registry(model, CoordRegistry())
+        add_sigma_component(site_indicator, prior_args={"pdf": "uniform", "lower": 0.1, "upper": 1.0}, sigma_freq_index=sigma_freq_index)
+        assert "sigma" in model.named_vars
+
+    with pm.Model(coords={"nmeasure": np.arange(4)}) as model:
+        attach_coord_registry(model, CoordRegistry())
+        add_sigma_component(
+            site_indicator,
+            prior_args={"pdf": "uniform", "lower": 0.1, "upper": 1.0},
+            sigma_freq="monthly",
+            per_site=False,
+        )
+        assert model.named_vars["sigma"].eval().shape[0] == 1
+
+
+def test_add_offset_component_supports_manual_and_derived_freq() -> None:
+    site_indicator = _site_indicator()
+    manual_freq = xr.DataArray([0, 0, 1, 1], dims=("nmeasure",), coords=site_indicator.coords)
+
+    with pm.Model(coords={"nmeasure": np.arange(4)}) as model:
+        attach_coord_registry(model, CoordRegistry())
+        add_offset_component(
+            site_indicator,
+            prior_args={"pdf": "normal", "mu": 0.0, "sigma": 1.0},
+            offset_freq_indicator=manual_freq,
+            output_name="offset",
+        )
+        assert "offset" in model.named_vars
+
+    with pm.Model(coords={"nmeasure": np.arange(4)}) as model:
+        attach_coord_registry(model, CoordRegistry())
+        add_offset_component(
+            site_indicator,
+            prior_args={"pdf": "normal", "mu": 0.0, "sigma": 1.0},
+            offset_freq="monthly",
+            output_name="offset",
+        )
+        assert "offset" in model.named_vars
+
+
+def test_add_inferpymc_likelihood_component_adds_epsilon_and_y() -> None:
+    ds = _likelihood_dataset()
+
+    with pm.Model(coords={"nmeasure": np.arange(4)}) as model:
+        attach_coord_registry(model, CoordRegistry())
+        mu = pm.Data("mu_input", np.ones(4), dims="nmeasure")
+        mu_bc = pm.Data("mu_bc_input", np.zeros(4), dims="nmeasure")
+        add_inferpymc_likelihood_component(
+            ds,
+            mu=mu,
+            mu_bc=mu_bc,
+            sigprior={"pdf": "uniform", "lower": 0.1, "upper": 1.0},
+            sigma_per_site=True,
+        )
+
+    assert {"epsilon", "y", "sigma"}.issubset(model.named_vars)

--- a/tests/models/test_components.py
+++ b/tests/models/test_components.py
@@ -4,6 +4,7 @@ import pymc as pm
 import xarray as xr
 
 from openghg_inversions.models.components import (
+    LinearComponentResult,
     add_inferpymc_likelihood_component,
     add_linear_component,
     add_model_data,
@@ -65,9 +66,9 @@ def test_add_linear_component_creates_expected_named_vars() -> None:
         name="H",
     )
 
-    with pm.Model(coords={"nmeasure": np.arange(4), "nx": np.arange(2)}) as model:
+    with pm.Model() as model:
         attach_coord_registry(model, CoordRegistry())
-        add_linear_component(
+        result = add_linear_component(
             data,
             data_name="hx",
             prior_args={"pdf": "normal", "mu": 1.0, "sigma": 1.0},
@@ -75,7 +76,11 @@ def test_add_linear_component_creates_expected_named_vars() -> None:
             output_name="mu",
         )
 
+    assert isinstance(result, LinearComponentResult)
     assert {"hx", "x", "mu"}.issubset(model.named_vars)
+    assert result.data is model.named_vars["hx"]
+    assert result.latent is model.named_vars["x"]
+    assert result.output is model.named_vars["mu"]
 
 
 def test_add_sigma_component_supports_explicit_and_derived_freq() -> None:
@@ -86,6 +91,7 @@ def test_add_sigma_component_supports_explicit_and_derived_freq() -> None:
         attach_coord_registry(model, CoordRegistry())
         add_sigma_component(site_indicator, prior_args={"pdf": "uniform", "lower": 0.1, "upper": 1.0}, sigma_freq_index=sigma_freq_index)
         assert "sigma" in model.named_vars
+        assert "sigma_freq_index" in model.named_vars
 
     with pm.Model(coords={"nmeasure": np.arange(4)}) as model:
         attach_coord_registry(model, CoordRegistry())
@@ -96,6 +102,7 @@ def test_add_sigma_component_supports_explicit_and_derived_freq() -> None:
             per_site=False,
         )
         assert model.named_vars["sigma"].eval().shape[0] == 1
+        assert "sigma_freq_index" in model.named_vars
 
 
 def test_add_offset_component_supports_manual_and_derived_freq() -> None:
@@ -111,6 +118,7 @@ def test_add_offset_component_supports_manual_and_derived_freq() -> None:
             output_name="offset",
         )
         assert "offset" in model.named_vars
+        assert "offset_freq_indicator" in model.named_vars
 
     with pm.Model(coords={"nmeasure": np.arange(4)}) as model:
         attach_coord_registry(model, CoordRegistry())
@@ -121,6 +129,7 @@ def test_add_offset_component_supports_manual_and_derived_freq() -> None:
             output_name="offset",
         )
         assert "offset" in model.named_vars
+        assert "offset_freq_indicator" in model.named_vars
 
 
 def test_add_inferpymc_likelihood_component_adds_epsilon_and_y() -> None:

--- a/tests/models/test_coords.py
+++ b/tests/models/test_coords.py
@@ -16,12 +16,14 @@ from openghg_inversions.models.coords import (
 
 
 def test_sanitize_coords_for_pymc_returns_range_coords() -> None:
+    """Check coordinate sanitization produces range-based PyMC coords."""
     coords = {"nmeasure": xr.DataArray([10, 20, 30], dims=("nmeasure",))}
     result = sanitize_coords_for_pymc(coords)
     np.testing.assert_array_equal(result["nmeasure"], np.arange(3))
 
 
 def test_coord_registry_stores_original_and_sanitized_multiindex() -> None:
+    """Check the coord registry preserves MultiIndex coords and derived auxiliaries."""
     multi_index = pd.MultiIndex.from_arrays(
         [["MHD", "MHD", "TAC"], pd.to_datetime(["2019-01-01", "2019-01-02", "2019-01-03"])],
         names=["site", "time"],
@@ -37,6 +39,7 @@ def test_coord_registry_stores_original_and_sanitized_multiindex() -> None:
 
 
 def test_coord_registry_repeated_registration_and_conflict() -> None:
+    """Check repeated coordinate registration is idempotent but rejects conflicts."""
     coords = {"nx": np.array([0, 1, 2])}
     registry = CoordRegistry()
     registry.add(coords)
@@ -47,6 +50,7 @@ def test_coord_registry_repeated_registration_and_conflict() -> None:
 
 
 def test_add_coords_works_with_and_without_registry() -> None:
+    """Check add_coords works whether or not a coord registry is attached."""
     coords = {"nmeasure": xr.DataArray([1, 2], dims=("nmeasure",))}
 
     with pm.Model() as model:
@@ -62,6 +66,7 @@ def test_add_coords_works_with_and_without_registry() -> None:
 
 
 def test_add_coords_preserves_auxiliary_coords_for_model_dims() -> None:
+    """Check add_coords stores auxiliary coords attached to model dimensions."""
     multi_index = pd.MultiIndex.from_arrays(
         [["MHD", "TAC"], pd.to_datetime(["2019-01-01", "2019-01-02"])],
         names=["site", "time"],
@@ -79,6 +84,7 @@ def test_add_coords_preserves_auxiliary_coords_for_model_dims() -> None:
 
 
 def test_restore_inferencedata_coords_supports_registry_and_legacy_dict() -> None:
+    """Check coordinate restoration works with both registry and legacy mappings."""
     multi_index = pd.MultiIndex.from_arrays(
         [["MHD", "TAC"], pd.to_datetime(["2019-01-01", "2019-01-02"])],
         names=["site", "time"],

--- a/tests/models/test_coords.py
+++ b/tests/models/test_coords.py
@@ -1,0 +1,80 @@
+import arviz as az
+import numpy as np
+import pandas as pd
+import pymc as pm
+import xarray as xr
+import pytest
+
+from openghg_inversions.models.coords import (
+    CoordRegistry,
+    add_coords,
+    attach_coord_registry,
+    get_coord_registry,
+    restore_inferencedata_coords,
+    sanitize_coords_for_pymc,
+)
+
+
+def test_sanitize_coords_for_pymc_returns_range_coords() -> None:
+    coords = {"nmeasure": xr.DataArray([10, 20, 30], dims=("nmeasure",))}
+    result = sanitize_coords_for_pymc(coords)
+    np.testing.assert_array_equal(result["nmeasure"], np.arange(3))
+
+
+def test_coord_registry_stores_original_and_sanitized_multiindex() -> None:
+    multi_index = pd.MultiIndex.from_arrays(
+        [["MHD", "MHD", "TAC"], pd.to_datetime(["2019-01-01", "2019-01-02", "2019-01-03"])],
+        names=["site", "time"],
+    )
+    coords = xr.Coordinates({"nmeasure": multi_index})
+    registry = CoordRegistry()
+
+    registry.add(coords)
+
+    assert registry.original_coords["nmeasure"].equals(multi_index)
+    np.testing.assert_array_equal(registry.pymc_coords["nmeasure"], np.arange(3))
+    assert "nmeasure_time" in registry.auxiliary_coords
+
+
+def test_coord_registry_repeated_registration_and_conflict() -> None:
+    coords = {"nx": np.array([0, 1, 2])}
+    registry = CoordRegistry()
+    registry.add(coords)
+    registry.add(coords)
+
+    with pytest.raises(ValueError, match="values differ"):
+        registry.add({"nx": np.array([0, 2, 3])})
+
+
+def test_add_coords_works_with_and_without_registry() -> None:
+    coords = {"nmeasure": xr.DataArray([1, 2], dims=("nmeasure",))}
+
+    with pm.Model() as model:
+        add_coords(coords)
+        assert "nmeasure" in model.coords
+        assert get_coord_registry(model) is None
+
+    with pm.Model() as model:
+        registry = CoordRegistry()
+        attach_coord_registry(model, registry)
+        add_coords(coords)
+        assert "nmeasure" in registry.original_coords
+
+
+def test_restore_inferencedata_coords_supports_registry_and_legacy_dict() -> None:
+    multi_index = pd.MultiIndex.from_arrays(
+        [["MHD", "TAC"], pd.to_datetime(["2019-01-01", "2019-01-02"])],
+        names=["site", "time"],
+    )
+    posterior = xr.Dataset(
+        data_vars={"x": (("chain", "draw", "nmeasure"), np.zeros((1, 1, 2)))},
+        coords={"chain": [0], "draw": [0], "nmeasure": np.arange(2)},
+    )
+    idata = az.InferenceData(posterior=posterior)
+    registry = CoordRegistry(original_coords={"nmeasure": multi_index})
+
+    restored = restore_inferencedata_coords(idata, registry)
+    assert restored.posterior.indexes["nmeasure"].equals(multi_index)
+
+    restored2 = restore_inferencedata_coords(idata, {"nmeasure": multi_index})
+    assert restored2.posterior.indexes["nmeasure"].equals(multi_index)

--- a/tests/models/test_coords.py
+++ b/tests/models/test_coords.py
@@ -33,7 +33,7 @@ def test_coord_registry_stores_original_and_sanitized_multiindex() -> None:
 
     assert registry.original_coords["nmeasure"].equals(multi_index)
     np.testing.assert_array_equal(registry.pymc_coords["nmeasure"], np.arange(3))
-    assert "nmeasure_time" in registry.auxiliary_coords
+    assert "time" in registry.auxiliary_coords
 
 
 def test_coord_registry_repeated_registration_and_conflict() -> None:
@@ -59,6 +59,23 @@ def test_add_coords_works_with_and_without_registry() -> None:
         attach_coord_registry(model, registry)
         add_coords(coords)
         assert "nmeasure" in registry.original_coords
+
+
+def test_add_coords_preserves_auxiliary_coords_for_model_dims() -> None:
+    multi_index = pd.MultiIndex.from_arrays(
+        [["MHD", "TAC"], pd.to_datetime(["2019-01-01", "2019-01-02"])],
+        names=["site", "time"],
+    )
+    coords = xr.Coordinates.from_pandas_multiindex(multi_index, "nmeasure")
+
+    with pm.Model() as model:
+        registry = CoordRegistry()
+        attach_coord_registry(model, registry)
+        add_coords(coords, model_dims=("nmeasure",))
+
+    assert "nmeasure" in registry.original_coords
+    assert "site" in registry.auxiliary_coords
+    assert "time" in registry.auxiliary_coords
 
 
 def test_restore_inferencedata_coords_supports_registry_and_legacy_dict() -> None:

--- a/tests/models/test_priors.py
+++ b/tests/models/test_priors.py
@@ -1,0 +1,32 @@
+import numpy as np
+import pymc as pm
+import pytest
+
+from openghg_inversions.models.priors import lognormal_mu_sigma, parse_prior
+
+
+def test_lognormal_mu_sigma_matches_requested_moments() -> None:
+    mu, sigma = lognormal_mu_sigma(2.0, 0.5)
+    expected_mean = np.exp(mu + 0.5 * sigma**2)
+    expected_stdev = np.sqrt((np.exp(sigma**2) - 1) * np.exp(2 * mu + sigma**2))
+    assert np.isclose(expected_mean, 2.0)
+    assert np.isclose(expected_stdev, 0.5)
+
+
+def test_parse_prior_reparameterised_lognormal_uses_latent_name() -> None:
+    with pm.Model(coords={"nx": np.arange(3)}) as model:
+        prior = parse_prior(
+            "x",
+            {"pdf": "lognormal", "mean": 1.5, "stdev": 0.2, "reparameterise": True},
+            dims="nx",
+        )
+
+    assert prior.name == "x"
+    assert "x_latent" in model.named_vars
+    assert "x" in model.named_vars
+
+
+def test_parse_prior_rejects_unknown_distribution() -> None:
+    with pm.Model():
+        with pytest.raises(ValueError, match="continuous distribution"):
+            parse_prior("bad", {"pdf": "definitely_not_real"})

--- a/tests/models/test_priors.py
+++ b/tests/models/test_priors.py
@@ -6,6 +6,7 @@ from openghg_inversions.models.priors import lognormal_mu_sigma, parse_prior
 
 
 def test_lognormal_mu_sigma_matches_requested_moments() -> None:
+    """Check lognormal moment conversion reproduces the requested moments."""
     mu, sigma = lognormal_mu_sigma(2.0, 0.5)
     expected_mean = np.exp(mu + 0.5 * sigma**2)
     expected_stdev = np.sqrt((np.exp(sigma**2) - 1) * np.exp(2 * mu + sigma**2))
@@ -14,6 +15,7 @@ def test_lognormal_mu_sigma_matches_requested_moments() -> None:
 
 
 def test_parse_prior_reparameterised_lognormal_uses_latent_name() -> None:
+    """Check reparameterized lognormal priors use the ``_latent`` naming convention."""
     with pm.Model(coords={"nx": np.arange(3)}) as model:
         prior = parse_prior(
             "x",
@@ -27,6 +29,7 @@ def test_parse_prior_reparameterised_lognormal_uses_latent_name() -> None:
 
 
 def test_parse_prior_rejects_unknown_distribution() -> None:
+    """Check parse_prior rejects unsupported continuous distributions."""
     with pm.Model():
         with pytest.raises(ValueError, match="continuous distribution"):
             parse_prior("bad", {"pdf": "definitely_not_real"})

--- a/tests/test_full_inversion.py
+++ b/tests/test_full_inversion.py
@@ -188,12 +188,14 @@ def test_full_inversion_min_error_no_bc(mcmc_args):
 
 
 def test_full_inversion_pollution_events_from_obs_no_bc(mcmc_args):
+    """Test inversion with pollution-event scaling and no boundary conditions."""
     mcmc_args["pollution_events_from_obs"] = True
     mcmc_args["use_bc"] = False
     fixedbasisMCMC(**mcmc_args)
 
 
 def test_full_inversion_two_sites(mcmc_args, mhd_and_tac_ch4_data_args):
+    """Test inversion with two sites and an offset term."""
     mcmc_args.update(mhd_and_tac_ch4_data_args)
     mcmc_args["reload_merged_data"] = False
     mcmc_args["add_offset"] = True
@@ -202,11 +204,13 @@ def test_full_inversion_two_sites(mcmc_args, mhd_and_tac_ch4_data_args):
 
 
 def test_full_inversion_components_builder(mcmc_args):
+    """Test full inversion can opt into the temporary components builder."""
     mcmc_args["model_builder"] = "components"
     fixedbasisMCMC(**mcmc_args)
 
 
 def test_full_inversion_offset_args(mcmc_args):
+    """Test full inversion accepts explicit offset arguments through runtime plumbing."""
     mcmc_args["add_offset"] = True
     mcmc_args["offset_args"] = {"drop_first": False,
                                 "offset_freq": "D"}

--- a/tests/test_full_inversion.py
+++ b/tests/test_full_inversion.py
@@ -200,6 +200,12 @@ def test_full_inversion_two_sites(mcmc_args, mhd_and_tac_ch4_data_args):
     mcmc_args["offset_args"] = {"drop_first": True}
     fixedbasisMCMC(**mcmc_args)
 
+
+def test_full_inversion_components_builder(mcmc_args):
+    mcmc_args["model_builder"] = "components"
+    fixedbasisMCMC(**mcmc_args)
+
+
 def test_full_inversion_offset_args(mcmc_args):
     mcmc_args["add_offset"] = True
     mcmc_args["offset_args"] = {"drop_first": False,

--- a/tests/test_full_inversion.py
+++ b/tests/test_full_inversion.py
@@ -157,6 +157,24 @@ def test_full_inversion_lognormal_reparam(mcmc_args):
     fixedbasisMCMC(**mcmc_args)
 
 
+def test_full_inversion_paris_outputs_lognormal_reparam_conflict(mcmc_args):
+    """Check PARIS outputs ignore reparameterized latent-only traces.
+
+    This regression test covers the Stage C components builder path, where
+    reparameterized lognormal priors add ``x_latent`` traces that should not be
+    treated as public emissions traces by post-processing.
+    """
+    mcmc_args["reload_merged_data"] = False
+    mcmc_args["output_format"] = "paris"
+    mcmc_args["model_builder"] = "components"
+    mcmc_args["reparameterise_log_normal"] = True
+    mcmc_args["xprior"] = {"pdf": "lognormal", "mu": 1.0, "sigma": 1.0}
+
+    out = fixedbasisMCMC(**mcmc_args)
+
+    assert "Yapost" in out
+
+
 def test_full_inversion_min_error(mcmc_args):
     mcmc_args["min_error"] = 20.0
     fixedbasisMCMC(**mcmc_args)

--- a/tests/test_inferpymc.py
+++ b/tests/test_inferpymc.py
@@ -82,7 +82,8 @@ def inferpymc_inputs_dataset(mhd_and_tac_fp_data) -> xr.Dataset:
     return ds
 
 
-def test_build_inferpymc_model_returns_setup_for_pymc(inferpymc_args: dict) -> None:
+@pytest.mark.parametrize("model_builder", ["legacy", "components"])
+def test_build_inferpymc_model_returns_setup_for_pymc(inferpymc_args: dict, model_builder: str) -> None:
     """Check extracted model builder returns PyMC step methods for the pymc sampler."""
     setup = build_inferpymc_model(
         Hx=inferpymc_args["Hx"],
@@ -105,6 +106,7 @@ def test_build_inferpymc_model_returns_setup_for_pymc(inferpymc_args: dict) -> N
         offset_args=inferpymc_args["offset_args"],
         power=inferpymc_args["power"],
         nuts_sampler="pymc",
+        model_builder=model_builder,
     )
 
     assert isinstance(setup, InferPyMCModelSetup)
@@ -114,7 +116,8 @@ def test_build_inferpymc_model_returns_setup_for_pymc(inferpymc_args: dict) -> N
     assert setup.sample_kwargs["step"] == [setup.step1, setup.step2]
 
 
-def test_build_inferpymc_model_returns_no_steps_for_numpyro(inferpymc_args: dict) -> None:
+@pytest.mark.parametrize("model_builder", ["legacy", "components"])
+def test_build_inferpymc_model_returns_no_steps_for_numpyro(inferpymc_args: dict, model_builder: str) -> None:
     """Check model setup does not pass steps them via sample_kwargs['step'] for the numpyro sampler.
 
     The steps are still created by build_inferpymc_model and stored in the dataclass. This matches
@@ -141,6 +144,7 @@ def test_build_inferpymc_model_returns_no_steps_for_numpyro(inferpymc_args: dict
         offset_args=inferpymc_args["offset_args"],
         power=inferpymc_args["power"],
         nuts_sampler="numpyro",
+        model_builder=model_builder,
     )
 
     assert isinstance(setup, InferPyMCModelSetup)
@@ -267,8 +271,9 @@ def test_prepare_inferpymc_inputs_dataset_matches_legacy(
     assert prepared_dataset.original_coords
 
 
+@pytest.mark.parametrize("model_builder", ["legacy", "components"])
 def test_build_inferpymc_model_accepts_dataset(
-    inferpymc_args: dict, inferpymc_inputs_dataset: xr.Dataset
+    inferpymc_args: dict, inferpymc_inputs_dataset: xr.Dataset, model_builder: str
 ) -> None:
     """Check model builder accepts direct xarray inversion inputs."""
     setup = build_inferpymc_model(
@@ -286,6 +291,7 @@ def test_build_inferpymc_model_accepts_dataset(
         offset_args=inferpymc_args["offset_args"],
         power=inferpymc_args["power"],
         nuts_sampler="pymc",
+        model_builder=model_builder,
     )
 
     assert isinstance(setup, InferPyMCModelSetup)
@@ -349,6 +355,19 @@ def test_build_inferpymc_model_rejects_mixed_input_modes(
         )
 
 
+def test_build_inferpymc_model_rejects_unknown_builder(inferpymc_args: dict) -> None:
+    with pytest.raises(ValueError, match="Unsupported model_builder"):
+        build_inferpymc_model(
+            Hx=inferpymc_args["Hx"],
+            Y=inferpymc_args["Y"],
+            error=inferpymc_args["error"],
+            siteindicator=inferpymc_args["siteindicator"],
+            sigma_freq_index=inferpymc_args["sigma_freq_index"],
+            Hbc=inferpymc_args["Hbc"],
+            model_builder="definitely-not-real",
+        )
+
+
 def test_restore_inferencedata_coords_helper_restores_multiindex() -> None:
     """Check restoration helper can re-attach a MultiIndex coordinate."""
     multi_index = pd.MultiIndex.from_arrays(
@@ -382,3 +401,13 @@ def test_inferpymc_runs_without_boundary_conditions(inferpymc_args: dict) -> Non
     assert "bc" not in model.named_vars
     assert "hbc" not in model.named_vars
     assert "mu_bc" not in model.named_vars
+
+
+def test_inferpymc_accepts_components_builder(inferpymc_args: dict) -> None:
+    args = dict(inferpymc_args)
+    args["model_builder"] = "components"
+
+    result = inferpymc(**args)
+
+    assert "xouts" in result
+    assert "sigouts" in result

--- a/tests/test_inferpymc.py
+++ b/tests/test_inferpymc.py
@@ -11,6 +11,7 @@ from openghg_inversions.hbmcmc.hbmcmc import make_inv_inputs_legacy
 from openghg_inversions.inversion_inputs import make_inv_inputs
 from openghg_inversions.hbmcmc.inversion_pymc import (
     InferPyMCModelSetup,
+    _canonicalise_inferpymc_dataset,
     _prepare_inferpymc_inputs,
     _restore_inferencedata_coords,
     build_inferpymc_model,
@@ -291,6 +292,46 @@ def test_build_inferpymc_model_accepts_dataset(
     assert isinstance(setup.model, pm.Model)
     assert len(setup.model.coords["nmeasure"]) == inferpymc_inputs_dataset.sizes["nmeasure"]
     assert len(setup.model.coords["nx"]) == inferpymc_inputs_dataset.sizes["region"]
+
+
+def test_canonicalise_inferpymc_dataset_preserves_dataset_observation_coords(
+    inferpymc_inputs_dataset: xr.Dataset,
+) -> None:
+    prepared = _prepare_inferpymc_inputs(
+        inv_inputs=inferpymc_inputs_dataset,
+        sigma_per_site=True,
+        use_bc=True,
+        state="region",
+        bc_state="bc_region",
+    )
+
+    canonical = _canonicalise_inferpymc_dataset(prepared, sigma_per_site=True, use_bc=True)
+
+    assert set(["H", "H_bc", "mf", "mf_error", "site_indicator", "sigma_freq_index", "min_error"]).issubset(
+        canonical.data_vars
+    )
+    assert canonical["H"].dims == ("nmeasure", "nx")
+    assert canonical["H_bc"].dims == ("nmeasure", "nbc")
+    assert "time" in canonical.coords
+    assert canonical.indexes["nmeasure"].equals(inferpymc_inputs_dataset.indexes["nmeasure"])
+
+
+def test_canonicalise_inferpymc_dataset_expands_scalar_min_error(inferpymc_args: dict) -> None:
+    prepared = _prepare_inferpymc_inputs(
+        Hx=inferpymc_args["Hx"],
+        Y=inferpymc_args["Y"],
+        error=inferpymc_args["error"],
+        siteindicator=inferpymc_args["siteindicator"],
+        sigma_freq_index=inferpymc_args["sigma_freq_index"],
+        Hbc=inferpymc_args["Hbc"],
+        min_error=0.0,
+        sigma_per_site=True,
+        use_bc=True,
+    )
+
+    canonical = _canonicalise_inferpymc_dataset(prepared, sigma_per_site=True, use_bc=True)
+    assert canonical["min_error"].sizes["nmeasure"] == canonical.sizes["nmeasure"]
+    np.testing.assert_array_equal(canonical["min_error"].values, np.zeros(canonical.sizes["nmeasure"]))
 
 
 def test_build_inferpymc_model_rejects_mixed_input_modes(

--- a/tests/test_inferpymc.py
+++ b/tests/test_inferpymc.py
@@ -311,7 +311,7 @@ def test_canonicalise_inferpymc_dataset_preserves_dataset_observation_coords(
         bc_state="bc_region",
     )
 
-    canonical = _canonicalise_inferpymc_dataset(prepared, sigma_per_site=True, use_bc=True)
+    canonical = _canonicalise_inferpymc_dataset(prepared, use_bc=True)
 
     assert set(["H", "H_bc", "mf", "mf_error", "site_indicator", "sigma_freq_index", "min_error"]).issubset(
         canonical.data_vars
@@ -335,7 +335,7 @@ def test_canonicalise_inferpymc_dataset_expands_scalar_min_error(inferpymc_args:
         use_bc=True,
     )
 
-    canonical = _canonicalise_inferpymc_dataset(prepared, sigma_per_site=True, use_bc=True)
+    canonical = _canonicalise_inferpymc_dataset(prepared, use_bc=True)
     assert canonical["min_error"].sizes["nmeasure"] == canonical.sizes["nmeasure"]
     np.testing.assert_array_equal(canonical["min_error"].values, np.zeros(canonical.sizes["nmeasure"]))
 

--- a/tests/test_inferpymc.py
+++ b/tests/test_inferpymc.py
@@ -303,7 +303,13 @@ def test_build_inferpymc_model_accepts_dataset(
 def test_canonicalise_inferpymc_dataset_preserves_dataset_observation_coords(
     inferpymc_inputs_dataset: xr.Dataset,
 ) -> None:
-    prepared = _prepare_inferpymc_inputs(
+    """Check canonicalisation keeps dataset observation coordinates intact.
+
+    This is a temporary refactor-support test. It guards the Stage B to Stage C
+    adapter so the new component builder can be introduced without changing the
+    scientific observation coordinates carried by dataset inputs.
+    """
+    prepared_inputs = _prepare_inferpymc_inputs(
         inv_inputs=inferpymc_inputs_dataset,
         sigma_per_site=True,
         use_bc=True,
@@ -311,7 +317,7 @@ def test_canonicalise_inferpymc_dataset_preserves_dataset_observation_coords(
         bc_state="bc_region",
     )
 
-    canonical = _canonicalise_inferpymc_dataset(prepared, use_bc=True)
+    canonical = _canonicalise_inferpymc_dataset(prepared_inputs, use_bc=True)
 
     assert set(["H", "H_bc", "mf", "mf_error", "site_indicator", "sigma_freq_index", "min_error"]).issubset(
         canonical.data_vars
@@ -323,7 +329,12 @@ def test_canonicalise_inferpymc_dataset_preserves_dataset_observation_coords(
 
 
 def test_canonicalise_inferpymc_dataset_expands_scalar_min_error(inferpymc_args: dict) -> None:
-    prepared = _prepare_inferpymc_inputs(
+    """Check canonicalisation expands scalar min_error to the observation dimension.
+
+    This is a temporary refactor-support test for the Stage B to Stage C
+    adapter, which is expected to disappear once the legacy plumbing is removed.
+    """
+    prepared_inputs = _prepare_inferpymc_inputs(
         Hx=inferpymc_args["Hx"],
         Y=inferpymc_args["Y"],
         error=inferpymc_args["error"],
@@ -335,7 +346,7 @@ def test_canonicalise_inferpymc_dataset_expands_scalar_min_error(inferpymc_args:
         use_bc=True,
     )
 
-    canonical = _canonicalise_inferpymc_dataset(prepared, use_bc=True)
+    canonical = _canonicalise_inferpymc_dataset(prepared_inputs, use_bc=True)
     assert canonical["min_error"].sizes["nmeasure"] == canonical.sizes["nmeasure"]
     np.testing.assert_array_equal(canonical["min_error"].values, np.zeros(canonical.sizes["nmeasure"]))
 
@@ -356,6 +367,7 @@ def test_build_inferpymc_model_rejects_mixed_input_modes(
 
 
 def test_build_inferpymc_model_rejects_unknown_builder(inferpymc_args: dict) -> None:
+    """Check the public builder selector rejects unsupported values."""
     with pytest.raises(ValueError, match="Unsupported model_builder"):
         build_inferpymc_model(
             Hx=inferpymc_args["Hx"],
@@ -404,6 +416,12 @@ def test_inferpymc_runs_without_boundary_conditions(inferpymc_args: dict) -> Non
 
 
 def test_inferpymc_accepts_components_builder(inferpymc_args: dict) -> None:
+    """Check inferpymc forwards the temporary component-builder selector.
+
+    This is a temporary refactor-support test for the Stage C legacy/components
+    split and can be simplified or removed once Stage D makes the component
+    builder the default runtime path.
+    """
     args = dict(inferpymc_args)
     args["model_builder"] = "components"
 

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -6,7 +6,7 @@ from openghg_inversions.hbmcmc.hbmcmc import fixedbasisMCMC
 from openghg_inversions.hbmcmc.hbmcmc_output import define_output_filename
 from openghg_inversions.postprocessing.inversion_output import InversionOutput
 from openghg_inversions.postprocessing.legacy_outputs import make_legacy_hbmcmc_output
-from openghg_inversions.postprocessing.make_outputs import basic_output
+from openghg_inversions.postprocessing.make_outputs import basic_output, make_country_outputs
 from openghg_inversions.postprocessing.make_paris_outputs import (
     make_paris_flux_outputs_from_rhime,
     make_paris_outputs,
@@ -136,6 +136,31 @@ def test_save_inversion_output(mcmc_args, tmpdir):
     inv_out_reloaded = InversionOutput.load(tmpdir / "inv_out.nc")
 
     assert inv_out == inv_out_reloaded
+
+
+def test_country_outputs_lognormal_reparam_conflict(mcmc_args, europe_country_file):
+    """Check country outputs ignore reparameterized latent-only traces.
+
+    This is a smaller regression test for the Stage C components builder path.
+    It stops at the ``InversionOutput`` stage and checks that country
+    post-processing uses the public ``x`` trace rather than the internal
+    ``x_latent`` trace introduced by lognormal reparameterisation.
+    """
+    mcmc_args["output_format"] = "inv_out"
+    mcmc_args["model_builder"] = "components"
+    mcmc_args["reparameterise_log_normal"] = True
+    mcmc_args["xprior"] = {"pdf": "lognormal", "mu": 1.0, "sigma": 1.0}
+
+    inv_out = fixedbasisMCMC(**mcmc_args)
+    trace_ds = inv_out.get_trace_dataset(var_names="x")
+    assert "x_prior" in trace_ds
+    assert "x_posterior" in trace_ds
+    assert "x_latent_prior" not in trace_ds
+    assert "x_latent_posterior" not in trace_ds
+
+    country_outs = make_country_outputs(inv_out, country_file=europe_country_file, country_regions="paris")
+    assert "country_prior_mean" in country_outs
+    assert "country_posterior_mean" in country_outs
 
 
 def test_hbmcmc_postprocessing_saves_legacy_output(mcmc_args, tmpdir):


### PR DESCRIPTION
* **Summary of changes**

# Summary

This PR introduces the Stage C model-building architecture for PyMC
inversions, while keeping the pre-existing runtime path available as an
explicit legacy model builder. (The full plan is here: #370.)

To see what the code will eventually look like, look at `build_inferpymc_model_components` in `inversion_pymc.py`. The end result will be simpler because we will not need to support the old numpy-based model building code.

It adds reusable model-building helpers under
`openghg_inversions.models`, and introduces a temporary dual-builder
arrangement in `hbmcmc.inversion_pymc`:

- `model_builder="legacy"` = exact pre-PR legacy builder path
- `model_builder="components"` = new Stage C component-based builder

The intended stage split is:

- **Stage C:** introduce and validate the new builder architecture
  without changing the default scientific workflow
- **Stage D:** switch the default `inferpymc` builder to the
  component-based path once parity is established

# Main changes

## New reusable model-building code

Added a new top-level `openghg_inversions.models` package with:

- `models.coords`
  - coordinate sanitization for PyMC (PyMC only accepts certain types of coordinates)
  - `CoordRegistry` for preserving scientific/original coordinates
  - restoration helpers for `InferenceData`
- `models.priors`
  - `parse_prior`
  - lognormal `mean`/`stdev` conversion
  - lognormal reparameterisation support
- `models.components`
  - reusable function-based PyMC model components
  - currently includes linear, sigma, offset, and inferpymc likelihood
    helpers

## Temporary dual-builder support

`openghg_inversions.hbmcmc.inversion_pymc` now has:

- `build_inferpymc_model_legacy(...)`
- `build_inferpymc_model_components(...)`
- `build_inferpymc_model(...)` as a temporary dispatcher

and `inferpymc(...)` now accepts:

``` python
model_builder="legacy"  # default
```

Accepted values are:

- `"legacy"`
- `"components"`

## Exact legacy builder retained

The legacy builder path uses the exact code from the previous ("Stage B") PR #380 

This is intentional:

- it gives a clean baseline for parity testing
- it avoids blurring the comparison by partially rewriting the legacy
  path to use new helpers

The new code will not be used by default until the next PR in the sequence (for issue #374).

## Builder selection through runtime plumbing

The model builder selection can be forwarded through the kwargs in `fixedbasisMCMC`, so it can be set in the .ini file:

``` python
model_builder="components"
```

This is intended to make it easier to trial the new builder on real
inversion cases before Stage D.

## Component return object for linear components

`add_linear_component(...)` now returns a small dataclass
(`LinearComponentResult`) so the calling code can access:

- registered model data
- the actual sampling latent variable
- the aligned output tensor

This avoids leaking implementation details like `{name}_latent` naming
into the top-level model assembly code.

# How to try the new builder

By default, the current path remains:

``` python
model_builder="legacy"
```

To use the new component-based model builder, pass:

``` python
model_builder="components"
```

This can be supplied:

- directly to `inferpymc(...)`
- via kwargs passed through `fixedbasisMCMC(...)`
- via config/runtime plumbing that forwards those kwargs

# Testing

This PR adds/updates tests for:

- coordinate sanitization and restoration
- prior parsing and lognormal reparameterisation
- reusable model components
- canonical dataset adaptation
- temporary builder selection (`legacy` vs `components`)
- forwarding `model_builder` through higher-level runtime paths

The legacy and component builders can now be compared more directly
because the legacy path is the exact pre-PR implementation.

# Notes for review

1.  **This is transitional code.** Stage C intentionally introduces some
    temporary duplication and indirection so the new builder path can be
    validated before it becomes the default.

2.  **The `legacy` builder is the exact pre-PR model-building path.**
    This PR keeps that code explicitly so the new component-based
    builder can be tested against a clean baseline.

3.  **Complexity is temporarily higher than the intended final design.**
    This PR carries:

    - backward compatibility for existing inferpymc inputs
    - the new reusable model-building layer
    - temporary dual-builder support
    - coordinate-registry machinery for xarray/PyMC compatibility

    Some of this should simplify in later stages once the component
    builder is validated and the legacy path can be removed.

4.  **The main purpose of this PR is architectural groundwork plus
    validation.** The intended scientific behavior of the current
    default model path should remain unchanged.

5.  **Real-world testing of `model_builder`"components"= would be
    especially helpful.** The new path now exists specifically so it can
    be exercised on realistic inversion cases before becoming the
    default.

# Expected next step

If the new builder behaves well on tests and real inversion cases, the
next stage will be to:

- switch `inferpymc` / `build_inferpymc_model` to the component-based
  builder by default
- remove duplicated legacy model-assembly code retained for the Stage C
  transition

* **Please check if the PR fulfills these requirements**

- [x] Closes #373
- [x] Tests added and passing
- Documentation and tutorials updated/added
- [x] Added an entry to the `CHANGELOG.md` file
- Added any new requirements to `requirements.txt`
