### PR TITLE
Iss386 flux timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Code changes
 
+
+- Fix bug which was assigninig the wrong times to inversion flux outputs in non-standard cases, such as 3-monthly inversions. [#PR 387](https://github.com/openghg/openghg_inversions/pull/387)
 - Fix small bug where postprocessing was failing if country codes in file didn't match exactly those in `paris_regions_dict`. [#PR 377](https://github.com/openghg/openghg_inversions/pull/377)
 - More flexibility for new inversion domains. [#PR 333](https://github.com/openghg/openghg_inversions/pull/333)
 - More flexibility for types of boundary condition basis functions. [#PR 333](https://github.com/openghg/openghg_inversions/pull/333)

--- a/openghg_inversions/postprocessing/inversion_output.py
+++ b/openghg_inversions/postprocessing/inversion_output.py
@@ -382,7 +382,7 @@ class InversionOutput:
     @property
     def period_midpoint(self) -> pd.Timestamp:
         """Midpoint of inversion period."""
-        return self.start_time + (self.start_time - self.end_time) / 2
+        return self.start_time + (self.end_time - self.start_time) / 2
 
     def get_total_err(self, take_mean: bool = True) -> xr.DataArray:
         """Return the posterior model-data mismatch error.

--- a/openghg_inversions/postprocessing/make_paris_outputs.py
+++ b/openghg_inversions/postprocessing/make_paris_outputs.py
@@ -304,7 +304,7 @@ def paris_flux_output(
             offset = pd.to_timedelta(flux_frequency) / 2
 
         def time_func(ds):
-            return ds.assign_coords(time=(pd.to_datetime(ds.time.values) + offset))
+            return ds.assign_coords(time=[inv_out.period_midpoint])
     else:
 
         def time_func(ds):

--- a/openghg_inversions/postprocessing/make_paris_outputs.py
+++ b/openghg_inversions/postprocessing/make_paris_outputs.py
@@ -236,6 +236,38 @@ def _flux_frequency_to_offset(flux_frequency: str) -> pd.DateOffset | pd.Timedel
         return pd.to_timedelta(flux_frequency)
 
 
+def _flux_interval_midpoints(
+    flux_times: list[pd.Timestamp],
+    flux_period: pd.DateOffset | pd.Timedelta,
+    inv_start: pd.Timestamp,
+    inv_end: pd.Timestamp,
+) -> list[pd.Timestamp]:
+    """Compute output timestamps as midpoints of each flux interval clipped to the inversion period.
+
+    For each flux interval [ft, ft + flux_period], the output timestamp is the
+    midpoint of the overlap with [inv_start, inv_end]. This correctly handles
+    cases where the flux period and inversion period differ in length, e.g.:
+
+    - 3-monthly inversion on yearly fluxes: the yearly flux interval is clipped
+      to the inversion period, so the midpoint is within the inversion period.
+    - 2-yearly inversion on yearly fluxes: each yearly flux interval lies fully
+      within the inversion period, so the midpoint is mid-year as expected.
+
+    Args:
+        flux_times: Start timestamps of each flux interval.
+        flux_period: Duration of a single flux interval.
+        inv_start: Start of the inversion period.
+        inv_end: End of the inversion period.
+
+    Returns:
+        List of midpoint timestamps, one per flux interval.
+    """
+    return [
+        max(ft, inv_start) + (min(ft + flux_period, inv_end) - max(ft, inv_start)) / 2
+        for ft in flux_times
+    ]
+
+
 def paris_flux_output(
     inv_out: InversionOutput,
     country_file: str | Path | None = None,
@@ -312,10 +344,7 @@ def paris_flux_output(
 
         def time_func(ds):
             flux_times = pd.to_datetime(ds.time.values)
-            midpoints = [
-                max(ft, inv_start) + (min(ft + flux_period, inv_end) - max(ft, inv_start)) / 2
-                for ft in flux_times
-            ]
+            midpoints = _flux_interval_midpoints(flux_times, flux_period, inv_start, inv_end)
             return ds.assign_coords(time=midpoints)
     else:
 

--- a/openghg_inversions/postprocessing/make_paris_outputs.py
+++ b/openghg_inversions/postprocessing/make_paris_outputs.py
@@ -226,6 +226,16 @@ def paris_concentration_outputs(
     return result
 
 
+def _flux_frequency_to_offset(flux_frequency: str) -> pd.DateOffset | pd.Timedelta:
+    """Convert a flux frequency string to a calendar-aware pandas offset."""
+    if flux_frequency == "monthly":
+        return pd.DateOffset(months=1)
+    elif flux_frequency == "yearly":
+        return pd.DateOffset(years=1)
+    else:
+        return pd.to_timedelta(flux_frequency)
+
+
 def paris_flux_output(
     inv_out: InversionOutput,
     country_file: str | Path | None = None,
@@ -296,15 +306,17 @@ def paris_flux_output(
         dim_rename_dict["lon"] = "longitude"
 
     if time_point == "midpoint":
-        if flux_frequency == "monthly":
-            offset = pd.DateOffset(weeks=2)
-        elif flux_frequency == "yearly":
-            offset = pd.DateOffset(months=6)
-        else:
-            offset = pd.to_timedelta(flux_frequency) / 2
+        flux_period = _flux_frequency_to_offset(flux_frequency)
+        inv_start = inv_out.start_time
+        inv_end = inv_out.end_time
 
         def time_func(ds):
-            return ds.assign_coords(time=[inv_out.period_midpoint])
+            flux_times = pd.to_datetime(ds.time.values)
+            midpoints = [
+                max(ft, inv_start) + (min(ft + flux_period, inv_end) - max(ft, inv_start)) / 2
+                for ft in flux_times
+            ]
+            return ds.assign_coords(time=midpoints)
     else:
 
         def time_func(ds):

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -10,6 +10,7 @@ from openghg_inversions.postprocessing.legacy_outputs import make_legacy_hbmcmc_
 from openghg_inversions.postprocessing.make_outputs import basic_output, make_country_outputs
 
 from openghg_inversions.postprocessing.make_paris_outputs import (
+    _flux_interval_midpoints,
     make_paris_flux_outputs_from_rhime,
     make_paris_outputs,
     paris_flux_output,
@@ -47,6 +48,46 @@ def inv_out(raw_data_path):
 @pytest.fixture(scope="module")
 def inv_out_eastasia(raw_data_path):
     return InversionOutput.load(raw_data_path / "inversion_output_EASTASIA.nc")
+
+
+@pytest.mark.parametrize(
+    "flux_times, flux_period, inv_start, inv_end, expected",
+    [
+        # Monthly inversion, monthly flux: overlap = full month, midpoint = mid-month
+        (
+            [pd.Timestamp("2019-02-01")],
+            pd.DateOffset(months=1),
+            pd.Timestamp("2019-02-01"),
+            pd.Timestamp("2019-03-01"),
+            [pd.Timestamp("2019-02-01") + (pd.Timestamp("2019-03-01") - pd.Timestamp("2019-02-01")) / 2],
+        ),
+        # 3-monthly inversion, yearly flux: yearly interval clipped to Jan-Apr,
+        # so midpoint is mid-Feb, not mid-year (Jul)
+        (
+            [pd.Timestamp("2019-01-01")],
+            pd.DateOffset(years=1),
+            pd.Timestamp("2019-01-01"),
+            pd.Timestamp("2019-04-01"),
+            [pd.Timestamp("2019-01-01") + (pd.Timestamp("2019-04-01") - pd.Timestamp("2019-01-01")) / 2],
+        ),
+        # 2-yearly inversion, yearly flux: two flux steps, each fully within
+        # inversion period, so midpoints are mid-2019 and mid-2020
+        (
+            [pd.Timestamp("2019-01-01"), pd.Timestamp("2020-01-01")],
+            pd.DateOffset(years=1),
+            pd.Timestamp("2019-01-01"),
+            pd.Timestamp("2021-01-01"),
+            [
+                pd.Timestamp("2019-01-01") + (pd.Timestamp("2020-01-01") - pd.Timestamp("2019-01-01")) / 2,
+                pd.Timestamp("2020-01-01") + (pd.Timestamp("2021-01-01") - pd.Timestamp("2020-01-01")) / 2,
+            ],
+        ),
+    ],
+)
+def test_flux_interval_midpoints(flux_times, flux_period, inv_start, inv_end, expected):
+    """Check midpoint timestamps are computed from the flux/inversion period overlap."""
+    result = _flux_interval_midpoints(flux_times, flux_period, inv_start, inv_end)
+    assert result == expected
 
 
 def test_paris_flux_output_timestamp(inv_out, europe_country_file):

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -70,6 +70,30 @@ def inv_out_eastasia(raw_data_path):
             pd.Timestamp("2019-04-01"),
             [pd.Timestamp("2019-01-01") + (pd.Timestamp("2019-04-01") - pd.Timestamp("2019-01-01")) / 2],
         ),
+        # 3-monthly inversion, yearly flux, flux starts before inversion: the flux
+        # time (Jan) differs from the inversion start (Feb), as in the original bug.
+        # The overlap is clipped to Feb-May, so the midpoint is still mid-March,
+        # not mid-year (Jul) and not mid-January.
+        (
+            [pd.Timestamp("2019-01-01")],
+            pd.DateOffset(years=1),
+            pd.Timestamp("2019-02-01"),
+            pd.Timestamp("2019-05-01"),
+            [pd.Timestamp("2019-02-01") + (pd.Timestamp("2019-05-01") - pd.Timestamp("2019-02-01")) / 2],
+        ),
+        # 3-monthly inversion, monthly flux: three flux steps each fully within
+        # the inversion period, so each midpoint is the middle of its own month
+        (
+            [pd.Timestamp("2019-01-01"), pd.Timestamp("2019-02-01"), pd.Timestamp("2019-03-01")],
+            pd.DateOffset(months=1),
+            pd.Timestamp("2019-01-01"),
+            pd.Timestamp("2019-04-01"),
+            [
+                pd.Timestamp("2019-01-01") + (pd.Timestamp("2019-02-01") - pd.Timestamp("2019-01-01")) / 2,
+                pd.Timestamp("2019-02-01") + (pd.Timestamp("2019-03-01") - pd.Timestamp("2019-02-01")) / 2,
+                pd.Timestamp("2019-03-01") + (pd.Timestamp("2019-04-01") - pd.Timestamp("2019-03-01")) / 2,
+            ],
+        ),
         # 2-yearly inversion, yearly flux: two flux steps, each fully within
         # inversion period, so midpoints are mid-2019 and mid-2020
         (

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -1,3 +1,4 @@
+import pandas as pd
 import pytest
 import xarray as xr
 from pathlib import Path
@@ -7,9 +8,11 @@ from openghg_inversions.hbmcmc.hbmcmc_output import define_output_filename
 from openghg_inversions.postprocessing.inversion_output import InversionOutput
 from openghg_inversions.postprocessing.legacy_outputs import make_legacy_hbmcmc_output
 from openghg_inversions.postprocessing.make_outputs import basic_output, make_country_outputs
+
 from openghg_inversions.postprocessing.make_paris_outputs import (
     make_paris_flux_outputs_from_rhime,
     make_paris_outputs,
+    paris_flux_output,
 )
 
 
@@ -44,6 +47,23 @@ def inv_out(raw_data_path):
 @pytest.fixture(scope="module")
 def inv_out_eastasia(raw_data_path):
     return InversionOutput.load(raw_data_path / "inversion_output_EASTASIA.nc")
+
+
+def test_paris_flux_output_timestamp(inv_out, europe_country_file):
+    """Check that the flux output time coordinate is the midpoint of the inversion period.
+
+    The flux file has a yearly period but the inversion is shorter; the output
+    timestamp should be the midpoint of the overlap between the flux interval
+    and the inversion period (i.e. the midpoint of the inversion period itself),
+    not 6 months into the flux's own year.
+    """
+    flux_outs = paris_flux_output(inv_out, country_file=europe_country_file, flux_frequency="yearly")
+
+    # time is stored as days since Unix epoch; convert back for comparison
+    actual = pd.Timestamp("1970-01-01") + pd.Timedelta(days=float(flux_outs.time.values[0]))
+    expected = inv_out.start_time + (inv_out.end_time - inv_out.start_time) / 2
+
+    assert actual == expected
 
 
 def test_rhime_flux_reprocessing(europe_country_file, raw_data_path):


### PR DESCRIPTION
First attempt at fixing the bug where monthly inversions weren't being assigned the correct timestamps in the flux files. 

Previously, timestamp for the flux file was defined as the start date for the prior flux file plus 2 weeks (for monthly inversions) or 6 months (for yearly inversions). 

This wasn't able to cope with other inversion periods such as 6 months (or indeed 2 years). 

The fix implemented here is to define the flux time as the midpoint of the inversion period (taken as halfway between the start and end dates). 

The problem here is that this won't necessarily give a 'nice' timestamp. For example, for a month with 31 days this will give a timestamp halfway through the 16th day, and for a year this will give midday on the 2nd of July, rather than midnight on the 1st as currently implemented. 

An alternative solution would solve this issue would be to expand (via hard-coding) the `infer_flux_frequency` function to be able to deal with other inversion periods. Then the old 'offset' functionality could be used (e.g. L298 of `make_paris_outputs`), although we would still need to use the `inv_out.start_date` rather than `ds.time.values` to give the correct date from which to start the offset. @brendan-m-murphy and @supriyamantri, what do you think?

(A) [currently implemented] - exact midpoint. Pros - works for any inversion period. Cons - doesn't give 'nice' timestamp (and may not align with InTEM or ELRIS as a result). 

(B) [not implemented] - hard-code inversion intervals including 3-monthly and fix bug to ensure correct start date. 


* **Please check if the PR fulfills these requirements**

- [X] Closes #386 
- [x] Tests added and passing
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry to the `CHANGELOG.md` file
- [ ] Added any new requirements to `requirements.txt`
