### PR TITLE
Switch current inferpymc to the new builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Stage A of PyMC model refactor. Added regression tests for `inferpymc` and extracted function to build the PyMC model. [PR #378](https://github.com/openghg/openghg_inversions/pull/378)
 - Stage B of PyMC model refactor. Updated `inferpymc` to accept current/legacy inputs as well as xarray `Dataset`. [PR #380](https://github.com/openghg/openghg_inversions/pull/380)
 - Stage C of PyMC model refactor. Added function for building PyMC "model components". The model building code from Stage B is still used by default, but the new code can be selected by adding `model_builder="components"` to the .ini file. [PR #382](https://github.com/openghg/openghg_inversions/pull/382)
+- Stage D of PyMC model refactor. Removed temporary scaffolding to preserve legacy model building code. `inferpymc` now only accepts inversion inputs as `xr.Dataset`, and `fixedbasisMCMC` has been updated to reflect this. [PR #389](https://github.com/openghg/openghg_inversions/pull/389)
 
 # Version 0.6.0
 

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -922,6 +922,7 @@ def rerun_output(input_file: str, outputname: str, outputpath: str, verbose: boo
     step1 = mcmc_results["step1"]
     step2 = mcmc_results["step2"]
     Ytrace = mcmc_results["Ytrace"]
+    OFFSETtrace = mcmc_results["OFFSETtrace"]
     bcouts = mcmc_results.get("bcouts")
     YBCtrace = mcmc_results.get("YBCtrace")
 
@@ -935,6 +936,7 @@ def rerun_output(input_file: str, outputname: str, outputpath: str, verbose: boo
         Y=Y,
         error=error,
         Ytrace=Ytrace,
+        OFFSETtrace=OFFSETtrace,
         YBCtrace=YBCtrace,
         step1=step1,
         step2=step2,

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -272,7 +272,14 @@ def fixedbasisMCMC(
     calculate_min_error: Literal["percentile", "residual"] | None = None,
     min_error_options: dict | None = None,
     output_format: Literal[
-        "hbmcmc", "hbmcmc_postprocessing", "paris", "basic", "merged_data", "inv_out", "mcmc_args", "mcmc_results"
+        "hbmcmc",
+        "hbmcmc_postprocessing",
+        "paris",
+        "basic",
+        "merged_data",
+        "inv_out",
+        "mcmc_args",
+        "mcmc_results",
     ] = "hbmcmc",
     paris_postprocessing: bool = False,
     paris_postprocessing_kwargs: dict | None = None,
@@ -746,7 +753,9 @@ def fixedbasisMCMC(
             country_file=country_file,
             use_bc=use_bc,
         )
-        output_filename = define_output_filename(outputpath, species, domain, outputname, start_date, ext=".nc")
+        output_filename = define_output_filename(
+            outputpath, species, domain, outputname, start_date, ext=".nc"
+        )
         Path(outputpath).mkdir(parents=True, exist_ok=True)
         outputs.to_netcdf(output_filename, encoding=ncdf_encoding(outputs), mode="w")
         end_post = time.time()

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -39,9 +39,14 @@ import openghg_inversions.hbmcmc.inversion_pymc as mcmc
 from openghg_inversions.models.priors import lognormal_mu_sigma
 from openghg_inversions.utils import ncdf_encoding
 from openghg_inversions.basis import basis_functions_wrapper
-from openghg_inversions.inversion_data import data_processing_surface_notracer, load_merged_data
+from openghg_inversions.inversion_data import (
+    data_processing_surface_notracer,
+    load_merged_data,
+)
 from openghg_inversions.filters import filtering
-from openghg_inversions.postprocessing.inversion_output import make_inv_out_for_fixed_basis_mcmc
+from openghg_inversions.postprocessing.inversion_output import (
+    make_inv_out_for_fixed_basis_mcmc,
+)
 from openghg_inversions.inversion_inputs import make_inv_inputs
 
 
@@ -66,21 +71,35 @@ def update_log_normal_prior(prior):
 # ----------------------------------------
 
 
-def make_inv_inputs_legacy(
+def _prepare_runtime_inv_inputs(
     *,
     fp_data,
     sites,
     start_date,
-    use_bc,
     bc_freq,
     sigma_freq,
     min_error,
     calculate_min_error,
     min_error_options,
-) -> tuple[dict[str, np.ndarray], dict[str, np.ndarray]]:
-    """Create inputs for PyMC.
+) -> xr.Dataset:
+    """Create the dataset consumed by the current inferpymc runtime path.
 
-    This combines the data for each site into total sensitivity, obs, etc. arrays.
+    Args:
+        fp_data: Forward-model datasets keyed by site name.
+        sites: Sites to include in the inversion inputs.
+        start_date: Inversion start date used when anchoring time-derived
+            indices.
+        bc_freq: Frequency used for BC grouping.
+        sigma_freq: Frequency used for sigma grouping.
+        min_error: Minimum-error configuration passed through to
+            ``make_inv_inputs``.
+        calculate_min_error: Deprecated compatibility argument. When provided,
+            its value overrides ``min_error``.
+        min_error_options: Extra options controlling minimum-error
+            construction.
+
+    Returns:
+        Dataset produced by ``make_inv_inputs`` for the active runtime path.
     """
     if calculate_min_error is not None:
         warnings.warn(
@@ -90,7 +109,7 @@ def make_inv_inputs_legacy(
 
     min_error_options = min_error_options or {}
 
-    ds = make_inv_inputs(
+    return make_inv_inputs(
         fp_data,
         sites=sites,
         bc_freq=bc_freq,
@@ -100,54 +119,93 @@ def make_inv_inputs_legacy(
         start_date=start_date,
     )
 
-    y = ds.mf.values
-    y_time = ds.time.values
-    siteindicator = ds.site_indicator.values
-    error = ds.mf_error.values
-    obs_repeatability = ds.mf_repeatability.values
-    obs_variability = ds.mf_variability.values
-    obs_prior_factor = ds.mf_prior_factor.values if "mf_prior_factor" in ds else None
+
+def _extract_post_process_args(inv_inputs: xr.Dataset) -> dict[str, np.ndarray]:
+    """Extract legacy-shaped postprocessing arrays from inversion inputs.
+
+    NOTE: This is for compatibility at Stage D of #370. This should be removed in Stage E.
+
+    Args:
+        inv_inputs: Dataset produced by ``make_inv_inputs``.
+
+    Returns:
+        Dictionary of legacy-shaped arrays still expected by postprocessing
+        functions.
+    """
+    y = inv_inputs.mf.values
+    obs_prior_factor = inv_inputs.mf_prior_factor.values if "mf_prior_factor" in inv_inputs else None
     obs_prior_upper_level_factor = (
-        ds.mf_prior_upper_level_factor.values if "mf_prior_upper_level_factor" in ds else None
+        inv_inputs.mf_prior_upper_level_factor.values if "mf_prior_upper_level_factor" in inv_inputs else None
     )
-    h_x = ds.H.values
-    h_bc = ds.H_bc.values if "H_bc" in ds else None
-    sigma_freq_index = ds.sigma_freq_index.values
-    min_error_arr = ds.min_error.values
-
-    if np.isnan(h_x).any():
-        warnings.warn(f"Hx matrix contains {np.isnan(h_x).flatten().sum()} NaN values")
-
-    mcmc_args = {
-        "Hx": h_x,
-        "Y": y,
-        "error": error,
-        "siteindicator": siteindicator,
-        "sigma_freq_index": sigma_freq_index,
-        "min_error": min_error_arr,
-    }
-
-    if use_bc is True:
-        assert h_bc is not None  # for mypy
-
-        if np.isnan(h_bc).any():
-            warnings.warn(f"Hbc matrix contains {np.isnan(h_bc).flatten().sum()} NaN values")
-
-        mcmc_args["Hbc"] = h_bc
-
-    post_process_args = {
-        "Ytime": y_time,
-        "obs_repeatability": obs_repeatability,
-        "obs_variability": obs_variability,
-        "obs_prior_factor": (
-            obs_prior_factor if obs_prior_factor is not None else np.zeros_like(y)
-        ),  # use zeros instead of None
+    return {
+        "Ytime": inv_inputs.time.values,
+        "obs_repeatability": inv_inputs.mf_repeatability.values,
+        "obs_variability": inv_inputs.mf_variability.values,
+        "obs_prior_factor": obs_prior_factor if obs_prior_factor is not None else np.zeros_like(y),
         "obs_prior_upper_level_factor": (
             obs_prior_upper_level_factor if obs_prior_upper_level_factor is not None else np.zeros_like(y)
-        ),  # same
+        ),
+        "Hx": inv_inputs.H.values,
+        "Y": inv_inputs.mf.values,
+        "error": inv_inputs.mf_error.values,
+        "siteindicator": inv_inputs.site_indicator.values,
+        "sigma_freq_index": inv_inputs.sigma_freq_index.values,
+        "min_error": inv_inputs.min_error.values,
     }
 
-    return mcmc_args, post_process_args
+
+def _inv_inputs_from_rerun_arrays(
+    *,
+    Hx: np.ndarray,
+    Y: np.ndarray,
+    error: np.ndarray,
+    siteindicator: np.ndarray,
+    sigma_freq_index: np.ndarray,
+    Ytime: np.ndarray,
+    Hbc: np.ndarray | None = None,
+    min_error: float | np.ndarray = 0.0,
+) -> xr.Dataset:
+    """Build a minimal inferpymc-compatible dataset from saved output arrays.
+
+    NOTE: this is a temporary fix for `rerun_output` while `inferpymc` is being refactored.
+    This should be removed once `rerun_output` is updated.
+
+    Args:
+        Hx: Emissions sensitivity array with shape ``(region, nmeasure)``.
+        Y: Observation vector.
+        error: Observation error vector.
+        siteindicator: Site indicator for each observation.
+        sigma_freq_index: Sigma-period indicator for each observation.
+        Ytime: Observation timestamps.
+        Hbc: Optional BC sensitivity array with shape ``(bc_region, nmeasure)``.
+        min_error: Minimum error values to attach to the dataset.
+
+    Returns:
+        Minimal dataset compatible with the dataset-first ``inferpymc`` path.
+    """
+    nmeasure = len(Y)
+    coords: dict[str, object] = {
+        "nmeasure": np.arange(nmeasure),
+        "time": ("nmeasure", Ytime),
+    }
+    data_vars: dict[str, tuple[tuple[str, ...], np.ndarray]] = {
+        "H": (("region", "nmeasure"), Hx),
+        "mf": (("nmeasure",), Y),
+        "mf_error": (("nmeasure",), error),
+        "site_indicator": (("nmeasure",), siteindicator.astype(int)),
+        "sigma_freq_index": (("nmeasure",), sigma_freq_index.astype(int)),
+        "min_error": (
+            ("nmeasure",),
+            np.broadcast_to(np.asarray(min_error), (nmeasure,)),
+        ),
+    }
+    coords["region"] = np.arange(Hx.shape[0])
+
+    if Hbc is not None:
+        data_vars["H_bc"] = (("bc_region", "nmeasure"), Hbc)
+        coords["bc_region"] = np.arange(Hbc.shape[0])
+
+    return xr.Dataset(data_vars=data_vars, coords=coords)
 
 
 def fixedbasisMCMC(
@@ -529,8 +587,25 @@ def fixedbasisMCMC(
     if use_tracer:
         raise ValueError("Model does not currently include tracer model. Watch this space")
 
+    inv_inputs = _prepare_runtime_inv_inputs(
+        fp_data=fp_data,
+        sites=sites,
+        start_date=start_date,
+        bc_freq=bc_freq,
+        sigma_freq=sigma_freq,
+        min_error=min_error,
+        calculate_min_error=calculate_min_error,
+        min_error_options=min_error_options,
+    )
+
+    if np.isnan(inv_inputs.H.values).any():
+        warnings.warn(f"Hx matrix contains {np.isnan(inv_inputs.H.values).flatten().sum()} NaN values")
+    if use_bc and "H_bc" in inv_inputs and np.isnan(inv_inputs.H_bc.values).any():
+        warnings.warn(f"Hbc matrix contains {np.isnan(inv_inputs.H_bc.values).flatten().sum()} NaN values")
+
     # TODO keep this config separate from mcmc_args in the future
     mcmc_config = {
+        "inv_inputs": inv_inputs,
         "xprior": update_log_normal_prior(xprior),
         "sigprior": sigprior,
         "nit": nit,
@@ -548,19 +623,8 @@ def fixedbasisMCMC(
     if use_bc:
         mcmc_config["bcprior"] = update_log_normal_prior(bcprior)
 
-    mcmc_args, post_process_args = make_inv_inputs_legacy(
-        fp_data=fp_data,
-        sites=sites,
-        start_date=start_date,
-        use_bc=use_bc,
-        bc_freq=bc_freq,
-        sigma_freq=sigma_freq,
-        min_error=min_error,
-        calculate_min_error=calculate_min_error,
-        min_error_options=min_error_options,
-    )
-
-    mcmc_args.update(mcmc_config)
+    mcmc_args = mcmc_config.copy()
+    post_process_args = _extract_post_process_args(inv_inputs)
 
     post_process_args.update(
         {
@@ -578,6 +642,9 @@ def fixedbasisMCMC(
         }
     )
 
+    if use_bc and "H_bc" in inv_inputs:
+        post_process_args["Hbc"] = inv_inputs.H_bc.values
+
     # cast float64 to float32
     for k in list(post_process_args.keys()):  # use list to get keys before modifying dict
         v = post_process_args[k]
@@ -587,6 +654,7 @@ def fixedbasisMCMC(
     # add mcmc_args to post_process_args
     # and delete a few we don't need
     post_process_args.update(mcmc_args)
+    del post_process_args["inv_inputs"]
     del post_process_args["nit"]
     del post_process_args["verbose"]
     del post_process_args["offset_args"]
@@ -612,9 +680,8 @@ def fixedbasisMCMC(
 
     print(f"MCMC Inversion complete. Time taken = {end_inversion - start_inversion:.2f} seconds")
 
-    # get trace and model: for future updates
+    # get trace: for future updates
     trace = mcmc_results["trace"]
-    model = mcmc_results["model"]
 
     # Path to save trace
     if save_trace:
@@ -760,6 +827,9 @@ def rerun_output(input_file: str, outputname: str, outputpath: str, verbose: boo
         At the moment fluxapriori in the output is the mean apriori flux
         over the inversion period and so will not be identical to the
         original a priori flux, if it varies over the inversion period.
+
+    TODO: update this function to use `InversionOutput` (and possibly an ini file) as its inputs.
+    This may require updating `InversionOutput` to hold more model metadata.
     """
 
     def isFloat(string):
@@ -812,22 +882,18 @@ def rerun_output(input_file: str, outputname: str, outputpath: str, verbose: boo
     else:
         country_unit_prefix = None
 
-    (
-        xouts,
-        bcouts,
-        sigouts,
-        Ytrace,
-        YBCtrace,
-        convergence,
-        step1,
-        step2,
-    ) = mcmc.inferpymc(
+    inv_inputs = _inv_inputs_from_rerun_arrays(
         Hx=Hx,
         Hbc=Hbc,
         Y=Y,
         error=error,
         siteindicator=siteindicator,
         sigma_freq_index=sigma_freq_index,
+        Ytime=Ytime,
+    )
+
+    mcmc_results = mcmc.inferpymc(
+        inv_inputs=inv_inputs,
         xprior=xprior,
         bcprior=bcprior,
         sigprior=sigprior,
@@ -840,6 +906,15 @@ def rerun_output(input_file: str, outputname: str, outputpath: str, verbose: boo
         add_offset=add_offset,
         verbose=verbose,
     )
+
+    xouts = mcmc_results["xouts"]
+    sigouts = mcmc_results["sigouts"]
+    convergence = mcmc_results["convergence"]
+    step1 = mcmc_results["step1"]
+    step2 = mcmc_results["step2"]
+    Ytrace = mcmc_results["Ytrace"]
+    bcouts = mcmc_results.get("bcouts")
+    YBCtrace = mcmc_results.get("YBCtrace")
 
     mcmc.inferpymc_postprocessouts(
         xouts=xouts,

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -1,13 +1,4 @@
-"""Functions for performing MCMC inversion.
-PyMC library used for Bayesian modelling.
-
-Notes:
-    Some internal helpers in this module are temporary compatibility code for
-    the Stage B refactor in issue #372, part of the model-building work tracked
-    in issue #370. They support both legacy ndarray inputs and direct xarray
-    inputs from ``make_inv_inputs``. These helpers should be simplified or
-    removed once the legacy path is retired in a later stage.
-"""
+"""Functions for performing MCMC inversion with the xarray-first PyMC builder."""
 
 import re
 import getpass
@@ -23,322 +14,40 @@ import pytensor
 pytensor.config.floatX = "float32"
 pytensor.config.warn_float64 = "warn"
 
-import pymc as pm
-import pandas as pd
-import xarray as xr
-import pytensor.tensor as pt
-import arviz as az
-from scipy import stats
+import pymc as pm  # noqa: E402
+import pandas as pd  # noqa: E402
+import xarray as xr  # noqa: E402
+import arviz as az  # noqa: E402
+from scipy import stats  # noqa: E402
 
-from openghg_inversions import convert
-from openghg_inversions import utils
-from openghg_inversions.hbmcmc.components import make_offset
-from openghg_inversions.hbmcmc.hbmcmc_output import define_output_filename
-from openghg_inversions.config.version import code_version
-from openghg_inversions.models.components import (
+from openghg_inversions import convert  # noqa: E402
+from openghg_inversions import utils  # noqa: E402
+from openghg_inversions.hbmcmc.hbmcmc_output import define_output_filename  # noqa: E402
+from openghg_inversions.config.version import code_version  # noqa: E402
+from openghg_inversions.models.components import (  # noqa: E402
     add_inferpymc_likelihood_component,
     add_linear_component,
     add_offset_component,
 )
-from openghg_inversions.models.coords import (
-    CoordRegistry,
-    attach_coord_registry,
-    restore_inferencedata_coords,
-)
-from openghg_inversions.models.priors import PriorArgs, parse_prior
+from openghg_inversions.models.coords import CoordRegistry, attach_coord_registry  # noqa: E402
+from openghg_inversions.models.priors import PriorArgs  # noqa: E402
 
 
 @dataclass
 class InferPyMCModelSetup:
-    """Container for the PyMC model and sampler configuration used by inferpymc."""
+    """Container for the PyMC model and sampler configuration used by inferpymc.
+
+    Attributes:
+        model: PyMC model built for the inversion.
+        step1: Step method used for emissions and boundary-condition variables.
+        step2: Step method used for sigma variables.
+        sample_kwargs: Extra keyword arguments forwarded to ``pm.sample``.
+    """
 
     model: pm.Model
     step1: Any
     step2: Any
     sample_kwargs: dict[str, Any]
-
-
-@dataclass
-class InferPyMCInputs:
-    """Normalised inputs for PyMC model construction.
-
-    Temporary Stage B compatibility container for issue #372. This should be
-    simplified once the legacy ndarray input path is removed in a later stage.
-    """
-
-    hx: np.ndarray
-    y: np.ndarray
-    error: np.ndarray
-    site_indicator: np.ndarray
-    sigma_freq_index: np.ndarray
-    hbc: np.ndarray | None
-    min_error: np.ndarray | float
-    coords: dict[str, np.ndarray]
-    original_coords: dict[str, Any]
-    source: xr.Dataset | None
-
-
-
-def _make_range_coords(
-    *,
-    nmeasure: int,
-    nx: int,
-    nbc: int | None,
-    nsigma_site: int | None,
-    nsigma_time: int,
-) -> dict[str, np.ndarray]:
-    """Create simple range coordinates for PyMC.
-
-    Temporary Stage B compatibility helper for issue #372. We intentionally use
-    only range coordinates in PyMC and preserve richer xarray coordinates
-    separately for potential restoration after sampling.
-    """
-    coords: dict[str, np.ndarray] = {
-        "nmeasure": np.arange(nmeasure),
-        "nx": np.arange(nx),
-        "nsigma_time": np.arange(nsigma_time),
-        "nsigma_site": np.arange(1 if nsigma_site is None else nsigma_site),
-    }
-    if nbc is not None:
-        coords["nbc"] = np.arange(nbc)
-    return coords
-
-
-def _extract_original_coords(ds: xr.Dataset) -> dict[str, Any]:
-    """Extract original dataset coordinates for possible later restoration.
-
-    Temporary Stage B compatibility helper for issue #372. This is not yet used
-    by inferpymc directly because post-processing still expects the current
-    outputs, but keeping it here lets us test coordinate restoration separately.
-    """
-    original_coords: dict[str, Any] = {}
-    for dim in ds.dims:
-        if dim in ds.indexes:
-            original_coords[dim] = ds.indexes[dim]
-        elif dim in ds.coords:
-            original_coords[dim] = ds.coords[dim].values
-    return original_coords
-
-
-def _validate_inferpymc_input_mode(
-    inv_inputs: xr.Dataset | None,
-    *,
-    Hx: np.ndarray | None,
-    Y: np.ndarray | None,
-    error: np.ndarray | None,
-    siteindicator: np.ndarray | None,
-    sigma_freq_index: np.ndarray | None,
-    Hbc: np.ndarray | None,
-    min_error: np.ndarray | float | None,
-) -> str:
-    """Validate whether dataset or legacy ndarray inputs are being used.
-
-    Temporary Stage B compatibility helper for issue #372.
-    """
-    legacy_args = {
-        "Hx": Hx,
-        "Y": Y,
-        "error": error,
-        "siteindicator": siteindicator,
-        "sigma_freq_index": sigma_freq_index,
-        "Hbc": Hbc,
-        "min_error": min_error,
-    }
-    provided_legacy = [name for name, value in legacy_args.items() if value is not None]
-
-    if inv_inputs is not None:
-        if provided_legacy:
-            raise ValueError(
-                "`inv_inputs` cannot be combined with legacy array arguments: " + ", ".join(provided_legacy)
-            )
-        return "dataset"
-
-    required_legacy = ["Hx", "Y", "error", "siteindicator", "sigma_freq_index"]
-    missing = [name for name in required_legacy if legacy_args[name] is None]
-    if missing:
-        raise ValueError(
-            "Either provide `inv_inputs` or all required legacy arguments. Missing: " + ", ".join(missing)
-        )
-    return "legacy"
-
-
-def _prepare_inferpymc_inputs_from_dataset(
-    ds: xr.Dataset,
-    *,
-    sigma_per_site: bool,
-    use_bc: bool,
-    state: str = "region",
-    bc_state: str = "bc_region",
-) -> InferPyMCInputs:
-    """Prepare normalised PyMC inputs from an xarray dataset.
-
-    Temporary Stage B compatibility helper for issue #372.
-
-    Args:
-        ds: xarray.Dataset containing inversion inputs created by make_inv_inputs.
-        sigma_per_site: whether sigma is per-site
-        use_bc: whether to use boundary conditions
-        state: name of the spatial state dimension in the dataset (e.g. "region").
-        bc_state: name of the BC state dimension in the dataset (e.g. "bc_region").
-    """
-    # Use the dataset-provided state dimension names when extracting H/H_bc.
-    hx = ds["H"].transpose("nmeasure", state).values
-    y = ds["mf"].values
-    error = ds["mf_error"].values
-    site_indicator = ds["site_indicator"].values.astype(int)
-    sigma_freq_index = ds["sigma_freq_index"].values.astype(int)
-
-    hbc: np.ndarray | None = None
-    if use_bc:
-        if "H_bc" not in ds:
-            raise ValueError("If `use_bc` is True, the dataset must contain `H_bc`.")
-        hbc = ds["H_bc"].transpose("nmeasure", bc_state).values
-
-    min_error: np.ndarray | float
-    min_error = ds["min_error"].values if "min_error" in ds else 0.0
-
-    sigma_freq_index_model = _contiguous_sigma_time_index(sigma_freq_index)
-
-    nmeasure, nx = hx.shape
-    nbc = None if hbc is None else hbc.shape[1]
-    nsigma_site = int(np.max(site_indicator)) + 1 if sigma_per_site else None
-    nsigma_time = int(np.max(sigma_freq_index_model)) + 1 if sigma_freq_index_model.size else 0
-
-    return InferPyMCInputs(
-        hx=hx,
-        y=y,
-        error=error,
-        site_indicator=site_indicator,
-        sigma_freq_index=sigma_freq_index_model,
-        hbc=hbc,
-        min_error=min_error,
-        coords=_make_range_coords(
-            nmeasure=nmeasure,
-            nx=nx,
-            nbc=nbc,
-            nsigma_site=nsigma_site,
-            nsigma_time=nsigma_time,
-        ),
-        original_coords=_extract_original_coords(ds),
-        source=ds,
-    )
-
-
-def _prepare_inferpymc_inputs_from_legacy(
-    *,
-    Hx: np.ndarray,
-    Y: np.ndarray,
-    error: np.ndarray,
-    siteindicator: np.ndarray,
-    sigma_freq_index: np.ndarray,
-    Hbc: np.ndarray | None,
-    min_error: np.ndarray | float | None,
-    sigma_per_site: bool,
-    use_bc: bool,
-) -> InferPyMCInputs:
-    """Prepare normalised PyMC inputs from legacy ndarray arguments.
-
-    Temporary Stage B compatibility helper for issue #372.
-    """
-    if use_bc and Hbc is None:
-        raise ValueError(
-            "In legacy-array mode, `Hbc` must be provided when `use_bc` is True. "
-            "Either supply a non-None boundary-condition influence matrix `Hbc` "
-            "or disable BCs by setting `use_bc=False`."
-        )
-    hx = Hx.T
-    hbc = Hbc.T if use_bc and Hbc is not None else None
-    site_indicator = siteindicator.astype(int)
-    sigma_freq_index_model = _contiguous_sigma_time_index(sigma_freq_index)
-
-    nmeasure, nx = hx.shape
-    nbc = None if hbc is None else hbc.shape[1]
-    nsigma_site = int(np.max(site_indicator)) + 1 if sigma_per_site else None
-    nsigma_time = int(np.max(sigma_freq_index_model)) + 1 if sigma_freq_index_model.size else 0
-
-    return InferPyMCInputs(
-        hx=hx,
-        y=Y,
-        error=error,
-        site_indicator=site_indicator,
-        sigma_freq_index=sigma_freq_index_model,
-        hbc=hbc,
-        min_error=0.0 if min_error is None else min_error,
-        coords=_make_range_coords(
-            nmeasure=nmeasure,
-            nx=nx,
-            nbc=nbc,
-            nsigma_site=nsigma_site,
-            nsigma_time=nsigma_time,
-        ),
-        original_coords={},
-        source=None,
-    )
-
-
-def _prepare_inferpymc_inputs(
-    inv_inputs: xr.Dataset | None = None,
-    *,
-    Hx: np.ndarray | None = None,
-    Y: np.ndarray | None = None,
-    error: np.ndarray | None = None,
-    siteindicator: np.ndarray | None = None,
-    sigma_freq_index: np.ndarray | None = None,
-    Hbc: np.ndarray | None = None,
-    min_error: np.ndarray | float | None = None,
-    sigma_per_site: bool = True,
-    use_bc: bool = True,
-    state: str = "region",
-    bc_state: str = "bc_region",
-) -> InferPyMCInputs:
-    """Normalise dataset or legacy inputs for PyMC model building.
-
-    Temporary Stage B compatibility helper for issue #372.
-    """
-    mode = _validate_inferpymc_input_mode(
-        inv_inputs,
-        Hx=Hx,
-        Y=Y,
-        error=error,
-        siteindicator=siteindicator,
-        sigma_freq_index=sigma_freq_index,
-        Hbc=Hbc,
-        min_error=min_error,
-    )
-
-    if mode == "dataset":
-        assert inv_inputs is not None
-        return _prepare_inferpymc_inputs_from_dataset(
-            inv_inputs,
-            sigma_per_site=sigma_per_site,
-            use_bc=use_bc,
-            state=state,
-            bc_state=bc_state,
-        )
-
-    assert Hx is not None
-    assert Y is not None
-    assert error is not None
-    assert siteindicator is not None
-    assert sigma_freq_index is not None
-    return _prepare_inferpymc_inputs_from_legacy(
-        Hx=Hx,
-        Y=Y,
-        error=error,
-        siteindicator=siteindicator,
-        sigma_freq_index=sigma_freq_index,
-        Hbc=Hbc,
-        min_error=min_error,
-        sigma_per_site=sigma_per_site,
-        use_bc=use_bc,
-    )
-
-
-def _restore_inferencedata_coords(
-    idata: az.InferenceData, original_coords: dict[str, Any]
-) -> az.InferenceData:
-    """Restore saved coordinates onto matching InferenceData groups."""
-    return restore_inferencedata_coords(idata, original_coords)
 
 
 def _contiguous_index(index: np.ndarray) -> np.ndarray:
@@ -391,19 +100,21 @@ def _prepare_builder_priors(
     offsetprior: dict | None,
     reparameterise_log_normal: bool,
 ) -> tuple[dict, dict, dict, dict]:
-    """Copy builder priors and apply temporary compatibility flags.
+    """Copy builder priors and apply builder-level prior options.
 
     Args:
         xprior: Optional emissions prior overrides.
         bcprior: Optional boundary-condition prior overrides.
         sigprior: Optional sigma prior overrides.
         offsetprior: Optional offset prior overrides.
-        reparameterise_log_normal: Temporary public compatibility flag used to
-            request lognormal reparameterisation.
+        reparameterise_log_normal: Public compatibility flag for requesting
+            lognormal reparameterisation. The preferred long-term interface is
+            to set ``"reparameterise": True`` directly in the relevant prior
+            argument dictionary.
 
     Returns:
-        Copies of the prior dictionaries with defaults filled in and temporary
-        compatibility flags applied.
+        Copies of the prior dictionaries with defaults filled in and any
+        builder-level reparameterisation settings applied.
     """
     prepared_xprior = DEFAULT_XPRIOR.copy() if xprior is None else xprior.copy()
     prepared_bcprior = DEFAULT_BCPRIOR.copy() if bcprior is None else bcprior.copy()
@@ -420,109 +131,113 @@ def _prepare_builder_priors(
     return prepared_xprior, prepared_bcprior, prepared_sigprior, prepared_offsetprior
 
 
-def _validate_model_builder(model_builder: str) -> str:
-    """Validate the temporary Stage C model-builder selector."""
-    if model_builder not in {"legacy", "components"}:
-        raise ValueError(f"Unsupported model_builder {model_builder!r}. Expected 'legacy' or 'components'.")
-    return model_builder
-
-
 def _canonicalise_inferpymc_dataset(
-    prepared_inputs: InferPyMCInputs,
+    inv_inputs: xr.Dataset,
     /,
     use_bc: bool,
     obs_dim: str = "nmeasure",
+    input_state_dim: str = "region",
+    input_bc_state_dim: str = "bc_region",
     state_dim: str = "nx",
     bc_state_dim: str = "nbc",
 ) -> xr.Dataset:
-    """Convert normalized Stage B inputs into canonical xarray model inputs.
+    """Convert inversion inputs into the canonical dataset used by the builder.
 
     Args:
-        prepared_inputs: Temporary Stage B compatibility container holding the
-            normalized inversion inputs.
+        inv_inputs: Dataset produced by ``make_inv_inputs``.
         use_bc: Whether the canonical dataset should include boundary-condition
             sensitivities.
         obs_dim: Observation dimension name used by the model components.
+        input_state_dim: State dimension name used by emissions sensitivities in
+            ``inv_inputs``.
+        input_bc_state_dim: State dimension name used by BC sensitivities in
+            ``inv_inputs``.
         state_dim: State dimension name used for emissions sensitivities.
         bc_state_dim: State dimension name used for boundary-condition
             sensitivities.
 
     Returns:
-        An xarray dataset containing the canonical Stage C model inputs.
+        An xarray dataset with observation-first sensitivities and compact sigma
+        period indices.
 
-    This helper is temporary transition code. It exists to keep the Stage B
-    input-normalization path separate from the Stage C component builder until
-    the legacy path is removed in Stage D.
+    Raises:
+        ValueError: If boundary conditions are requested but ``inv_inputs`` does
+            not contain ``H_bc``.
     """
-    nmeasure = prepared_inputs.hx.shape[0]
-    obs_coord = (
-        prepared_inputs.source.indexes[obs_dim]
-        if prepared_inputs.source is not None and obs_dim in prepared_inputs.source.indexes
-        else np.arange(nmeasure)
-    )
-    coords: dict[str, Any] = {obs_dim: obs_coord, state_dim: np.arange(prepared_inputs.hx.shape[1])}
-
-    if use_bc and prepared_inputs.hbc is not None:
-        coords[bc_state_dim] = np.arange(prepared_inputs.hbc.shape[1])
-
-    min_error = prepared_inputs.min_error
-    if np.isscalar(min_error) or (isinstance(min_error, np.ndarray) and np.ndim(min_error) == 0):
-        min_error_values = np.full(nmeasure, min_error)
-    else:
-        min_error_values = np.asarray(min_error)
-
+    obs_coord = inv_inputs.indexes[obs_dim] if obs_dim in inv_inputs.indexes else inv_inputs[obs_dim].values
+    state_coord = inv_inputs[input_state_dim].values
     data_vars: dict[str, xr.DataArray] = {
         "H": xr.DataArray(
-            prepared_inputs.hx,
+            inv_inputs["H"].transpose(obs_dim, input_state_dim).values,
             dims=(obs_dim, state_dim),
-            coords={obs_dim: obs_coord, state_dim: coords[state_dim]},
+            coords={obs_dim: obs_coord, state_dim: np.arange(state_coord.size)},
             name="H",
         ),
-        "mf": xr.DataArray(prepared_inputs.y, dims=(obs_dim,), coords={obs_dim: coords[obs_dim]}, name="mf"),
+        "mf": xr.DataArray(inv_inputs["mf"].values, dims=(obs_dim,), coords={obs_dim: obs_coord}, name="mf"),
         "mf_error": xr.DataArray(
-            prepared_inputs.error,
+            inv_inputs["mf_error"].values,
             dims=(obs_dim,),
-            coords={obs_dim: coords[obs_dim]},
+            coords={obs_dim: obs_coord},
             name="mf_error",
         ),
         "site_indicator": xr.DataArray(
-            prepared_inputs.site_indicator,
+            inv_inputs["site_indicator"].values.astype(int),
             dims=(obs_dim,),
-            coords={obs_dim: coords[obs_dim]},
+            coords={obs_dim: obs_coord},
             name="site_indicator",
         ),
         "sigma_freq_index": xr.DataArray(
-            prepared_inputs.sigma_freq_index,
+            _contiguous_sigma_time_index(inv_inputs["sigma_freq_index"].values),
             dims=(obs_dim,),
-            coords={obs_dim: coords[obs_dim]},
+            coords={obs_dim: obs_coord},
             name="sigma_freq_index",
         ),
-        "min_error": xr.DataArray(
-            min_error_values,
-            dims=(obs_dim,),
-            coords={obs_dim: coords[obs_dim]},
-            name="min_error",
-        ),
     }
+    min_error_values = inv_inputs["min_error"].values
+    if np.isscalar(min_error_values) or np.ndim(min_error_values) == 0:
+        min_error_values = np.full(inv_inputs.sizes[obs_dim], min_error_values)
+    data_vars["min_error"] = xr.DataArray(
+        min_error_values,
+        dims=(obs_dim,),
+        coords={obs_dim: obs_coord},
+        name="min_error",
+    )
+    coords: dict[str, Any] = {obs_dim: obs_coord, state_dim: np.arange(state_coord.size)}
 
-    if use_bc and prepared_inputs.hbc is not None:
+    if not isinstance(obs_coord, pd.MultiIndex):
+        if "time" in inv_inputs.coords:
+            coords["time"] = xr.DataArray(
+                inv_inputs["time"].values,
+                dims=(obs_dim,),
+                coords={obs_dim: obs_coord},
+                name="time",
+            )
+
+        for coord_name in ("site",):
+            if coord_name in inv_inputs.coords:
+                coords[coord_name] = xr.DataArray(
+                    inv_inputs[coord_name].values,
+                    dims=(obs_dim,),
+                    coords={obs_dim: obs_coord},
+                    name=coord_name,
+                )
+
+    if use_bc:
+        if "H_bc" not in inv_inputs:
+            raise ValueError("If `use_bc` is True, `inv_inputs` must contain `H_bc`.")
+        bc_coord = inv_inputs[input_bc_state_dim].values
+        coords[bc_state_dim] = np.arange(bc_coord.size)
         data_vars["H_bc"] = xr.DataArray(
-            prepared_inputs.hbc,
+            inv_inputs["H_bc"].transpose(obs_dim, input_bc_state_dim).values,
             dims=(obs_dim, bc_state_dim),
-            coords={obs_dim: coords[obs_dim], bc_state_dim: coords[bc_state_dim]},
+            coords={obs_dim: obs_coord, bc_state_dim: np.arange(bc_coord.size)},
             name="H_bc",
         )
 
     return xr.Dataset(data_vars=data_vars, coords=coords)
 
 
-def build_inferpymc_model_legacy(
-    Hx: np.ndarray | None = None,
-    Y: np.ndarray | None = None,
-    error: np.ndarray | None = None,
-    siteindicator: np.ndarray | None = None,
-    sigma_freq_index: np.ndarray | None = None,
-    Hbc: np.ndarray | None = None,
+def build_inferpymc_model(
     xprior: dict | None = None,
     bcprior: dict | None = None,
     sigprior: dict | None = None,
@@ -538,171 +253,42 @@ def build_inferpymc_model_legacy(
     power: dict | float = 1.99,
     nuts_sampler: str = "pymc",
     inv_inputs: xr.Dataset | None = None,
-    state: str = "region",
-    bc_state: str = "bc_region",
 ) -> InferPyMCModelSetup:
-    """Build the temporary legacy inferpymc model path kept for Stage C parity.
+    """Build the current component-based inferpymc model.
 
-    This transitional builder preserves the pre-Stage-C runtime behavior so the
-    new component-based builder can be compared against it during the Stage C
-    to Stage D migration.
+    Args:
+        xprior: Prior specification for emissions scaling factors.
+        bcprior: Prior specification for boundary-condition scaling factors.
+        sigprior: Prior specification for model-error terms.
+        sigma_per_site: Whether sigma should vary by site.
+        offsetprior: Prior specification for optional offsets.
+        add_offset: Whether to include an offset term in the model.
+        min_error: Retained for API compatibility. The active runtime path uses
+            ``inv_inputs["min_error"]``.
+        use_bc: Whether to include boundary-condition terms in the model.
+        reparameterise_log_normal: Whether to request lognormal
+            reparameterisation for supported priors.
+        pollution_events_from_obs: Whether to derive pollution-event scaling
+            from observations rather than modelled concentrations.
+        no_model_error: Whether to suppress the explicit model-error term.
+        offset_args: Extra keyword arguments forwarded to
+            ``add_offset_component``.
+        power: Exponent or prior specification used in the likelihood error
+            scaling.
+        nuts_sampler: Sampler backend name passed through to the model setup.
+        inv_inputs: Dataset produced by ``make_inv_inputs``.
+
+    Returns:
+        ``InferPyMCModelSetup`` containing the built model and sampler
+        configuration.
+
+    Raises:
+        ValueError: If ``inv_inputs`` is not provided.
     """
-    prepared_inputs = _prepare_inferpymc_inputs(
-        inv_inputs=inv_inputs,
-        Hx=Hx,
-        Y=Y,
-        error=error,
-        siteindicator=siteindicator,
-        sigma_freq_index=sigma_freq_index,
-        Hbc=Hbc,
-        min_error=min_error,
-        sigma_per_site=sigma_per_site,
-        use_bc=use_bc,
-        state=state,
-        bc_state=bc_state,
-    )
+    if inv_inputs is None:
+        raise ValueError("`inferpymc` now expects `inv_inputs` from `make_inv_inputs`.")
 
-    # Assign defaults here to avoid sharing the same dict across calls.
-    xprior = DEFAULT_XPRIOR.copy() if xprior is None else xprior
-    bcprior = DEFAULT_BCPRIOR.copy() if bcprior is None else bcprior
-    sigprior = DEFAULT_SIGPRIOR.copy() if sigprior is None else sigprior
-    offsetprior = DEFAULT_OFFSETPRIOR.copy() if offsetprior is None else offsetprior
-
-    sites = (
-        prepared_inputs.site_indicator.astype(int)
-        if sigma_per_site
-        else np.zeros_like(prepared_inputs.site_indicator).astype(int)
-    )
-
-    if isinstance(prepared_inputs.min_error, float) or (
-        isinstance(prepared_inputs.min_error, np.ndarray) and prepared_inputs.min_error.ndim == 0
-    ):
-        min_error_data = prepared_inputs.min_error * np.ones_like(prepared_inputs.y)
-    else:
-        min_error_data = prepared_inputs.min_error
-
-    with pm.Model(coords=prepared_inputs.coords) as model:
-        step1_vars = []
-
-        if reparameterise_log_normal and xprior["pdf"] == "lognormal":
-            x0 = pm.Normal("x0", 0, 1, dims="nx")
-            x = pm.Deterministic("x", pt.exp(xprior["mu"] + xprior["sigma"] * x0), dims="nx")
-            step1_vars.append(x0)
-        else:
-            x = parse_prior("x", xprior, dims="nx")
-            step1_vars.append(x)
-
-        if use_bc:
-            if reparameterise_log_normal and bcprior["pdf"] == "lognormal":
-                bc0 = pm.Normal("bc0", 0, 1, dims="nbc")
-                bc = pm.Deterministic("bc", pt.exp(bcprior["mu"] + bcprior["sigma"] * bc0), dims="nbc")
-                step1_vars.append(bc0)
-            else:
-                bc = parse_prior("bc", bcprior, dims="nbc")
-                step1_vars.append(bc)
-
-        sigma = parse_prior("sigma", sigprior, dims=("nsigma_site", "nsigma_time"))
-
-        hx_data = pm.Data("hx", prepared_inputs.hx, dims=("nmeasure", "nx"))
-        mu = pm.Deterministic("mu", pt.dot(hx_data, x), dims="nmeasure")
-
-        if use_bc and prepared_inputs.hbc is not None:
-            hbc_data = pm.Data("hbc", prepared_inputs.hbc, dims=("nmeasure", "nbc"))
-            mu_bc = pm.Deterministic("mu_bc", pt.dot(hbc_data, bc), dims="nmeasure")
-            mu += mu_bc
-
-        if add_offset:
-            offset_args = offset_args or {}
-            offset = make_offset(prepared_inputs.site_indicator, offsetprior, **offset_args)
-            mu += offset
-
-        y_data = pm.Data("Y", prepared_inputs.y, dims="nmeasure")  # type: ignore[arg-type]
-        error_data = pm.Data("error", prepared_inputs.error, dims="nmeasure")  # type: ignore[arg-type]
-        min_error_data = pm.Data("min_error", min_error_data, dims="nmeasure")  # type: ignore[arg-type]
-
-        if pollution_events_from_obs is True:
-            if use_bc is True and prepared_inputs.hbc is not None:
-                pollution_event = pt.abs(y_data - mu_bc)
-            else:
-                pollution_event = pt.abs(y_data) + 1e-6 * pt.mean(y_data)
-        else:
-            pollution_event = pt.abs(pt.dot(hx_data, x))
-
-        pollution_event_scaled_error = pollution_event * sigma[sites, prepared_inputs.sigma_freq_index]
-
-        if no_model_error is True:
-            mean_obs = np.nanmean(prepared_inputs.y)
-            small_amount = 1e-12 * mean_obs
-            eps = pt.maximum(pt.abs(error_data), small_amount)
-        else:
-            power0 = parse_prior("power", power) if isinstance(power, dict) else power
-            eps = pt.maximum(
-                pt.sqrt(error_data**2 + pt.pow(pollution_event_scaled_error, power0)), min_error_data
-            )
-
-        pm.Deterministic("epsilon", eps, dims="nmeasure")
-        pm.Normal("y", mu=mu, sigma=eps, observed=y_data, dims="nmeasure")
-
-        step1 = pm.NUTS(vars=step1_vars)
-        step2 = pm.Slice(vars=[sigma])
-
-    return InferPyMCModelSetup(
-        model=model,
-        step1=step1,
-        step2=step2,
-        sample_kwargs={"step": [step1, step2] if nuts_sampler == "pymc" else None},
-    )
-
-
-def build_inferpymc_model_components(
-    Hx: np.ndarray | None = None,
-    Y: np.ndarray | None = None,
-    error: np.ndarray | None = None,
-    siteindicator: np.ndarray | None = None,
-    sigma_freq_index: np.ndarray | None = None,
-    Hbc: np.ndarray | None = None,
-    xprior: dict | None = None,
-    bcprior: dict | None = None,
-    sigprior: dict | None = None,
-    sigma_per_site: bool = True,
-    offsetprior: dict | None = None,
-    add_offset: bool = False,
-    min_error: np.ndarray | float | None = None,
-    use_bc: bool = True,
-    reparameterise_log_normal: bool = False,
-    pollution_events_from_obs: bool = False,
-    no_model_error: bool = False,
-    offset_args: dict | None = None,
-    power: dict | float = 1.99,
-    nuts_sampler: str = "pymc",
-    inv_inputs: xr.Dataset | None = None,
-    state: str = "region",
-    bc_state: str = "bc_region",
-) -> InferPyMCModelSetup:
-    """Build the Stage C component-based model path.
-
-    This builder represents the intended future architecture introduced in
-    Stage C. It is expected to become the default inferpymc runtime path in
-    Stage D after parity with the temporary legacy builder is established.
-    """
-    prepared_inputs = _prepare_inferpymc_inputs(
-        inv_inputs=inv_inputs,
-        Hx=Hx,
-        Y=Y,
-        error=error,
-        siteindicator=siteindicator,
-        sigma_freq_index=sigma_freq_index,
-        Hbc=Hbc,
-        min_error=min_error,
-        sigma_per_site=sigma_per_site,
-        use_bc=use_bc,
-        state=state,
-        bc_state=bc_state,
-    )
-    canonical_ds = _canonicalise_inferpymc_dataset(
-        prepared_inputs,
-        use_bc=use_bc,
-    )
+    canonical_ds = _canonicalise_inferpymc_dataset(inv_inputs, use_bc=use_bc)
     xprior, bcprior, sigprior, offsetprior = _prepare_builder_priors(
         xprior=xprior,
         bcprior=bcprior,
@@ -776,81 +362,13 @@ def build_inferpymc_model_components(
     )
 
 
-def build_inferpymc_model(
-    Hx: np.ndarray | None = None,
-    Y: np.ndarray | None = None,
-    error: np.ndarray | None = None,
-    siteindicator: np.ndarray | None = None,
-    sigma_freq_index: np.ndarray | None = None,
-    Hbc: np.ndarray | None = None,
-    xprior: dict | None = None,
-    bcprior: dict | None = None,
-    sigprior: dict | None = None,
-    sigma_per_site: bool = True,
-    offsetprior: dict | None = None,
-    add_offset: bool = False,
-    min_error: np.ndarray | float | None = None,
-    use_bc: bool = True,
-    reparameterise_log_normal: bool = False,
-    pollution_events_from_obs: bool = False,
-    no_model_error: bool = False,
-    offset_args: dict | None = None,
-    power: dict | float = 1.99,
-    nuts_sampler: str = "pymc",
-    inv_inputs: xr.Dataset | None = None,
-    state: str = "region",
-    bc_state: str = "bc_region",
-    model_builder: str = "legacy",
-) -> InferPyMCModelSetup:
-    """Dispatch temporarily between the Stage C legacy and component builders.
-
-    Stage C keeps the legacy runtime path as the default while exposing the new
-    component-based builder for parity testing. Stage D is expected to switch
-    the default to the component builder once parity is established.
-    """
-    model_builder = _validate_model_builder(model_builder)
-    builder = (
-        build_inferpymc_model_legacy if model_builder == "legacy" else build_inferpymc_model_components
-    )
-    return builder(
-        Hx=Hx,
-        Y=Y,
-        error=error,
-        siteindicator=siteindicator,
-        sigma_freq_index=sigma_freq_index,
-        Hbc=Hbc,
-        xprior=xprior,
-        bcprior=bcprior,
-        sigprior=sigprior,
-        sigma_per_site=sigma_per_site,
-        offsetprior=offsetprior,
-        add_offset=add_offset,
-        min_error=min_error,
-        use_bc=use_bc,
-        reparameterise_log_normal=reparameterise_log_normal,
-        pollution_events_from_obs=pollution_events_from_obs,
-        no_model_error=no_model_error,
-        offset_args=offset_args,
-        power=power,
-        nuts_sampler=nuts_sampler,
-        inv_inputs=inv_inputs,
-        state=state,
-        bc_state=bc_state,
-    )
-
-
 # ----------------------------------------
 # Build/run model
 # ----------------------------------------
 
 
 def inferpymc(
-    Hx: np.ndarray | None = None,
-    Y: np.ndarray | None = None,
-    error: np.ndarray | None = None,
-    siteindicator: np.ndarray | None = None,
-    sigma_freq_index: np.ndarray | None = None,
-    Hbc: np.ndarray | None = None,
+    inv_inputs: xr.Dataset | None = None,
     xprior: dict | None = None,
     bcprior: dict | None = None,
     sigprior: dict | None = None,
@@ -863,7 +381,6 @@ def inferpymc(
     offsetprior: dict | None = None,
     add_offset: bool = False,
     verbose: bool = False,
-    min_error: np.ndarray | float | None = None,
     use_bc: bool = True,
     reparameterise_log_normal: bool = False,
     pollution_events_from_obs: bool = False,
@@ -871,28 +388,15 @@ def inferpymc(
     offset_args: dict | None = None,
     power: dict | float = 1.99,
     sampler_kwargs: dict | None = None,
-    inv_inputs: xr.Dataset | None = None,
-    state: str = "region",
-    bc_state: str = "bc_region",
-    model_builder: str = "legacy",
 ) -> dict:
-    """Perform Bayesian inference with PyMC for emissions, boundary conditions, and model error.
+    """Perform Bayesian inference with PyMC for emissions, BCs, and model error.
 
-    This routine constructs and runs a PyMC model (by default using a Normal
-    likelihood) to infer emissions, boundary conditions, and a single model-
-    error parameter (or may vary by site and/or over a given period, if requested).
-    The function can accept either numpy-based inputs (Hx, Y, etc.) or an xarray.Dataset
-    produced by `inversion_inputs.make_inv_inputs`, which preserves dims and coordinates for
-    cleaner model construction.
+    This routine builds the current component-based PyMC model from
+    ``make_inv_inputs`` output, runs sampling, and returns legacy-compatible
+    result keys used by downstream postprocessing.
 
     Args:
-        Hx: Transpose of the sensitivity matrix mapping emissions to measurements.
-            This is typically fp_data[site].H.values stacked for all sites.
-        Y: Measurement vector containing all observations.
-        error: Measurement error vector, containing a value for each element of Y.
-        siteindicator: Array of indexing integers that relate each measurement to a site.
-        sigma_freq_index: Array of integer indexes that converts time into periods.
-        Hbc: Transpose of the sensitivity matrix for boundary conditions. Only used if use_bc is True.
+        inv_inputs: xarray.Dataset produced by ``make_inv_inputs``.
         xprior: Dictionary describing the prior PDF for emissions. The entry "pdf"
             is the name of the analytical PDF used; other entries are shape
             parameters (e.g., {'pdf': 'lognormal', 'stdev': 1.0}).
@@ -908,7 +412,6 @@ def inferpymc(
         offsetprior: Prior specification for offsets applied to sites or observations.
         add_offset: If True, include an offset term in the model.
         verbose: If True, print additional diagnostic information.
-        min_error: Minimum allowed measurement error. Can be a scalar or an array matching Y.
         use_bc: If True, include boundary condition terms in the model.
         reparameterise_log_normal: If True, reparameterise log-normal priors for numerical stability.
         pollution_events_from_obs: If True, derive pollution event terms from observations.
@@ -916,58 +419,34 @@ def inferpymc(
         offset_args: Additional arguments used when constructing offsets.
         power: Exponent used in certain weighting or prior schemes; may be a dict or float.
         sampler_kwargs: Extra keyword arguments passed to the sampler.
-        inv_inputs: xarray.Dataset produced by `make_inv_inputs`, providing xarray-native
-            inputs (e.g., sensitivity matrices, coordinates, and dims) so the function
-            can accept inversion inputs without reconstructing dims and coords.
-        state: Dimension name of the state variable for flux sensitivities ("H") in inv_inputs.
-            Defaults to "region".
-        bc_state: Dimension name of the state variable for BC sensitivities ("H_bc") in inv_inputs.
-            Defaults to "bc_region".
-        model_builder: Temporary builder selector used during the Stage C to Stage D
-            transition. Accepted values are ``"legacy"`` and ``"components"``.
 
     Returns:
-        dict: Dictionary containing inference results, samples, and diagnostics.
+        Dictionary containing inference results, samples, and diagnostics.
 
-            The returned dictionary uses the legacy key structure. Depending on
-            the options used (e.g. whether BCs or offsets are included, and which
-            priors are active), keys typically include:
+        The returned dictionary uses the legacy key structure. Depending on the
+        selected options, keys typically include:
 
-            - ``'xouts'``: Posterior samples or summaries for the state vector
-              (emissions / fluxes).
-            - ``'sigouts'``: Posterior samples or summaries for model–data
-              mismatch (sigma) parameters.
-            - ``'Ytrace'``: Trace of the modelled observations corresponding to
-              the data vector ``Y``.
-            - ``'bcouts'``: Posterior samples or summaries for boundary condition
-              state variables (if boundary conditions are used).
-            - ``'offset_trace'`` or similar keys: Traces for site- or
-              observation-specific offset terms when ``add_offset`` is enabled.
-            - Additional diagnostic arrays and traces needed for convergence
-              checking and postprocessing.
+        - ``"xouts"``: posterior samples for emissions / fluxes
+        - ``"sigouts"``: posterior samples for sigma terms
+        - ``"Ytrace"``: modelled concentrations
+        - ``"bcouts"`` and ``"YBCtrace"`` when boundary conditions are used
+        - ``"OFFSETtrace"`` when offsets are enabled
+        - ``"trace"``, ``"model"``, and convergence metadata
 
-            The returned dict is intended to contain enough information for
-            postprocessing and diagnostic checks (convergence, effective sample
-            size, R-hat, and so on). Exact key names and contents may vary with
-            sampler settings and options used.
+        Raises:
+            ValueError: If the model cannot be built from the supplied
+                ``inv_inputs`` and configuration.
     """
     burn = int(burn)
     nit = int(nit)
 
     setup = build_inferpymc_model(
-        Hx=Hx,
-        Y=Y,
-        error=error,
-        siteindicator=siteindicator,
-        sigma_freq_index=sigma_freq_index,
-        Hbc=Hbc,
         xprior=xprior,
         bcprior=bcprior,
         sigprior=sigprior,
         sigma_per_site=sigma_per_site,
         offsetprior=offsetprior,
         add_offset=add_offset,
-        min_error=min_error,
         use_bc=use_bc,
         reparameterise_log_normal=reparameterise_log_normal,
         pollution_events_from_obs=pollution_events_from_obs,
@@ -976,9 +455,6 @@ def inferpymc(
         power=power,
         nuts_sampler=nuts_sampler,
         inv_inputs=inv_inputs,
-        state=state,
-        bc_state=bc_state,
-        model_builder=model_builder,
     )
 
     sampler_kwargs = sampler_kwargs or {}

--- a/openghg_inversions/inversion_inputs.py
+++ b/openghg_inversions/inversion_inputs.py
@@ -178,7 +178,9 @@ def transform_bc(
 
 
 # INVERSION INPUTS PIPELINE
-def _drop_nan_and_compute(ds: xr.Dataset, drop_nan_from: Iterable[str] = ("H", "H_bc", "mf", "mf_error")) -> xr.Dataset:
+def _drop_nan_and_compute(
+    ds: xr.Dataset, drop_nan_from: Iterable[str] = ("H", "H_bc", "mf", "mf_error")
+) -> xr.Dataset:
     """Drop NaNs in required inversion variables and materialize core variables.
 
     This centralizes the dataset cleanup that was previously duplicated in

--- a/openghg_inversions/inversion_inputs.py
+++ b/openghg_inversions/inversion_inputs.py
@@ -79,6 +79,8 @@ def make_freq_indicator(
         return time.dt.month - time.min().dt.month + 12 * (time.dt.year - time.min().dt.year)
 
     # fixed-duration freq strings (e.g. "8d", "12h", "3h")
+    if isinstance(freq, str) and freq.isalpha():
+        freq = f"1{freq}"
     anchor = np.datetime64(anchor_time) if anchor_time is not None else time.min().values
     dt = np.timedelta64(pd.to_timedelta(freq).value, "ns")  # robust to xarray dtype
     idx = ((time.values.astype("datetime64[ns]") - anchor) // dt).astype(int)

--- a/openghg_inversions/models/coords.py
+++ b/openghg_inversions/models/coords.py
@@ -5,7 +5,7 @@ from stacked or ragged dimensions such as ``nmeasure`` representing stacked
 ``(site, time)`` observations. PyMC does not reliably accept all such objects as
 model coordinates, so model construction should use sanitized, PyMC-safe coords.
 
-For Stage C, the sanitization policy is intentionally simple: convert each known
+The current sanitization policy is intentionally simple: convert each known
 dimension coordinate to a range index. The original scientific coordinates are
 stored separately so they can later be restored onto ArviZ ``InferenceData``.
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,9 @@ default-groups = ["uv_dev"]
 line-length = 110
 target-version = ["py310"]
 
+[tool.ruff]
+line-length = 110
+
 [tool.pytest.ini_options]
 minversion = "6.0"
 testpaths = ["tests"]

--- a/tests/models/test_components.py
+++ b/tests/models/test_components.py
@@ -17,7 +17,10 @@ from openghg_inversions.models.coords import CoordRegistry, attach_coord_registr
 def _obs_index() -> pd.MultiIndex:
     """Create a stacked observation index used by component tests."""
     return pd.MultiIndex.from_arrays(
-        [["MHD", "MHD", "TAC", "TAC"], pd.to_datetime(["2019-01-01", "2019-01-02", "2019-02-01", "2019-02-02"])],
+        [
+            ["MHD", "MHD", "TAC", "TAC"],
+            pd.to_datetime(["2019-01-01", "2019-01-02", "2019-02-01", "2019-02-02"]),
+        ],
         names=["site", "time"],
     )
 
@@ -119,7 +122,11 @@ def test_add_sigma_component_supports_explicit_and_derived_freq() -> None:
 
     with pm.Model(coords={"nmeasure": np.arange(4)}) as model:
         attach_coord_registry(model, CoordRegistry())
-        add_sigma_component(site_indicator, prior_args={"pdf": "uniform", "lower": 0.1, "upper": 1.0}, sigma_freq_index=sigma_freq_index)
+        add_sigma_component(
+            site_indicator,
+            prior_args={"pdf": "uniform", "lower": 0.1, "upper": 1.0},
+            sigma_freq_index=sigma_freq_index,
+        )
         assert "sigma" in model.named_vars
         assert "sigma_freq_index" in model.named_vars
 

--- a/tests/models/test_components.py
+++ b/tests/models/test_components.py
@@ -89,12 +89,7 @@ def test_add_linear_component_creates_expected_named_vars() -> None:
 
 
 def test_add_linear_component_returns_effective_reparameterised_latent() -> None:
-    """Check the component result exposes the true reparameterized latent variable.
-
-    This is a temporary refactor-support test. It protects the Stage C
-    component API while the legacy and component builders coexist and ensures
-    the builder does not need to inspect model internals to find ``x_latent``.
-    """
+    """Check the component result exposes the true reparameterized latent variable."""
     data = xr.DataArray(
         np.ones((4, 2)),
         dims=("nmeasure", "nx"),

--- a/tests/test_full_inversion.py
+++ b/tests/test_full_inversion.py
@@ -217,8 +217,7 @@ def test_full_inversion_two_sites(mcmc_args, mhd_and_tac_ch4_data_args):
 def test_full_inversion_offset_args(mcmc_args):
     """Test full inversion accepts explicit offset arguments through runtime plumbing."""
     mcmc_args["add_offset"] = True
-    mcmc_args["offset_args"] = {"drop_first": False,
-                                "offset_freq": "D"}
+    mcmc_args["offset_args"] = {"drop_first": False, "offset_freq": "D"}
     fixedbasisMCMC(**mcmc_args)
 
 

--- a/tests/test_full_inversion.py
+++ b/tests/test_full_inversion.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 
 from openghg_inversions.hbmcmc.hbmcmc import fixedbasisMCMC
-from conftest import raw_data_path
 
 
 @pytest.fixture
@@ -158,15 +157,9 @@ def test_full_inversion_lognormal_reparam(mcmc_args):
 
 
 def test_full_inversion_paris_outputs_lognormal_reparam_conflict(mcmc_args):
-    """Check PARIS outputs ignore reparameterized latent-only traces.
-
-    This regression test covers the Stage C components builder path, where
-    reparameterized lognormal priors add ``x_latent`` traces that should not be
-    treated as public emissions traces by post-processing.
-    """
+    """Check PARIS outputs ignore reparameterized latent-only traces."""
     mcmc_args["reload_merged_data"] = False
     mcmc_args["output_format"] = "paris"
-    mcmc_args["model_builder"] = "components"
     mcmc_args["reparameterise_log_normal"] = True
     mcmc_args["xprior"] = {"pdf": "lognormal", "mu": 1.0, "sigma": 1.0}
 
@@ -218,12 +211,6 @@ def test_full_inversion_two_sites(mcmc_args, mhd_and_tac_ch4_data_args):
     mcmc_args["reload_merged_data"] = False
     mcmc_args["add_offset"] = True
     mcmc_args["offset_args"] = {"drop_first": True}
-    fixedbasisMCMC(**mcmc_args)
-
-
-def test_full_inversion_components_builder(mcmc_args):
-    """Test full inversion can opt into the temporary components builder."""
-    mcmc_args["model_builder"] = "components"
     fixedbasisMCMC(**mcmc_args)
 
 

--- a/tests/test_inferpymc.py
+++ b/tests/test_inferpymc.py
@@ -111,7 +111,9 @@ def inferpymc_with_bc_result(inferpymc_args: dict):
     return inferpymc(**inferpymc_args)
 
 
-def test_inferpymc_runs_on_inversion_inputs(inferpymc_inputs_dataset: xr.Dataset, inferpymc_with_bc_result) -> None:
+def test_inferpymc_runs_on_inversion_inputs(
+    inferpymc_inputs_dataset: xr.Dataset, inferpymc_with_bc_result
+) -> None:
     result = inferpymc_with_bc_result
 
     expected_keys = {
@@ -130,8 +132,12 @@ def test_inferpymc_runs_on_inversion_inputs(inferpymc_inputs_dataset: xr.Dataset
     assert expected_keys.issubset(result.keys())
 
     assert result["xouts"].sizes["nx"] == inferpymc_inputs_dataset.sizes["region"]
-    assert result["sigouts"].sizes["nsigma_time"] == len(np.unique(inferpymc_inputs_dataset["sigma_freq_index"].values))
-    assert result["sigouts"].sizes["nsigma_site"] == len(np.unique(inferpymc_inputs_dataset["site_indicator"].values))
+    assert result["sigouts"].sizes["nsigma_time"] == len(
+        np.unique(inferpymc_inputs_dataset["sigma_freq_index"].values)
+    )
+    assert result["sigouts"].sizes["nsigma_site"] == len(
+        np.unique(inferpymc_inputs_dataset["site_indicator"].values)
+    )
 
     y = inferpymc_inputs_dataset["mf"].values
     assert y.size in result["Ytrace"].shape
@@ -167,8 +173,12 @@ def test_inferpymc_model_contains_expected_variables(
     assert len(model.coords["nmeasure"]) == inferpymc_inputs_dataset.sizes["nmeasure"]
     assert len(model.coords["nx"]) == inferpymc_inputs_dataset.sizes["region"]
     assert len(model.coords["nbc"]) == inferpymc_inputs_dataset.sizes["bc_region"]
-    assert len(model.coords["nsigma_site"]) == len(np.unique(inferpymc_inputs_dataset["site_indicator"].values))
-    assert len(model.coords["nsigma_time"]) == len(np.unique(inferpymc_inputs_dataset["sigma_freq_index"].values))
+    assert len(model.coords["nsigma_site"]) == len(
+        np.unique(inferpymc_inputs_dataset["site_indicator"].values)
+    )
+    assert len(model.coords["nsigma_time"]) == len(
+        np.unique(inferpymc_inputs_dataset["sigma_freq_index"].values)
+    )
 
 
 def test_build_inferpymc_model_accepts_dataset(

--- a/tests/test_inferpymc.py
+++ b/tests/test_inferpymc.py
@@ -7,70 +7,19 @@ import pymc as pm
 import pytest
 import xarray as xr
 
-from openghg_inversions.hbmcmc.hbmcmc import make_inv_inputs_legacy
 from openghg_inversions.inversion_inputs import make_inv_inputs
 from openghg_inversions.hbmcmc.inversion_pymc import (
     InferPyMCModelSetup,
     _canonicalise_inferpymc_dataset,
-    _prepare_inferpymc_inputs,
-    _restore_inferencedata_coords,
     build_inferpymc_model,
     inferpymc,
 )
-
-
-@pytest.fixture(scope="module")
-def inferpymc_args(mhd_and_tac_fp_data) -> MappingProxyType:
-    """Create direct inputs for inferpymc using existing inversion input machinery.
-
-    NOTE: the module level scope allows us to define other module scoped fixtures
-    using this fixture, but it means we need to be careful about not mutating the
-    return of the fixture.
-
-    The result is wrapped in a MappingProxyType as a precaution.
-    """
-    mcmc_args, _ = make_inv_inputs_legacy(
-        fp_data=mhd_and_tac_fp_data,
-        sites=["MHD", "TAC"],
-        start_date="2019-01-01",
-        use_bc=True,
-        bc_freq="3h",
-        sigma_freq="3h",
-        min_error="percentile",
-        calculate_min_error=None,
-        min_error_options={},
-    )
-
-    mcmc_args.update(
-        {
-            "nit": 1,
-            "burn": 0,
-            "tune": 0,
-            "nchain": 1,
-            "xprior": {"pdf": "normal", "mu": 1.0, "sigma": 1.0},
-            "bcprior": {"pdf": "normal", "mu": 1.0, "sigma": 1.0},
-            "sigprior": {"pdf": "uniform", "lower": 0.1, "upper": 10.0},
-            "sigma_per_site": True,
-            "offsetprior": {"pdf": "normal", "mu": 0, "sigma": 1},
-            "add_offset": False,
-            "min_error": 0.0,
-            "use_bc": True,
-            "reparameterise_log_normal": False,
-            "pollution_events_from_obs": True,
-            "no_model_error": False,
-            "offset_args": {"drop_first": False, "offset_freq": "D"},
-            "power": 1.99,
-            "verbose": False,
-            "sampler_kwargs": {"random_seed": 123, "compute_convergence_checks": False},
-        }
-    )
-    return MappingProxyType(mcmc_args)
+from openghg_inversions.models.coords import restore_inferencedata_coords
 
 
 @pytest.fixture(scope="module")
 def inferpymc_inputs_dataset(mhd_and_tac_fp_data) -> xr.Dataset:
-    """Create xarray inversion inputs for the Stage B dataset path."""
-    ds = make_inv_inputs(
+    return make_inv_inputs(
         mhd_and_tac_fp_data,
         sites=["MHD", "TAC"],
         bc_freq="3h",
@@ -79,26 +28,43 @@ def inferpymc_inputs_dataset(mhd_and_tac_fp_data) -> xr.Dataset:
         min_error_per_site=False,
         start_date="2019-01-01",
     )
-    return ds
 
 
-@pytest.mark.parametrize("model_builder", ["legacy", "components"])
-def test_build_inferpymc_model_returns_setup_for_pymc(inferpymc_args: dict, model_builder: str) -> None:
-    """Check extracted model builder returns PyMC step methods for the pymc sampler."""
+@pytest.fixture(scope="module")
+def inferpymc_args(inferpymc_inputs_dataset: xr.Dataset) -> MappingProxyType:
+    args = {
+        "inv_inputs": inferpymc_inputs_dataset,
+        "nit": 1,
+        "burn": 0,
+        "tune": 0,
+        "nchain": 1,
+        "xprior": {"pdf": "normal", "mu": 1.0, "sigma": 1.0},
+        "bcprior": {"pdf": "normal", "mu": 1.0, "sigma": 1.0},
+        "sigprior": {"pdf": "uniform", "lower": 0.1, "upper": 10.0},
+        "sigma_per_site": True,
+        "offsetprior": {"pdf": "normal", "mu": 0, "sigma": 1},
+        "add_offset": False,
+        "use_bc": True,
+        "reparameterise_log_normal": False,
+        "pollution_events_from_obs": True,
+        "no_model_error": False,
+        "offset_args": {"drop_first": False, "offset_freq": "D"},
+        "power": 1.99,
+        "verbose": False,
+        "sampler_kwargs": {"random_seed": 123, "compute_convergence_checks": False},
+    }
+    return MappingProxyType(args)
+
+
+def test_build_inferpymc_model_returns_setup_for_pymc(inferpymc_args: dict) -> None:
     setup = build_inferpymc_model(
-        Hx=inferpymc_args["Hx"],
-        Y=inferpymc_args["Y"],
-        error=inferpymc_args["error"],
-        siteindicator=inferpymc_args["siteindicator"],
-        sigma_freq_index=inferpymc_args["sigma_freq_index"],
-        Hbc=inferpymc_args["Hbc"],
+        inv_inputs=inferpymc_args["inv_inputs"],
         xprior=inferpymc_args["xprior"],
         bcprior=inferpymc_args["bcprior"],
         sigprior=inferpymc_args["sigprior"],
         sigma_per_site=inferpymc_args["sigma_per_site"],
         offsetprior=inferpymc_args["offsetprior"],
         add_offset=inferpymc_args["add_offset"],
-        min_error=inferpymc_args["min_error"],
         use_bc=inferpymc_args["use_bc"],
         reparameterise_log_normal=inferpymc_args["reparameterise_log_normal"],
         pollution_events_from_obs=inferpymc_args["pollution_events_from_obs"],
@@ -106,7 +72,6 @@ def test_build_inferpymc_model_returns_setup_for_pymc(inferpymc_args: dict, mode
         offset_args=inferpymc_args["offset_args"],
         power=inferpymc_args["power"],
         nuts_sampler="pymc",
-        model_builder=model_builder,
     )
 
     assert isinstance(setup, InferPyMCModelSetup)
@@ -116,27 +81,15 @@ def test_build_inferpymc_model_returns_setup_for_pymc(inferpymc_args: dict, mode
     assert setup.sample_kwargs["step"] == [setup.step1, setup.step2]
 
 
-@pytest.mark.parametrize("model_builder", ["legacy", "components"])
-def test_build_inferpymc_model_returns_no_steps_for_numpyro(inferpymc_args: dict, model_builder: str) -> None:
-    """Check model setup does not pass steps them via sample_kwargs['step'] for the numpyro sampler.
-
-    The steps are still created by build_inferpymc_model and stored in the dataclass. This matches
-    the pre-existing behaviour, but perhaps should be changed.
-    """
+def test_build_inferpymc_model_returns_no_steps_for_numpyro(inferpymc_args: dict) -> None:
     setup = build_inferpymc_model(
-        Hx=inferpymc_args["Hx"],
-        Y=inferpymc_args["Y"],
-        error=inferpymc_args["error"],
-        siteindicator=inferpymc_args["siteindicator"],
-        sigma_freq_index=inferpymc_args["sigma_freq_index"],
-        Hbc=inferpymc_args["Hbc"],
+        inv_inputs=inferpymc_args["inv_inputs"],
         xprior=inferpymc_args["xprior"],
         bcprior=inferpymc_args["bcprior"],
         sigprior=inferpymc_args["sigprior"],
         sigma_per_site=inferpymc_args["sigma_per_site"],
         offsetprior=inferpymc_args["offsetprior"],
         add_offset=inferpymc_args["add_offset"],
-        min_error=inferpymc_args["min_error"],
         use_bc=inferpymc_args["use_bc"],
         reparameterise_log_normal=inferpymc_args["reparameterise_log_normal"],
         pollution_events_from_obs=inferpymc_args["pollution_events_from_obs"],
@@ -144,7 +97,6 @@ def test_build_inferpymc_model_returns_no_steps_for_numpyro(inferpymc_args: dict
         offset_args=inferpymc_args["offset_args"],
         power=inferpymc_args["power"],
         nuts_sampler="numpyro",
-        model_builder=model_builder,
     )
 
     assert isinstance(setup, InferPyMCModelSetup)
@@ -156,16 +108,10 @@ def test_build_inferpymc_model_returns_no_steps_for_numpyro(inferpymc_args: dict
 
 @pytest.fixture(scope="module")
 def inferpymc_with_bc_result(inferpymc_args: dict):
-    """Run inferpymc with inferpymc_args, including use_bc=True.
-
-    The results from `inferpymc(**inferpymc_args)` are used at least
-    twice in the tests, so this fixture saves some computation.
-    """
     return inferpymc(**inferpymc_args)
 
 
-def test_inferpymc_runs_on_inversion_inputs(inferpymc_args: dict, inferpymc_with_bc_result) -> None:
-    """Smoke test inferpymc directly on prepared inversion inputs."""
+def test_inferpymc_runs_on_inversion_inputs(inferpymc_inputs_dataset: xr.Dataset, inferpymc_with_bc_result) -> None:
     result = inferpymc_with_bc_result
 
     expected_keys = {
@@ -183,15 +129,11 @@ def test_inferpymc_runs_on_inversion_inputs(inferpymc_args: dict, inferpymc_with
     }
     assert expected_keys.issubset(result.keys())
 
-    y = np.asarray(inferpymc_args["Y"])
-    hx = np.asarray(inferpymc_args["Hx"])
-    siteindicator = np.asarray(inferpymc_args["siteindicator"])
-    sigma_freq_index = np.asarray(inferpymc_args["sigma_freq_index"])
+    assert result["xouts"].sizes["nx"] == inferpymc_inputs_dataset.sizes["region"]
+    assert result["sigouts"].sizes["nsigma_time"] == len(np.unique(inferpymc_inputs_dataset["sigma_freq_index"].values))
+    assert result["sigouts"].sizes["nsigma_site"] == len(np.unique(inferpymc_inputs_dataset["site_indicator"].values))
 
-    assert result["xouts"].sizes["nx"] == hx.shape[0]
-    assert result["sigouts"].sizes["nsigma_time"] == len(np.unique(sigma_freq_index))
-    assert result["sigouts"].sizes["nsigma_site"] == len(np.unique(siteindicator))
-
+    y = inferpymc_inputs_dataset["mf"].values
     assert y.size in result["Ytrace"].shape
     assert result["OFFSETtrace"].shape == result["Ytrace"].shape
     assert result["YBCtrace"].shape == result["Ytrace"].shape
@@ -201,10 +143,10 @@ def test_inferpymc_runs_on_inversion_inputs(inferpymc_args: dict, inferpymc_with
     assert np.isfinite(result["YBCtrace"]).all()
 
 
-def test_inferpymc_model_contains_expected_variables(inferpymc_args: dict, inferpymc_with_bc_result) -> None:
-    """Check that inferpymc builds the expected PyMC model structure."""
-    result = inferpymc_with_bc_result
-    model = result["model"]
+def test_inferpymc_model_contains_expected_variables(
+    inferpymc_inputs_dataset: xr.Dataset, inferpymc_with_bc_result
+) -> None:
+    model = inferpymc_with_bc_result["model"]
 
     expected_named_vars = {
         "x",
@@ -220,62 +162,18 @@ def test_inferpymc_model_contains_expected_variables(inferpymc_args: dict, infer
         "epsilon",
         "y",
     }
-
     assert expected_named_vars.issubset(model.named_vars)
 
-    coords = model.coords
-    y = np.asarray(inferpymc_args["Y"])
-    hx = np.asarray(inferpymc_args["Hx"])
-    hbc = np.asarray(inferpymc_args["Hbc"])
-    siteindicator = np.asarray(inferpymc_args["siteindicator"])
-    sigma_freq_index = np.asarray(inferpymc_args["sigma_freq_index"])
-
-    assert len(coords["nmeasure"]) == y.size
-    assert len(coords["nx"]) == hx.shape[0]
-    assert len(coords["nbc"]) == hbc.shape[0]
-    assert len(coords["nsigma_site"]) == len(np.unique(siteindicator))
-    assert len(coords["nsigma_time"]) == len(np.unique(sigma_freq_index))
+    assert len(model.coords["nmeasure"]) == inferpymc_inputs_dataset.sizes["nmeasure"]
+    assert len(model.coords["nx"]) == inferpymc_inputs_dataset.sizes["region"]
+    assert len(model.coords["nbc"]) == inferpymc_inputs_dataset.sizes["bc_region"]
+    assert len(model.coords["nsigma_site"]) == len(np.unique(inferpymc_inputs_dataset["site_indicator"].values))
+    assert len(model.coords["nsigma_time"]) == len(np.unique(inferpymc_inputs_dataset["sigma_freq_index"].values))
 
 
-def test_prepare_inferpymc_inputs_dataset_matches_legacy(
+def test_build_inferpymc_model_accepts_dataset(
     inferpymc_args: dict, inferpymc_inputs_dataset: xr.Dataset
 ) -> None:
-    """Check dataset and legacy preparation paths agree on core arrays."""
-    prepared_dataset = _prepare_inferpymc_inputs(
-        inv_inputs=inferpymc_inputs_dataset,
-        sigma_per_site=True,
-        use_bc=True,
-        state="region",
-        bc_state="bc_region",
-    )
-    prepared_legacy = _prepare_inferpymc_inputs(
-        Hx=inferpymc_args["Hx"],
-        Y=inferpymc_args["Y"],
-        error=inferpymc_args["error"],
-        siteindicator=inferpymc_args["siteindicator"],
-        sigma_freq_index=inferpymc_args["sigma_freq_index"],
-        Hbc=inferpymc_args["Hbc"],
-        min_error=inferpymc_args["min_error"],
-        sigma_per_site=True,
-        use_bc=True,
-    )
-
-    np.testing.assert_allclose(prepared_dataset.hx, prepared_legacy.hx)
-    np.testing.assert_allclose(prepared_dataset.y, prepared_legacy.y)
-    np.testing.assert_allclose(prepared_dataset.error, prepared_legacy.error)
-    np.testing.assert_array_equal(prepared_dataset.site_indicator, prepared_legacy.site_indicator)
-    np.testing.assert_array_equal(prepared_dataset.sigma_freq_index, prepared_legacy.sigma_freq_index)
-    assert prepared_dataset.hbc is not None
-    assert prepared_legacy.hbc is not None
-    np.testing.assert_allclose(prepared_dataset.hbc, prepared_legacy.hbc)
-    assert prepared_dataset.original_coords
-
-
-@pytest.mark.parametrize("model_builder", ["legacy", "components"])
-def test_build_inferpymc_model_accepts_dataset(
-    inferpymc_args: dict, inferpymc_inputs_dataset: xr.Dataset, model_builder: str
-) -> None:
-    """Check model builder accepts direct xarray inversion inputs."""
     setup = build_inferpymc_model(
         inv_inputs=inferpymc_inputs_dataset,
         xprior=inferpymc_args["xprior"],
@@ -291,7 +189,6 @@ def test_build_inferpymc_model_accepts_dataset(
         offset_args=inferpymc_args["offset_args"],
         power=inferpymc_args["power"],
         nuts_sampler="pymc",
-        model_builder=model_builder,
     )
 
     assert isinstance(setup, InferPyMCModelSetup)
@@ -303,23 +200,9 @@ def test_build_inferpymc_model_accepts_dataset(
 def test_canonicalise_inferpymc_dataset_preserves_dataset_observation_coords(
     inferpymc_inputs_dataset: xr.Dataset,
 ) -> None:
-    """Check canonicalisation keeps dataset observation coordinates intact.
+    canonical = _canonicalise_inferpymc_dataset(inferpymc_inputs_dataset, use_bc=True)
 
-    This is a temporary refactor-support test. It guards the Stage B to Stage C
-    adapter so the new component builder can be introduced without changing the
-    scientific observation coordinates carried by dataset inputs.
-    """
-    prepared_inputs = _prepare_inferpymc_inputs(
-        inv_inputs=inferpymc_inputs_dataset,
-        sigma_per_site=True,
-        use_bc=True,
-        state="region",
-        bc_state="bc_region",
-    )
-
-    canonical = _canonicalise_inferpymc_dataset(prepared_inputs, use_bc=True)
-
-    assert set(["H", "H_bc", "mf", "mf_error", "site_indicator", "sigma_freq_index", "min_error"]).issubset(
+    assert {"H", "H_bc", "mf", "mf_error", "site_indicator", "sigma_freq_index", "min_error"}.issubset(
         canonical.data_vars
     )
     assert canonical["H"].dims == ("nmeasure", "nx")
@@ -328,60 +211,7 @@ def test_canonicalise_inferpymc_dataset_preserves_dataset_observation_coords(
     assert canonical.indexes["nmeasure"].equals(inferpymc_inputs_dataset.indexes["nmeasure"])
 
 
-def test_canonicalise_inferpymc_dataset_expands_scalar_min_error(inferpymc_args: dict) -> None:
-    """Check canonicalisation expands scalar min_error to the observation dimension.
-
-    This is a temporary refactor-support test for the Stage B to Stage C
-    adapter, which is expected to disappear once the legacy plumbing is removed.
-    """
-    prepared_inputs = _prepare_inferpymc_inputs(
-        Hx=inferpymc_args["Hx"],
-        Y=inferpymc_args["Y"],
-        error=inferpymc_args["error"],
-        siteindicator=inferpymc_args["siteindicator"],
-        sigma_freq_index=inferpymc_args["sigma_freq_index"],
-        Hbc=inferpymc_args["Hbc"],
-        min_error=0.0,
-        sigma_per_site=True,
-        use_bc=True,
-    )
-
-    canonical = _canonicalise_inferpymc_dataset(prepared_inputs, use_bc=True)
-    assert canonical["min_error"].sizes["nmeasure"] == canonical.sizes["nmeasure"]
-    np.testing.assert_array_equal(canonical["min_error"].values, np.zeros(canonical.sizes["nmeasure"]))
-
-
-def test_build_inferpymc_model_rejects_mixed_input_modes(
-    inferpymc_args: dict, inferpymc_inputs_dataset: xr.Dataset
-) -> None:
-    """Check dataset and legacy input paths cannot be combined."""
-    with pytest.raises(ValueError, match="cannot be combined"):
-        build_inferpymc_model(
-            inv_inputs=inferpymc_inputs_dataset,
-            Hx=inferpymc_args["Hx"],
-            Y=inferpymc_args["Y"],
-            error=inferpymc_args["error"],
-            siteindicator=inferpymc_args["siteindicator"],
-            sigma_freq_index=inferpymc_args["sigma_freq_index"],
-        )
-
-
-def test_build_inferpymc_model_rejects_unknown_builder(inferpymc_args: dict) -> None:
-    """Check the public builder selector rejects unsupported values."""
-    with pytest.raises(ValueError, match="Unsupported model_builder"):
-        build_inferpymc_model(
-            Hx=inferpymc_args["Hx"],
-            Y=inferpymc_args["Y"],
-            error=inferpymc_args["error"],
-            siteindicator=inferpymc_args["siteindicator"],
-            sigma_freq_index=inferpymc_args["sigma_freq_index"],
-            Hbc=inferpymc_args["Hbc"],
-            model_builder="definitely-not-real",
-        )
-
-
 def test_restore_inferencedata_coords_helper_restores_multiindex() -> None:
-    """Check restoration helper can re-attach a MultiIndex coordinate."""
     multi_index = pd.MultiIndex.from_arrays(
         [["MHD", "MHD", "TAC"], pd.to_datetime(["2019-01-01", "2019-01-02", "2019-01-01"])],
         names=["site", "time"],
@@ -392,19 +222,17 @@ def test_restore_inferencedata_coords_helper_restores_multiindex() -> None:
     )
     idata = az.InferenceData(posterior=posterior)
 
-    restored = _restore_inferencedata_coords(idata, {"nmeasure": multi_index})
+    restored = restore_inferencedata_coords(idata, {"nmeasure": multi_index})
 
     assert "nmeasure" in restored.posterior.indexes
     assert restored.posterior.indexes["nmeasure"].equals(multi_index)
 
 
 def test_inferpymc_runs_without_boundary_conditions(inferpymc_args: dict) -> None:
-    """Check inferpymc direct call when boundary conditions are disabled."""
-    inferpymc_args = dict(inferpymc_args)
-    inferpymc_args["use_bc"] = False
-    inferpymc_args["Hbc"] = None
+    args = dict(inferpymc_args)
+    args["use_bc"] = False
 
-    result = inferpymc(**inferpymc_args)
+    result = inferpymc(**args)
 
     assert "bcouts" not in result
     assert "YBCtrace" not in result
@@ -413,19 +241,3 @@ def test_inferpymc_runs_without_boundary_conditions(inferpymc_args: dict) -> Non
     assert "bc" not in model.named_vars
     assert "hbc" not in model.named_vars
     assert "mu_bc" not in model.named_vars
-
-
-def test_inferpymc_accepts_components_builder(inferpymc_args: dict) -> None:
-    """Check inferpymc forwards the temporary component-builder selector.
-
-    This is a temporary refactor-support test for the Stage C legacy/components
-    split and can be simplified or removed once Stage D makes the component
-    builder the default runtime path.
-    """
-    args = dict(inferpymc_args)
-    args["model_builder"] = "components"
-
-    result = inferpymc(**args)
-
-    assert "xouts" in result
-    assert "sigouts" in result

--- a/tests/test_inferpymc_month_gap.py
+++ b/tests/test_inferpymc_month_gap.py
@@ -5,8 +5,9 @@ import pandas as pd
 import xarray as xr
 
 from openghg_inversions import utils
-from openghg_inversions.hbmcmc.hbmcmc import make_inv_inputs_legacy
+from openghg_inversions.inversion_inputs import make_inv_inputs
 from openghg_inversions.hbmcmc.inversion_pymc import (
+    _canonicalise_inferpymc_dataset,
     _weighted_apriori_flux_for_months,
     inferpymc,
 )
@@ -52,39 +53,38 @@ def _synthetic_fp_data_one_site_with_missing_month() -> dict[str, xr.Dataset]:
 def test_make_inv_inputs_month_gap_monthly_indices_are_non_contiguous():
     fp_data = _synthetic_fp_data_one_site_with_missing_month()
 
-    mcmc_args, _ = make_inv_inputs_legacy(
-        fp_data=fp_data,
+    inv_inputs = make_inv_inputs(
+        fp_data,
         sites=["AAA"],
-        start_date="2019-01-01",
-        use_bc=True,
         bc_freq="monthly",
         sigma_freq="monthly",
         min_error=0.0,
-        calculate_min_error=None,
-        min_error_options={},
+        min_error_per_site=False,
+        start_date="2019-01-01",
     )
 
-    uniq = np.unique(mcmc_args["sigma_freq_index"])
+    uniq = np.unique(inv_inputs["sigma_freq_index"].values)
     np.testing.assert_array_equal(uniq, np.array([0, 2]))
+
+    canonical = _canonicalise_inferpymc_dataset(inv_inputs, use_bc=True)
+    np.testing.assert_array_equal(np.unique(canonical["sigma_freq_index"].values), np.array([0, 1]))
 
 
 def test_inferpymc_smoke_runs_for_month_gap():
     fp_data = _synthetic_fp_data_one_site_with_missing_month()
 
-    mcmc_args, _ = make_inv_inputs_legacy(
-        fp_data=fp_data,
+    inv_inputs = make_inv_inputs(
+        fp_data,
         sites=["AAA"],
-        start_date="2019-01-01",
-        use_bc=True,
         bc_freq="monthly",
         sigma_freq="monthly",
         min_error=0.0,
-        calculate_min_error=None,
-        min_error_options={},
+        min_error_per_site=False,
+        start_date="2019-01-01",
     )
 
     result = inferpymc(
-        **mcmc_args,
+        inv_inputs=inv_inputs,
         xprior={"pdf": "normal", "mu": 1.0, "sigma": 1.0},
         bcprior={"pdf": "normal", "mu": 1.0, "sigma": 0.1},
         sigprior={"pdf": "uniform", "lower": 0.1, "upper": 0.4},

--- a/tests/test_inferpymc_month_gap.py
+++ b/tests/test_inferpymc_month_gap.py
@@ -29,7 +29,9 @@ def _synthetic_fp_data_one_site_with_missing_month() -> dict[str, xr.Dataset]:
             np.linspace(0.1, 0.4, ntime),
         ]
     ).astype(np.float32)
-    h_bc = (np.arange(1, len(bc_regions) + 1)[:, None] * np.linspace(0.01, 0.1, ntime)[None, :]).astype(np.float32)
+    h_bc = (np.arange(1, len(bc_regions) + 1)[:, None] * np.linspace(0.01, 0.1, ntime)[None, :]).astype(
+        np.float32
+    )
 
     ds = xr.Dataset(
         data_vars={

--- a/tests/test_inversion_inputs.py
+++ b/tests/test_inversion_inputs.py
@@ -1,4 +1,16 @@
-"""Test functions for creating inputs for PyMC."""
+"""Regression tests for inversion-input preparation.
+
+This module is intentionally transitional.
+
+The committed ``.npz`` fixture stores a legacy-shaped projection of
+``make_inv_inputs(...)`` output so that changes to the new inversion-input
+pipeline can still be checked conservatively against a frozen reference used
+during the refactor.
+
+The marked ``create_frozen`` test is developer-only. Running it rewrites the
+committed frozen data file and should only be done when the reference fixture is
+being intentionally refreshed.
+"""
 
 from pathlib import Path
 
@@ -7,8 +19,7 @@ from numpy.testing import assert_almost_equal
 import pytest
 import xarray as xr
 
-from openghg_inversions.hbmcmc.hbmcmc import make_inv_inputs_legacy
-from openghg_inversions.inversion_inputs import add_site_indicator, concat_gather_datasets
+from openghg_inversions.inversion_inputs import add_site_indicator, concat_gather_datasets, make_inv_inputs
 
 
 # Helpers for saving result of make_inv_inputs
@@ -91,23 +102,98 @@ def inv_inputs_args(mhd_and_tac_fp_data):
 
 @pytest.mark.create_frozen
 def test_inversion_input_create_frozen(raw_data_path, inv_inputs_args):
-    """This 'test' just regenerates frozen data for use in other tests."""
-    mcmc_args, post_args = make_inv_inputs_legacy(**inv_inputs_args)
+    """Regenerate the committed frozen compatibility fixture.
 
+    This test is not intended for routine runs. It exists only so developers can
+    intentionally refresh the committed ``.npz`` file when the frozen reference
+    for this transitional regression check needs to change.
+    """
     out_name = raw_data_path / "frozen_mhd_tac_make_inv_inputs_hbmcmc.npz"
-    save_frozen_npz(out_name, mcmc_args=mcmc_args, post_process_args=post_args)
+    inv_inputs = make_inv_inputs(
+        **{
+            k: v
+            for k, v in inv_inputs_args.items()
+            if k != "calculate_min_error" and k != "use_bc" and k != "min_error_options"
+        },
+        min_error_per_site=inv_inputs_args["min_error_options"].get("by_site", False),
+    )
+    obs_prior_factor = (
+        inv_inputs.mf_prior_factor.values
+        if "mf_prior_factor" in inv_inputs
+        else np.zeros_like(inv_inputs.mf.values)
+    )
+    obs_prior_upper_level_factor = (
+        inv_inputs.mf_prior_upper_level_factor.values
+        if "mf_prior_upper_level_factor" in inv_inputs
+        else np.zeros_like(inv_inputs.mf.values)
+    )
+
+    save_frozen_npz(
+        out_name,
+        mcmc_args={
+            "Hx": inv_inputs.H.values,
+            "Y": inv_inputs.mf.values,
+            "error": inv_inputs.mf_error.values,
+            "siteindicator": inv_inputs.site_indicator.values,
+            "sigma_freq_index": inv_inputs.sigma_freq_index.values,
+            "min_error": inv_inputs.min_error.values,
+            "Hbc": inv_inputs.H_bc.values,
+        },
+        post_process_args={
+            "Ytime": inv_inputs.time.values,
+            "obs_repeatability": inv_inputs.mf_repeatability.values,
+            "obs_variability": inv_inputs.mf_variability.values,
+            "obs_prior_factor": obs_prior_factor,
+            "obs_prior_upper_level_factor": obs_prior_upper_level_factor,
+        },
+    )
 
 
 def test_inversion_input_hbmcmc_matches_frozen(raw_data_path, inv_inputs_args):
-    """Test that result of make_inv_inputs from hbmcmc.py matches frozen data."""
+    """Check the current compatibility projection matches the frozen fixture."""
     frozen_path = raw_data_path / "frozen_mhd_tac_make_inv_inputs_hbmcmc.npz"
 
     frozen_mcmc, frozen_post = load_frozen_npz(frozen_path)
 
-    mcmc_args, post_args = make_inv_inputs_legacy(**inv_inputs_args)
+    inv_inputs = make_inv_inputs(
+        fp_data=inv_inputs_args["fp_data"],
+        sites=inv_inputs_args["sites"],
+        start_date=inv_inputs_args["start_date"],
+        bc_freq=inv_inputs_args["bc_freq"],
+        sigma_freq=inv_inputs_args["sigma_freq"],
+        min_error=inv_inputs_args["min_error"],
+        min_error_per_site=inv_inputs_args["min_error_options"].get("by_site", False),
+    )
 
-    _compare_with_frozen(mcmc_args, frozen_mcmc)
-    _compare_with_frozen(post_args, frozen_post)
+    result_mcmc = {
+        "Hx": inv_inputs.H.values,
+        "Y": inv_inputs.mf.values,
+        "error": inv_inputs.mf_error.values,
+        "siteindicator": inv_inputs.site_indicator.values,
+        "sigma_freq_index": inv_inputs.sigma_freq_index.values,
+        "min_error": inv_inputs.min_error.values,
+        "Hbc": inv_inputs.H_bc.values,
+    }
+    obs_prior_factor = (
+        inv_inputs.mf_prior_factor.values
+        if "mf_prior_factor" in inv_inputs
+        else np.zeros_like(inv_inputs.mf.values)
+    )
+    obs_prior_upper_level_factor = (
+        inv_inputs.mf_prior_upper_level_factor.values
+        if "mf_prior_upper_level_factor" in inv_inputs
+        else np.zeros_like(inv_inputs.mf.values)
+    )
+    result_post = {
+        "Ytime": inv_inputs.time.values,
+        "obs_repeatability": inv_inputs.mf_repeatability.values,
+        "obs_variability": inv_inputs.mf_variability.values,
+        "obs_prior_factor": obs_prior_factor,
+        "obs_prior_upper_level_factor": obs_prior_upper_level_factor,
+    }
+
+    _compare_with_frozen(result_mcmc, frozen_mcmc)
+    _compare_with_frozen(result_post, frozen_post)
 
 
 # ----------------------------------------

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -40,6 +40,7 @@ def mcmc_args(tmp_path, tac_ch4_data_args, merged_data_dir, merged_data_file_nam
 def inv_out(raw_data_path):
     return InversionOutput.load(raw_data_path / "inversion_output.nc")
 
+
 @pytest.fixture(scope="module")
 def inv_out_eastasia(raw_data_path):
     return InversionOutput.load(raw_data_path / "inversion_output_EASTASIA.nc")
@@ -85,6 +86,7 @@ def test_basic_outputs(inv_out, europe_country_file):
         for stat in stats:
             assert cv + "_" + stat in outs
 
+
 def test_basic_outputs_eastasia(inv_out_eastasia, eastasia_country_file):
     """Test creation of basic output for EASTASIA domain.
 
@@ -127,6 +129,7 @@ def test_make_paris_outputs(inv_out, europe_country_file, tmpdir, offset):
     flux_outs.to_netcdf(tmpdir / "flux.nc")
     conc_outs.to_netcdf(tmpdir / "conc.nc")
 
+
 def test_save_inversion_output(mcmc_args, tmpdir):
     """Check that we can save and reload inversion outputs"""
     mcmc_args["save_inversion_output"] = str(tmpdir / "inv_out.nc")
@@ -139,15 +142,8 @@ def test_save_inversion_output(mcmc_args, tmpdir):
 
 
 def test_country_outputs_lognormal_reparam_conflict(mcmc_args, europe_country_file):
-    """Check country outputs ignore reparameterized latent-only traces.
-
-    This is a smaller regression test for the Stage C components builder path.
-    It stops at the ``InversionOutput`` stage and checks that country
-    post-processing uses the public ``x`` trace rather than the internal
-    ``x_latent`` trace introduced by lognormal reparameterisation.
-    """
+    """Check country outputs ignore reparameterized latent-only traces."""
     mcmc_args["output_format"] = "inv_out"
-    mcmc_args["model_builder"] = "components"
     mcmc_args["reparameterise_log_normal"] = True
     mcmc_args["xprior"] = {"pdf": "lognormal", "mu": 1.0, "sigma": 1.0}
 

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -56,6 +56,7 @@ def test_rhime_flux_reprocessing(europe_country_file, raw_data_path):
     assert "flux_total_prior" in paris_outs
     assert "flux_total_posterior" in paris_outs
 
+
 def test_rhime_flux_reprocessing_eastasia(eastasia_country_file, raw_data_path):
     """Check that we can re-run PARIS flux outputs on standard RHIME outputs from EASTASIA."""
     rhime_outs = xr.open_dataset(raw_data_path / "standard_rhime_outs_EASTASIA.nc")
@@ -104,7 +105,7 @@ def test_basic_outputs_eastasia(inv_out_eastasia, eastasia_country_file):
 
     for cv in conc_vars:
         for stat in stats:
-            assert cv + "_" + stat in outs    
+            assert cv + "_" + stat in outs
 
 
 @pytest.mark.parametrize("offset", [False, True])
@@ -120,7 +121,9 @@ def test_make_paris_outputs(inv_out, europe_country_file, tmpdir, offset):
 
     print(inv_out.trace.posterior)
 
-    flux_outs, conc_outs = make_paris_outputs(inv_out, country_file=europe_country_file, obs_avg_period="1h", domain="europe")
+    flux_outs, conc_outs = make_paris_outputs(
+        inv_out, country_file=europe_country_file, obs_avg_period="1h", domain="europe"
+    )
 
     if offset:
         assert "Yapriori_bias" in conc_outs


### PR DESCRIPTION
* **Summary of changes**

This is Stage D of the multi-stage refactor of the PyMC code in inversions; see #370 for the overview issue.

## Summary

Stage D makes the component-based PyMC builder the only `inferpymc` path and moves the normal `fixedbasisMCMC` runtime onto `make_inv_inputs(...)` datasets.

## Main changes

- Removed the Stage C dual-builder scaffolding from `hbmcmc.inversion_pymc`:
  - removed the legacy builder path
  - removed builder dispatch and the `model_builder` flag
  - made `build_inferpymc_model(...)` directly use the component-based builder

- Switched `inferpymc(...)` to a dataset-first API:
  - `inferpymc(...)` now expects `inv_inputs`
  - removed legacy ndarray-style direct inputs from the public runtime path
  - kept legacy-shaped outputs for downstream postprocessing compatibility

- Simplified `fixedbasisMCMC(...)`:
  - now prepares inputs with `make_inv_inputs(...)`
  - passes `inv_inputs` into `inferpymc(...)`
  - reconstructs the legacy-shaped postprocessing arrays from the dataset where still needed

- Updated `rerun_output(...)` to use a minimal dataset adapter for the new `inferpymc(...)` path

- Kept the reusable model-building pieces introduced earlier:
  - `openghg_inversions.models.coords`
  - `openghg_inversions.models.priors`
  - `openghg_inversions.models.components`

## Tests

- Rewrote `tests/test_inferpymc.py` around dataset-first `inferpymc(...)`
- Rewrote the month-gap regression to use `make_inv_inputs(...)`
- Removed Stage C-only `model_builder` tests and usages
- Updated full-inversion and postprocessing regressions to exercise the single current builder path
- Kept `tests/test_inversion_inputs.py` as a transitional frozen-regression check and documented that status more clearly

## Notes

- Added/expanded docstrings for the changed public functions and the main private helpers involved in the new runtime path
- Added `[tool.ruff] line-length = 110` to align Ruff with the existing project formatting width

* **Please check if the PR fulfills these requirements**

- [x] Closes #374
- [x] Tests added and passing
- Documentation and tutorials updated/added
- [x] Added an entry to the `CHANGELOG.md` file
- [x] Added any new requirements to `requirements.txt` (added ruff line length to pyproject.toml)
