### PR TITLE
Stage E follow up tidying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Stage C of PyMC model refactor. Added function for building PyMC "model components". The model building code from Stage B is still used by default, but the new code can be selected by adding `model_builder="components"` to the .ini file. [PR #382](https://github.com/openghg/openghg_inversions/pull/382)
 - Stage D of PyMC model refactor. Removed temporary scaffolding to preserve legacy model building code. `inferpymc` now only accepts inversion inputs as `xr.Dataset`, and `fixedbasisMCMC` has been updated to reflect this. [PR #389](https://github.com/openghg/openghg_inversions/pull/389)
 - Neutral refactor of `fixedbasisMCMC` output handling to make the end-of-run logic clearer, whichis now split into explicit stages for artefact creation, `InversionOutput` construction, and output mode dispatch. [PR #390](https://github.com/openghg/openghg_inversions/pull/390)
+- Stage E follow-up PyMC refactor tidy-up. `inferpymc` is now a thinner compatibility wrapper over model building, modern `InferenceData` sampling, and explicit legacy adaptation; legacy trace renaming moved out of model construction; `InversionOutput` no longer carries a PyMC model; and the current latent/step compatibility logic is more clearly isolated ahead of a future modern run-inversion path. [PR #391](https://github.com/openghg/openghg_inversions/pull/391)
 
 # Version 0.6.0
 

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -125,7 +125,8 @@ def _prepare_runtime_inv_inputs(
 def _extract_post_process_args(inv_inputs: xr.Dataset) -> dict[str, np.ndarray]:
     """Extract legacy-shaped postprocessing arrays from inversion inputs.
 
-    NOTE: This is for compatibility at Stage D of #370. This should be removed in Stage E.
+    NOTE: Transitional compatibility bridge. This extracts legacy-shaped arrays
+    from already-prepared inversion inputs; it is not a core data-preparation step.
 
     Args:
         inv_inputs: Dataset produced by ``make_inv_inputs``.

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -107,6 +107,12 @@ def build_inferpymc_model(
     """Build the current component-based inferpymc model.
 
     Args:
+        inv_inputs: Canonical inversion-input dataset, usually produced by
+            ``make_inv_inputs(...)``. This dataset must contain the observation
+            and model variables required by the current component-based model,
+            including at minimum ``H``, ``mf``, ``mf_error``,
+            ``site_indicator``, ``sigma_freq_index``, and ``min_error``. When
+            ``use_bc`` is ``True``, it must also contain ``H_bc``.
         xprior: Prior specification for emissions scaling factors.
         bcprior: Prior specification for boundary-condition scaling factors.
         sigprior: Prior specification for model-error terms.
@@ -518,7 +524,8 @@ def inferpymc(
             A common choice is {'pdf': 'truncatednormal', 'lower': 0.0, 'mu': 1.0, 'sigma': 0.1}.
         sigprior: Prior specification for the model-error parameter(s).
         nuts_sampler: Name of the NUTS sampler used by pymc.sample (e.g., "pymc" or "numpyro").
-        nit: Total number of iterations (samples + tuning) to draw per chain.
+        nit: Number of posterior draws to keep per chain. Tuning draws are
+            controlled separately via ``tune``.
         burn: Number of samples to discard as burn-in.
         tune: Number of tuning steps passed to the sampler.
         nchain: Number of MCMC chains to run.

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -237,9 +237,7 @@ def extend_inferencedata_predictive(
             None if sample_posterior_predictive is True else list(sample_posterior_predictive)
         )
         with model:
-            trace.extend(
-                pm.sample_posterior_predictive(trace, model=model, var_names=posterior_var_names)
-            )
+            trace.extend(pm.sample_posterior_predictive(trace, model=model, var_names=posterior_var_names))
 
     return trace
 

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -39,8 +39,8 @@ from openghg_inversions.inversion_inputs import _compact_integer_index  # noqa: 
 # ----------------------------------------
 
 # Defaults to avoid mutable default arguments in model building functions.
-DEFAULT_XPRIOR: PriorArgs = {"pdf": "normal", "mu": 1.0, "sigma": 1.0}
-DEFAULT_BCPRIOR: PriorArgs = {"pdf": "normal", "mu": 1.0, "sigma": 1.0}
+DEFAULT_XPRIOR: PriorArgs = {"pdf": "lognormal", "mean": 1.0, "stdev": 1.0, "reparameterise": True}
+DEFAULT_BCPRIOR: PriorArgs = {"pdf": "truncatednormal", "mu": 1.0, "sigma": 0.05, "lower": 0.0}
 DEFAULT_SIGPRIOR: PriorArgs = {"pdf": "uniform", "lower": 0.1, "upper": 3.0}
 DEFAULT_OFFSETPRIOR: PriorArgs = {"pdf": "normal", "mu": 0, "sigma": 1}
 
@@ -209,6 +209,9 @@ def extend_inferencedata_predictive(
 ) -> az.InferenceData:
     """Extend an InferenceData trace with optional predictive groups.
 
+    Updates InferenceData in-place with requested groups and returns the
+    result for convenience.
+
     Args:
         trace: Posterior trace to extend with predictive groups.
         model: Built PyMC model used for predictive sampling.
@@ -220,27 +223,25 @@ def extend_inferencedata_predictive(
             posterior predictive sampling to those variable names.
 
     Returns:
-        A copy of ``trace`` extended with the requested predictive groups.
+        Input ``trace`` extended with the requested predictive groups.
     """
-    extended = trace.copy()
-
     if sample_prior_predictive:
         prior_draws = (
             trace.posterior.sizes["draw"] if sample_prior_predictive is True else int(sample_prior_predictive)
         )
         with model:
-            extended.extend(pm.sample_prior_predictive(prior_draws, model))
+            trace.extend(pm.sample_prior_predictive(prior_draws, model))
 
     if sample_posterior_predictive:
         posterior_var_names = (
             None if sample_posterior_predictive is True else list(sample_posterior_predictive)
         )
         with model:
-            extended.extend(
-                pm.sample_posterior_predictive(extended, model=model, var_names=posterior_var_names)
+            trace.extend(
+                pm.sample_posterior_predictive(trace, model=model, var_names=posterior_var_names)
             )
 
-    return extended
+    return trace
 
 
 def sample(

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -571,6 +571,8 @@ def inferpymc(
     configured_sample_kwargs = _make_legacy_inferpymc_step_kwargs(model, nuts_sampler=nuts_sampler)
     if sampler_kwargs is not None:
         configured_sample_kwargs.update(sampler_kwargs)
+    configured_sample_kwargs.setdefault("progressbar", False)
+    configured_sample_kwargs.setdefault("cores", nchain)
 
     trace = sample(
         model,

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -2,7 +2,7 @@
 
 import re
 import getpass
-from dataclasses import dataclass
+import warnings
 from pathlib import Path
 from typing import Any
 
@@ -28,57 +28,11 @@ from openghg_inversions.models.components import (  # noqa: E402
     add_inferpymc_likelihood_component,
     add_linear_component,
     add_offset_component,
+    resolve_model_variable,
 )
 from openghg_inversions.models.coords import CoordRegistry, attach_coord_registry  # noqa: E402
 from openghg_inversions.models.priors import PriorArgs  # noqa: E402
-
-
-@dataclass
-class InferPyMCModelSetup:
-    """Container for the PyMC model and sampler configuration used by inferpymc.
-
-    Attributes:
-        model: PyMC model built for the inversion.
-        step1: Step method used for emissions and boundary-condition variables.
-        step2: Step method used for sigma variables.
-        sample_kwargs: Extra keyword arguments forwarded to ``pm.sample``.
-    """
-
-    model: pm.Model
-    step1: Any
-    step2: Any
-    sample_kwargs: dict[str, Any]
-
-
-def _contiguous_index(index: np.ndarray) -> np.ndarray:
-    """Remap integer period indices to contiguous 0..N-1 values."""
-    index = np.asarray(index, dtype=int)
-    if index.size == 0:
-        return index
-
-    uniq = np.unique(index)
-    return np.searchsorted(uniq, index).astype(int)
-
-
-def _contiguous_sigma_time_index(sigma_freq_index: np.ndarray) -> np.ndarray:
-    """Remap sigma period indices to contiguous 0..N-1 values.
-
-    Monthly period indices can legitimately have gaps when entire periods have no
-    data (e.g. Jan and Mar only => [0, 2]). PyMC array indexing is positional, so
-    these values must be compacted before using `sigma[..., sigma_freq_index]`.
-    """
-    return _contiguous_index(sigma_freq_index)
-
-
-def _weighted_apriori_flux_for_months(flux_array_all: np.ndarray, month_index: np.ndarray) -> np.ndarray:
-    """Compute a weighted prior flux average using compacted month positions."""
-    month_index = _contiguous_index(month_index)
-    apriori_flux = np.zeros_like(flux_array_all[:, :, 0])
-
-    for month_pos in np.unique(month_index):
-        apriori_flux += flux_array_all[:, :, month_pos] * np.sum(month_index == month_pos) / len(month_index)
-
-    return apriori_flux
+from openghg_inversions.inversion_inputs import _compact_integer_index  # noqa: E402
 
 
 # ----------------------------------------
@@ -122,7 +76,11 @@ def _prepare_builder_priors(
     prepared_offsetprior = DEFAULT_OFFSETPRIOR.copy() if offsetprior is None else offsetprior.copy()
 
     if reparameterise_log_normal:
-        # TODO: later prefer prior-native `reparameterise=True` over this separate public flag.
+        warnings.warn(
+            "`reparameterise_log_normal` is deprecated. Set `reparameterise=True` in the relevant prior args instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if str(prepared_xprior.get("pdf", "")).lower() == "lognormal":
             prepared_xprior["reparameterise"] = True
         if str(prepared_bcprior.get("pdf", "")).lower() == "lognormal":
@@ -131,129 +89,22 @@ def _prepare_builder_priors(
     return prepared_xprior, prepared_bcprior, prepared_sigprior, prepared_offsetprior
 
 
-def _canonicalise_inferpymc_dataset(
-    inv_inputs: xr.Dataset,
-    /,
-    use_bc: bool,
-    obs_dim: str = "nmeasure",
-    input_state_dim: str = "region",
-    input_bc_state_dim: str = "bc_region",
-    state_dim: str = "nx",
-    bc_state_dim: str = "nbc",
-) -> xr.Dataset:
-    """Convert inversion inputs into the canonical dataset used by the builder.
-
-    Args:
-        inv_inputs: Dataset produced by ``make_inv_inputs``.
-        use_bc: Whether the canonical dataset should include boundary-condition
-            sensitivities.
-        obs_dim: Observation dimension name used by the model components.
-        input_state_dim: State dimension name used by emissions sensitivities in
-            ``inv_inputs``.
-        input_bc_state_dim: State dimension name used by BC sensitivities in
-            ``inv_inputs``.
-        state_dim: State dimension name used for emissions sensitivities.
-        bc_state_dim: State dimension name used for boundary-condition
-            sensitivities.
-
-    Returns:
-        An xarray dataset with observation-first sensitivities and compact sigma
-        period indices.
-
-    Raises:
-        ValueError: If boundary conditions are requested but ``inv_inputs`` does
-            not contain ``H_bc``.
-    """
-    obs_coord = inv_inputs.indexes[obs_dim] if obs_dim in inv_inputs.indexes else inv_inputs[obs_dim].values
-    state_coord = inv_inputs[input_state_dim].values
-    data_vars: dict[str, xr.DataArray] = {
-        "H": xr.DataArray(
-            inv_inputs["H"].transpose(obs_dim, input_state_dim).values,
-            dims=(obs_dim, state_dim),
-            coords={obs_dim: obs_coord, state_dim: np.arange(state_coord.size)},
-            name="H",
-        ),
-        "mf": xr.DataArray(inv_inputs["mf"].values, dims=(obs_dim,), coords={obs_dim: obs_coord}, name="mf"),
-        "mf_error": xr.DataArray(
-            inv_inputs["mf_error"].values,
-            dims=(obs_dim,),
-            coords={obs_dim: obs_coord},
-            name="mf_error",
-        ),
-        "site_indicator": xr.DataArray(
-            inv_inputs["site_indicator"].values.astype(int),
-            dims=(obs_dim,),
-            coords={obs_dim: obs_coord},
-            name="site_indicator",
-        ),
-        "sigma_freq_index": xr.DataArray(
-            _contiguous_sigma_time_index(inv_inputs["sigma_freq_index"].values),
-            dims=(obs_dim,),
-            coords={obs_dim: obs_coord},
-            name="sigma_freq_index",
-        ),
-    }
-    min_error_values = inv_inputs["min_error"].values
-    if np.isscalar(min_error_values) or np.ndim(min_error_values) == 0:
-        min_error_values = np.full(inv_inputs.sizes[obs_dim], min_error_values)
-    data_vars["min_error"] = xr.DataArray(
-        min_error_values,
-        dims=(obs_dim,),
-        coords={obs_dim: obs_coord},
-        name="min_error",
-    )
-    coords: dict[str, Any] = {obs_dim: obs_coord, state_dim: np.arange(state_coord.size)}
-
-    if not isinstance(obs_coord, pd.MultiIndex):
-        if "time" in inv_inputs.coords:
-            coords["time"] = xr.DataArray(
-                inv_inputs["time"].values,
-                dims=(obs_dim,),
-                coords={obs_dim: obs_coord},
-                name="time",
-            )
-
-        for coord_name in ("site",):
-            if coord_name in inv_inputs.coords:
-                coords[coord_name] = xr.DataArray(
-                    inv_inputs[coord_name].values,
-                    dims=(obs_dim,),
-                    coords={obs_dim: obs_coord},
-                    name=coord_name,
-                )
-
-    if use_bc:
-        if "H_bc" not in inv_inputs:
-            raise ValueError("If `use_bc` is True, `inv_inputs` must contain `H_bc`.")
-        bc_coord = inv_inputs[input_bc_state_dim].values
-        coords[bc_state_dim] = np.arange(bc_coord.size)
-        data_vars["H_bc"] = xr.DataArray(
-            inv_inputs["H_bc"].transpose(obs_dim, input_bc_state_dim).values,
-            dims=(obs_dim, bc_state_dim),
-            coords={obs_dim: obs_coord, bc_state_dim: np.arange(bc_coord.size)},
-            name="H_bc",
-        )
-
-    return xr.Dataset(data_vars=data_vars, coords=coords)
-
-
 def build_inferpymc_model(
+    inv_inputs: xr.Dataset,
+    *,
     xprior: dict | None = None,
     bcprior: dict | None = None,
     sigprior: dict | None = None,
     sigma_per_site: bool = True,
     offsetprior: dict | None = None,
     add_offset: bool = False,
-    min_error: np.ndarray | float | None = None,
     use_bc: bool = True,
     reparameterise_log_normal: bool = False,
     pollution_events_from_obs: bool = False,
     no_model_error: bool = False,
     offset_args: dict | None = None,
     power: dict | float = 1.99,
-    nuts_sampler: str = "pymc",
-    inv_inputs: xr.Dataset | None = None,
-) -> InferPyMCModelSetup:
+) -> pm.Model:
     """Build the current component-based inferpymc model.
 
     Args:
@@ -263,8 +114,6 @@ def build_inferpymc_model(
         sigma_per_site: Whether sigma should vary by site.
         offsetprior: Prior specification for optional offsets.
         add_offset: Whether to include an offset term in the model.
-        min_error: Retained for API compatibility. The active runtime path uses
-            ``inv_inputs["min_error"]``.
         use_bc: Whether to include boundary-condition terms in the model.
         reparameterise_log_normal: Whether to request lognormal
             reparameterisation for supported priors.
@@ -275,20 +124,10 @@ def build_inferpymc_model(
             ``add_offset_component``.
         power: Exponent or prior specification used in the likelihood error
             scaling.
-        nuts_sampler: Sampler backend name passed through to the model setup.
-        inv_inputs: Dataset produced by ``make_inv_inputs``.
 
     Returns:
-        ``InferPyMCModelSetup`` containing the built model and sampler
-        configuration.
-
-    Raises:
-        ValueError: If ``inv_inputs`` is not provided.
+        Built PyMC model for the current inferpymc path.
     """
-    if inv_inputs is None:
-        raise ValueError("`inferpymc` now expects `inv_inputs` from `make_inv_inputs`.")
-
-    canonical_ds = _canonicalise_inferpymc_dataset(inv_inputs, use_bc=use_bc)
     xprior, bcprior, sigprior, offsetprior = _prepare_builder_priors(
         xprior=xprior,
         bcprior=bcprior,
@@ -299,10 +138,8 @@ def build_inferpymc_model(
 
     with pm.Model() as model:
         attach_coord_registry(model, CoordRegistry())
-        step1_vars = []
-
         flux_component = add_linear_component(
-            canonical_ds["H"],
+            inv_inputs["H"],
             data_name="hx",
             prior_args=xprior,
             var_name="x",
@@ -310,12 +147,13 @@ def build_inferpymc_model(
             output_dim="nmeasure",
             compute_deterministic=True,
         )
-        step1_vars.append(flux_component.latent)
 
         mu_bc = None
-        if use_bc and "H_bc" in canonical_ds:
+        if use_bc:
+            if "H_bc" not in inv_inputs:
+                raise ValueError("If `use_bc` is True, `inv_inputs` must contain `H_bc`.")
             bc_component = add_linear_component(
-                canonical_ds["H_bc"],
+                inv_inputs["H_bc"],
                 data_name="hbc",
                 prior_args=bcprior,
                 var_name="bc",
@@ -324,13 +162,12 @@ def build_inferpymc_model(
                 compute_deterministic=True,
             )
             mu_bc = bc_component.output
-            step1_vars.append(bc_component.latent)
 
         offset = None
         if add_offset:
             offset_args = offset_args or {}
             offset = add_offset_component(
-                canonical_ds["site_indicator"],
+                inv_inputs["site_indicator"],
                 prior_args=offsetprior,
                 output_name="offset",
                 output_dim="nmeasure",
@@ -338,7 +175,7 @@ def build_inferpymc_model(
             )
 
         add_inferpymc_likelihood_component(
-            canonical_ds,
+            inv_inputs,
             mu=flux_component.output,
             mu_bc=mu_bc,
             offset=offset,
@@ -350,16 +187,7 @@ def build_inferpymc_model(
             output_dim="nmeasure",
         )
 
-        sigma = model.named_vars["sigma"]
-        step1 = pm.NUTS(vars=step1_vars)
-        step2 = pm.Slice(vars=[sigma])
-
-    return InferPyMCModelSetup(
-        model=model,
-        step1=step1,
-        step2=step2,
-        sample_kwargs={"step": [step1, step2] if nuts_sampler == "pymc" else None},
-    )
+    return model
 
 
 # ----------------------------------------
@@ -367,8 +195,188 @@ def build_inferpymc_model(
 # ----------------------------------------
 
 
+def extend_inferencedata_predictive(
+    trace: az.InferenceData,
+    *,
+    model: pm.Model,
+    sample_prior_predictive: bool | int = False,
+    sample_posterior_predictive: bool | list[str] = False,
+) -> az.InferenceData:
+    """Extend an InferenceData trace with optional predictive groups."""
+    extended = trace.copy()
+
+    if sample_prior_predictive:
+        prior_draws = trace.posterior.sizes["draw"] if sample_prior_predictive is True else int(sample_prior_predictive)
+        with model:
+            extended.extend(pm.sample_prior_predictive(prior_draws, model))
+
+    if sample_posterior_predictive:
+        posterior_var_names = None if sample_posterior_predictive is True else list(sample_posterior_predictive)
+        with model:
+            extended.extend(pm.sample_posterior_predictive(extended, model=model, var_names=posterior_var_names))
+
+    return extended
+
+
+def sample(
+    model: pm.Model,
+    *,
+    draws: int = 1000,
+    tune: int = 1000,
+    chains: int = 4,
+    burn: int = 0,  # TODO: add sensible defaults
+    sample_prior_predictive: bool | int = False,
+    sample_posterior_predictive: bool | list[str] = False,
+    **kwargs: Any,
+) -> az.InferenceData:
+    """Sample from an inferpymc model and return a burn-sliced InferenceData trace."""
+    sample_kwargs = dict(kwargs)
+    sample_kwargs.pop("return_inferencedata", None)
+    idata_kwargs = dict(sample_kwargs.pop("idata_kwargs", {}))
+    idata_kwargs["log_likelihood"] = True
+
+    with model:
+        raw_trace = pm.sample(
+            draws=draws,
+            tune=tune,
+            chains=chains,
+            return_inferencedata=True,
+            idata_kwargs=idata_kwargs,
+            **sample_kwargs,
+        )
+
+    burned_trace = raw_trace.isel(draw=slice(burn, None))
+    burned_trace = extend_inferencedata_predictive(
+        burned_trace,
+        model=model,
+        sample_prior_predictive=sample_prior_predictive,
+        sample_posterior_predictive=sample_posterior_predictive,
+    )
+
+    nuts_sampler = sample_kwargs.get("nuts_sampler", "pymc")
+    if nuts_sampler != "pymc" and sample_kwargs.get("compute_convergence_checks", True):
+        if "sample_stats" in burned_trace and "diverging" in burned_trace.sample_stats:
+            divergences = np.sum(burned_trace.sample_stats.diverging).values
+            if divergences > 0:
+                warnings.warn(
+                    f"There were {divergences} divergences. Try increasing target accept or reparameterise.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+
+    return burned_trace
+
+
+# ------------------------------------------------------------
+# Legacy compatibility helpers
+# ------------------------------------------------------------
+
+def _make_legacy_inferpymc_step_kwargs(model: pm.Model, *, nuts_sampler: str) -> dict[str, Any]:
+    """Return inferpymc compatibility step kwargs for the current model."""
+    if nuts_sampler != "pymc":
+        return {}
+
+    if "sigma" not in model.named_vars:
+        return {}
+
+    return {"step": pm.Slice(vars=[model.named_vars["sigma"]], model=model)}
+
+
+def _rename_trace_for_legacy_inferpymc(trace: az.InferenceData) -> az.InferenceData:
+    """Return a legacy-compatible trace view with inferpymc dim names."""
+    rename_map = {"region": "nx", "bc_region": "nbc"}
+    renamed_groups: dict[str, xr.Dataset] = {}
+
+    for group in trace.groups():
+        ds = trace[group]
+        applicable = {old: new for old, new in rename_map.items() if old in ds.dims or old in ds.coords}
+        renamed_groups[group] = ds.rename(applicable) if applicable else ds.copy()
+
+    return az.InferenceData(**renamed_groups)
+
+
+def _resolve_legacy_step_metadata(model: pm.Model, *, sample_kwargs: dict[str, Any]) -> tuple[Any | None, Any | None]:
+    """Return compatibility sampler metadata derived from actual sampling kwargs."""
+    step = sample_kwargs.get("step")
+    if step is None:
+        return None, None
+
+    latent_var_names = tuple(
+        variable.name
+        for variable in (resolve_model_variable(model, "x"), resolve_model_variable(model, "bc"))
+        if variable is not None
+    )
+
+    if isinstance(step, list):
+        slice_step = next((current_step for current_step in step if isinstance(current_step, pm.Slice)), None)
+        latent_step = next((current_step for current_step in step if not isinstance(current_step, pm.Slice)), None)
+        return latent_step, slice_step
+
+    step_var_names = tuple(getattr(variable, "name", None) for variable in getattr(step, "vars", []))
+    if latent_var_names and any(name in latent_var_names for name in step_var_names):
+        return step, None
+    return None, step
+
+
+def _adapt_legacy_inferpymc_results(
+    *,
+    trace: az.InferenceData,
+    model: pm.Model,
+    use_bc: bool,
+    add_offset: bool,
+    sample_kwargs: dict[str, Any],
+) -> dict:
+    """Adapt a modern sampling result into the legacy inferpymc return structure."""
+    legacy_trace = _rename_trace_for_legacy_inferpymc(trace)
+    posterior = legacy_trace.posterior.isel(chain=0, drop=True)
+
+    xouts = posterior.x
+    sigouts = posterior.sigma
+
+    if use_bc:
+        bcouts = posterior.bc
+
+    gelrub = pm.rhat(legacy_trace)["x"].max()
+    if gelrub > 1.05:
+        print("Failed Gelman-Rubin at 1.05")
+        convergence = "Failed"
+    else:
+        convergence = "Passed"
+
+    if add_offset:
+        offset_trace = posterior.offset
+    else:
+        offset_trace = xr.zeros_like(posterior.mu)
+
+    if use_bc:
+        ybc_trace = posterior.mu_bc + offset_trace
+        y_trace = posterior.mu + ybc_trace
+    else:
+        y_trace = posterior.mu + offset_trace
+
+    step1, step2 = _resolve_legacy_step_metadata(model, sample_kwargs=sample_kwargs)
+
+    result = {
+        "xouts": xouts,
+        "sigouts": sigouts,
+        "Ytrace": y_trace.values.T,
+        "OFFSETtrace": offset_trace.values.T,
+        "convergence": convergence,
+        "step1": step1,
+        "step2": step2,
+        "model": model,
+        "trace": legacy_trace,
+    }
+
+    if use_bc:
+        result["bcouts"] = bcouts
+        result["YBCtrace"] = ybc_trace.values.T
+
+    return result
+
+
 def inferpymc(
-    inv_inputs: xr.Dataset | None = None,
+    inv_inputs: xr.Dataset,
     xprior: dict | None = None,
     bcprior: dict | None = None,
     sigprior: dict | None = None,
@@ -391,9 +399,10 @@ def inferpymc(
 ) -> dict:
     """Perform Bayesian inference with PyMC for emissions, BCs, and model error.
 
-    This routine builds the current component-based PyMC model from
-    ``make_inv_inputs`` output, runs sampling, and returns legacy-compatible
-    result keys used by downstream postprocessing.
+    This routine is the compatibility entrypoint for the current PyMC path.
+    It builds the component-based model from ``make_inv_inputs`` output, runs
+    sampling, and adapts the result into the legacy return structure used by
+    downstream postprocessing.
 
     Args:
         inv_inputs: xarray.Dataset produced by ``make_inv_inputs``.
@@ -421,10 +430,9 @@ def inferpymc(
         sampler_kwargs: Extra keyword arguments passed to the sampler.
 
     Returns:
-        Dictionary containing inference results, samples, and diagnostics.
-
-        The returned dictionary uses the legacy key structure. Depending on the
-        selected options, keys typically include:
+        Dictionary containing inference results, samples, and diagnostics in
+        the legacy ``inferpymc`` key structure. Depending on the selected
+        options, keys typically include:
 
         - ``"xouts"``: posterior samples for emissions / fluxes
         - ``"sigouts"``: posterior samples for sigma terms
@@ -440,7 +448,8 @@ def inferpymc(
     burn = int(burn)
     nit = int(nit)
 
-    setup = build_inferpymc_model(
+    model = build_inferpymc_model(
+        inv_inputs,
         xprior=xprior,
         bcprior=bcprior,
         sigprior=sigprior,
@@ -453,85 +462,45 @@ def inferpymc(
         no_model_error=no_model_error,
         offset_args=offset_args,
         power=power,
+    )
+    configured_sample_kwargs = _make_legacy_inferpymc_step_kwargs(model, nuts_sampler=nuts_sampler)
+    if sampler_kwargs is not None:
+        configured_sample_kwargs.update(sampler_kwargs)
+
+    trace = sample(
+        model,
+        draws=nit,
+        burn=burn,
+        tune=int(tune),
+        chains=nchain,
+        sample_prior_predictive=True,
+        sample_posterior_predictive=["y"],
         nuts_sampler=nuts_sampler,
-        inv_inputs=inv_inputs,
+        **configured_sample_kwargs,
     )
 
-    sampler_kwargs = sampler_kwargs or {}
-    with setup.model:
-        trace = pm.sample(
-            nit,
-            tune=int(tune),
-            chains=nchain,
-            step=setup.sample_kwargs["step"],
-            # progressbar=verbose,
-            progressbar=False,
-            cores=nchain,
-            nuts_sampler=nuts_sampler,
-            idata_kwargs={"log_likelihood": True},
-            **sampler_kwargs,
-        )
+    return _adapt_legacy_inferpymc_results(
+        trace=trace,
+        model=model,
+        use_bc=use_bc,
+        add_offset=add_offset,
+        sample_kwargs=configured_sample_kwargs,
+    )
 
-    model = setup.model
-    step1 = setup.step1
-    step2 = setup.step2
 
-    posterior_burned = trace.posterior.isel(chain=0, draw=slice(burn, nit)).drop_vars("chain")
+# ------------------------------------------------------------
+# Legacy post-processing
+# ------------------------------------------------------------
 
-    xouts = posterior_burned.x
+def _weighted_apriori_flux_for_months(flux_array_all: np.ndarray, month_index: np.ndarray) -> np.ndarray:
+    """Compute a weighted prior flux average using compacted month positions."""
+    month_index = _compact_integer_index(month_index)
+    apriori_flux = np.zeros_like(flux_array_all[:, :, 0])
 
-    if use_bc:
-        bcouts = posterior_burned.bc
+    for month_pos in np.unique(month_index):
+        apriori_flux += flux_array_all[:, :, month_pos] * np.sum(month_index == month_pos) / len(month_index)
 
-    sigouts = posterior_burned.sigma
-
-    # Check for convergence
-    gelrub = pm.rhat(trace)["x"].max()
-    if gelrub > 1.05:
-        print("Failed Gelman-Rubin at 1.05")
-        convergence = "Failed"
-    else:
-        convergence = "Passed"
-
-    if nuts_sampler != "pymc":
-        divergences = np.sum(trace.sample_stats.diverging).values
-        if divergences > 0:
-            print(f"There were {divergences} divergences. Try increasing target accept or reparameterise.")
-
-    if add_offset:
-        OFFtrace = posterior_burned.offset
-    else:
-        OFFtrace = xr.zeros_like(posterior_burned.mu)
-
-    if use_bc:
-        YBCtrace = posterior_burned.mu_bc + OFFtrace
-        Ytrace = posterior_burned.mu + YBCtrace
-    else:
-        Ytrace = posterior_burned.mu + OFFtrace
-
-    # truncate trace and sample prior and predictive distributions
-    trace = trace.isel(draw=slice(burn, None))
-    ndraw = nit - burn
-    trace.extend(pm.sample_prior_predictive(ndraw, model))
-    trace.extend(pm.sample_posterior_predictive(trace, model=model, var_names=["y"]))
-
-    result = {
-        "xouts": xouts,
-        "sigouts": sigouts,
-        "Ytrace": Ytrace.values.T,
-        "OFFSETtrace": OFFtrace.values.T,
-        "convergence": convergence,
-        "step1": step1,
-        "step2": step2,
-        "model": model,
-        "trace": trace,
-    }
-
-    if use_bc:
-        result["bcouts"] = bcouts
-        result["YBCtrace"] = YBCtrace.values.T
-
-    return result
+    return apriori_flux
 
 
 def inferpymc_postprocessouts(

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -318,30 +318,6 @@ def sample(
 # ------------------------------------------------------------
 
 
-def _make_legacy_inferpymc_step_kwargs(model: pm.Model, *, nuts_sampler: str) -> dict[str, Any]:
-    """Return inferpymc compatibility step kwargs for the current model.
-
-    Note:
-        Legacy adapter code. This helper preserves the current legacy inferpymc
-        step policy and should not shape the modern sampling API.
-
-    Args:
-        model: Built PyMC model used by ``inferpymc``.
-        nuts_sampler: Sampler backend selected for the compatibility path.
-
-    Returns:
-        Sampling keyword arguments containing any legacy-only explicit step
-        configuration required for the current inferpymc path.
-    """
-    if nuts_sampler != "pymc":
-        return {}
-
-    if "sigma" not in model.named_vars:
-        return {}
-
-    return {"step": pm.Slice(vars=[model.named_vars["sigma"]], model=model)}
-
-
 def _rename_trace_for_legacy_inferpymc(trace: az.InferenceData) -> az.InferenceData:
     """Return a legacy-compatible trace view with inferpymc dim names.
 
@@ -367,48 +343,6 @@ def _rename_trace_for_legacy_inferpymc(trace: az.InferenceData) -> az.InferenceD
         renamed_groups[group] = ds.rename(applicable) if applicable else ds.copy()
 
     return az.InferenceData(**renamed_groups)
-
-
-def _resolve_legacy_step_metadata(
-    model: pm.Model, *, sample_kwargs: dict[str, Any]
-) -> tuple[Any | None, Any | None]:
-    """Return compatibility sampler metadata derived from actual sampling kwargs.
-
-    Note:
-        Legacy adapter code. This helper reconstructs the legacy ``step1`` and
-        ``step2`` metadata from the actual sampling configuration used by
-        ``inferpymc``.
-
-    Args:
-        model: Built PyMC model used for the compatibility sampling run.
-        sample_kwargs: Sampling keyword arguments actually passed to
-            ``pm.sample`` by the compatibility path.
-
-    Returns:
-        A ``(step1, step2)`` tuple matching the legacy inferpymc metadata
-        convention.
-    """
-    step = sample_kwargs.get("step")
-    if step is None:
-        return None, None
-
-    latent_var_names = tuple(
-        variable.name
-        for variable in (resolve_model_variable(model, "x"), resolve_model_variable(model, "bc"))
-        if variable is not None
-    )
-
-    if isinstance(step, list):
-        slice_step = next((current_step for current_step in step if isinstance(current_step, pm.Slice)), None)
-        latent_step = next(
-            (current_step for current_step in step if not isinstance(current_step, pm.Slice)), None
-        )
-        return latent_step, slice_step
-
-    step_var_names = tuple(getattr(variable, "name", None) for variable in getattr(step, "vars", []))
-    if latent_var_names and any(name in latent_var_names for name in step_var_names):
-        return step, None
-    return None, step
 
 
 def _adapt_legacy_inferpymc_results(
@@ -465,7 +399,7 @@ def _adapt_legacy_inferpymc_results(
     else:
         y_trace = posterior.mu + offset_trace
 
-    step1, step2 = _resolve_legacy_step_metadata(model, sample_kwargs=sample_kwargs)
+    step1, step2 = sample_kwargs.get("steps", (None, None))
 
     result = {
         "xouts": xouts,
@@ -575,11 +509,24 @@ def inferpymc(
         offset_args=offset_args,
         power=power,
     )
-    configured_sample_kwargs = _make_legacy_inferpymc_step_kwargs(model, nuts_sampler=nuts_sampler)
-    if sampler_kwargs is not None:
-        configured_sample_kwargs.update(sampler_kwargs)
-    configured_sample_kwargs.setdefault("progressbar", False)
-    configured_sample_kwargs.setdefault("cores", nchain)
+
+    sampler_kwargs = sampler_kwargs or {}
+
+    # add steps for pymc sampler
+    if nuts_sampler == "pymc":
+        with model:
+            latent_vars = tuple(
+                variable
+                for variable in (resolve_model_variable(model, "x"), resolve_model_variable(model, "bc"))
+                if variable is not None
+            )
+            sampler_kwargs["steps"] = [
+                pm.NUTS(latent_vars),
+                pm.Slice([resolve_model_variable(model, "sigma")]),
+            ]
+
+    sampler_kwargs.setdefault("progressbar", False)
+    sampler_kwargs.setdefault("cores", nchain)
 
     trace = sample(
         model,
@@ -590,7 +537,7 @@ def inferpymc(
         sample_prior_predictive=True,
         sample_posterior_predictive=["y"],
         nuts_sampler=nuts_sampler,
-        **configured_sample_kwargs,
+        **sampler_kwargs,
     )
 
     return _adapt_legacy_inferpymc_results(
@@ -598,7 +545,7 @@ def inferpymc(
         model=model,
         use_bc=use_bc,
         add_offset=add_offset,
-        sample_kwargs=configured_sample_kwargs,
+        sample_kwargs=sampler_kwargs,
     )
 
 

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -400,7 +400,7 @@ def _adapt_legacy_inferpymc_results(
     else:
         y_trace = posterior.mu + offset_trace
 
-    step1, step2 = sample_kwargs.get("steps", (None, None))
+    step1, step2 = sample_kwargs.get("step", (None, None))
 
     result = {
         "xouts": xouts,
@@ -521,7 +521,7 @@ def inferpymc(
                 for variable in (resolve_model_variable(model, "x"), resolve_model_variable(model, "bc"))
                 if variable is not None
             )
-            sampler_kwargs["steps"] = [
+            sampler_kwargs["step"] = [
                 pm.NUTS(latent_vars),
                 pm.Slice([resolve_model_variable(model, "sigma")]),
             ]

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -34,7 +34,6 @@ from openghg_inversions.models.coords import CoordRegistry, attach_coord_registr
 from openghg_inversions.models.priors import PriorArgs  # noqa: E402
 from openghg_inversions.inversion_inputs import _compact_integer_index  # noqa: E402
 
-
 # ----------------------------------------
 # Model building code
 # ----------------------------------------
@@ -202,18 +201,38 @@ def extend_inferencedata_predictive(
     sample_prior_predictive: bool | int = False,
     sample_posterior_predictive: bool | list[str] = False,
 ) -> az.InferenceData:
-    """Extend an InferenceData trace with optional predictive groups."""
+    """Extend an InferenceData trace with optional predictive groups.
+
+    Args:
+        trace: Posterior trace to extend with predictive groups.
+        model: Built PyMC model used for predictive sampling.
+        sample_prior_predictive: If truthy, sample prior predictive draws and
+            append ``prior`` and ``prior_predictive`` groups. If an integer,
+            use that many draws; if ``True``, reuse the posterior draw count.
+        sample_posterior_predictive: If truthy, sample posterior predictive
+            draws and append ``posterior_predictive``. If a list, restrict
+            posterior predictive sampling to those variable names.
+
+    Returns:
+        A copy of ``trace`` extended with the requested predictive groups.
+    """
     extended = trace.copy()
 
     if sample_prior_predictive:
-        prior_draws = trace.posterior.sizes["draw"] if sample_prior_predictive is True else int(sample_prior_predictive)
+        prior_draws = (
+            trace.posterior.sizes["draw"] if sample_prior_predictive is True else int(sample_prior_predictive)
+        )
         with model:
             extended.extend(pm.sample_prior_predictive(prior_draws, model))
 
     if sample_posterior_predictive:
-        posterior_var_names = None if sample_posterior_predictive is True else list(sample_posterior_predictive)
+        posterior_var_names = (
+            None if sample_posterior_predictive is True else list(sample_posterior_predictive)
+        )
         with model:
-            extended.extend(pm.sample_posterior_predictive(extended, model=model, var_names=posterior_var_names))
+            extended.extend(
+                pm.sample_posterior_predictive(extended, model=model, var_names=posterior_var_names)
+            )
 
     return extended
 
@@ -229,7 +248,28 @@ def sample(
     sample_posterior_predictive: bool | list[str] = False,
     **kwargs: Any,
 ) -> az.InferenceData:
-    """Sample from an inferpymc model and return a burn-sliced InferenceData trace."""
+    """Sample from a built inferpymc model.
+
+    Args:
+        model: Built PyMC model to sample from.
+        draws: Number of posterior draws to keep per chain.
+        tune: Number of tuning draws passed to ``pm.sample``.
+        chains: Number of MCMC chains to run.
+        burn: Number of posterior draws to discard from the returned
+            ``InferenceData``.
+        sample_prior_predictive: Optional prior predictive sampling request.
+            If an integer, use that many draws; if ``True``, reuse the
+            posterior draw count.
+        sample_posterior_predictive: Optional posterior predictive sampling
+            request. If a list, restrict sampling to those variable names.
+        **kwargs: Additional keyword arguments forwarded to ``pm.sample``.
+            ``return_inferencedata`` is always forced to ``True`` and
+            ``idata_kwargs["log_likelihood"]`` is always enabled.
+
+    Returns:
+        Burn-sliced ``InferenceData`` for the requested model, optionally
+        extended with predictive groups.
+    """
     sample_kwargs = dict(kwargs)
     sample_kwargs.pop("return_inferencedata", None)
     idata_kwargs = dict(sample_kwargs.pop("idata_kwargs", {}))
@@ -271,8 +311,22 @@ def sample(
 # Legacy compatibility helpers
 # ------------------------------------------------------------
 
+
 def _make_legacy_inferpymc_step_kwargs(model: pm.Model, *, nuts_sampler: str) -> dict[str, Any]:
-    """Return inferpymc compatibility step kwargs for the current model."""
+    """Return inferpymc compatibility step kwargs for the current model.
+
+    Note:
+        Legacy adapter code. This helper preserves the current legacy inferpymc
+        step policy and should not shape the modern sampling API.
+
+    Args:
+        model: Built PyMC model used by ``inferpymc``.
+        nuts_sampler: Sampler backend selected for the compatibility path.
+
+    Returns:
+        Sampling keyword arguments containing any legacy-only explicit step
+        configuration required for the current inferpymc path.
+    """
     if nuts_sampler != "pymc":
         return {}
 
@@ -283,7 +337,21 @@ def _make_legacy_inferpymc_step_kwargs(model: pm.Model, *, nuts_sampler: str) ->
 
 
 def _rename_trace_for_legacy_inferpymc(trace: az.InferenceData) -> az.InferenceData:
-    """Return a legacy-compatible trace view with inferpymc dim names."""
+    """Return a legacy-compatible trace view with inferpymc dim names.
+
+    Note:
+        Legacy adapter code. This helper converts canonical modern trace
+        dimension names into the legacy inferpymc naming expected by
+        downstream compatibility code.
+
+    Args:
+        trace: Canonical ``InferenceData`` returned by the modern sampling
+            path.
+
+    Returns:
+        A copied ``InferenceData`` whose groups use the legacy inferpymc
+        dimension names where required.
+    """
     rename_map = {"region": "nx", "bc_region": "nbc"}
     renamed_groups: dict[str, xr.Dataset] = {}
 
@@ -295,8 +363,25 @@ def _rename_trace_for_legacy_inferpymc(trace: az.InferenceData) -> az.InferenceD
     return az.InferenceData(**renamed_groups)
 
 
-def _resolve_legacy_step_metadata(model: pm.Model, *, sample_kwargs: dict[str, Any]) -> tuple[Any | None, Any | None]:
-    """Return compatibility sampler metadata derived from actual sampling kwargs."""
+def _resolve_legacy_step_metadata(
+    model: pm.Model, *, sample_kwargs: dict[str, Any]
+) -> tuple[Any | None, Any | None]:
+    """Return compatibility sampler metadata derived from actual sampling kwargs.
+
+    Note:
+        Legacy adapter code. This helper reconstructs the legacy ``step1`` and
+        ``step2`` metadata from the actual sampling configuration used by
+        ``inferpymc``.
+
+    Args:
+        model: Built PyMC model used for the compatibility sampling run.
+        sample_kwargs: Sampling keyword arguments actually passed to
+            ``pm.sample`` by the compatibility path.
+
+    Returns:
+        A ``(step1, step2)`` tuple matching the legacy inferpymc metadata
+        convention.
+    """
     step = sample_kwargs.get("step")
     if step is None:
         return None, None
@@ -309,7 +394,9 @@ def _resolve_legacy_step_metadata(model: pm.Model, *, sample_kwargs: dict[str, A
 
     if isinstance(step, list):
         slice_step = next((current_step for current_step in step if isinstance(current_step, pm.Slice)), None)
-        latent_step = next((current_step for current_step in step if not isinstance(current_step, pm.Slice)), None)
+        latent_step = next(
+            (current_step for current_step in step if not isinstance(current_step, pm.Slice)), None
+        )
         return latent_step, slice_step
 
     step_var_names = tuple(getattr(variable, "name", None) for variable in getattr(step, "vars", []))
@@ -326,7 +413,25 @@ def _adapt_legacy_inferpymc_results(
     add_offset: bool,
     sample_kwargs: dict[str, Any],
 ) -> dict:
-    """Adapt a modern sampling result into the legacy inferpymc return structure."""
+    """Adapt modern sampling outputs into the legacy inferpymc return structure.
+
+    Note:
+        Legacy adapter code. This helper is the compatibility boundary between
+        the modern ``InferenceData``-first sampling path and the legacy
+        inferpymc dict-of-arrays return contract.
+
+    Args:
+        trace: Canonical ``InferenceData`` returned by the modern sampling
+            path.
+        model: Built PyMC model used for sampling.
+        use_bc: Whether boundary-condition terms are enabled.
+        add_offset: Whether offset terms are enabled.
+        sample_kwargs: Sampling keyword arguments actually used by the legacy
+            compatibility run.
+
+    Returns:
+        Dictionary matching the legacy inferpymc return contract.
+    """
     legacy_trace = _rename_trace_for_legacy_inferpymc(trace)
     posterior = legacy_trace.posterior.isel(chain=0, drop=True)
 
@@ -491,6 +596,7 @@ def inferpymc(
 # ------------------------------------------------------------
 # Legacy post-processing
 # ------------------------------------------------------------
+
 
 def _weighted_apriori_flux_for_months(flux_array_all: np.ndarray, month_index: np.ndarray) -> np.ndarray:
     """Compute a weighted prior flux average using compacted month positions."""

--- a/openghg_inversions/inversion_inputs.py
+++ b/openghg_inversions/inversion_inputs.py
@@ -13,6 +13,16 @@ from openghg_inversions.model_error import percentile_error_method, residual_err
 DatetimeLike = str | dt.datetime | np.datetime64 | pd.Timestamp
 
 
+def _compact_integer_index(values: np.ndarray) -> np.ndarray:
+    """Remap integer indicator values to contiguous 0..N-1 positions."""
+    values = np.asarray(values, dtype=int)
+    if values.size == 0:
+        return values
+
+    unique_values = np.unique(values)
+    return np.searchsorted(unique_values, values).astype(int)
+
+
 def xr_unique_inv(da: xr.DataArray, sort: bool = True) -> xr.DataArray:
     if sort:
 
@@ -93,12 +103,13 @@ def make_sigma_freq(
     freq: Literal["monthly"] | str | None = None,
     anchor_time: DatetimeLike | None = None,
 ) -> xr.DataArray:
-    res = (
+    result = (
         xr.zeros_like(time).astype(int)
         if freq is None
         else make_freq_indicator(time, freq, anchor_time=anchor_time)
     )
-    return res.rename("sigma_freq_index")
+    result = xr.apply_ufunc(_compact_integer_index, result.astype(int))
+    return result.rename("sigma_freq_index")
 
 
 # ADD FUNCTIONS
@@ -109,24 +120,33 @@ def add_min_error(
     min_error_per_site: bool = True,
 ) -> xr.Dataset:
     """Add min_error to combined Dataset."""
+    min_error_data: xr.DataArray | float | np.ndarray
     if isinstance(min_error, float) or (isinstance(min_error, np.ndarray) and min_error.ndim == 0):
-        ds["min_error"] = min_error * xr.ones_like(ds.mf)
+        min_error_data = min_error * xr.ones_like(ds.mf)
     elif isinstance(min_error, dict):
         sites = [k for k in fp_data if not k.startswith(".")]
         err_per_site = np.array([min_error[site] for site in sites])
-        ds["min_error"] = xr_setup_min_error(err_per_site, ds.site_indicator)
+        min_error_data = xr_setup_min_error(err_per_site, ds.site_indicator)
     elif min_error == "residual":
         res_err = residual_error_method(fp_data)
         if min_error_per_site:
-            ds["min_error"] = xr_setup_min_error(res_err, ds.site_indicator)
+            min_error_data = xr_setup_min_error(res_err, ds.site_indicator)
         else:
-            ds["min_error"] = res_err
+            min_error_data = res_err
     elif min_error == "percentile":
         perc_err = percentile_error_method(fp_data)
-        ds["min_error"] = xr_setup_min_error(perc_err, ds.site_indicator)
+        min_error_data = xr_setup_min_error(perc_err, ds.site_indicator)
     else:
         raise ValueError(f"Option '{min_error}' is not valid.")
 
+    if not isinstance(min_error_data, xr.DataArray):
+        min_error_data = xr.full_like(ds.mf, min_error_data).rename("min_error")
+    elif "nmeasure" not in min_error_data.dims:
+        min_error_data = xr.full_like(ds.mf, min_error_data.values).rename("min_error")
+    else:
+        min_error_data = min_error_data.rename("min_error")
+
+    ds["min_error"] = min_error_data
     return ds
 
 

--- a/openghg_inversions/models/components.py
+++ b/openghg_inversions/models/components.py
@@ -65,7 +65,17 @@ def get_model_latent(variable: TensorVariable, base_name: str) -> TensorVariable
 
 
 def resolve_model_variable(model: pm.Model, base_name: str) -> TensorVariable | None:
-    """Return a named model variable, preferring the reparameterised latent form."""
+    """Return a named model variable, preferring the reparameterised latent form.
+
+    Args:
+        model: PyMC model to inspect.
+        base_name: Base variable name to resolve.
+
+    Returns:
+        The reparameterised latent variable ``{base_name}_latent`` when it is
+        present on ``model``, otherwise the user-facing variable named
+        ``base_name``. Returns ``None`` if neither variable exists.
+    """
     latent_name = f"{base_name}_latent"
     if latent_name in model.named_vars:
         return cast(TensorVariable, model.named_vars[latent_name])
@@ -118,7 +128,9 @@ def _resolve_freq_indicator(
 
     time_coord = _extract_time_coord(data, output_dim=output_dim)
     if time_coord is None:
-        raise ValueError(f"Cannot derive frequency indicator for {fallback_name!r}: no time coordinate found.")
+        raise ValueError(
+            f"Cannot derive frequency indicator for {fallback_name!r}: no time coordinate found."
+        )
 
     # TODO: thread sigma_freq/sigma_per_site explicitly through inferpymc model
     # building so sigma components can derive their own indicator, then remove
@@ -235,7 +247,9 @@ def add_sigma_component(
         fallback_name="sigma_freq_index" if var_name == "sigma" else f"{var_name}_freq_indicator",
     )
     if freq_index is None:
-        raise ValueError("Sigma frequency information must be provided via `sigma_freq_index` or `sigma_freq`.")
+        raise ValueError(
+            "Sigma frequency information must be provided via `sigma_freq_index` or `sigma_freq`."
+        )
 
     site_data = site_indicator if per_site else xr.zeros_like(site_indicator)
     site_data_var = add_model_data(site_data, "site_indicator")
@@ -305,9 +319,9 @@ def add_offset_component(
     if indicator is not None:
         period_codes = np.asarray(indicator.values, dtype=int)
         period_matrix = pd.get_dummies(period_codes, dtype=int).values
-        design_matrix = (
-            site_matrix[:, :, None] * period_matrix[:, None, :]
-        ).reshape(site_matrix.shape[0], -1)
+        design_matrix = (site_matrix[:, :, None] * period_matrix[:, None, :]).reshape(
+            site_matrix.shape[0], -1
+        )
     else:
         design_matrix = site_matrix
 
@@ -316,7 +330,10 @@ def add_offset_component(
         xr.DataArray(
             design_matrix,
             dims=(output_dim, "noffset_term"),
-            coords={output_dim: site_indicator.coords[output_dim], "noffset_term": np.arange(design_matrix.shape[1])},
+            coords={
+                output_dim: site_indicator.coords[output_dim],
+                "noffset_term": np.arange(design_matrix.shape[1]),
+            },
             name=design_name,
         ),
         design_name,

--- a/openghg_inversions/models/components.py
+++ b/openghg_inversions/models/components.py
@@ -58,10 +58,20 @@ def get_model_latent(variable: TensorVariable, base_name: str) -> TensorVariable
         present on the active model, otherwise ``variable``.
     """
     model = pm.modelcontext(None)
+    resolved = resolve_model_variable(model, base_name)
+    if resolved is not None:
+        return resolved
+    return variable
+
+
+def resolve_model_variable(model: pm.Model, base_name: str) -> TensorVariable | None:
+    """Return a named model variable, preferring the reparameterised latent form."""
     latent_name = f"{base_name}_latent"
     if latent_name in model.named_vars:
-        return model.named_vars[latent_name]
-    return variable
+        return cast(TensorVariable, model.named_vars[latent_name])
+    if base_name in model.named_vars:
+        return cast(TensorVariable, model.named_vars[base_name])
+    return None
 
 
 def _extract_time_coord(data: xr.DataArray, output_dim: str) -> xr.DataArray | None:
@@ -110,8 +120,9 @@ def _resolve_freq_indicator(
     if time_coord is None:
         raise ValueError(f"Cannot derive frequency indicator for {fallback_name!r}: no time coordinate found.")
 
-    # TODO: once component-side derivation is relied on consistently, some
-    # explicit frequency-indicator plumbing in make_inv_inputs(...) may be removable.
+    # TODO: thread sigma_freq/sigma_per_site explicitly through inferpymc model
+    # building so sigma components can derive their own indicator, then remove
+    # sigma_freq_index from make_inv_inputs(...).
     return make_freq_indicator(time_coord, freq).rename(fallback_name)
 
 
@@ -353,6 +364,9 @@ def add_inferpymc_likelihood_component(
     error_data = add_model_data(data["mf_error"].transpose(output_dim), "error")
     min_error_data = add_model_data(data["min_error"].transpose(output_dim), "min_error")
 
+    # TODO: once inferpymc threads sigma configuration explicitly, let
+    # add_sigma_component(...) derive sigma_freq_index locally and remove this
+    # canonical input dependency from make_inv_inputs(...).
     sigma = add_sigma_component(
         data["site_indicator"].transpose(output_dim),
         prior_args=sigprior,

--- a/openghg_inversions/postprocessing/inversion_output.py
+++ b/openghg_inversions/postprocessing/inversion_output.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 from typing_extensions import Self
-import warnings
 from dataclasses import dataclass
 from typing import Any, Hashable, Literal, TypeVar
 

--- a/openghg_inversions/postprocessing/inversion_output.py
+++ b/openghg_inversions/postprocessing/inversion_output.py
@@ -7,7 +7,6 @@ from typing import Any, Hashable, Literal, TypeVar
 import arviz as az
 import numpy as np
 import pandas as pd
-import pymc as pm
 import xarray as xr
 
 from openghg_inversions.array_ops import get_xr_dummies, align_sparse_lat_lon
@@ -230,7 +229,6 @@ class InversionOutput:
     species: str
     domain: str
     site_names: xr.DataArray | None = None
-    model: pm.Model | None = None
     obs_prior_factor: xr.DataArray | None = None
     obs_prior_upper_level_factor: xr.DataArray | None = None
 
@@ -238,9 +236,6 @@ class InversionOutput:
         """Check that trace has posterior traces, and fix flux time values."""
         if not hasattr(self.trace, "posterior"):
             raise ValueError("`trace` InferenceData must have `posterior` traces.")
-
-        if self.model is not None:
-            self.sample_predictive_distributions()
 
         # check if flux has time coordinate, and add one if necessary
         if "time" not in self.flux.dims:
@@ -259,7 +254,10 @@ class InversionOutput:
             # time not in dims, so just delete the coord
             self.basis = self.basis.drop_vars("time")
 
-        # create trace dataset
+        self._refresh_derived_datasets()
+
+    def _refresh_derived_datasets(self) -> None:
+        """Refresh derived datasets cached from trace and observation inputs."""
         trace_ds = convert_idata_to_dataset(self.trace)
 
         if "longname" in self.obs.attrs:
@@ -285,6 +283,15 @@ class InversionOutput:
             self.obs_repeatability.rename("y_obs_repeatability")
         )
         self.obs_variability = self.nmeasure_to_site_time(self.obs_variability.rename("y_obs_variability"))
+        obs_inputs = [
+            self.obs,
+            self.obs_err,
+            self.obs_prior_factor,
+            self.obs_prior_upper_level_factor,
+            self.obs_repeatability,
+            self.obs_variability,
+        ]
+        self.obs_inputs = xr.merge([x for x in obs_inputs if x is not None])
 
     def __eq__(self, other: Any) -> bool:
         """Check equality between InversionOutput objects.
@@ -324,28 +331,25 @@ class InversionOutput:
         return all(checks)
 
     def sample_predictive_distributions(self, ndraw: int | None = None) -> None:
-        """Sample prior and posterior predictive distributions.
+        """Refresh derived state without mutating the stored trace.
 
-        This creates prior samples as a side-effect.
-
-        Args:
-            ndraw: optional number of prior samples to draw; defaults to the number of
-              posterior samples.
-
+        Predictive groups must be requested in the sampling layer before
+        constructing ``InversionOutput``.
         """
-        if self.model is None:
-            warnings.warn("Cannot sample predictive distributions without PyMC model.")
+        if not all(group in self.trace for group in ("posterior_predictive", "prior", "prior_predictive")):
+            warnings.warn(
+                "InversionOutput no longer samples predictive distributions. Request predictive groups before construction.",
+                UserWarning,
+            )
             return None
 
-        # don't recompute if prior and predictive samples already present
-        if all(group in self.trace for group in ("posterior_predictive", "prior", "prior_predictive")):
-            return None
+        if ndraw is not None and ndraw != self.trace.posterior.sizes["draw"]:
+            warnings.warn(
+                "`ndraw` is ignored because InversionOutput does not resample predictive groups.",
+                UserWarning,
+            )
 
-        if ndraw is None:
-            ndraw = self.trace.posterior.sizes["draw"]
-
-        self.trace.extend(pm.sample_prior_predictive(ndraw, self.model))
-        self.trace.extend(pm.sample_posterior_predictive(self.trace, model=self.model, var_names=["y"]))
+        self._refresh_derived_datasets()
 
     def nmeasure_to_site_time(self, data: XrDataArrayOrSet) -> XrDataArrayOrSet:
         """Convert `nmeasure` coordinate of dataset to stacked (site, time) coordinate.
@@ -469,21 +473,7 @@ class InversionOutput:
             xr.Dataset containing obs and error data
 
         """
-        # TODO: some of these variables could just be stored in a dataset in InversionOutput,
-        # rather than in separate data arrays
-        to_merge = [
-            self.obs,
-            self.obs_err,
-            self.obs_prior_factor,
-            self.obs_prior_upper_level_factor,
-            self.obs_repeatability,
-            self.obs_variability,
-            self.get_model_err(),
-            self.get_total_err(),
-        ]
-
-        to_merge = [x for x in to_merge if x is not None]
-        result = xr.merge(to_merge)
+        result = xr.merge([self.obs_inputs, self.get_model_err(), self.get_total_err()])
         result.attrs = {}
 
         return result
@@ -700,8 +690,13 @@ def make_inv_out_for_fixed_basis_mcmc(
         site_names, dims=["nsite"], coords={"nsite": np.arange(len(site_names))}, name="site_names"
     )
 
-    _, nx = mcmc_results["xouts"].shape
-    nx = np.arange(nx)
+    if "trace" in mcmc_results and hasattr(mcmc_results["trace"], "posterior") and "x" in mcmc_results["trace"].posterior:
+        x_posterior = mcmc_results["trace"].posterior["x"]
+        nx_dim = "nx" if "nx" in x_posterior.coords else "region"
+        nx = np.asarray(x_posterior.coords[nx_dim].values)
+    else:
+        _, nx_size = mcmc_results["xouts"].shape
+        nx = np.arange(nx_size)
 
     basis = get_xr_dummies(fp_data[".basis"], cat_dim="nx", categories=nx)
 
@@ -742,7 +737,6 @@ def make_inv_out_for_fixed_basis_mcmc(
         site_indicators=site_indicator_da,
         flux=flux,
         basis=basis,
-        model=mcmc_results["model"],
         trace=mcmc_results["trace"],
         site_names=site_names_da,
         times=times,

--- a/openghg_inversions/postprocessing/inversion_output.py
+++ b/openghg_inversions/postprocessing/inversion_output.py
@@ -674,17 +674,8 @@ def make_inv_out_for_fixed_basis_mcmc(
         site_names, dims=["nsite"], coords={"nsite": np.arange(len(site_names))}, name="site_names"
     )
 
-    if (
-        "trace" in mcmc_results
-        and hasattr(mcmc_results["trace"], "posterior")
-        and "x" in mcmc_results["trace"].posterior
-    ):
-        x_posterior = mcmc_results["trace"].posterior["x"]
-        nx_dim = "nx" if "nx" in x_posterior.coords else "region"
-        nx = np.asarray(x_posterior.coords[nx_dim].values)
-    else:
-        _, nx_size = mcmc_results["xouts"].shape
-        nx = np.arange(nx_size)
+    _, nx = mcmc_results["xouts"].shape
+    nx = np.arange(nx)
 
     basis = get_xr_dummies(fp_data[".basis"], cat_dim="nx", categories=nx)
 

--- a/openghg_inversions/postprocessing/inversion_output.py
+++ b/openghg_inversions/postprocessing/inversion_output.py
@@ -629,7 +629,11 @@ class InversionOutput:
         open_errors: list[Exception] = []
         for engine in ("h5netcdf", None):
             try:
-                dt = xr.open_datatree(file_path, engine=engine) if engine is not None else xr.open_datatree(file_path)
+                dt = (
+                    xr.open_datatree(file_path, engine=engine)
+                    if engine is not None
+                    else xr.open_datatree(file_path)
+                )
             except (OSError, RuntimeError, ValueError) as exc:
                 open_errors.append(exc)
             else:
@@ -690,7 +694,11 @@ def make_inv_out_for_fixed_basis_mcmc(
         site_names, dims=["nsite"], coords={"nsite": np.arange(len(site_names))}, name="site_names"
     )
 
-    if "trace" in mcmc_results and hasattr(mcmc_results["trace"], "posterior") and "x" in mcmc_results["trace"].posterior:
+    if (
+        "trace" in mcmc_results
+        and hasattr(mcmc_results["trace"], "posterior")
+        and "x" in mcmc_results["trace"].posterior
+    ):
         x_posterior = mcmc_results["trace"].posterior["x"]
         nx_dim = "nx" if "nx" in x_posterior.coords else "region"
         nx = np.asarray(x_posterior.coords[nx_dim].values)

--- a/openghg_inversions/postprocessing/inversion_output.py
+++ b/openghg_inversions/postprocessing/inversion_output.py
@@ -331,26 +331,6 @@ class InversionOutput:
         ]
         return all(checks)
 
-    def sample_predictive_distributions(self, ndraw: int | None = None) -> None:
-        """Refresh derived state without mutating the stored trace.
-
-        Predictive groups must be requested in the sampling layer before
-        constructing ``InversionOutput``.
-        """
-        if not all(group in self.trace for group in ("posterior_predictive", "prior", "prior_predictive")):
-            warnings.warn(
-                "InversionOutput no longer samples predictive distributions. Request predictive groups before construction.",
-                UserWarning,
-            )
-
-        if ndraw is not None and ndraw != self.trace.posterior.sizes["draw"]:
-            warnings.warn(
-                "`ndraw` is ignored because InversionOutput does not resample predictive groups.",
-                UserWarning,
-            )
-
-        self._refresh_derived_datasets()
-
     def nmeasure_to_site_time(self, data: XrDataArrayOrSet) -> XrDataArrayOrSet:
         """Convert `nmeasure` coordinate of dataset to stacked (site, time) coordinate.
 

--- a/openghg_inversions/postprocessing/inversion_output.py
+++ b/openghg_inversions/postprocessing/inversion_output.py
@@ -272,10 +272,11 @@ class InversionOutput:
         self.obs = self.nmeasure_to_site_time(self.obs.rename("y_obs"))
         self.obs_err = self.nmeasure_to_site_time(self.obs_err.rename("y_obs_error"))
 
-        if self.obs_prior_factor is not None and self.obs_prior_upper_level_factor is not None:
+        if self.obs_prior_factor is not None:
             self.obs_prior_factor = self.nmeasure_to_site_time(
                 self.obs_prior_factor.rename("y_obs_prior_factor")
             )
+        if self.obs_prior_upper_level_factor is not None:
             self.obs_prior_upper_level_factor = self.nmeasure_to_site_time(
                 self.obs_prior_upper_level_factor.rename("y_obs_prior_upper_level_factor")
             )
@@ -341,7 +342,6 @@ class InversionOutput:
                 "InversionOutput no longer samples predictive distributions. Request predictive groups before construction.",
                 UserWarning,
             )
-            return None
 
         if ndraw is not None and ndraw != self.trace.posterior.sizes["draw"]:
             warnings.warn(

--- a/openghg_inversions/postprocessing/legacy_outputs.py
+++ b/openghg_inversions/postprocessing/legacy_outputs.py
@@ -231,6 +231,19 @@ def _flatten_nmeasure_for_legacy(data: xr.DataArray) -> xr.DataArray:
     return result.assign_coords(nmeasure=np.arange(result.sizes["nmeasure"]))
 
 
+def _normalise_legacy_sampling_outputs(mcmc_results: dict) -> dict[str, xr.DataArray | str]:
+    """Extract the compatibility fields needed by legacy hbmcmc outputs."""
+    outputs: dict[str, xr.DataArray | str] = {
+        "xouts": mcmc_results["xouts"],
+        "sigouts": mcmc_results["sigouts"],
+    }
+    if "bcouts" in mcmc_results:
+        outputs["bcouts"] = mcmc_results["bcouts"]
+    if "convergence" in mcmc_results:
+        outputs["convergence"] = mcmc_results["convergence"]
+    return outputs
+
+
 def make_legacy_hbmcmc_output(
     inv_out: InversionOutput,
     mcmc_results: dict,
@@ -240,11 +253,11 @@ def make_legacy_hbmcmc_output(
     country_file: str | Path | None = None,
     use_bc: bool = False,
 ) -> xr.Dataset:
-    """Create a legacy-format hbmcmc output dataset from postprocessing products.
+    """Create a legacy-format hbmcmc output dataset from compatibility inputs.
 
     Args:
         inv_out: Inversion outputs container.
-        mcmc_results: Raw dictionary returned by ``inferpymc``.
+        mcmc_results: Compatibility sampling outputs returned by ``inferpymc``.
         sigma_freq_index: Sigma frequency index per measurement.
         Hx: Emissions sensitivity matrix with shape ``(nparam, nmeasure)``.
         Hbc: Boundary-condition sensitivity matrix with shape ``(nBC, nmeasure)``.
@@ -256,6 +269,7 @@ def make_legacy_hbmcmc_output(
         ``inferpymc_postprocessouts``.
 
     """
+    legacy_sampling = _normalise_legacy_sampling_outputs(mcmc_results)
     Hx_arr = np.asarray(Hx)
     Hbc_arr = np.asarray(Hbc) if Hbc is not None else None
     sigma_freq = np.asarray(sigma_freq_index)
@@ -314,8 +328,8 @@ def make_legacy_hbmcmc_output(
         "Yoffmode": conc.get("offset_posterior_mode", xr.zeros_like(inv_out.obs)),
         "Yoff68": conc.get("offset_posterior_hdi_68", xr.zeros_like(conc["y_posterior_predictive_hdi_68"])),
         "Yoff95": conc.get("offset_posterior_hdi_95", xr.zeros_like(conc["y_posterior_predictive_hdi_95"])),
-        "xtrace": (("steps", "nparam"), mcmc_results["xouts"].values),
-        "sigtrace": (("steps", "nsigma_site", "nsigma_time"), mcmc_results["sigouts"].values),
+        "xtrace": (("steps", "nparam"), legacy_sampling["xouts"].values),
+        "sigtrace": (("steps", "nsigma_site", "nsigma_time"), legacy_sampling["sigouts"].values),
         "siteindicator": inv_out.site_indicators,
         "sigmafreqindex": ("nmeasure", sigma_freq),
         "sitenames": inv_out.site_names,
@@ -344,7 +358,7 @@ def make_legacy_hbmcmc_output(
                 "YmodmodeBC": conc["mu_bc_posterior_mode"],
                 "Ymod95BC": conc["mu_bc_posterior_hdi_95"],
                 "Ymod68BC": conc["mu_bc_posterior_hdi_68"],
-                "bctrace": (("steps", "nBC"), mcmc_results["bcouts"].values),
+                "bctrace": (("steps", "nBC"), legacy_sampling["bcouts"].values),
                 "bcsensitivity": (("nmeasure", "nBC"), Hbc_arr.T),
             }
         )
@@ -353,8 +367,8 @@ def make_legacy_hbmcmc_output(
         if isinstance(value, xr.DataArray):
             data_vars[name] = _flatten_nmeasure_for_legacy(value)
 
-    xouts_arr = np.asarray(mcmc_results["xouts"])
-    sigouts_arr = np.asarray(mcmc_results["sigouts"])
+    xouts_arr = np.asarray(legacy_sampling["xouts"])
+    sigouts_arr = np.asarray(legacy_sampling["sigouts"])
     coords: dict[str, xr.DataArray | tuple[tuple[str, ...], np.ndarray]] = {
         "stepnum": ("steps", np.arange(xouts_arr.shape[0])),
         "paramnum": ("nparam", np.arange(Hx_arr.shape[0])),
@@ -385,7 +399,7 @@ def make_legacy_hbmcmc_output(
 
     out.attrs["Start date"] = str(inv_out.start_date)
     out.attrs["End date"] = str(inv_out.end_date)
-    if "convergence" in mcmc_results:
-        out.attrs["Convergence"] = mcmc_results["convergence"]
+    if "convergence" in legacy_sampling:
+        out.attrs["Convergence"] = legacy_sampling["convergence"]
 
     return out

--- a/openghg_inversions/postprocessing/legacy_outputs.py
+++ b/openghg_inversions/postprocessing/legacy_outputs.py
@@ -231,19 +231,6 @@ def _flatten_nmeasure_for_legacy(data: xr.DataArray) -> xr.DataArray:
     return result.assign_coords(nmeasure=np.arange(result.sizes["nmeasure"]))
 
 
-def _normalise_legacy_sampling_outputs(mcmc_results: dict) -> dict[str, xr.DataArray | str]:
-    """Extract the compatibility fields needed by legacy hbmcmc outputs."""
-    outputs: dict[str, xr.DataArray | str] = {
-        "xouts": mcmc_results["xouts"],
-        "sigouts": mcmc_results["sigouts"],
-    }
-    if "bcouts" in mcmc_results:
-        outputs["bcouts"] = mcmc_results["bcouts"]
-    if "convergence" in mcmc_results:
-        outputs["convergence"] = mcmc_results["convergence"]
-    return outputs
-
-
 def make_legacy_hbmcmc_output(
     inv_out: InversionOutput,
     mcmc_results: dict,
@@ -254,6 +241,8 @@ def make_legacy_hbmcmc_output(
     use_bc: bool = False,
 ) -> xr.Dataset:
     """Create a legacy-format hbmcmc output dataset from compatibility inputs.
+
+    TODO: needs to handle offsets
 
     Args:
         inv_out: Inversion outputs container.
@@ -269,7 +258,6 @@ def make_legacy_hbmcmc_output(
         ``inferpymc_postprocessouts``.
 
     """
-    legacy_sampling = _normalise_legacy_sampling_outputs(mcmc_results)
     Hx_arr = np.asarray(Hx)
     Hbc_arr = np.asarray(Hbc) if Hbc is not None else None
     sigma_freq = np.asarray(sigma_freq_index)
@@ -328,8 +316,8 @@ def make_legacy_hbmcmc_output(
         "Yoffmode": conc.get("offset_posterior_mode", xr.zeros_like(inv_out.obs)),
         "Yoff68": conc.get("offset_posterior_hdi_68", xr.zeros_like(conc["y_posterior_predictive_hdi_68"])),
         "Yoff95": conc.get("offset_posterior_hdi_95", xr.zeros_like(conc["y_posterior_predictive_hdi_95"])),
-        "xtrace": (("steps", "nparam"), legacy_sampling["xouts"].values),
-        "sigtrace": (("steps", "nsigma_site", "nsigma_time"), legacy_sampling["sigouts"].values),
+        "xtrace": (("steps", "nparam"), mcmc_results["xouts"].values),
+        "sigtrace": (("steps", "nsigma_site", "nsigma_time"), mcmc_results["sigouts"].values),
         "siteindicator": inv_out.site_indicators,
         "sigmafreqindex": ("nmeasure", sigma_freq),
         "sitenames": inv_out.site_names,
@@ -358,7 +346,7 @@ def make_legacy_hbmcmc_output(
                 "YmodmodeBC": conc["mu_bc_posterior_mode"],
                 "Ymod95BC": conc["mu_bc_posterior_hdi_95"],
                 "Ymod68BC": conc["mu_bc_posterior_hdi_68"],
-                "bctrace": (("steps", "nBC"), legacy_sampling["bcouts"].values),
+                "bctrace": (("steps", "nBC"), mcmc_results["bcouts"].values),
                 "bcsensitivity": (("nmeasure", "nBC"), Hbc_arr.T),
             }
         )
@@ -367,8 +355,8 @@ def make_legacy_hbmcmc_output(
         if isinstance(value, xr.DataArray):
             data_vars[name] = _flatten_nmeasure_for_legacy(value)
 
-    xouts_arr = np.asarray(legacy_sampling["xouts"])
-    sigouts_arr = np.asarray(legacy_sampling["sigouts"])
+    xouts_arr = np.asarray(mcmc_results["xouts"])
+    sigouts_arr = np.asarray(mcmc_results["sigouts"])
     coords: dict[str, xr.DataArray | tuple[tuple[str, ...], np.ndarray]] = {
         "stepnum": ("steps", np.arange(xouts_arr.shape[0])),
         "paramnum": ("nparam", np.arange(Hx_arr.shape[0])),
@@ -399,7 +387,7 @@ def make_legacy_hbmcmc_output(
 
     out.attrs["Start date"] = str(inv_out.start_date)
     out.attrs["End date"] = str(inv_out.end_date)
-    if "convergence" in legacy_sampling:
-        out.attrs["Convergence"] = legacy_sampling["convergence"]
+    if "convergence" in mcmc_results:
+        out.attrs["Convergence"] = mcmc_results["convergence"]
 
     return out

--- a/tests/models/test_components.py
+++ b/tests/models/test_components.py
@@ -10,6 +10,7 @@ from openghg_inversions.models.components import (
     add_model_data,
     add_offset_component,
     add_sigma_component,
+    resolve_model_variable,
 )
 from openghg_inversions.models.coords import CoordRegistry, attach_coord_registry
 
@@ -113,6 +114,29 @@ def test_add_linear_component_returns_effective_reparameterised_latent() -> None
     assert "x_latent" in model.named_vars
     assert "x" in model.named_vars
     assert result.latent is model.named_vars["x_latent"]
+
+
+def test_resolve_model_variable_prefers_latent() -> None:
+    """Check shared model-variable resolution prefers the reparameterised latent."""
+    data = xr.DataArray(
+        np.ones((4, 2)),
+        dims=("nmeasure", "nx"),
+        coords={"nmeasure": np.arange(4), "nx": np.arange(2)},
+        name="H",
+    )
+
+    with pm.Model() as model:
+        attach_coord_registry(model, CoordRegistry())
+        add_linear_component(
+            data,
+            data_name="hx",
+            prior_args={"pdf": "lognormal", "mean": 1.5, "stdev": 0.2, "reparameterise": True},
+            var_name="x",
+            output_name="mu",
+        )
+
+    assert resolve_model_variable(model, "x") is model.named_vars["x_latent"]
+    assert resolve_model_variable(model, "missing") is None
 
 
 def test_add_sigma_component_supports_explicit_and_derived_freq() -> None:

--- a/tests/postprocessing/test_legacy_outputs.py
+++ b/tests/postprocessing/test_legacy_outputs.py
@@ -96,3 +96,24 @@ def test_compute_apriori_flux_handles_multi_year_flux_time():
         apriori_flux,
         xr.DataArray([[1.75]], dims=["lat", "lon"], coords={"lat": [0.0], "lon": [0.0]}),
     )
+
+
+def test_make_legacy_hbmcmc_output_only_sets_convergence_when_present(raw_data_path, europe_country_file):
+    legacy = xr.open_dataset(raw_data_path / "standard_rhime_outs.nc")
+    inv_out = InversionOutput.load(raw_data_path / "inversion_output.nc")
+
+    compat = make_legacy_hbmcmc_output(
+        inv_out=inv_out,
+        mcmc_results={
+            "xouts": legacy["xtrace"],
+            "sigouts": legacy["sigtrace"],
+            "bcouts": legacy["bctrace"],
+        },
+        sigma_freq_index=legacy["sigmafreqindex"].values,
+        Hx=legacy["xsensitivity"].values.T,
+        Hbc=legacy["bcsensitivity"].values.T,
+        country_file=europe_country_file,
+        use_bc=True,
+    )
+
+    assert "Convergence" not in compat.attrs

--- a/tests/postprocessing/test_legacy_outputs.py
+++ b/tests/postprocessing/test_legacy_outputs.py
@@ -11,6 +11,7 @@ from openghg_inversions.postprocessing.legacy_outputs import (
 
 
 def test_make_legacy_hbmcmc_output_handles_mixed_nmeasure_indexes(raw_data_path, europe_country_file):
+    """Legacy output generation tolerates flattened nmeasure-only indexes."""
     legacy = xr.open_dataset(raw_data_path / "standard_rhime_outs.nc")
     inv_out = InversionOutput.load(raw_data_path / "inversion_output.nc")
     inv_out.times = xr.DataArray(
@@ -47,6 +48,7 @@ def test_make_legacy_hbmcmc_output_handles_mixed_nmeasure_indexes(raw_data_path,
 
 
 def test_compute_apriori_flux_handles_missing_month():
+    """Apriori flux weighting handles skipped monthly flux periods."""
     flux = xr.DataArray(
         np.array([[[1.0, 3.0]]]),
         dims=["lat", "lon", "flux_time"],
@@ -69,6 +71,7 @@ def test_compute_apriori_flux_handles_missing_month():
 
 
 def test_map_times_to_available_period_positions_handles_gappy_flux_months():
+    """Period mapping uses the nearest available monthly flux positions."""
     times = pd.to_datetime(["2019-01-15", "2019-01-20", "2019-03-10", "2019-04-20"])
     flux_times = pd.to_datetime(["2019-01-01", "2019-03-01", "2019-04-01"])
 
@@ -78,6 +81,7 @@ def test_map_times_to_available_period_positions_handles_gappy_flux_months():
 
 
 def test_compute_apriori_flux_handles_multi_year_flux_time():
+    """Apriori flux weighting handles yearly flux periods across multiple years."""
     flux = xr.DataArray(
         np.array([[[1.0, 2.0, 3.0]]]),
         dims=["lat", "lon", "flux_time"],
@@ -101,6 +105,7 @@ def test_compute_apriori_flux_handles_multi_year_flux_time():
 
 
 def test_make_legacy_hbmcmc_output_only_sets_convergence_when_present(raw_data_path, europe_country_file):
+    """Legacy outputs omit convergence metadata when it is not supplied."""
     with xr.open_dataset(raw_data_path / "standard_rhime_outs.nc") as legacy:
         inv_out = InversionOutput.load(raw_data_path / "inversion_output.nc")
 

--- a/tests/postprocessing/test_legacy_outputs.py
+++ b/tests/postprocessing/test_legacy_outputs.py
@@ -63,7 +63,9 @@ def test_compute_apriori_flux_handles_missing_month():
 
     apriori_flux = _compute_apriori_flux(flux, "2019-01-01", "2019-04-01", times)
 
-    xr.testing.assert_allclose(apriori_flux, xr.DataArray([[2.0]], dims=["lat", "lon"], coords={"lat": [0.0], "lon": [0.0]}))
+    xr.testing.assert_allclose(
+        apriori_flux, xr.DataArray([[2.0]], dims=["lat", "lon"], coords={"lat": [0.0], "lon": [0.0]})
+    )
 
 
 def test_map_times_to_available_period_positions_handles_gappy_flux_months():
@@ -99,21 +101,21 @@ def test_compute_apriori_flux_handles_multi_year_flux_time():
 
 
 def test_make_legacy_hbmcmc_output_only_sets_convergence_when_present(raw_data_path, europe_country_file):
-    legacy = xr.open_dataset(raw_data_path / "standard_rhime_outs.nc")
-    inv_out = InversionOutput.load(raw_data_path / "inversion_output.nc")
+    with xr.open_dataset(raw_data_path / "standard_rhime_outs.nc") as legacy:
+        inv_out = InversionOutput.load(raw_data_path / "inversion_output.nc")
 
-    compat = make_legacy_hbmcmc_output(
-        inv_out=inv_out,
-        mcmc_results={
-            "xouts": legacy["xtrace"],
-            "sigouts": legacy["sigtrace"],
-            "bcouts": legacy["bctrace"],
-        },
-        sigma_freq_index=legacy["sigmafreqindex"].values,
-        Hx=legacy["xsensitivity"].values.T,
-        Hbc=legacy["bcsensitivity"].values.T,
-        country_file=europe_country_file,
-        use_bc=True,
-    )
+        compat = make_legacy_hbmcmc_output(
+            inv_out=inv_out,
+            mcmc_results={
+                "xouts": legacy["xtrace"],
+                "sigouts": legacy["sigtrace"],
+                "bcouts": legacy["bctrace"],
+            },
+            sigma_freq_index=legacy["sigmafreqindex"].values,
+            Hx=legacy["xsensitivity"].values.T,
+            Hbc=legacy["bcsensitivity"].values.T,
+            country_file=europe_country_file,
+            use_bc=True,
+        )
 
-    assert "Convergence" not in compat.attrs
+        assert "Convergence" not in compat.attrs

--- a/tests/test_inferpymc.py
+++ b/tests/test_inferpymc.py
@@ -292,9 +292,17 @@ def test_legacy_inferpymc_adapter_preserves_compatibility_keys(inferpymc_args: d
         sample_kwargs={"step": pm.Slice(vars=[model.named_vars["sigma"]], model=model)},
     )
 
-    assert {"xouts", "sigouts", "Ytrace", "OFFSETtrace", "trace", "model", "step1", "step2", "convergence"}.issubset(
-        legacy_result
-    )
+    assert {
+        "xouts",
+        "sigouts",
+        "Ytrace",
+        "OFFSETtrace",
+        "trace",
+        "model",
+        "step1",
+        "step2",
+        "convergence",
+    }.issubset(legacy_result)
     assert "bcouts" in legacy_result
     assert "YBCtrace" in legacy_result
     assert "prior_predictive" in legacy_result["trace"]

--- a/tests/test_inferpymc.py
+++ b/tests/test_inferpymc.py
@@ -1,5 +1,3 @@
-from types import MappingProxyType
-
 import arviz as az
 import numpy as np
 import pandas as pd
@@ -9,7 +7,6 @@ import xarray as xr
 
 from openghg_inversions.inversion_inputs import make_inv_inputs
 from openghg_inversions.hbmcmc.inversion_pymc import (
-    _adapt_legacy_inferpymc_results,
     build_inferpymc_model,
     inferpymc,
     sample,
@@ -18,7 +15,7 @@ from openghg_inversions.models.coords import restore_inferencedata_coords
 
 
 @pytest.fixture(scope="module")
-def inferpymc_inputs_dataset(mhd_and_tac_fp_data) -> xr.Dataset:
+def inv_inputs(mhd_and_tac_fp_data) -> xr.Dataset:
     return make_inv_inputs(
         mhd_and_tac_fp_data,
         sites=["MHD", "TAC"],
@@ -30,14 +27,9 @@ def inferpymc_inputs_dataset(mhd_and_tac_fp_data) -> xr.Dataset:
     )
 
 
-@pytest.fixture(scope="module")
-def inferpymc_args(inferpymc_inputs_dataset: xr.Dataset) -> MappingProxyType:
-    args = {
-        "inv_inputs": inferpymc_inputs_dataset,
-        "nit": 1,
-        "burn": 0,
-        "tune": 0,
-        "nchain": 1,
+@pytest.fixture
+def model_args() -> dict:
+    return {
         "xprior": {"pdf": "normal", "mu": 1.0, "sigma": 1.0},
         "bcprior": {"pdf": "normal", "mu": 1.0, "sigma": 1.0},
         "sigprior": {"pdf": "uniform", "lower": 0.1, "upper": 10.0},
@@ -50,82 +42,53 @@ def inferpymc_args(inferpymc_inputs_dataset: xr.Dataset) -> MappingProxyType:
         "no_model_error": False,
         "offset_args": {"drop_first": False, "offset_freq": "D"},
         "power": 1.99,
-        "verbose": False,
-        "sampler_kwargs": {"random_seed": 123, "compute_convergence_checks": False},
     }
-    return MappingProxyType(args)
 
 
-def test_build_inferpymc_model_returns_model(inferpymc_args: dict) -> None:
-    model = build_inferpymc_model(
-        inferpymc_args["inv_inputs"],
-        xprior=inferpymc_args["xprior"],
-        bcprior=inferpymc_args["bcprior"],
-        sigprior=inferpymc_args["sigprior"],
-        sigma_per_site=inferpymc_args["sigma_per_site"],
-        offsetprior=inferpymc_args["offsetprior"],
-        add_offset=inferpymc_args["add_offset"],
-        use_bc=inferpymc_args["use_bc"],
-        reparameterise_log_normal=inferpymc_args["reparameterise_log_normal"],
-        pollution_events_from_obs=inferpymc_args["pollution_events_from_obs"],
-        no_model_error=inferpymc_args["no_model_error"],
-        offset_args=inferpymc_args["offset_args"],
-        power=inferpymc_args["power"],
-    )
+@pytest.fixture
+def sample_args() -> dict:
+    return {"draws": 1, "tune": 0, "chains": 1, "random_seed": 123, "compute_convergence_checks": False}
+
+
+def test_build_inferpymc_model_returns_model(inv_inputs: xr.Dataset, model_args: dict) -> None:
+    """Building the modern inferpymc model returns a PyMC model with canonical coords."""
+    model = build_inferpymc_model(inv_inputs, **model_args)
 
     assert isinstance(model, pm.Model)
+    assert len(model.coords["nmeasure"]) == inv_inputs.sizes["nmeasure"]
+    assert len(model.coords["region"]) == inv_inputs.sizes["region"]
+    assert len(model.coords["bc_region"]) == inv_inputs.sizes["bc_region"]
+    assert len(model.coords["nsigma_site"]) == len(np.unique(inv_inputs["site_indicator"].values))
+    assert len(model.coords["nsigma_time"]) == len(np.unique(inv_inputs["sigma_freq_index"].values))
 
 
-def test_build_inferpymc_model_warns_for_deprecated_reparameterise_flag(inferpymc_args: dict) -> None:
+def test_build_inferpymc_model_warns_for_deprecated_reparameterise_flag(
+    inv_inputs: xr.Dataset, model_args: dict
+) -> None:
+    """The transitional lognormal reparameterisation flag still warns."""
+    args = dict(model_args)
+    args["xprior"] = {"pdf": "lognormal", "mu": 1.0, "sigma": 1.0}
+    args["reparameterise_log_normal"] = True
+
     with pytest.warns(DeprecationWarning, match="reparameterise=True"):
-        build_inferpymc_model(
-            inferpymc_args["inv_inputs"],
-            xprior={"pdf": "lognormal", "mu": 1.0, "sigma": 1.0},
-            bcprior=inferpymc_args["bcprior"],
-            sigprior=inferpymc_args["sigprior"],
-            sigma_per_site=inferpymc_args["sigma_per_site"],
-            offsetprior=inferpymc_args["offsetprior"],
-            add_offset=inferpymc_args["add_offset"],
-            use_bc=inferpymc_args["use_bc"],
-            reparameterise_log_normal=True,
-            pollution_events_from_obs=inferpymc_args["pollution_events_from_obs"],
-            no_model_error=inferpymc_args["no_model_error"],
-            offset_args=inferpymc_args["offset_args"],
-            power=inferpymc_args["power"],
-        )
+        build_inferpymc_model(inv_inputs, **args)
 
 
 def test_build_inferpymc_model_requires_inv_inputs() -> None:
+    """The model builder requires canonical inversion inputs."""
     with pytest.raises(TypeError):
         build_inferpymc_model()  # type: ignore[call-arg]
 
 
-def test_sample_returns_burned_modern_result(inferpymc_args: dict) -> None:
-    model = build_inferpymc_model(
-        inferpymc_args["inv_inputs"],
-        xprior=inferpymc_args["xprior"],
-        bcprior=inferpymc_args["bcprior"],
-        sigprior=inferpymc_args["sigprior"],
-        sigma_per_site=inferpymc_args["sigma_per_site"],
-        offsetprior=inferpymc_args["offsetprior"],
-        add_offset=inferpymc_args["add_offset"],
-        use_bc=inferpymc_args["use_bc"],
-        reparameterise_log_normal=inferpymc_args["reparameterise_log_normal"],
-        pollution_events_from_obs=inferpymc_args["pollution_events_from_obs"],
-        no_model_error=inferpymc_args["no_model_error"],
-        offset_args=inferpymc_args["offset_args"],
-        power=inferpymc_args["power"],
-    )
+def test_sample_returns_burned_modern_result(
+    inv_inputs: xr.Dataset, model_args: dict, sample_args: dict
+) -> None:
+    """Modern sampling returns burn-sliced inference data with canonical dims."""
+    model = build_inferpymc_model(inv_inputs, **model_args)
+    args = dict(sample_args)
+    args.update({"draws": 2, "burn": 1})
 
-    modern_result = sample(
-        model,
-        draws=2,
-        burn=1,
-        tune=0,
-        chains=1,
-        random_seed=123,
-        compute_convergence_checks=False,
-    )
+    modern_result = sample(model, **args)
 
     assert isinstance(modern_result, az.InferenceData)
     assert modern_result.posterior.sizes["draw"] == 1
@@ -133,197 +96,66 @@ def test_sample_returns_burned_modern_result(inferpymc_args: dict) -> None:
     assert "bc_region" in modern_result.posterior["bc"].dims
 
 
-def test_sample_does_not_add_predictive_groups_by_default(inferpymc_args: dict) -> None:
-    model = build_inferpymc_model(
-        inferpymc_args["inv_inputs"],
-        xprior=inferpymc_args["xprior"],
-        bcprior=inferpymc_args["bcprior"],
-        sigprior=inferpymc_args["sigprior"],
-        sigma_per_site=inferpymc_args["sigma_per_site"],
-        offsetprior=inferpymc_args["offsetprior"],
-        add_offset=inferpymc_args["add_offset"],
-        use_bc=inferpymc_args["use_bc"],
-        reparameterise_log_normal=inferpymc_args["reparameterise_log_normal"],
-        pollution_events_from_obs=inferpymc_args["pollution_events_from_obs"],
-        no_model_error=inferpymc_args["no_model_error"],
-        offset_args=inferpymc_args["offset_args"],
-        power=inferpymc_args["power"],
-    )
-
-    modern_result = sample(
-        model,
-        draws=1,
-        tune=0,
-        chains=1,
-        random_seed=123,
-        compute_convergence_checks=False,
-    )
+def test_sample_does_not_add_predictive_groups_by_default(
+    inv_inputs: xr.Dataset, model_args: dict, sample_args: dict
+) -> None:
+    """Modern sampling leaves predictive groups out unless requested."""
+    model = build_inferpymc_model(inv_inputs, **model_args)
+    modern_result = sample(model, **sample_args)
 
     assert "prior" not in modern_result
     assert "prior_predictive" not in modern_result
     assert "posterior_predictive" not in modern_result
 
 
-def test_sample_accepts_plain_model_and_predictive_options(inferpymc_args: dict) -> None:
-    model = build_inferpymc_model(
-        inferpymc_args["inv_inputs"],
-        xprior=inferpymc_args["xprior"],
-        bcprior=inferpymc_args["bcprior"],
-        sigprior=inferpymc_args["sigprior"],
-        sigma_per_site=inferpymc_args["sigma_per_site"],
-        offsetprior=inferpymc_args["offsetprior"],
-        add_offset=inferpymc_args["add_offset"],
-        use_bc=inferpymc_args["use_bc"],
-        reparameterise_log_normal=inferpymc_args["reparameterise_log_normal"],
-        pollution_events_from_obs=inferpymc_args["pollution_events_from_obs"],
-        no_model_error=inferpymc_args["no_model_error"],
-        offset_args=inferpymc_args["offset_args"],
-        power=inferpymc_args["power"],
-    )
+def test_sample_accepts_plain_model_and_predictive_options(
+    inv_inputs: xr.Dataset, model_args: dict, sample_args: dict
+) -> None:
+    """Modern sampling adds predictive groups only when explicitly requested."""
+    model = build_inferpymc_model(inv_inputs, **model_args)
+    args = dict(sample_args)
+    args.update({"sample_prior_predictive": True, "sample_posterior_predictive": ["y"]})
 
-    modern_result = sample(
-        model,
-        draws=1,
-        tune=0,
-        chains=1,
-        random_seed=123,
-        compute_convergence_checks=False,
-        sample_prior_predictive=True,
-        sample_posterior_predictive=["y"],
-    )
+    modern_result = sample(model, **args)
 
     assert "prior" in modern_result
     assert "prior_predictive" in modern_result
     assert "posterior_predictive" in modern_result
 
 
-def test_sample_always_returns_inferencedata(inferpymc_args: dict) -> None:
-    model = build_inferpymc_model(
-        inferpymc_args["inv_inputs"],
-        xprior=inferpymc_args["xprior"],
-        bcprior=inferpymc_args["bcprior"],
-        sigprior=inferpymc_args["sigprior"],
-        sigma_per_site=inferpymc_args["sigma_per_site"],
-        offsetprior=inferpymc_args["offsetprior"],
-        add_offset=inferpymc_args["add_offset"],
-        use_bc=inferpymc_args["use_bc"],
-        reparameterise_log_normal=inferpymc_args["reparameterise_log_normal"],
-        pollution_events_from_obs=inferpymc_args["pollution_events_from_obs"],
-        no_model_error=inferpymc_args["no_model_error"],
-        offset_args=inferpymc_args["offset_args"],
-        power=inferpymc_args["power"],
-    )
+def test_sample_always_returns_inferencedata(
+    inv_inputs: xr.Dataset, model_args: dict, sample_args: dict
+) -> None:
+    """Modern sampling always returns InferenceData regardless of caller kwargs."""
+    model = build_inferpymc_model(inv_inputs, **model_args)
+    args = dict(sample_args)
+    args["return_inferencedata"] = False
 
-    modern_result = sample(
-        model,
-        draws=1,
-        tune=0,
-        chains=1,
-        random_seed=123,
-        compute_convergence_checks=False,
-        return_inferencedata=False,
-    )
+    modern_result = sample(model, **args)
 
     assert isinstance(modern_result, az.InferenceData)
 
 
-def test_sample_preserves_log_likelihood(inferpymc_args: dict) -> None:
-    model = build_inferpymc_model(
-        inferpymc_args["inv_inputs"],
-        xprior=inferpymc_args["xprior"],
-        bcprior=inferpymc_args["bcprior"],
-        sigprior=inferpymc_args["sigprior"],
-        sigma_per_site=inferpymc_args["sigma_per_site"],
-        offsetprior=inferpymc_args["offsetprior"],
-        add_offset=inferpymc_args["add_offset"],
-        use_bc=inferpymc_args["use_bc"],
-        reparameterise_log_normal=inferpymc_args["reparameterise_log_normal"],
-        pollution_events_from_obs=inferpymc_args["pollution_events_from_obs"],
-        no_model_error=inferpymc_args["no_model_error"],
-        offset_args=inferpymc_args["offset_args"],
-        power=inferpymc_args["power"],
-    )
-
-    modern_result = sample(
-        model,
-        draws=1,
-        tune=0,
-        chains=1,
-        random_seed=123,
-        compute_convergence_checks=False,
-    )
+def test_sample_preserves_log_likelihood(inv_inputs: xr.Dataset, model_args: dict, sample_args: dict) -> None:
+    """Modern sampling keeps log likelihood data in the trace."""
+    model = build_inferpymc_model(inv_inputs, **model_args)
+    modern_result = sample(model, **sample_args)
 
     assert "log_likelihood" in modern_result
 
 
-def test_legacy_inferpymc_adapter_preserves_compatibility_keys(inferpymc_args: dict) -> None:
-    model = build_inferpymc_model(
-        inferpymc_args["inv_inputs"],
-        xprior=inferpymc_args["xprior"],
-        bcprior=inferpymc_args["bcprior"],
-        sigprior=inferpymc_args["sigprior"],
-        sigma_per_site=inferpymc_args["sigma_per_site"],
-        offsetprior=inferpymc_args["offsetprior"],
-        add_offset=inferpymc_args["add_offset"],
-        use_bc=inferpymc_args["use_bc"],
-        reparameterise_log_normal=inferpymc_args["reparameterise_log_normal"],
-        pollution_events_from_obs=inferpymc_args["pollution_events_from_obs"],
-        no_model_error=inferpymc_args["no_model_error"],
-        offset_args=inferpymc_args["offset_args"],
-        power=inferpymc_args["power"],
-    )
-    modern_result = sample(
-        model,
-        draws=1,
+def test_inferpymc_preserves_legacy_compatibility_outputs(inv_inputs: xr.Dataset, model_args: dict) -> None:
+    """The public inferpymc wrapper still returns the legacy-shaped outputs."""
+    result = inferpymc(
+        inv_inputs=inv_inputs,
+        nit=1,
         burn=0,
         tune=0,
-        chains=1,
-        random_seed=123,
-        compute_convergence_checks=False,
-        sample_prior_predictive=True,
-        sample_posterior_predictive=["y"],
+        nchain=1,
+        verbose=False,
+        sampler_kwargs={"random_seed": 123, "compute_convergence_checks": False},
+        **model_args,
     )
-
-    legacy_result = _adapt_legacy_inferpymc_results(
-        trace=modern_result,
-        model=model,
-        use_bc=True,
-        add_offset=False,
-        sample_kwargs={"step": pm.Slice(vars=[model.named_vars["sigma"]], model=model)},
-    )
-
-    assert {
-        "xouts",
-        "sigouts",
-        "Ytrace",
-        "OFFSETtrace",
-        "trace",
-        "model",
-        "step1",
-        "step2",
-        "convergence",
-    }.issubset(legacy_result)
-    assert "bcouts" in legacy_result
-    assert "YBCtrace" in legacy_result
-    assert "prior_predictive" in legacy_result["trace"]
-    assert "posterior_predictive" in legacy_result["trace"]
-    assert "nx" in legacy_result["trace"].posterior["x"].dims
-    assert "nbc" in legacy_result["trace"].posterior["bc"].dims
-    assert "region" not in legacy_result["trace"].posterior["x"].dims
-    assert "bc_region" not in legacy_result["trace"].posterior["bc"].dims
-    assert legacy_result["step1"] is None
-    assert isinstance(legacy_result["step2"], pm.Slice)
-
-
-@pytest.fixture(scope="module")
-def inferpymc_with_bc_result(inferpymc_args: dict):
-    return inferpymc(**inferpymc_args)
-
-
-def test_inferpymc_runs_on_inversion_inputs(
-    inferpymc_inputs_dataset: xr.Dataset, inferpymc_with_bc_result
-) -> None:
-    result = inferpymc_with_bc_result
 
     expected_keys = {
         "xouts",
@@ -340,15 +172,18 @@ def test_inferpymc_runs_on_inversion_inputs(
     }
     assert expected_keys.issubset(result.keys())
 
-    assert result["xouts"].sizes["nx"] == inferpymc_inputs_dataset.sizes["region"]
-    assert result["sigouts"].sizes["nsigma_time"] == len(
-        np.unique(inferpymc_inputs_dataset["sigma_freq_index"].values)
-    )
-    assert result["sigouts"].sizes["nsigma_site"] == len(
-        np.unique(inferpymc_inputs_dataset["site_indicator"].values)
-    )
+    assert "prior_predictive" in result["trace"]
+    assert "posterior_predictive" in result["trace"]
+    assert "nx" in result["trace"].posterior["x"].dims
+    assert "nbc" in result["trace"].posterior["bc"].dims
+    assert "region" not in result["trace"].posterior["x"].dims
+    assert "bc_region" not in result["trace"].posterior["bc"].dims
 
-    y = inferpymc_inputs_dataset["mf"].values
+    assert result["xouts"].sizes["nx"] == inv_inputs.sizes["region"]
+    assert result["sigouts"].sizes["nsigma_time"] == len(np.unique(inv_inputs["sigma_freq_index"].values))
+    assert result["sigouts"].sizes["nsigma_site"] == len(np.unique(inv_inputs["site_indicator"].values))
+
+    y = inv_inputs["mf"].values
     assert y.size in result["Ytrace"].shape
     assert result["OFFSETtrace"].shape == result["Ytrace"].shape
     assert result["YBCtrace"].shape == result["Ytrace"].shape
@@ -357,11 +192,13 @@ def test_inferpymc_runs_on_inversion_inputs(
     assert np.isfinite(result["OFFSETtrace"]).all()
     assert np.isfinite(result["YBCtrace"]).all()
 
+    assert "step1" in result
+    assert "step2" in result
 
-def test_inferpymc_model_contains_expected_variables(
-    inferpymc_inputs_dataset: xr.Dataset, inferpymc_with_bc_result
-) -> None:
-    model = inferpymc_with_bc_result["model"]
+
+def test_build_inferpymc_model_contains_expected_variables(inv_inputs: xr.Dataset, model_args: dict) -> None:
+    """The builder adds the core named variables expected by downstream code."""
+    model = build_inferpymc_model(inv_inputs, **model_args)
 
     expected_named_vars = {
         "x",
@@ -379,42 +216,9 @@ def test_inferpymc_model_contains_expected_variables(
     }
     assert expected_named_vars.issubset(model.named_vars)
 
-    assert len(model.coords["nmeasure"]) == inferpymc_inputs_dataset.sizes["nmeasure"]
-    assert len(model.coords["region"]) == inferpymc_inputs_dataset.sizes["region"]
-    assert len(model.coords["bc_region"]) == inferpymc_inputs_dataset.sizes["bc_region"]
-    assert len(model.coords["nsigma_site"]) == len(
-        np.unique(inferpymc_inputs_dataset["site_indicator"].values)
-    )
-    assert len(model.coords["nsigma_time"]) == len(
-        np.unique(inferpymc_inputs_dataset["sigma_freq_index"].values)
-    )
-
-
-def test_build_inferpymc_model_accepts_dataset(
-    inferpymc_args: dict, inferpymc_inputs_dataset: xr.Dataset
-) -> None:
-    model = build_inferpymc_model(
-        inferpymc_inputs_dataset,
-        xprior=inferpymc_args["xprior"],
-        bcprior=inferpymc_args["bcprior"],
-        sigprior=inferpymc_args["sigprior"],
-        sigma_per_site=inferpymc_args["sigma_per_site"],
-        offsetprior=inferpymc_args["offsetprior"],
-        add_offset=inferpymc_args["add_offset"],
-        use_bc=inferpymc_args["use_bc"],
-        reparameterise_log_normal=inferpymc_args["reparameterise_log_normal"],
-        pollution_events_from_obs=inferpymc_args["pollution_events_from_obs"],
-        no_model_error=inferpymc_args["no_model_error"],
-        offset_args=inferpymc_args["offset_args"],
-        power=inferpymc_args["power"],
-    )
-
-    assert isinstance(model, pm.Model)
-    assert len(model.coords["nmeasure"]) == inferpymc_inputs_dataset.sizes["nmeasure"]
-    assert len(model.coords["region"]) == inferpymc_inputs_dataset.sizes["region"]
-
 
 def test_restore_inferencedata_coords_helper_restores_multiindex() -> None:
+    """Coordinate restoration recreates the original MultiIndex on InferenceData."""
     multi_index = pd.MultiIndex.from_arrays(
         [["MHD", "MHD", "TAC"], pd.to_datetime(["2019-01-01", "2019-01-02", "2019-01-01"])],
         names=["site", "time"],
@@ -431,16 +235,14 @@ def test_restore_inferencedata_coords_helper_restores_multiindex() -> None:
     assert restored.posterior.indexes["nmeasure"].equals(multi_index)
 
 
-def test_inferpymc_runs_without_boundary_conditions(inferpymc_args: dict) -> None:
-    args = dict(inferpymc_args)
+def test_build_inferpymc_model_without_boundary_conditions_omits_bc_vars(
+    inv_inputs: xr.Dataset, model_args: dict
+) -> None:
+    """Disabling boundary conditions removes BC variables at model-build time."""
+    args = dict(model_args)
     args["use_bc"] = False
 
-    result = inferpymc(**args)
-
-    assert "bcouts" not in result
-    assert "YBCtrace" not in result
-
-    model = result["model"]
+    model = build_inferpymc_model(inv_inputs, **args)
     assert "bc" not in model.named_vars
     assert "hbc" not in model.named_vars
     assert "mu_bc" not in model.named_vars

--- a/tests/test_inferpymc.py
+++ b/tests/test_inferpymc.py
@@ -9,10 +9,10 @@ import xarray as xr
 
 from openghg_inversions.inversion_inputs import make_inv_inputs
 from openghg_inversions.hbmcmc.inversion_pymc import (
-    InferPyMCModelSetup,
-    _canonicalise_inferpymc_dataset,
+    _adapt_legacy_inferpymc_results,
     build_inferpymc_model,
     inferpymc,
+    sample,
 )
 from openghg_inversions.models.coords import restore_inferencedata_coords
 
@@ -56,9 +56,9 @@ def inferpymc_args(inferpymc_inputs_dataset: xr.Dataset) -> MappingProxyType:
     return MappingProxyType(args)
 
 
-def test_build_inferpymc_model_returns_setup_for_pymc(inferpymc_args: dict) -> None:
-    setup = build_inferpymc_model(
-        inv_inputs=inferpymc_args["inv_inputs"],
+def test_build_inferpymc_model_returns_model(inferpymc_args: dict) -> None:
+    model = build_inferpymc_model(
+        inferpymc_args["inv_inputs"],
         xprior=inferpymc_args["xprior"],
         bcprior=inferpymc_args["bcprior"],
         sigprior=inferpymc_args["sigprior"],
@@ -71,19 +71,38 @@ def test_build_inferpymc_model_returns_setup_for_pymc(inferpymc_args: dict) -> N
         no_model_error=inferpymc_args["no_model_error"],
         offset_args=inferpymc_args["offset_args"],
         power=inferpymc_args["power"],
-        nuts_sampler="pymc",
     )
 
-    assert isinstance(setup, InferPyMCModelSetup)
-    assert isinstance(setup.model, pm.Model)
-    assert isinstance(setup.step1, pm.NUTS)
-    assert isinstance(setup.step2, pm.Slice)
-    assert setup.sample_kwargs["step"] == [setup.step1, setup.step2]
+    assert isinstance(model, pm.Model)
 
 
-def test_build_inferpymc_model_returns_no_steps_for_numpyro(inferpymc_args: dict) -> None:
-    setup = build_inferpymc_model(
-        inv_inputs=inferpymc_args["inv_inputs"],
+def test_build_inferpymc_model_warns_for_deprecated_reparameterise_flag(inferpymc_args: dict) -> None:
+    with pytest.warns(DeprecationWarning, match="reparameterise=True"):
+        build_inferpymc_model(
+            inferpymc_args["inv_inputs"],
+            xprior={"pdf": "lognormal", "mu": 1.0, "sigma": 1.0},
+            bcprior=inferpymc_args["bcprior"],
+            sigprior=inferpymc_args["sigprior"],
+            sigma_per_site=inferpymc_args["sigma_per_site"],
+            offsetprior=inferpymc_args["offsetprior"],
+            add_offset=inferpymc_args["add_offset"],
+            use_bc=inferpymc_args["use_bc"],
+            reparameterise_log_normal=True,
+            pollution_events_from_obs=inferpymc_args["pollution_events_from_obs"],
+            no_model_error=inferpymc_args["no_model_error"],
+            offset_args=inferpymc_args["offset_args"],
+            power=inferpymc_args["power"],
+        )
+
+
+def test_build_inferpymc_model_requires_inv_inputs() -> None:
+    with pytest.raises(TypeError):
+        build_inferpymc_model()  # type: ignore[call-arg]
+
+
+def test_sample_returns_burned_modern_result(inferpymc_args: dict) -> None:
+    model = build_inferpymc_model(
+        inferpymc_args["inv_inputs"],
         xprior=inferpymc_args["xprior"],
         bcprior=inferpymc_args["bcprior"],
         sigprior=inferpymc_args["sigprior"],
@@ -96,14 +115,196 @@ def test_build_inferpymc_model_returns_no_steps_for_numpyro(inferpymc_args: dict
         no_model_error=inferpymc_args["no_model_error"],
         offset_args=inferpymc_args["offset_args"],
         power=inferpymc_args["power"],
-        nuts_sampler="numpyro",
     )
 
-    assert isinstance(setup, InferPyMCModelSetup)
-    assert isinstance(setup.model, pm.Model)
-    assert isinstance(setup.step1, pm.NUTS)
-    assert isinstance(setup.step2, pm.Slice)
-    assert setup.sample_kwargs["step"] is None
+    modern_result = sample(
+        model,
+        draws=2,
+        burn=1,
+        tune=0,
+        chains=1,
+        random_seed=123,
+        compute_convergence_checks=False,
+    )
+
+    assert isinstance(modern_result, az.InferenceData)
+    assert modern_result.posterior.sizes["draw"] == 1
+    assert "region" in modern_result.posterior["x"].dims
+    assert "bc_region" in modern_result.posterior["bc"].dims
+
+
+def test_sample_does_not_add_predictive_groups_by_default(inferpymc_args: dict) -> None:
+    model = build_inferpymc_model(
+        inferpymc_args["inv_inputs"],
+        xprior=inferpymc_args["xprior"],
+        bcprior=inferpymc_args["bcprior"],
+        sigprior=inferpymc_args["sigprior"],
+        sigma_per_site=inferpymc_args["sigma_per_site"],
+        offsetprior=inferpymc_args["offsetprior"],
+        add_offset=inferpymc_args["add_offset"],
+        use_bc=inferpymc_args["use_bc"],
+        reparameterise_log_normal=inferpymc_args["reparameterise_log_normal"],
+        pollution_events_from_obs=inferpymc_args["pollution_events_from_obs"],
+        no_model_error=inferpymc_args["no_model_error"],
+        offset_args=inferpymc_args["offset_args"],
+        power=inferpymc_args["power"],
+    )
+
+    modern_result = sample(
+        model,
+        draws=1,
+        tune=0,
+        chains=1,
+        random_seed=123,
+        compute_convergence_checks=False,
+    )
+
+    assert "prior" not in modern_result
+    assert "prior_predictive" not in modern_result
+    assert "posterior_predictive" not in modern_result
+
+
+def test_sample_accepts_plain_model_and_predictive_options(inferpymc_args: dict) -> None:
+    model = build_inferpymc_model(
+        inferpymc_args["inv_inputs"],
+        xprior=inferpymc_args["xprior"],
+        bcprior=inferpymc_args["bcprior"],
+        sigprior=inferpymc_args["sigprior"],
+        sigma_per_site=inferpymc_args["sigma_per_site"],
+        offsetprior=inferpymc_args["offsetprior"],
+        add_offset=inferpymc_args["add_offset"],
+        use_bc=inferpymc_args["use_bc"],
+        reparameterise_log_normal=inferpymc_args["reparameterise_log_normal"],
+        pollution_events_from_obs=inferpymc_args["pollution_events_from_obs"],
+        no_model_error=inferpymc_args["no_model_error"],
+        offset_args=inferpymc_args["offset_args"],
+        power=inferpymc_args["power"],
+    )
+
+    modern_result = sample(
+        model,
+        draws=1,
+        tune=0,
+        chains=1,
+        random_seed=123,
+        compute_convergence_checks=False,
+        sample_prior_predictive=True,
+        sample_posterior_predictive=["y"],
+    )
+
+    assert "prior" in modern_result
+    assert "prior_predictive" in modern_result
+    assert "posterior_predictive" in modern_result
+
+
+def test_sample_always_returns_inferencedata(inferpymc_args: dict) -> None:
+    model = build_inferpymc_model(
+        inferpymc_args["inv_inputs"],
+        xprior=inferpymc_args["xprior"],
+        bcprior=inferpymc_args["bcprior"],
+        sigprior=inferpymc_args["sigprior"],
+        sigma_per_site=inferpymc_args["sigma_per_site"],
+        offsetprior=inferpymc_args["offsetprior"],
+        add_offset=inferpymc_args["add_offset"],
+        use_bc=inferpymc_args["use_bc"],
+        reparameterise_log_normal=inferpymc_args["reparameterise_log_normal"],
+        pollution_events_from_obs=inferpymc_args["pollution_events_from_obs"],
+        no_model_error=inferpymc_args["no_model_error"],
+        offset_args=inferpymc_args["offset_args"],
+        power=inferpymc_args["power"],
+    )
+
+    modern_result = sample(
+        model,
+        draws=1,
+        tune=0,
+        chains=1,
+        random_seed=123,
+        compute_convergence_checks=False,
+        return_inferencedata=False,
+    )
+
+    assert isinstance(modern_result, az.InferenceData)
+
+
+def test_sample_preserves_log_likelihood(inferpymc_args: dict) -> None:
+    model = build_inferpymc_model(
+        inferpymc_args["inv_inputs"],
+        xprior=inferpymc_args["xprior"],
+        bcprior=inferpymc_args["bcprior"],
+        sigprior=inferpymc_args["sigprior"],
+        sigma_per_site=inferpymc_args["sigma_per_site"],
+        offsetprior=inferpymc_args["offsetprior"],
+        add_offset=inferpymc_args["add_offset"],
+        use_bc=inferpymc_args["use_bc"],
+        reparameterise_log_normal=inferpymc_args["reparameterise_log_normal"],
+        pollution_events_from_obs=inferpymc_args["pollution_events_from_obs"],
+        no_model_error=inferpymc_args["no_model_error"],
+        offset_args=inferpymc_args["offset_args"],
+        power=inferpymc_args["power"],
+    )
+
+    modern_result = sample(
+        model,
+        draws=1,
+        tune=0,
+        chains=1,
+        random_seed=123,
+        compute_convergence_checks=False,
+    )
+
+    assert "log_likelihood" in modern_result
+
+
+def test_legacy_inferpymc_adapter_preserves_compatibility_keys(inferpymc_args: dict) -> None:
+    model = build_inferpymc_model(
+        inferpymc_args["inv_inputs"],
+        xprior=inferpymc_args["xprior"],
+        bcprior=inferpymc_args["bcprior"],
+        sigprior=inferpymc_args["sigprior"],
+        sigma_per_site=inferpymc_args["sigma_per_site"],
+        offsetprior=inferpymc_args["offsetprior"],
+        add_offset=inferpymc_args["add_offset"],
+        use_bc=inferpymc_args["use_bc"],
+        reparameterise_log_normal=inferpymc_args["reparameterise_log_normal"],
+        pollution_events_from_obs=inferpymc_args["pollution_events_from_obs"],
+        no_model_error=inferpymc_args["no_model_error"],
+        offset_args=inferpymc_args["offset_args"],
+        power=inferpymc_args["power"],
+    )
+    modern_result = sample(
+        model,
+        draws=1,
+        burn=0,
+        tune=0,
+        chains=1,
+        random_seed=123,
+        compute_convergence_checks=False,
+        sample_prior_predictive=True,
+        sample_posterior_predictive=["y"],
+    )
+
+    legacy_result = _adapt_legacy_inferpymc_results(
+        trace=modern_result,
+        model=model,
+        use_bc=True,
+        add_offset=False,
+        sample_kwargs={"step": pm.Slice(vars=[model.named_vars["sigma"]], model=model)},
+    )
+
+    assert {"xouts", "sigouts", "Ytrace", "OFFSETtrace", "trace", "model", "step1", "step2", "convergence"}.issubset(
+        legacy_result
+    )
+    assert "bcouts" in legacy_result
+    assert "YBCtrace" in legacy_result
+    assert "prior_predictive" in legacy_result["trace"]
+    assert "posterior_predictive" in legacy_result["trace"]
+    assert "nx" in legacy_result["trace"].posterior["x"].dims
+    assert "nbc" in legacy_result["trace"].posterior["bc"].dims
+    assert "region" not in legacy_result["trace"].posterior["x"].dims
+    assert "bc_region" not in legacy_result["trace"].posterior["bc"].dims
+    assert legacy_result["step1"] is None
+    assert isinstance(legacy_result["step2"], pm.Slice)
 
 
 @pytest.fixture(scope="module")
@@ -171,8 +372,8 @@ def test_inferpymc_model_contains_expected_variables(
     assert expected_named_vars.issubset(model.named_vars)
 
     assert len(model.coords["nmeasure"]) == inferpymc_inputs_dataset.sizes["nmeasure"]
-    assert len(model.coords["nx"]) == inferpymc_inputs_dataset.sizes["region"]
-    assert len(model.coords["nbc"]) == inferpymc_inputs_dataset.sizes["bc_region"]
+    assert len(model.coords["region"]) == inferpymc_inputs_dataset.sizes["region"]
+    assert len(model.coords["bc_region"]) == inferpymc_inputs_dataset.sizes["bc_region"]
     assert len(model.coords["nsigma_site"]) == len(
         np.unique(inferpymc_inputs_dataset["site_indicator"].values)
     )
@@ -184,8 +385,8 @@ def test_inferpymc_model_contains_expected_variables(
 def test_build_inferpymc_model_accepts_dataset(
     inferpymc_args: dict, inferpymc_inputs_dataset: xr.Dataset
 ) -> None:
-    setup = build_inferpymc_model(
-        inv_inputs=inferpymc_inputs_dataset,
+    model = build_inferpymc_model(
+        inferpymc_inputs_dataset,
         xprior=inferpymc_args["xprior"],
         bcprior=inferpymc_args["bcprior"],
         sigprior=inferpymc_args["sigprior"],
@@ -198,27 +399,11 @@ def test_build_inferpymc_model_accepts_dataset(
         no_model_error=inferpymc_args["no_model_error"],
         offset_args=inferpymc_args["offset_args"],
         power=inferpymc_args["power"],
-        nuts_sampler="pymc",
     )
 
-    assert isinstance(setup, InferPyMCModelSetup)
-    assert isinstance(setup.model, pm.Model)
-    assert len(setup.model.coords["nmeasure"]) == inferpymc_inputs_dataset.sizes["nmeasure"]
-    assert len(setup.model.coords["nx"]) == inferpymc_inputs_dataset.sizes["region"]
-
-
-def test_canonicalise_inferpymc_dataset_preserves_dataset_observation_coords(
-    inferpymc_inputs_dataset: xr.Dataset,
-) -> None:
-    canonical = _canonicalise_inferpymc_dataset(inferpymc_inputs_dataset, use_bc=True)
-
-    assert {"H", "H_bc", "mf", "mf_error", "site_indicator", "sigma_freq_index", "min_error"}.issubset(
-        canonical.data_vars
-    )
-    assert canonical["H"].dims == ("nmeasure", "nx")
-    assert canonical["H_bc"].dims == ("nmeasure", "nbc")
-    assert "time" in canonical.coords
-    assert canonical.indexes["nmeasure"].equals(inferpymc_inputs_dataset.indexes["nmeasure"])
+    assert isinstance(model, pm.Model)
+    assert len(model.coords["nmeasure"]) == inferpymc_inputs_dataset.sizes["nmeasure"]
+    assert len(model.coords["region"]) == inferpymc_inputs_dataset.sizes["region"]
 
 
 def test_restore_inferencedata_coords_helper_restores_multiindex() -> None:

--- a/tests/test_inferpymc_month_gap.py
+++ b/tests/test_inferpymc_month_gap.py
@@ -52,6 +52,7 @@ def _synthetic_fp_data_one_site_with_missing_month() -> dict[str, xr.Dataset]:
 
 
 def test_make_inv_inputs_month_gap_monthly_indices_are_contiguous():
+    """Monthly sigma indices stay contiguous when a month is missing entirely."""
     fp_data = _synthetic_fp_data_one_site_with_missing_month()
 
     inv_inputs = make_inv_inputs(
@@ -69,6 +70,7 @@ def test_make_inv_inputs_month_gap_monthly_indices_are_contiguous():
 
 
 def test_inferpymc_smoke_runs_for_month_gap():
+    """The legacy inferpymc wrapper still runs on gappy monthly inputs."""
     fp_data = _synthetic_fp_data_one_site_with_missing_month()
 
     inv_inputs = make_inv_inputs(
@@ -102,6 +104,7 @@ def test_inferpymc_smoke_runs_for_month_gap():
 
 
 def test_weighted_apriori_flux_handles_missing_month():
+    """Weighted prior fluxes use compacted month positions for missing months."""
     flux_array_all = np.array([[[1.0, 3.0]]], dtype=np.float32)
     month_index = np.array([0, 0, 2, 2], dtype=int)
 
@@ -111,6 +114,7 @@ def test_weighted_apriori_flux_handles_missing_month():
 
 
 def test_map_times_to_available_period_positions_handles_gappy_flux_months():
+    """Monthly period mapping uses available periods even when months are skipped."""
     times = pd.to_datetime(["2019-01-15", "2019-01-20", "2019-03-10", "2019-04-20"])
     flux_times = pd.to_datetime(["2019-01-01", "2019-03-01", "2019-04-01"])
 
@@ -120,6 +124,7 @@ def test_map_times_to_available_period_positions_handles_gappy_flux_months():
 
 
 def test_map_times_to_available_period_positions_handles_multi_year_flux_time():
+    """Yearly period mapping stays stable across multiple available years."""
     times = pd.to_datetime(["2023-03-15", "2023-11-20", "2024-07-10", "2025-04-20"])
     flux_times = pd.to_datetime(["2023-01-01", "2024-01-01", "2025-01-01"])
 

--- a/tests/test_inferpymc_month_gap.py
+++ b/tests/test_inferpymc_month_gap.py
@@ -7,7 +7,6 @@ import xarray as xr
 from openghg_inversions import utils
 from openghg_inversions.inversion_inputs import make_inv_inputs
 from openghg_inversions.hbmcmc.inversion_pymc import (
-    _canonicalise_inferpymc_dataset,
     _weighted_apriori_flux_for_months,
     inferpymc,
 )
@@ -52,7 +51,7 @@ def _synthetic_fp_data_one_site_with_missing_month() -> dict[str, xr.Dataset]:
     return {"AAA": ds}
 
 
-def test_make_inv_inputs_month_gap_monthly_indices_are_non_contiguous():
+def test_make_inv_inputs_month_gap_monthly_indices_are_contiguous():
     fp_data = _synthetic_fp_data_one_site_with_missing_month()
 
     inv_inputs = make_inv_inputs(
@@ -66,10 +65,7 @@ def test_make_inv_inputs_month_gap_monthly_indices_are_non_contiguous():
     )
 
     uniq = np.unique(inv_inputs["sigma_freq_index"].values)
-    np.testing.assert_array_equal(uniq, np.array([0, 2]))
-
-    canonical = _canonicalise_inferpymc_dataset(inv_inputs, use_bc=True)
-    np.testing.assert_array_equal(np.unique(canonical["sigma_freq_index"].values), np.array([0, 1]))
+    np.testing.assert_array_equal(uniq, np.array([0, 1]))
 
 
 def test_inferpymc_smoke_runs_for_month_gap():

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -1,6 +1,7 @@
 import pytest
 import xarray as xr
 from pathlib import Path
+import arviz as az
 
 from openghg_inversions.hbmcmc.hbmcmc import _resolve_output_format, fixedbasisMCMC
 from openghg_inversions.hbmcmc.hbmcmc_output import define_output_filename
@@ -253,6 +254,61 @@ def test_inv_out_and_trace_outputs_preserve_downstream_dims_and_custom_paths(mcm
     assert "time" not in inv_out.flux.dims
     if "flux_time" in inv_out.flux.coords:
         assert "flux_time" in inv_out.flux.dims
+
+
+def test_inversion_output_construction_and_explicit_predictive_sampling(mcmc_args):
+    mcmc_args["output_format"] = "inv_out"
+    base_inv_out = fixedbasisMCMC(**mcmc_args)
+
+    posterior_only_trace = az.InferenceData(
+        **{
+            group: getattr(base_inv_out.trace, group)
+            for group in ("posterior", "sample_stats", "observed_data", "constant_data")
+            if group in base_inv_out.trace
+        }
+    )
+    inv_out = InversionOutput(
+        obs=base_inv_out.obs.reset_index("nmeasure", drop=True),
+        obs_err=base_inv_out.obs_err.reset_index("nmeasure", drop=True),
+        obs_prior_factor=(
+            base_inv_out.obs_prior_factor.reset_index("nmeasure", drop=True)
+            if base_inv_out.obs_prior_factor is not None
+            else None
+        ),
+        obs_prior_upper_level_factor=(
+            base_inv_out.obs_prior_upper_level_factor.reset_index("nmeasure", drop=True)
+            if base_inv_out.obs_prior_upper_level_factor is not None
+            else None
+        ),
+        obs_repeatability=base_inv_out.obs_repeatability.reset_index("nmeasure", drop=True),
+        obs_variability=base_inv_out.obs_variability.reset_index("nmeasure", drop=True),
+        flux=base_inv_out.flux.squeeze(drop=True),
+        basis=base_inv_out.basis,
+        trace=posterior_only_trace,
+        site_indicators=base_inv_out.site_indicators.reset_index("nmeasure", drop=True),
+        times=base_inv_out.times.reset_index("nmeasure", drop=True),
+        start_date=base_inv_out.start_date,
+        end_date=base_inv_out.end_date,
+        species=base_inv_out.species,
+        domain=base_inv_out.domain,
+        site_names=base_inv_out.site_names,
+    )
+
+    assert "prior" not in inv_out.trace
+    assert "posterior_predictive" not in inv_out.trace
+    assert {
+        "y_obs",
+        "y_obs_error",
+        "y_obs_repeatability",
+        "y_obs_variability",
+    }.issubset(inv_out.obs_inputs.data_vars)
+
+    with pytest.warns(UserWarning, match="no longer samples predictive distributions"):
+        inv_out.sample_predictive_distributions()
+
+    assert "prior" not in inv_out.trace
+    assert "prior_predictive" not in inv_out.trace
+    assert "posterior_predictive" not in inv_out.trace
 
 
 def test_hbmcmc_postprocessing_output_matches_legacy_core_fields(raw_data_path, europe_country_file):

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -1,7 +1,6 @@
 import pytest
 import xarray as xr
 from pathlib import Path
-import arviz as az
 
 from openghg_inversions.hbmcmc.hbmcmc import _resolve_output_format, fixedbasisMCMC
 from openghg_inversions.hbmcmc.hbmcmc_output import define_output_filename

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -256,61 +256,6 @@ def test_inv_out_and_trace_outputs_preserve_downstream_dims_and_custom_paths(mcm
         assert "flux_time" in inv_out.flux.dims
 
 
-def test_inversion_output_construction_and_explicit_predictive_sampling(mcmc_args):
-    mcmc_args["output_format"] = "inv_out"
-    base_inv_out = fixedbasisMCMC(**mcmc_args)
-
-    posterior_only_trace = az.InferenceData(
-        **{
-            group: getattr(base_inv_out.trace, group)
-            for group in ("posterior", "sample_stats", "observed_data", "constant_data")
-            if group in base_inv_out.trace
-        }
-    )
-    inv_out = InversionOutput(
-        obs=base_inv_out.obs.reset_index("nmeasure", drop=True),
-        obs_err=base_inv_out.obs_err.reset_index("nmeasure", drop=True),
-        obs_prior_factor=(
-            base_inv_out.obs_prior_factor.reset_index("nmeasure", drop=True)
-            if base_inv_out.obs_prior_factor is not None
-            else None
-        ),
-        obs_prior_upper_level_factor=(
-            base_inv_out.obs_prior_upper_level_factor.reset_index("nmeasure", drop=True)
-            if base_inv_out.obs_prior_upper_level_factor is not None
-            else None
-        ),
-        obs_repeatability=base_inv_out.obs_repeatability.reset_index("nmeasure", drop=True),
-        obs_variability=base_inv_out.obs_variability.reset_index("nmeasure", drop=True),
-        flux=base_inv_out.flux.squeeze(drop=True),
-        basis=base_inv_out.basis,
-        trace=posterior_only_trace,
-        site_indicators=base_inv_out.site_indicators.reset_index("nmeasure", drop=True),
-        times=base_inv_out.times.reset_index("nmeasure", drop=True),
-        start_date=base_inv_out.start_date,
-        end_date=base_inv_out.end_date,
-        species=base_inv_out.species,
-        domain=base_inv_out.domain,
-        site_names=base_inv_out.site_names,
-    )
-
-    assert "prior" not in inv_out.trace
-    assert "posterior_predictive" not in inv_out.trace
-    assert {
-        "y_obs",
-        "y_obs_error",
-        "y_obs_repeatability",
-        "y_obs_variability",
-    }.issubset(inv_out.obs_inputs.data_vars)
-
-    with pytest.warns(UserWarning, match="no longer samples predictive distributions"):
-        inv_out.sample_predictive_distributions()
-
-    assert "prior" not in inv_out.trace
-    assert "prior_predictive" not in inv_out.trace
-    assert "posterior_predictive" not in inv_out.trace
-
-
 def test_hbmcmc_postprocessing_output_matches_legacy_core_fields(raw_data_path, europe_country_file):
     """Regression test for deterministic prior concentration terms in legacy-compatible output."""
     with xr.open_dataset(raw_data_path / "standard_rhime_outs.nc") as legacy:

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -164,6 +164,7 @@ def test_country_outputs_lognormal_reparam_conflict(mcmc_args, europe_country_fi
 
 
 def test_hbmcmc_postprocessing_saves_legacy_output(mcmc_args, tmpdir):
+    """Legacy postprocessing output can still be saved and reloaded."""
     mcmc_args["output_format"] = "hbmcmc_postprocessing"
     mcmc_args["outputpath"] = str(tmpdir)
 
@@ -183,6 +184,7 @@ def test_hbmcmc_postprocessing_saves_legacy_output(mcmc_args, tmpdir):
 
 
 def test_resolve_output_format_canonicalizes_paris_compatibility():
+    """The old PARIS compatibility switch resolves to the canonical output format."""
     with pytest.warns(UserWarning, match="Use `output_format = 'paris'` instead"):
         resolved = _resolve_output_format("hbmcmc", paris_postprocessing=True, is_column=False)
 
@@ -190,6 +192,7 @@ def test_resolve_output_format_canonicalizes_paris_compatibility():
 
 
 def test_paris_postprocessing_compatibility_matches_paris_output_format(mcmc_args):
+    """Compatibility PARIS output matches the explicit canonical format."""
     explicit_args = mcmc_args.copy()
     explicit_args["output_format"] = "paris"
 
@@ -208,6 +211,7 @@ def test_paris_postprocessing_compatibility_matches_paris_output_format(mcmc_arg
 
 
 def test_hbmcmc_postprocessing_preserves_expected_vars_attrs_and_coords(mcmc_args, tmpdir):
+    """Legacy-style postprocessing keeps its core vars, attrs, and coords."""
     mcmc_args["output_format"] = "hbmcmc_postprocessing"
     mcmc_args["outputpath"] = str(tmpdir)
 
@@ -236,6 +240,7 @@ def test_hbmcmc_postprocessing_preserves_expected_vars_attrs_and_coords(mcmc_arg
 
 
 def test_inv_out_and_trace_outputs_preserve_downstream_dims_and_custom_paths(mcmc_args, tmpdir):
+    """Saved trace and inversion output files preserve downstream-facing dims."""
     trace_path = Path(tmpdir) / "custom_trace.nc"
     inv_out_path = Path(tmpdir) / "custom_inv_out.nc"
     mcmc_args["output_format"] = "inv_out"


### PR DESCRIPTION
* **Summary of changes**

## Summary

This PR is the Stage E PyMC refactor tidy-up (#375, part of #370). The goal is to make the modern/legacy boundary more explicit without changing legacy behaviour.

### Main changes

- Keep dimension names in `build_inferpymc_model(...)`: it now uses `inv_inputs` names/dims directly and no longer renames `region` / `bc_region` during model construction.
- Move legacy dim renaming to the compatibility boundary via `_rename_trace_for_legacy_inferpymc(...)`, used only by `_adapt_legacy_inferpymc_results(...)`.
- Remove the transitional `InferPyMCSamplingResult` wrapper so the modern sampling helper returns `InferenceData` directly.
- Keep explicit step handling legacy-only: `sample(...)` accepts `step` via kwargs (like `pm.sample`), while `inferpymc(...)` assembles the current compatibility step kwargs.
- Consolidate latent-resolution logic in `models.components.resolve_model_variable(...)`.
- Remove `model` from `InversionOutput`, which no longer performs any sampling or predictive extension.

### Why

The goal is to simplify the modern PyMC path, leveraging PyMC and `InferenceData`, while confining legacy naming and metadata to explicit compatibility code. This should make future work toward a parallel modern run-inversion pathway much simpler.

### Notes

- Legacy behaviour is preserved: `inferpymc(...)` still returns the legacy dict shape, including `model`, `step1`, `step2`, and custom `convergence`.
- `sigma_freq_index` remains in `make_inv_inputs(...)` for now, but the intended future move toward component-local sigma indicator derivation is documented in the code.


* **Please check if the PR fulfills these requirements**

- [x] Closes #375
- [x] Tests added and passing
- Documentation and tutorials updated/added
- [x] Added an entry to the `CHANGELOG.md` file
- Added any new requirements to `requirements.txt`
