### PR TITLE
Clean up `fixedbasisMCMC` output handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Stage B of PyMC model refactor. Updated `inferpymc` to accept current/legacy inputs as well as xarray `Dataset`. [PR #380](https://github.com/openghg/openghg_inversions/pull/380)
 - Stage C of PyMC model refactor. Added function for building PyMC "model components". The model building code from Stage B is still used by default, but the new code can be selected by adding `model_builder="components"` to the .ini file. [PR #382](https://github.com/openghg/openghg_inversions/pull/382)
 - Stage D of PyMC model refactor. Removed temporary scaffolding to preserve legacy model building code. `inferpymc` now only accepts inversion inputs as `xr.Dataset`, and `fixedbasisMCMC` has been updated to reflect this. [PR #389](https://github.com/openghg/openghg_inversions/pull/389)
+- Clean up of `fixedbasisMCMC` output handling. [PR #390](https://github.com/openghg/openghg_inversions/pull/390)
 
 # Version 0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Stage B of PyMC model refactor. Updated `inferpymc` to accept current/legacy inputs as well as xarray `Dataset`. [PR #380](https://github.com/openghg/openghg_inversions/pull/380)
 - Stage C of PyMC model refactor. Added function for building PyMC "model components". The model building code from Stage B is still used by default, but the new code can be selected by adding `model_builder="components"` to the .ini file. [PR #382](https://github.com/openghg/openghg_inversions/pull/382)
 - Stage D of PyMC model refactor. Removed temporary scaffolding to preserve legacy model building code. `inferpymc` now only accepts inversion inputs as `xr.Dataset`, and `fixedbasisMCMC` has been updated to reflect this. [PR #389](https://github.com/openghg/openghg_inversions/pull/389)
-- Clean up of `fixedbasisMCMC` output handling. [PR #390](https://github.com/openghg/openghg_inversions/pull/390)
+- Neutral refactor of `fixedbasisMCMC` output handling to make the end-of-run logic clearer, whichis now split into explicit stages for artefact creation, `InversionOutput` construction, and output mode dispatch. [PR #390](https://github.com/openghg/openghg_inversions/pull/390)
 
 # Version 0.6.0
 

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -45,7 +45,10 @@ from openghg_inversions.inversion_data import (
     load_merged_data,
 )
 from openghg_inversions.filters import filtering
-from openghg_inversions.postprocessing.inversion_output import InversionOutput, make_inv_out_for_fixed_basis_mcmc
+from openghg_inversions.postprocessing.inversion_output import (
+    InversionOutput,
+    make_inv_out_for_fixed_basis_mcmc,
+)
 from openghg_inversions.inversion_inputs import make_inv_inputs
 
 
@@ -152,6 +155,7 @@ def _extract_post_process_args(inv_inputs: xr.Dataset) -> dict[str, np.ndarray]:
         "min_error": inv_inputs.min_error.values,
     }
 
+
 def _inv_inputs_from_rerun_arrays(
     *,
     Hx: np.ndarray,
@@ -210,6 +214,7 @@ def _inv_inputs_from_rerun_arrays(
 # Output format handling
 # ------------------------------------------------------------
 
+
 @dataclass
 class _OutputContext:
     """Resolved output settings and runtime objects for final output handling."""
@@ -255,7 +260,9 @@ def _resolve_output_format(
     return resolved_output_format
 
 
-def _resolve_trace_path(save_trace: str | Path | bool, outputpath: str, outputname: str, start_date: str) -> Path | None:
+def _resolve_trace_path(
+    save_trace: str | Path | bool, outputpath: str, outputname: str, start_date: str
+) -> Path | None:
     """Resolve the output path for a saved trace file."""
     if not save_trace:
         return None
@@ -466,7 +473,12 @@ def _finalize_output(context: _OutputContext) -> xr.Dataset | dict | InversionOu
             use_bc=context.use_bc,
         )
         output_filename = define_output_filename(
-            context.outputpath, context.species, context.domain, context.outputname, context.start_date, ext=".nc"
+            context.outputpath,
+            context.species,
+            context.domain,
+            context.outputname,
+            context.start_date,
+            ext=".nc",
         )
         Path(context.outputpath).mkdir(parents=True, exist_ok=True)
         outputs.to_netcdf(output_filename, encoding=ncdf_encoding(outputs), mode="w")
@@ -492,10 +504,20 @@ def _finalize_output(context: _OutputContext) -> xr.Dataset | dict | InversionOu
         )
 
         conc_output_filename = define_output_filename(
-            context.outputpath, context.species, context.domain, context.outputname + "_conc", context.start_date, ext=".nc"
+            context.outputpath,
+            context.species,
+            context.domain,
+            context.outputname + "_conc",
+            context.start_date,
+            ext=".nc",
         )
         flux_output_filename = define_output_filename(
-            context.outputpath, context.species, context.domain, context.outputname + "_flux", context.start_date, ext=".nc"
+            context.outputpath,
+            context.species,
+            context.domain,
+            context.outputname + "_flux",
+            context.start_date,
+            ext=".nc",
         )
         Path(context.outputpath).mkdir(parents=True, exist_ok=True)
 
@@ -519,7 +541,9 @@ def _finalize_output(context: _OutputContext) -> xr.Dataset | dict | InversionOu
     del mcmc_results["model"]
     legacy_postprocess_args = _prepare_legacy_hbmcmc_postprocess_args(context)
     legacy_postprocess_args.update(mcmc_results)
-    post_process_args_selection, _ = split_function_inputs(legacy_postprocess_args, mcmc.inferpymc_postprocessouts)
+    post_process_args_selection, _ = split_function_inputs(
+        legacy_postprocess_args, mcmc.inferpymc_postprocessouts
+    )
     out = mcmc.inferpymc_postprocessouts(**post_process_args_selection)
 
     end_post = time.time()

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -910,10 +910,6 @@ def fixedbasisMCMC(
     end_inversion = time.time()
 
     print(f"MCMC Inversion complete. Time taken = {end_inversion - start_inversion:.2f} seconds")
-
-    # get trace: for future updates
-    trace = mcmc_results["trace"]
-
     # Get args needed for make_inv_out_for_fixed_basis_mcmc
     inv_out_args, _ = split_function_inputs(post_process_args, make_inv_out_for_fixed_basis_mcmc)
     inv_out_args["site_names"] = sites

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -464,8 +464,8 @@ def _finalize_output(context: _OutputContext) -> xr.Dataset | dict | InversionOu
         outputs = make_legacy_hbmcmc_output(
             inv_out=_get_inversion_output(context),
             mcmc_results=context.mcmc_results,
-            # TODO: Stop threading sigma_freq_index explicitly once the legacy model-building
-            # path is removed and sigma_freq_index always comes from model data.
+            # TODO: Stop threading these explicitly once make_legacy_hbmcmc_output
+            # can consume the needed arrays directly from the modern model/input data path.
             sigma_freq_index=context.legacy_postprocess_args["sigma_freq_index"],
             Hx=context.legacy_postprocess_args["Hx"],
             Hbc=context.legacy_postprocess_args.get("Hbc"),

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -542,7 +542,7 @@ def fixedbasisMCMC(
     paris_postprocessing_kwargs: dict | None = None,
     power: dict | float = 1.99,
     **kwargs,
-) -> xr.Dataset | dict:
+) -> xr.Dataset | dict | InversionOutput:
     """Script to run hierarchical Bayesian MCMC (RHIME) for inference of emissions.
 
     Uses PyMC to solve the inverse problem. Saves an output from the inversion code

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -25,6 +25,7 @@ the users OpenGHG config file (default location: ~/.openghg/openghg.conf).
 """
 
 import logging
+from dataclasses import dataclass, field
 from pathlib import Path
 import time
 from typing import Literal
@@ -206,6 +207,255 @@ def _inv_inputs_from_rerun_arrays(
         coords["bc_region"] = np.arange(Hbc.shape[0])
 
     return xr.Dataset(data_vars=data_vars, coords=coords)
+
+
+@dataclass(frozen=True)
+class _OutputMode:
+    output_format: str
+    merged_data_only: bool = False
+    return_inv_out: bool = False
+    new_postprocessing: bool = False
+    hbmcmc_postprocessing: bool = False
+    do_paris_postprocessing: bool = False
+    return_mcmc_args: bool = False
+    skip_postprocessing: bool = False
+    basis_output_format: Literal["legacy", "datatree"] = "legacy"
+    inversion_output_format: Literal["datatree"] = "datatree"
+
+
+@dataclass
+class _OutputContract:
+    mode: _OutputMode
+    outputpath: str
+    outputname: str
+    species: str
+    domain: str
+    start_date: str
+    averaging_period: list[str]
+    is_sat_column: bool
+    use_bc: bool
+    country_file: str | None
+    paris_postprocessing_kwargs: dict | None
+    save_trace: str | Path | bool
+    save_inversion_output: str | Path | bool
+    post_process_args: dict
+    mcmc_results: dict
+    inv_out_args: dict
+    inv_out: object | None = None
+    paths: dict[str, Path] = field(default_factory=dict)
+
+
+def _resolve_output_mode(
+    output_format: str,
+    *,
+    paris_postprocessing: bool,
+    is_sat_column: bool,
+) -> _OutputMode:
+    if paris_postprocessing is True:
+        output_format = "paris"
+        warnings.warn(
+            "The `paris_postprocessing` argument will be deprecated. Use `output_format = 'paris'` instead."
+        )
+
+    resolved_output_format = output_format.lower()
+
+    if resolved_output_format == "hbmcmc" and is_sat_column:
+        raise ValueError(
+            "Cannot use output_format 'hbmcmc' when satellite column measurements are included. Please choose another output_format."
+        )
+
+    return _OutputMode(
+        output_format=resolved_output_format,
+        merged_data_only=resolved_output_format == "merged_data",
+        return_inv_out=resolved_output_format == "inv_out",
+        new_postprocessing=resolved_output_format == "basic",
+        hbmcmc_postprocessing=resolved_output_format == "hbmcmc_postprocessing",
+        do_paris_postprocessing=resolved_output_format == "paris",
+        return_mcmc_args=resolved_output_format == "mcmc_args",
+        skip_postprocessing=resolved_output_format == "mcmc_results",
+    )
+
+
+def _resolve_trace_path(save_trace: str | Path | bool, outputpath: str, outputname: str, start_date: str) -> Path | None:
+    if not save_trace:
+        return None
+    if isinstance(save_trace, str | Path):
+        return Path(save_trace)
+    return Path(outputpath) / (outputname + f"{start_date}_trace.nc")
+
+
+def _resolve_inversion_output_path(
+    save_inversion_output: str | Path | bool, outputpath: str, outputname: str, start_date: str
+) -> Path | None:
+    if not save_inversion_output:
+        return None
+    if isinstance(save_inversion_output, str | Path):
+        return Path(save_inversion_output)
+    return Path(outputpath) / (outputname + f"{start_date}_inversion_output.nc")
+
+
+def _build_output_contract(
+    *,
+    mode: _OutputMode,
+    outputpath: str,
+    outputname: str,
+    species: str,
+    domain: str,
+    start_date: str,
+    averaging_period: list[str],
+    is_sat_column: bool,
+    use_bc: bool,
+    country_file: str | None,
+    paris_postprocessing_kwargs: dict | None,
+    save_trace: str | Path | bool,
+    save_inversion_output: str | Path | bool,
+    post_process_args: dict,
+    mcmc_results: dict,
+    inv_out_args: dict,
+) -> _OutputContract:
+    paths: dict[str, Path] = {}
+
+    trace_path = _resolve_trace_path(save_trace, outputpath, outputname, start_date)
+    if trace_path is not None:
+        paths["trace"] = trace_path
+
+    inversion_output_path = _resolve_inversion_output_path(
+        save_inversion_output, outputpath, outputname, start_date
+    )
+    if inversion_output_path is not None:
+        paths["inversion_output"] = inversion_output_path
+
+    return _OutputContract(
+        mode=mode,
+        outputpath=outputpath,
+        outputname=outputname,
+        species=species,
+        domain=domain,
+        start_date=start_date,
+        averaging_period=averaging_period,
+        is_sat_column=is_sat_column,
+        use_bc=use_bc,
+        country_file=country_file,
+        paris_postprocessing_kwargs=paris_postprocessing_kwargs,
+        save_trace=save_trace,
+        save_inversion_output=save_inversion_output,
+        post_process_args=post_process_args,
+        mcmc_results=mcmc_results,
+        inv_out_args=inv_out_args,
+        paths=paths,
+    )
+
+
+def _get_inversion_output(contract: _OutputContract):
+    if contract.inv_out is None:
+        contract.inv_out = make_inv_out_for_fixed_basis_mcmc(**contract.inv_out_args)
+    return contract.inv_out
+
+
+def _handle_core_output_artifacts(contract: _OutputContract) -> None:
+    trace_path = contract.paths.get("trace")
+    if trace_path is not None:
+        contract.mcmc_results["trace"].to_netcdf(str(trace_path), engine="netcdf4", compress=True)
+
+    inversion_output_path = contract.paths.get("inversion_output")
+    if inversion_output_path is not None:
+        _get_inversion_output(contract).save(inversion_output_path)
+
+
+def _run_postprocessing_from_contract(contract: _OutputContract) -> xr.Dataset | dict:
+    if contract.mode.skip_postprocessing:
+        return contract.mcmc_results
+
+    if contract.mode.return_inv_out:
+        return _get_inversion_output(contract)
+
+    start_post = time.time()
+
+    if contract.mode.new_postprocessing:
+        from ..postprocessing.make_outputs import basic_output
+
+        outputs = basic_output(_get_inversion_output(contract), country_file=contract.country_file)
+        end_post = time.time()
+        print(f"Post processing Complete. Time taken = {end_post - start_post:.2f} seconds")
+        return outputs
+
+    if contract.mode.hbmcmc_postprocessing:
+        from openghg_inversions.hbmcmc.hbmcmc_output import define_output_filename
+
+        from ..postprocessing.legacy_outputs import make_legacy_hbmcmc_output
+
+        outputs = make_legacy_hbmcmc_output(
+            inv_out=_get_inversion_output(contract),
+            mcmc_results=contract.mcmc_results,
+            sigma_freq_index=contract.post_process_args["sigma_freq_index"],
+            Hx=contract.post_process_args["Hx"],
+            Hbc=contract.post_process_args.get("Hbc"),
+            country_file=contract.country_file,
+            use_bc=contract.use_bc,
+        )
+        output_filename = define_output_filename(
+            contract.outputpath, contract.species, contract.domain, contract.outputname, contract.start_date, ext=".nc"
+        )
+        Path(contract.outputpath).mkdir(parents=True, exist_ok=True)
+        outputs.to_netcdf(output_filename, encoding=ncdf_encoding(outputs), mode="w")
+        end_post = time.time()
+        print(f"Post processing Complete. Time taken = {end_post - start_post:.2f} seconds")
+        return outputs
+
+    if contract.mode.do_paris_postprocessing:
+        from openghg_inversions.hbmcmc.hbmcmc_output import define_output_filename
+
+        from openghg_inversions.postprocessing.make_paris_outputs import make_paris_outputs
+
+        obs_avg_period = contract.averaging_period[0] or "0h"
+        if not contract.averaging_period[0]:
+            logging.info("Default obs averaging period %s used in PARIS post-processing.", obs_avg_period)
+        paris_postprocessing_kwargs = contract.paris_postprocessing_kwargs or {}
+        flux_outs, conc_outs = make_paris_outputs(
+            _get_inversion_output(contract),
+            country_file=contract.country_file,
+            domain=contract.domain,
+            obs_avg_period=obs_avg_period,
+            **paris_postprocessing_kwargs,
+        )
+
+        conc_output_filename = define_output_filename(
+            contract.outputpath, contract.species, contract.domain, contract.outputname + "_conc", contract.start_date, ext=".nc"
+        )
+        flux_output_filename = define_output_filename(
+            contract.outputpath, contract.species, contract.domain, contract.outputname + "_flux", contract.start_date, ext=".nc"
+        )
+        Path(contract.outputpath).mkdir(parents=True, exist_ok=True)
+
+        conc_outs.to_netcdf(
+            conc_output_filename, unlimited_dims=["time"], mode="w", encoding=ncdf_encoding(conc_outs)
+        )
+        flux_outs.to_netcdf(
+            flux_output_filename, unlimited_dims=["time"], mode="w", encoding=ncdf_encoding(flux_outs)
+        )
+
+        logging.info("PARIS concentration outputs saved to", conc_output_filename)
+        logging.info("PARIS flux outputs saved to", flux_output_filename)
+
+        end_post = time.time()
+        print(f"Post processing Complete. Time taken = {end_post - start_post:.2f} seconds")
+        return xr.merge([conc_outs, flux_outs.rename(time="flux_time")])
+
+    # Process and save inversion output
+    mcmc_results = contract.mcmc_results.copy()
+    del mcmc_results["trace"]
+    del mcmc_results["model"]
+    post_process_args = contract.post_process_args.copy()
+    post_process_args.update(mcmc_results)
+    post_process_args_selection, _ = split_function_inputs(post_process_args, mcmc.inferpymc_postprocessouts)
+    out = mcmc.inferpymc_postprocessouts(**post_process_args_selection)
+
+    end_post = time.time()
+
+    print(f"Post processing Complete. Time taken = {end_post - start_post:.2f} seconds")
+    print("---- Inversion completed ----")
+
+    return out
 
 
 def fixedbasisMCMC(
@@ -413,53 +663,20 @@ def fixedbasisMCMC(
         xr.Dataset | dict: Results from the inversion in a Dataset if skip_post_processing==False,
             in a dictionary if True.
     """
-    # select output format
-    merged_data_only = False
-    return_inv_out = False
-    new_postprocessing = False
-    hbmcmc_postprocessing = False
-    do_paris_postprocessing = False
-    return_mcmc_args = False
-    skip_postprocessing = False
-
-    if paris_postprocessing is True:
-        output_format = "paris"
-        warnings.warn(
-            "The `paris_postprocessing` argument will be deprecated. Use `output_format = 'paris'` instead."
-        )
-
-    output_format = output_format.lower()  # type: ignore
-
-    if output_format == "merged_data":
-        merged_data_only = True
-    elif output_format == "inv_out":
-        return_inv_out = True
-    elif output_format == "basic":
-        new_postprocessing = True
-    elif output_format == "hbmcmc_postprocessing":
-        hbmcmc_postprocessing = True
-    elif output_format == "paris":
-        do_paris_postprocessing = True
-    elif output_format == "mcmc_args":
-        return_mcmc_args = True
-    elif output_format == "mcmc_results":
-        skip_postprocessing = True
-    # otherwise (i.e. output_format == "hbmcmc"), mcmc.inferpymc_postprocessouts is used
-
     if inlet is not None:
         is_sat_column = any([i == "column" for i in inlet])
     else:
         is_sat_column = False
 
-    if output_format == "hbmcmc":
-        if is_sat_column:
-            raise ValueError(
-                "Cannot use output_format 'hbmcmc' when satellite column measurements are included. Please choose another output_format."
-            )
+    output_mode = _resolve_output_mode(
+        output_format,
+        paris_postprocessing=paris_postprocessing,
+        is_sat_column=is_sat_column,
+    )
 
     rerun_merge = True
 
-    if merged_data_only:
+    if output_mode.merged_data_only:
         reload_merged_data = False
 
     if reload_merged_data is True and merged_data_dir is not None:
@@ -539,7 +756,7 @@ def fixedbasisMCMC(
         elif use_tracer:
             raise ValueError("Model does not currently include tracer model. Watch this space")
 
-        if merged_data_only:
+        if output_mode.merged_data_only:
             return fp_all  # type: ignore
 
     # Basis function regions and sensitivity matrices
@@ -675,7 +892,7 @@ def fixedbasisMCMC(
     print(f"Data extraction and preparation complete. Time taken = {end_data - start_data:.2f} seconds")
 
     # for debugging
-    if return_mcmc_args:
+    if output_mode.return_mcmc_args:
         return mcmc_args
 
     start_inversion = time.time()
@@ -690,15 +907,6 @@ def fixedbasisMCMC(
     # get trace: for future updates
     trace = mcmc_results["trace"]
 
-    # Path to save trace
-    if save_trace:
-        if isinstance(save_trace, str | Path):
-            trace_path = save_trace
-        else:
-            trace_path = Path(outputpath) / (outputname + f"{start_date}_trace.nc")
-
-            trace.to_netcdf(str(trace_path), engine="netcdf4", compress=True)
-
     # Get args needed for make_inv_out_for_fixed_basis_mcmc
     inv_out_args, _ = split_function_inputs(post_process_args, make_inv_out_for_fixed_basis_mcmc)
     inv_out_args["site_names"] = sites
@@ -709,116 +917,26 @@ def fixedbasisMCMC(
         inv_out_args["obs_prior_factor"] = None
         inv_out_args["obs_prior_upper_level_factor"] = None
 
-    # Path to save trace
-    if save_inversion_output:
-        if isinstance(save_inversion_output, str | Path):
-            inversion_output_path = save_inversion_output
-        else:
-            inversion_output_path = Path(outputpath) / (outputname + f"{start_date}_inversion_output.nc")
-
-        inversion_output = make_inv_out_for_fixed_basis_mcmc(**inv_out_args)
-        inversion_output.save(inversion_output_path)
-
-    if skip_postprocessing:
-        return mcmc_results
-
-    if return_inv_out:
-        return make_inv_out_for_fixed_basis_mcmc(**inv_out_args)
-
-    start_post = time.time()
-
-    if new_postprocessing:
-        from ..postprocessing.make_outputs import basic_output
-
-        inv_out = make_inv_out_for_fixed_basis_mcmc(**inv_out_args)
-
-        outputs = basic_output(inv_out, country_file=country_file)
-        end_post = time.time()
-        print(f"Post processing Complete. Time taken = {end_post - start_post:.2f} seconds")
-
-        return outputs
-
-    if hbmcmc_postprocessing:
-        from openghg_inversions.hbmcmc.hbmcmc_output import define_output_filename
-
-        from ..postprocessing.legacy_outputs import make_legacy_hbmcmc_output
-
-        inv_out = make_inv_out_for_fixed_basis_mcmc(**inv_out_args)
-        outputs = make_legacy_hbmcmc_output(
-            inv_out=inv_out,
-            mcmc_results=mcmc_results,
-            sigma_freq_index=post_process_args["sigma_freq_index"],
-            Hx=post_process_args["Hx"],
-            Hbc=post_process_args.get("Hbc"),
-            country_file=country_file,
-            use_bc=use_bc,
-        )
-        output_filename = define_output_filename(
-            outputpath, species, domain, outputname, start_date, ext=".nc"
-        )
-        Path(outputpath).mkdir(parents=True, exist_ok=True)
-        outputs.to_netcdf(output_filename, encoding=ncdf_encoding(outputs), mode="w")
-        end_post = time.time()
-        print(f"Post processing Complete. Time taken = {end_post - start_post:.2f} seconds")
-
-        return outputs
-
-    if do_paris_postprocessing:
-        from openghg_inversions.hbmcmc.hbmcmc_output import define_output_filename
-
-        from openghg_inversions.postprocessing.make_paris_outputs import make_paris_outputs
-
-        inv_out = make_inv_out_for_fixed_basis_mcmc(**inv_out_args)
-
-        obs_avg_period = averaging_period[0] or "0h"
-        if not averaging_period[0]:
-            logging.info("Default obs averaging period %s used in PARIS post-processing.", obs_avg_period)
-        paris_postprocessing_kwargs = paris_postprocessing_kwargs or {}
-        flux_outs, conc_outs = make_paris_outputs(
-            inv_out,
-            country_file=country_file,
-            domain=domain,
-            obs_avg_period=obs_avg_period,
-            **paris_postprocessing_kwargs,
-        )
-
-        conc_output_filename = define_output_filename(
-            outputpath, species, domain, outputname + "_conc", start_date, ext=".nc"
-        )
-        flux_output_filename = define_output_filename(
-            outputpath, species, domain, outputname + "_flux", start_date, ext=".nc"
-        )
-        Path(outputpath).mkdir(parents=True, exist_ok=True)
-
-        conc_outs.to_netcdf(
-            conc_output_filename, unlimited_dims=["time"], mode="w", encoding=ncdf_encoding(conc_outs)
-        )
-        flux_outs.to_netcdf(
-            flux_output_filename, unlimited_dims=["time"], mode="w", encoding=ncdf_encoding(flux_outs)
-        )
-
-        logging.info("PARIS concentration outputs saved to", conc_output_filename)
-        logging.info("PARIS flux outputs saved to", flux_output_filename)
-
-        end_post = time.time()
-        print(f"Post processing Complete. Time taken = {end_post - start_post:.2f} seconds")
-
-        return xr.merge([conc_outs, flux_outs.rename(time="flux_time")])
-
-    # Process and save inversion output
-    del mcmc_results["trace"]
-    del mcmc_results["model"]
-    post_process_args.update(mcmc_results)
-    post_process_args_selection, _ = split_function_inputs(post_process_args, mcmc.inferpymc_postprocessouts)
-    out = mcmc.inferpymc_postprocessouts(**post_process_args_selection)
-
-    end_post = time.time()
-
-    print(f"Post processing Complete. Time taken = {end_post - start_post:.2f} seconds")
-
-    print("---- Inversion completed ----")
-
-    return out
+    output_contract = _build_output_contract(
+        mode=output_mode,
+        outputpath=outputpath,
+        outputname=outputname,
+        species=species,
+        domain=domain,
+        start_date=start_date,
+        averaging_period=averaging_period,
+        is_sat_column=is_sat_column,
+        use_bc=use_bc,
+        country_file=country_file,
+        paris_postprocessing_kwargs=paris_postprocessing_kwargs,
+        save_trace=save_trace,
+        save_inversion_output=save_inversion_output,
+        post_process_args=post_process_args,
+        mcmc_results=mcmc_results,
+        inv_out_args=inv_out_args,
+    )
+    _handle_core_output_artifacts(output_contract)
+    return _run_postprocessing_from_contract(output_contract)
 
 
 def rerun_output(input_file: str, outputname: str, outputpath: str, verbose: bool = False) -> None:

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -241,7 +241,7 @@ def _resolve_output_format(
     output_format: str,
     *,
     paris_postprocessing: bool,
-    is_sat_column: bool,
+    is_column: bool,
 ) -> str:
     """Resolve deprecated aliases and validate the canonical output format."""
     if paris_postprocessing is True:
@@ -252,9 +252,9 @@ def _resolve_output_format(
 
     resolved_output_format = output_format.lower()
 
-    if resolved_output_format == "hbmcmc" and is_sat_column:
+    if resolved_output_format == "hbmcmc" and is_column:
         raise ValueError(
-            "Cannot use output_format 'hbmcmc' when satellite column measurements are included. Please choose another output_format."
+            "Cannot use output_format 'hbmcmc' when column-based measurements are included. Please choose another output_format."
         )
 
     return resolved_output_format
@@ -365,7 +365,7 @@ def _build_inv_out_args(
     end_date: str,
     species: str,
     domain: str,
-    is_sat_column: bool,
+    is_column: bool,
 ) -> dict:
     """Build explicit arguments for ``make_inv_out_for_fixed_basis_mcmc``.
 
@@ -378,7 +378,7 @@ def _build_inv_out_args(
         end_date: Inversion end date.
         species: Species name for output metadata.
         domain: Domain name for output metadata.
-        is_sat_column: Whether satellite-column inputs are present.
+        is_column: Whether column-based inputs are present.
 
     Returns:
         dict: Explicit keyword arguments for ``make_inv_out_for_fixed_basis_mcmc``.
@@ -401,7 +401,7 @@ def _build_inv_out_args(
         "obs_prior_upper_level_factor": legacy_postprocess_args["obs_prior_upper_level_factor"],
     }
 
-    if not is_sat_column:
+    if not is_column:
         inv_out_args["obs_prior_factor"] = None
         inv_out_args["obs_prior_upper_level_factor"] = None
 
@@ -764,15 +764,16 @@ def fixedbasisMCMC(
         xr.Dataset | dict: Results from the inversion in a Dataset if skip_post_processing==False,
             in a dictionary if True.
     """
+    # Check if any observations are column based.
     if inlet is not None:
-        is_sat_column = any([i == "column" for i in inlet])
+        is_column = any(i == "column" for i in inlet)
     else:
-        is_sat_column = False
+        is_column = False
 
     output_format = _resolve_output_format(
         output_format,
         paris_postprocessing=paris_postprocessing,
-        is_sat_column=is_sat_column,
+        is_column=is_column,
     )
 
     rerun_merge = True
@@ -1005,7 +1006,7 @@ def fixedbasisMCMC(
         end_date=end_date,
         species=species,
         domain=domain,
-        is_sat_column=is_sat_column,
+        is_column=is_column,
     )
 
     output_context = _build_output_context(

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -45,9 +45,7 @@ from openghg_inversions.inversion_data import (
     load_merged_data,
 )
 from openghg_inversions.filters import filtering
-from openghg_inversions.postprocessing.inversion_output import (
-    make_inv_out_for_fixed_basis_mcmc,
-)
+from openghg_inversions.postprocessing.inversion_output import InversionOutput, make_inv_out_for_fixed_basis_mcmc
 from openghg_inversions.inversion_inputs import make_inv_inputs
 
 
@@ -209,48 +207,38 @@ def _inv_inputs_from_rerun_arrays(
     return xr.Dataset(data_vars=data_vars, coords=coords)
 
 
-@dataclass(frozen=True)
-class _OutputMode:
-    output_format: str
-    merged_data_only: bool = False
-    return_inv_out: bool = False
-    new_postprocessing: bool = False
-    hbmcmc_postprocessing: bool = False
-    do_paris_postprocessing: bool = False
-    return_mcmc_args: bool = False
-    skip_postprocessing: bool = False
-    basis_output_format: Literal["legacy", "datatree"] = "legacy"
-    inversion_output_format: Literal["datatree"] = "datatree"
-
+# ------------------------------------------------------------
+# Output format handling
+# ------------------------------------------------------------
 
 @dataclass
-class _OutputContract:
-    mode: _OutputMode
+class _OutputContext:
+    """Resolved output settings and runtime objects for final output handling."""
+
+    output_format: str
     outputpath: str
     outputname: str
     species: str
     domain: str
     start_date: str
     averaging_period: list[str]
-    is_sat_column: bool
     use_bc: bool
     country_file: str | None
     paris_postprocessing_kwargs: dict | None
-    save_trace: str | Path | bool
-    save_inversion_output: str | Path | bool
     post_process_args: dict
     mcmc_results: dict
     inv_out_args: dict
-    inv_out: object | None = None
+    inv_out: InversionOutput | None = None
     paths: dict[str, Path] = field(default_factory=dict)
 
 
-def _resolve_output_mode(
+def _resolve_output_format(
     output_format: str,
     *,
     paris_postprocessing: bool,
     is_sat_column: bool,
-) -> _OutputMode:
+) -> str:
+    """Resolve deprecated aliases and validate the canonical output format."""
     if paris_postprocessing is True:
         output_format = "paris"
         warnings.warn(
@@ -264,19 +252,11 @@ def _resolve_output_mode(
             "Cannot use output_format 'hbmcmc' when satellite column measurements are included. Please choose another output_format."
         )
 
-    return _OutputMode(
-        output_format=resolved_output_format,
-        merged_data_only=resolved_output_format == "merged_data",
-        return_inv_out=resolved_output_format == "inv_out",
-        new_postprocessing=resolved_output_format == "basic",
-        hbmcmc_postprocessing=resolved_output_format == "hbmcmc_postprocessing",
-        do_paris_postprocessing=resolved_output_format == "paris",
-        return_mcmc_args=resolved_output_format == "mcmc_args",
-        skip_postprocessing=resolved_output_format == "mcmc_results",
-    )
+    return resolved_output_format
 
 
 def _resolve_trace_path(save_trace: str | Path | bool, outputpath: str, outputname: str, start_date: str) -> Path | None:
+    """Resolve the output path for a saved trace file."""
     if not save_trace:
         return None
     if isinstance(save_trace, str | Path):
@@ -287,6 +267,7 @@ def _resolve_trace_path(save_trace: str | Path | bool, outputpath: str, outputna
 def _resolve_inversion_output_path(
     save_inversion_output: str | Path | bool, outputpath: str, outputname: str, start_date: str
 ) -> Path | None:
+    """Resolve the output path for a saved inversion-output file."""
     if not save_inversion_output:
         return None
     if isinstance(save_inversion_output, str | Path):
@@ -294,16 +275,15 @@ def _resolve_inversion_output_path(
     return Path(outputpath) / (outputname + f"{start_date}_inversion_output.nc")
 
 
-def _build_output_contract(
+def _build_output_context(
     *,
-    mode: _OutputMode,
+    output_format: str,
     outputpath: str,
     outputname: str,
     species: str,
     domain: str,
     start_date: str,
     averaging_period: list[str],
-    is_sat_column: bool,
     use_bc: bool,
     country_file: str | None,
     paris_postprocessing_kwargs: dict | None,
@@ -312,7 +292,29 @@ def _build_output_contract(
     post_process_args: dict,
     mcmc_results: dict,
     inv_out_args: dict,
-) -> _OutputContract:
+) -> _OutputContext:
+    """Build the output context used by later output-handling stages.
+
+    Args:
+        output_format: Canonical output mode string after normalization.
+        outputpath: Directory for saved outputs.
+        outputname: Base output name for saved files.
+        species: Species identifier for output naming.
+        domain: Domain identifier for output naming.
+        start_date: Inversion start date used in output naming.
+        averaging_period: Observation averaging period list for PARIS outputs.
+        use_bc: Whether boundary-condition outputs are enabled.
+        country_file: Optional country definition file passed to postprocessing.
+        paris_postprocessing_kwargs: Optional keyword arguments for PARIS output creation.
+        save_trace: Trace save setting passed to ``fixedbasisMCMC``.
+        save_inversion_output: InversionOutput save setting passed to ``fixedbasisMCMC``.
+        post_process_args: Postprocessing argument dictionary built during inversion setup.
+        mcmc_results: Raw sampler results from ``mcmc.inferpymc``.
+        inv_out_args: Arguments needed to build ``InversionOutput``.
+
+    Returns:
+        _OutputContext: Context object for final output handling.
+    """
     paths: dict[str, Path] = {}
 
     trace_path = _resolve_trace_path(save_trace, outputpath, outputname, start_date)
@@ -325,20 +327,17 @@ def _build_output_contract(
     if inversion_output_path is not None:
         paths["inversion_output"] = inversion_output_path
 
-    return _OutputContract(
-        mode=mode,
+    return _OutputContext(
+        output_format=output_format,
         outputpath=outputpath,
         outputname=outputname,
         species=species,
         domain=domain,
         start_date=start_date,
         averaging_period=averaging_period,
-        is_sat_column=is_sat_column,
         use_bc=use_bc,
         country_file=country_file,
         paris_postprocessing_kwargs=paris_postprocessing_kwargs,
-        save_trace=save_trace,
-        save_inversion_output=save_inversion_output,
         post_process_args=post_process_args,
         mcmc_results=mcmc_results,
         inv_out_args=inv_out_args,
@@ -346,86 +345,89 @@ def _build_output_contract(
     )
 
 
-def _get_inversion_output(contract: _OutputContract):
-    if contract.inv_out is None:
-        contract.inv_out = make_inv_out_for_fixed_basis_mcmc(**contract.inv_out_args)
-    return contract.inv_out
+def _get_inversion_output(context: _OutputContext) -> InversionOutput:
+    """Build and cache the InversionOutput object for output handling."""
+    if context.inv_out is None:
+        context.inv_out = make_inv_out_for_fixed_basis_mcmc(**context.inv_out_args)
+    return context.inv_out
 
 
-def _handle_core_output_artifacts(contract: _OutputContract) -> None:
-    trace_path = contract.paths.get("trace")
+def _handle_core_output_artifacts(context: _OutputContext) -> None:
+    """Write core inversion artifacts needed before final output dispatch."""
+    trace_path = context.paths.get("trace")
     if trace_path is not None:
-        contract.mcmc_results["trace"].to_netcdf(str(trace_path), engine="netcdf4", compress=True)
+        context.mcmc_results["trace"].to_netcdf(str(trace_path), engine="netcdf4", compress=True)
 
-    inversion_output_path = contract.paths.get("inversion_output")
+    inversion_output_path = context.paths.get("inversion_output")
     if inversion_output_path is not None:
-        _get_inversion_output(contract).save(inversion_output_path)
+        _get_inversion_output(context).save(inversion_output_path)
 
 
-def _run_postprocessing_from_contract(contract: _OutputContract) -> xr.Dataset | dict:
-    if contract.mode.skip_postprocessing:
-        return contract.mcmc_results
+def _finalize_output(context: _OutputContext) -> xr.Dataset | dict | InversionOutput:
+    """Dispatch the final output path for a completed inversion run."""
+    if context.output_format == "mcmc_results":
+        return context.mcmc_results
 
-    if contract.mode.return_inv_out:
-        return _get_inversion_output(contract)
+    if context.output_format == "inv_out":
+        return _get_inversion_output(context)
 
     start_post = time.time()
 
-    if contract.mode.new_postprocessing:
+    if context.output_format == "basic":
         from ..postprocessing.make_outputs import basic_output
 
-        outputs = basic_output(_get_inversion_output(contract), country_file=contract.country_file)
+        outputs = basic_output(_get_inversion_output(context), country_file=context.country_file)
         end_post = time.time()
         print(f"Post processing Complete. Time taken = {end_post - start_post:.2f} seconds")
         return outputs
 
-    if contract.mode.hbmcmc_postprocessing:
+    if context.output_format == "hbmcmc_postprocessing":
         from openghg_inversions.hbmcmc.hbmcmc_output import define_output_filename
 
         from ..postprocessing.legacy_outputs import make_legacy_hbmcmc_output
 
         outputs = make_legacy_hbmcmc_output(
-            inv_out=_get_inversion_output(contract),
-            mcmc_results=contract.mcmc_results,
-            sigma_freq_index=contract.post_process_args["sigma_freq_index"],
-            Hx=contract.post_process_args["Hx"],
-            Hbc=contract.post_process_args.get("Hbc"),
-            country_file=contract.country_file,
-            use_bc=contract.use_bc,
+            inv_out=_get_inversion_output(context),
+            mcmc_results=context.mcmc_results,
+            sigma_freq_index=context.post_process_args["sigma_freq_index"],
+            Hx=context.post_process_args["Hx"],
+            Hbc=context.post_process_args.get("Hbc"),
+            country_file=context.country_file,
+            use_bc=context.use_bc,
         )
         output_filename = define_output_filename(
-            contract.outputpath, contract.species, contract.domain, contract.outputname, contract.start_date, ext=".nc"
+            context.outputpath, context.species, context.domain, context.outputname, context.start_date, ext=".nc"
         )
-        Path(contract.outputpath).mkdir(parents=True, exist_ok=True)
+        Path(context.outputpath).mkdir(parents=True, exist_ok=True)
         outputs.to_netcdf(output_filename, encoding=ncdf_encoding(outputs), mode="w")
         end_post = time.time()
         print(f"Post processing Complete. Time taken = {end_post - start_post:.2f} seconds")
         return outputs
 
-    if contract.mode.do_paris_postprocessing:
+    if context.output_format == "paris":
         from openghg_inversions.hbmcmc.hbmcmc_output import define_output_filename
 
         from openghg_inversions.postprocessing.make_paris_outputs import make_paris_outputs
 
-        obs_avg_period = contract.averaging_period[0] or "0h"
-        if not contract.averaging_period[0]:
+        obs_avg_period = context.averaging_period[0] or "0h"
+        if not context.averaging_period[0]:
             logging.info("Default obs averaging period %s used in PARIS post-processing.", obs_avg_period)
-        paris_postprocessing_kwargs = contract.paris_postprocessing_kwargs or {}
+        paris_postprocessing_kwargs = context.paris_postprocessing_kwargs or {}
         flux_outs, conc_outs = make_paris_outputs(
-            _get_inversion_output(contract),
-            country_file=contract.country_file,
-            domain=contract.domain,
+            _get_inversion_output(context),
+            country_file=context.country_file,
+            domain=context.domain,
             obs_avg_period=obs_avg_period,
             **paris_postprocessing_kwargs,
         )
 
         conc_output_filename = define_output_filename(
-            contract.outputpath, contract.species, contract.domain, contract.outputname + "_conc", contract.start_date, ext=".nc"
+            context.outputpath, context.species, context.domain, context.outputname + "_conc", context.start_date, ext=".nc"
         )
         flux_output_filename = define_output_filename(
-            contract.outputpath, contract.species, contract.domain, contract.outputname + "_flux", contract.start_date, ext=".nc"
+            context.outputpath, context.species, context.domain, context.outputname + "_flux", context.start_date, ext=".nc"
         )
-        Path(contract.outputpath).mkdir(parents=True, exist_ok=True)
+        Path(context.outputpath).mkdir(parents=True, exist_ok=True)
 
         conc_outs.to_netcdf(
             conc_output_filename, unlimited_dims=["time"], mode="w", encoding=ncdf_encoding(conc_outs)
@@ -434,18 +436,18 @@ def _run_postprocessing_from_contract(contract: _OutputContract) -> xr.Dataset |
             flux_output_filename, unlimited_dims=["time"], mode="w", encoding=ncdf_encoding(flux_outs)
         )
 
-        logging.info("PARIS concentration outputs saved to", conc_output_filename)
-        logging.info("PARIS flux outputs saved to", flux_output_filename)
+        logging.info("PARIS concentration outputs saved to %s", conc_output_filename)
+        logging.info("PARIS flux outputs saved to %s", flux_output_filename)
 
         end_post = time.time()
         print(f"Post processing Complete. Time taken = {end_post - start_post:.2f} seconds")
         return xr.merge([conc_outs, flux_outs.rename(time="flux_time")])
 
-    # Process and save inversion output
-    mcmc_results = contract.mcmc_results.copy()
+    # Legacy default hbmcmc output path.
+    mcmc_results = context.mcmc_results.copy()
     del mcmc_results["trace"]
     del mcmc_results["model"]
-    post_process_args = contract.post_process_args.copy()
+    post_process_args = context.post_process_args.copy()
     post_process_args.update(mcmc_results)
     post_process_args_selection, _ = split_function_inputs(post_process_args, mcmc.inferpymc_postprocessouts)
     out = mcmc.inferpymc_postprocessouts(**post_process_args_selection)
@@ -456,6 +458,11 @@ def _run_postprocessing_from_contract(contract: _OutputContract) -> xr.Dataset |
     print("---- Inversion completed ----")
 
     return out
+
+
+# ------------------------------------------------------------
+# Main MCMC script
+# ------------------------------------------------------------
 
 
 def fixedbasisMCMC(
@@ -668,7 +675,7 @@ def fixedbasisMCMC(
     else:
         is_sat_column = False
 
-    output_mode = _resolve_output_mode(
+    output_format = _resolve_output_format(
         output_format,
         paris_postprocessing=paris_postprocessing,
         is_sat_column=is_sat_column,
@@ -676,7 +683,7 @@ def fixedbasisMCMC(
 
     rerun_merge = True
 
-    if output_mode.merged_data_only:
+    if output_format == "merged_data":
         reload_merged_data = False
 
     if reload_merged_data is True and merged_data_dir is not None:
@@ -756,7 +763,7 @@ def fixedbasisMCMC(
         elif use_tracer:
             raise ValueError("Model does not currently include tracer model. Watch this space")
 
-        if output_mode.merged_data_only:
+        if output_format == "merged_data":
             return fp_all  # type: ignore
 
     # Basis function regions and sensitivity matrices
@@ -892,7 +899,7 @@ def fixedbasisMCMC(
     print(f"Data extraction and preparation complete. Time taken = {end_data - start_data:.2f} seconds")
 
     # for debugging
-    if output_mode.return_mcmc_args:
+    if output_format == "mcmc_args":
         return mcmc_args
 
     start_inversion = time.time()
@@ -917,15 +924,14 @@ def fixedbasisMCMC(
         inv_out_args["obs_prior_factor"] = None
         inv_out_args["obs_prior_upper_level_factor"] = None
 
-    output_contract = _build_output_contract(
-        mode=output_mode,
+    output_context = _build_output_context(
+        output_format=output_format,
         outputpath=outputpath,
         outputname=outputname,
         species=species,
         domain=domain,
         start_date=start_date,
         averaging_period=averaging_period,
-        is_sat_column=is_sat_column,
         use_bc=use_bc,
         country_file=country_file,
         paris_postprocessing_kwargs=paris_postprocessing_kwargs,
@@ -935,8 +941,9 @@ def fixedbasisMCMC(
         mcmc_results=mcmc_results,
         inv_out_args=inv_out_args,
     )
-    _handle_core_output_artifacts(output_contract)
-    return _run_postprocessing_from_contract(output_contract)
+    _handle_core_output_artifacts(output_context)
+
+    return _finalize_output(output_context)
 
 
 def rerun_output(input_file: str, outputname: str, outputpath: str, verbose: bool = False) -> None:

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -152,7 +152,6 @@ def _extract_post_process_args(inv_inputs: xr.Dataset) -> dict[str, np.ndarray]:
         "min_error": inv_inputs.min_error.values,
     }
 
-
 def _inv_inputs_from_rerun_arrays(
     *,
     Hx: np.ndarray,
@@ -225,7 +224,8 @@ class _OutputContext:
     use_bc: bool
     country_file: str | None
     paris_postprocessing_kwargs: dict | None
-    post_process_args: dict
+    legacy_postprocess_args: dict
+    mcmc_args: dict
     mcmc_results: dict
     inv_out_args: dict
     inv_out: InversionOutput | None = None
@@ -289,7 +289,8 @@ def _build_output_context(
     paris_postprocessing_kwargs: dict | None,
     save_trace: str | Path | bool,
     save_inversion_output: str | Path | bool,
-    post_process_args: dict,
+    legacy_postprocess_args: dict,
+    mcmc_args: dict,
     mcmc_results: dict,
     inv_out_args: dict,
 ) -> _OutputContext:
@@ -308,7 +309,8 @@ def _build_output_context(
         paris_postprocessing_kwargs: Optional keyword arguments for PARIS output creation.
         save_trace: Trace save setting passed to ``fixedbasisMCMC``.
         save_inversion_output: InversionOutput save setting passed to ``fixedbasisMCMC``.
-        post_process_args: Postprocessing argument dictionary built during inversion setup.
+        legacy_postprocess_args: Legacy postprocessing argument dictionary built during inversion setup.
+        mcmc_args: Arguments passed to ``mcmc.inferpymc``.
         mcmc_results: Raw sampler results from ``mcmc.inferpymc``.
         inv_out_args: Arguments needed to build ``InversionOutput``.
 
@@ -338,11 +340,65 @@ def _build_output_context(
         use_bc=use_bc,
         country_file=country_file,
         paris_postprocessing_kwargs=paris_postprocessing_kwargs,
-        post_process_args=post_process_args,
+        legacy_postprocess_args=legacy_postprocess_args,
+        mcmc_args=mcmc_args,
         mcmc_results=mcmc_results,
         inv_out_args=inv_out_args,
         paths=paths,
     )
+
+
+def _build_inv_out_args(
+    *,
+    fp_data: dict,
+    legacy_postprocess_args: dict,
+    mcmc_results: dict,
+    sites: list[str],
+    start_date: str,
+    end_date: str,
+    species: str,
+    domain: str,
+    is_sat_column: bool,
+) -> dict:
+    """Build explicit arguments for ``make_inv_out_for_fixed_basis_mcmc``.
+
+    Args:
+        fp_data: Basis-applied inversion input datasets.
+        legacy_postprocess_args: Legacy postprocessing values computed alongside inversion inputs.
+        mcmc_results: Raw inversion outputs from ``mcmc.inferpymc``.
+        sites: Site names used in the inversion.
+        start_date: Inversion start date.
+        end_date: Inversion end date.
+        species: Species name for output metadata.
+        domain: Domain name for output metadata.
+        is_sat_column: Whether satellite-column inputs are present.
+
+    Returns:
+        dict: Explicit keyword arguments for ``make_inv_out_for_fixed_basis_mcmc``.
+    """
+    inv_out_args = {
+        "fp_data": fp_data,
+        "Y": legacy_postprocess_args["Y"],
+        "Ytime": legacy_postprocess_args["Ytime"],
+        "error": legacy_postprocess_args["error"],
+        "obs_repeatability": legacy_postprocess_args["obs_repeatability"],
+        "obs_variability": legacy_postprocess_args["obs_variability"],
+        "site_indicator": legacy_postprocess_args["siteindicator"],
+        "site_names": sites,
+        "mcmc_results": mcmc_results,
+        "start_date": start_date,
+        "end_date": end_date,
+        "species": species,
+        "domain": domain,
+        "obs_prior_factor": legacy_postprocess_args["obs_prior_factor"],
+        "obs_prior_upper_level_factor": legacy_postprocess_args["obs_prior_upper_level_factor"],
+    }
+
+    if not is_sat_column:
+        inv_out_args["obs_prior_factor"] = None
+        inv_out_args["obs_prior_upper_level_factor"] = None
+
+    return inv_out_args
 
 
 def _get_inversion_output(context: _OutputContext) -> InversionOutput:
@@ -350,6 +406,18 @@ def _get_inversion_output(context: _OutputContext) -> InversionOutput:
     if context.inv_out is None:
         context.inv_out = make_inv_out_for_fixed_basis_mcmc(**context.inv_out_args)
     return context.inv_out
+
+
+def _prepare_legacy_hbmcmc_postprocess_args(context: _OutputContext) -> dict:
+    """Prepare the legacy argument bag for ``inferpymc_postprocessouts``."""
+    legacy_postprocess_args = context.legacy_postprocess_args.copy()
+    legacy_postprocess_args.update(context.mcmc_args)
+    del legacy_postprocess_args["inv_inputs"]
+    del legacy_postprocess_args["nit"]
+    del legacy_postprocess_args["verbose"]
+    del legacy_postprocess_args["offset_args"]
+    del legacy_postprocess_args["power"]
+    return legacy_postprocess_args
 
 
 def _handle_core_output_artifacts(context: _OutputContext) -> None:
@@ -389,9 +457,11 @@ def _finalize_output(context: _OutputContext) -> xr.Dataset | dict | InversionOu
         outputs = make_legacy_hbmcmc_output(
             inv_out=_get_inversion_output(context),
             mcmc_results=context.mcmc_results,
-            sigma_freq_index=context.post_process_args["sigma_freq_index"],
-            Hx=context.post_process_args["Hx"],
-            Hbc=context.post_process_args.get("Hbc"),
+            # TODO: Stop threading sigma_freq_index explicitly once the legacy model-building
+            # path is removed and sigma_freq_index always comes from model data.
+            sigma_freq_index=context.legacy_postprocess_args["sigma_freq_index"],
+            Hx=context.legacy_postprocess_args["Hx"],
+            Hbc=context.legacy_postprocess_args.get("Hbc"),
             country_file=context.country_file,
             use_bc=context.use_bc,
         )
@@ -447,9 +517,9 @@ def _finalize_output(context: _OutputContext) -> xr.Dataset | dict | InversionOu
     mcmc_results = context.mcmc_results.copy()
     del mcmc_results["trace"]
     del mcmc_results["model"]
-    post_process_args = context.post_process_args.copy()
-    post_process_args.update(mcmc_results)
-    post_process_args_selection, _ = split_function_inputs(post_process_args, mcmc.inferpymc_postprocessouts)
+    legacy_postprocess_args = _prepare_legacy_hbmcmc_postprocess_args(context)
+    legacy_postprocess_args.update(mcmc_results)
+    post_process_args_selection, _ = split_function_inputs(legacy_postprocess_args, mcmc.inferpymc_postprocessouts)
     out = mcmc.inferpymc_postprocessouts(**post_process_args_selection)
 
     end_post = time.time()
@@ -855,9 +925,9 @@ def fixedbasisMCMC(
         mcmc_config["bcprior"] = update_log_normal_prior(bcprior)
 
     mcmc_args = mcmc_config.copy()
-    post_process_args = _extract_post_process_args(inv_inputs)
+    legacy_postprocess_args = _extract_post_process_args(inv_inputs)
 
-    post_process_args.update(
+    legacy_postprocess_args.update(
         {
             "domain": domain,
             "species": species,
@@ -874,22 +944,13 @@ def fixedbasisMCMC(
     )
 
     if use_bc and "H_bc" in inv_inputs:
-        post_process_args["Hbc"] = inv_inputs.H_bc.values
+        legacy_postprocess_args["Hbc"] = inv_inputs.H_bc.values
 
     # cast float64 to float32
-    for k in list(post_process_args.keys()):  # use list to get keys before modifying dict
-        v = post_process_args[k]
+    for k in list(legacy_postprocess_args.keys()):  # use list to get keys before modifying dict
+        v = legacy_postprocess_args[k]
         if isinstance(v, np.ndarray) and v.dtype == "float64":
-            post_process_args[k] = v.astype("float32")
-
-    # add mcmc_args to post_process_args
-    # and delete a few we don't need
-    post_process_args.update(mcmc_args)
-    del post_process_args["inv_inputs"]
-    del post_process_args["nit"]
-    del post_process_args["verbose"]
-    del post_process_args["offset_args"]
-    del post_process_args["power"]
+            legacy_postprocess_args[k] = v.astype("float32")
 
     # add any additional kwargs to mcmc_args (these aren't needed for post processing)
     mcmc_args.update(kwargs)
@@ -910,15 +971,18 @@ def fixedbasisMCMC(
     end_inversion = time.time()
 
     print(f"MCMC Inversion complete. Time taken = {end_inversion - start_inversion:.2f} seconds")
-    # Get args needed for make_inv_out_for_fixed_basis_mcmc
-    inv_out_args, _ = split_function_inputs(post_process_args, make_inv_out_for_fixed_basis_mcmc)
-    inv_out_args["site_names"] = sites
-    inv_out_args["site_indicator"] = post_process_args["siteindicator"]
-    inv_out_args["mcmc_results"] = mcmc_results
 
-    if not is_sat_column:
-        inv_out_args["obs_prior_factor"] = None
-        inv_out_args["obs_prior_upper_level_factor"] = None
+    inv_out_args = _build_inv_out_args(
+        fp_data=fp_data,
+        legacy_postprocess_args=legacy_postprocess_args,
+        mcmc_results=mcmc_results,
+        sites=sites,
+        start_date=start_date,
+        end_date=end_date,
+        species=species,
+        domain=domain,
+        is_sat_column=is_sat_column,
+    )
 
     output_context = _build_output_context(
         output_format=output_format,
@@ -933,7 +997,8 @@ def fixedbasisMCMC(
         paris_postprocessing_kwargs=paris_postprocessing_kwargs,
         save_trace=save_trace,
         save_inversion_output=save_inversion_output,
-        post_process_args=post_process_args,
+        legacy_postprocess_args=legacy_postprocess_args,
+        mcmc_args=mcmc_args,
         mcmc_results=mcmc_results,
         inv_out_args=inv_out_args,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "xarray>=2025.06.0",
     "pandas<3.0",
     "matplotlib",
-    "scipy", 
+    "scipy",
     "openghg",
     "sparse",
     "flox",

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -183,7 +183,7 @@ def test_hbmcmc_postprocessing_saves_legacy_output(mcmc_args, tmpdir):
 
 def test_resolve_output_format_canonicalizes_paris_compatibility():
     with pytest.warns(UserWarning, match="Use `output_format = 'paris'` instead"):
-        resolved = _resolve_output_format("hbmcmc", paris_postprocessing=True, is_sat_column=False)
+        resolved = _resolve_output_format("hbmcmc", paris_postprocessing=True, is_column=False)
 
     assert resolved == "paris"
 

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -2,7 +2,7 @@ import pytest
 import xarray as xr
 from pathlib import Path
 
-from openghg_inversions.hbmcmc.hbmcmc import fixedbasisMCMC
+from openghg_inversions.hbmcmc.hbmcmc import _resolve_output_format, fixedbasisMCMC
 from openghg_inversions.hbmcmc.hbmcmc_output import define_output_filename
 from openghg_inversions.postprocessing.inversion_output import InversionOutput
 from openghg_inversions.postprocessing.legacy_outputs import make_legacy_hbmcmc_output
@@ -179,6 +179,31 @@ def test_hbmcmc_postprocessing_saves_legacy_output(mcmc_args, tmpdir):
     assert Path(output_file).exists()
     reloaded = xr.open_dataset(output_file)
     assert reloaded.sizes["nmeasure"] == outputs.sizes["nmeasure"]
+
+
+def test_resolve_output_format_canonicalizes_paris_compatibility():
+    with pytest.warns(UserWarning, match="Use `output_format = 'paris'` instead"):
+        resolved = _resolve_output_format("hbmcmc", paris_postprocessing=True, is_sat_column=False)
+
+    assert resolved == "paris"
+
+
+def test_paris_postprocessing_compatibility_matches_paris_output_format(mcmc_args):
+    explicit_args = mcmc_args.copy()
+    explicit_args["output_format"] = "paris"
+
+    compat_args = mcmc_args.copy()
+    compat_args["output_format"] = "hbmcmc"
+    compat_args["paris_postprocessing"] = True
+
+    explicit = fixedbasisMCMC(**explicit_args)
+    with pytest.warns(UserWarning, match="Use `output_format = 'paris'` instead"):
+        compat = fixedbasisMCMC(**compat_args)
+
+    assert set(explicit.data_vars) == set(compat.data_vars)
+    assert explicit.sizes == compat.sizes
+    assert explicit["Yobs"].dims == compat["Yobs"].dims
+    assert explicit["Yapost"].dims == compat["Yapost"].dims
 
 
 def test_hbmcmc_postprocessing_preserves_expected_vars_attrs_and_coords(mcmc_args, tmpdir):

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -181,6 +181,55 @@ def test_hbmcmc_postprocessing_saves_legacy_output(mcmc_args, tmpdir):
     assert reloaded.sizes["nmeasure"] == outputs.sizes["nmeasure"]
 
 
+def test_hbmcmc_postprocessing_preserves_expected_vars_attrs_and_coords(mcmc_args, tmpdir):
+    mcmc_args["output_format"] = "hbmcmc_postprocessing"
+    mcmc_args["outputpath"] = str(tmpdir)
+
+    outputs = fixedbasisMCMC(**mcmc_args)
+
+    expected_vars = [
+        "Yobs",
+        "Yerror",
+        "Yerror_repeatability",
+        "Yerror_variability",
+        "Yapriori",
+        "Ymod68",
+        "country68",
+        "fluxapriori",
+        "basisfunctions",
+    ]
+    for var_name in expected_vars:
+        assert var_name in outputs
+        assert "longname" in outputs[var_name].attrs
+
+    assert outputs["Yobs"].dims == ("nmeasure",)
+    assert outputs["Ymod68"].dims == ("nmeasure", "nUI")
+    assert outputs["country68"].dims == ("countrynames", "nUI")
+    assert "UInum" in outputs.coords
+    assert "countrynames" in outputs.coords
+
+
+def test_inv_out_and_trace_outputs_preserve_downstream_dims_and_custom_paths(mcmc_args, tmpdir):
+    trace_path = Path(tmpdir) / "custom_trace.nc"
+    inv_out_path = Path(tmpdir) / "custom_inv_out.nc"
+    mcmc_args["output_format"] = "inv_out"
+    mcmc_args["save_trace"] = str(trace_path)
+    mcmc_args["save_inversion_output"] = str(inv_out_path)
+
+    inv_out = fixedbasisMCMC(**mcmc_args)
+
+    assert trace_path.exists()
+    assert inv_out_path.exists()
+    assert inv_out.obs.dims == ("nmeasure",)
+    assert inv_out.obs_err.dims == ("nmeasure",)
+    assert inv_out.trace_ds["x_posterior"].dims == ("draw", "nx")
+    assert "site" in inv_out.obs.coords
+    assert "time" in inv_out.obs.coords
+    assert "time" not in inv_out.flux.dims
+    if "flux_time" in inv_out.flux.coords:
+        assert "flux_time" in inv_out.flux.dims
+
+
 def test_hbmcmc_postprocessing_output_matches_legacy_core_fields(raw_data_path, europe_country_file):
     """Regression test for deterministic prior concentration terms in legacy-compatible output."""
     with xr.open_dataset(raw_data_path / "standard_rhime_outs.nc") as legacy:


### PR DESCRIPTION
* **Summary of changes**

This is an attempt to clean up the output handling in `fixedbasisMCMC`. This PR extracts most of the output logic from `fixedbasisMCMC`, but doesn't really simplify it.

To simplify the output logic we need to:
- remove the legacy `hbmcmc` format; this format can now be created using the new post-processing code
- simplify `make_inv_out_for_fixed_basis_mcmc`, and possibly make `InversionOutput` simpler too
- split some debugging options from the main script (e.g. if you just want to make/load/save merged data, that probably doesn't need to go through `fixedbasisMCMC`)

I think those changes need to happen in a separate PR. I will update the umbrella issue #360 with a new plan.

Another issue that needs to be addressed before completing #360 is how basis functions are routed to the postprocessing code. Currently the flat basis functions are passed via `fp_all`.

* **Please check if the PR fulfills these requirements**

- [x] Closes #376
- [x] Tests added and passing
- Documentation and tutorials updated/added
- [x] Added an entry to the `CHANGELOG.md` file
- Added any new requirements to `requirements.txt`
