### PR TITLE
Add option to drop missing vars from gather-concat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Code changes
 
 
+- Made concat-gather handling of mismatched site data variables order-independent, added an opt-in drop policy used by `make_inv_inputs`, and added lightweight regression tests for issue #394. [#394](https://github.com/openghg/openghg_inversions/issues/394)
 - Fix bug which was assigninig the wrong times to inversion flux outputs in non-standard cases, such as 3-monthly inversions. [#PR 387](https://github.com/openghg/openghg_inversions/pull/387)
 - Fix small bug where postprocessing was failing if country codes in file didn't match exactly those in `paris_regions_dict`. [#PR 377](https://github.com/openghg/openghg_inversions/pull/377)
 - More flexibility for new inversion domains. [#PR 333](https://github.com/openghg/openghg_inversions/pull/333)

--- a/openghg_inversions/array_ops.py
+++ b/openghg_inversions/array_ops.py
@@ -471,6 +471,7 @@ def _resolve_shared_data_vars(
             stacklevel=2,
         )
 
+    # Keep only shared vars, but preserve the first dataset's variable order.
     first_dataset = next(iter(ds_dict.values()))
     return [dv for dv in first_dataset.data_vars if dv in intersection]
 

--- a/openghg_inversions/array_ops.py
+++ b/openghg_inversions/array_ops.py
@@ -42,7 +42,7 @@ an xarray issue, which now is written in terms of ``force_align``.
 from __future__ import annotations
 
 from collections.abc import Hashable, Iterable, Mapping, Sequence
-from typing import Any, overload, TypeVar
+from typing import Any, Literal, overload, TypeVar
 import warnings
 
 from dask.array.core import Array as DaskArray
@@ -351,23 +351,32 @@ def concat_gather_datasets(
     key_dim: str,
     ragged_dim: str,
     stack_dim: str | None = None,
+    missing_data_vars: Literal["error", "drop"] = "error",
     **concat_kwargs,
 ) -> xr.Dataset:
     """Concatenate dictionary of xr.Datasets by gathering ragged coordinates.
 
-    This assumes that all datasets have the same data variables.
+    Args:
+        ds_dict: Mapping from key values to datasets to concatenate.
+        key_dim: Name for the key dimension level in the output MultiIndex.
+        ragged_dim: Ragged coordinate dimension to gather across datasets.
+        stack_dim: Optional name for the gathered dimension in the output.
+        missing_data_vars: Policy for handling data variables that are not shared
+            by every dataset. Use ``"error"`` to raise a ``ValueError`` listing
+            the per-dataset differences, or ``"drop"`` to keep only the
+            intersection of shared data variables and emit a warning when any are
+            dropped.
+        **concat_kwargs: Additional keyword arguments passed to ``xr.concat``.
 
-    TODO: need to handle missing data variables.
+    Returns:
+        Dataset containing gathered versions of the selected data variables.
+
+    Raises:
+        ValueError: If ``missing_data_vars="error"`` and the datasets do not
+            all have identical data-variable sets, or if ``missing_data_vars`` is
+            not recognised.
     """
-    dvs = next(iter(ds_dict.values())).data_vars
-
-    # check that all data vars are present
-    for k, v in ds_dict.items():
-        if any(dv not in v.data_vars for dv in dvs):
-            missing_dvs = [dv for dv in dvs if dv not in v.data_vars]
-            raise ValueError(
-                f"Datasets do not all have the same data variables: Dataset for key {k} missing {missing_dvs}"
-            )
+    dvs = _resolve_shared_data_vars(ds_dict, missing_data_vars=missing_data_vars)
 
     gathered_dvs = {}
 
@@ -379,14 +388,29 @@ def concat_gather_datasets(
 
 
 def concat_gather_datatree(
-    dt: xr.DataTree, key_dim: str, ragged_dim: str, stack_dim: str | None = None, **concat_kwargs
+    dt: xr.DataTree,
+    key_dim: str,
+    ragged_dim: str,
+    stack_dim: str | None = None,
+    missing_data_vars: Literal["error", "drop"] = "error",
+    **concat_kwargs,
 ) -> xr.Dataset:
     """Concatenate xr.DataTree children by gathering ragged coordinates.
 
-    This assumes that all children have the same data variables.
+    Args:
+        dt: DataTree whose children will be converted to datasets and gathered.
+        key_dim: Name for the key dimension level in the output MultiIndex.
+        ragged_dim: Ragged coordinate dimension to gather across children.
+        stack_dim: Optional name for the gathered dimension in the output.
+        missing_data_vars: Policy for handling child data variables that are not
+            shared by every dataset. See ``concat_gather_datasets``.
+        **concat_kwargs: Additional keyword arguments passed to ``xr.concat``.
+
+    Returns:
+        Dataset containing gathered versions of the selected data variables.
     """
     ds_dict = {str(k): v.to_dataset() for k, v in dt.items()}
-    dvs = next(iter(ds_dict.values())).data_vars
+    dvs = _resolve_shared_data_vars(ds_dict, missing_data_vars=missing_data_vars)
 
     gathered_dvs = {}
 
@@ -395,6 +419,59 @@ def concat_gather_datatree(
         gathered_dvs[dv] = concat_gather_data_arrays(da_dict, key_dim, ragged_dim, stack_dim, **concat_kwargs)
 
     return xr.Dataset(gathered_dvs)
+
+
+def _resolve_shared_data_vars(
+    ds_dict: Mapping[str, xr.Dataset], *, missing_data_vars: Literal["error", "drop"]
+) -> list[Hashable]:
+    """Resolve data variables to gather under the requested missing-data policy.
+
+    Args:
+        ds_dict: Mapping from dataset key to dataset.
+        missing_data_vars: Policy controlling how non-shared data variables are
+            handled.
+
+    Returns:
+        Ordered list of data variable names to gather.
+
+    Raises:
+        ValueError: If datasets have non-identical data-variable sets and
+            ``missing_data_vars="error"``, or if the policy is unrecognised.
+    """
+    if missing_data_vars not in {"error", "drop"}:
+        raise ValueError(f"Unknown missing_data_vars policy: {missing_data_vars!r}")
+
+    data_var_sets = {k: set(v.data_vars) for k, v in ds_dict.items()}
+    union = set().union(*data_var_sets.values())
+    intersection = set.intersection(*data_var_sets.values())
+
+    if missing_data_vars == "error" and any(
+        data_vars != intersection for data_vars in data_var_sets.values()
+    ):
+        differences = []
+        for key, dataset in ds_dict.items():
+            dataset_vars = set(dataset.data_vars)
+            missing = sorted(union - dataset_vars)
+            extra = sorted(dataset_vars - intersection)
+            details = []
+            if missing:
+                details.append(f"missing {missing}")
+            if extra:
+                details.append(f"extra {extra}")
+            differences.append(f"{key}: " + ", ".join(details))
+
+        raise ValueError("Datasets do not all have the same data variables: " + "; ".join(differences))
+
+    dropped = sorted(union - intersection)
+    if missing_data_vars == "drop" and dropped:
+        warnings.warn(
+            f"Dropping data variables not shared by all datasets: {dropped}",
+            UserWarning,
+            stacklevel=2,
+        )
+
+    first_dataset = next(iter(ds_dict.values()))
+    return [dv for dv in first_dataset.data_vars if dv in intersection]
 
 
 # ----------------------------------------

--- a/openghg_inversions/array_ops.py
+++ b/openghg_inversions/array_ops.py
@@ -458,7 +458,8 @@ def _resolve_shared_data_vars(
                 details.append(f"missing {missing}")
             if extra:
                 details.append(f"extra {extra}")
-            differences.append(f"{key}: " + ", ".join(details))
+            if details:
+                differences.append(f"{key}: " + ", ".join(details))
 
         raise ValueError("Datasets do not all have the same data variables: " + "; ".join(differences))
 

--- a/openghg_inversions/inversion_inputs.py
+++ b/openghg_inversions/inversion_inputs.py
@@ -287,6 +287,10 @@ def make_inv_inputs(
         stack_dim="nmeasure",
         missing_data_vars="drop",
     )
+
+    # Check that we have variables for standard RHIME inversion (`inferpymc`).
+    # Note that mf_prior_factor and mf_prior_upper_level_factor are only needed
+    # for post-processing (and only if column data is used).
     _check_required_inv_input_vars(
         ds,
         fp_data=fp_data,

--- a/openghg_inversions/inversion_inputs.py
+++ b/openghg_inversions/inversion_inputs.py
@@ -243,6 +243,32 @@ def _drop_nan_and_compute(
     return ds
 
 
+def _check_required_inv_input_vars(
+    ds: xr.Dataset, fp_data: dict[str, Any], sites: list[str], required_vars: Iterable[str] = ()
+) -> None:
+    """Raise if concat-drop mode removed variables required by the inversion pipeline.
+
+    Args:
+        ds: Gathered inversion-input dataset after concatenation.
+        fp_data: Original per-site input datasets.
+        sites: Site names included in the inversion input assembly.
+        required_vars: Variables that must always be present after concatenation.
+
+    Raises:
+        ValueError: If a required variable is missing from the gathered dataset.
+    """
+    missing_required = [var for var in required_vars if var not in ds]
+
+    if any("H_bc" in fp_data[site] for site in sites) and "H_bc" not in ds:
+        missing_required.append("H_bc")
+
+    if missing_required:
+        raise ValueError(
+            "Required inversion data variables were dropped during dataset gathering: "
+            f"{sorted(set(missing_required))}"
+        )
+
+
 def make_inv_inputs(
     fp_data: dict[str, Any],
     sites: list[str] | None = None,
@@ -260,6 +286,12 @@ def make_inv_inputs(
         ragged_dim="time",
         stack_dim="nmeasure",
         missing_data_vars="drop",
+    )
+    _check_required_inv_input_vars(
+        ds,
+        fp_data=fp_data,
+        sites=sites,
+        required_vars=("H", "mf", "mf_error", "mf_repeatability", "mf_variability"),
     )
 
     if "H_bc" in ds:

--- a/openghg_inversions/inversion_inputs.py
+++ b/openghg_inversions/inversion_inputs.py
@@ -259,6 +259,7 @@ def make_inv_inputs(
         key_dim="site",
         ragged_dim="time",
         stack_dim="nmeasure",
+        missing_data_vars="drop",
     )
 
     if "H_bc" in ds:

--- a/tests/test_array_ops.py
+++ b/tests/test_array_ops.py
@@ -4,7 +4,50 @@ import pytest
 import sparse
 import xarray as xr
 
-from openghg_inversions.array_ops import align_to_multi_index_level_values
+from openghg_inversions.array_ops import (
+    align_to_multi_index_level_values,
+    concat_gather_datatree,
+    concat_gather_datasets,
+)
+
+
+def _make_site_dataset(site: str, *, include_inlet_height: bool) -> xr.Dataset:
+    """Create a small site dataset for concat-gather tests."""
+    time = xr.DataArray(pd.date_range("2020-01-01", periods=2, freq="1h"), dims="time", name="time")
+    data_vars = {
+        "mf": xr.DataArray(np.array([1.0, 2.0]), dims="time", coords={"time": time}),
+        "mf_error": xr.DataArray(np.array([0.1, 0.2]), dims="time", coords={"time": time}),
+    }
+    if include_inlet_height:
+        data_vars["inlet_height"] = xr.DataArray(np.array([100.0, 100.0]), dims="time", coords={"time": time})
+
+    return xr.Dataset(data_vars).assign_coords(site=site)
+
+
+def _concat_with_policy(
+    datasets: dict[str, xr.Dataset],
+    *,
+    missing_data_vars: str,
+    use_datatree: bool,
+) -> xr.Dataset:
+    """Run concat-gather via datasets or datatree with the same options."""
+    if use_datatree:
+        datatree = xr.DataTree.from_dict({key: value for key, value in datasets.items()})
+        return concat_gather_datatree(
+            datatree,
+            key_dim="site",
+            ragged_dim="time",
+            stack_dim="nmeasure",
+            missing_data_vars=missing_data_vars,
+        )
+
+    return concat_gather_datasets(
+        datasets,
+        key_dim="site",
+        ragged_dim="time",
+        stack_dim="nmeasure",
+        missing_data_vars=missing_data_vars,
+    )
 
 
 def test_transpose():
@@ -111,3 +154,36 @@ def test_align_to_multi_index_level_values_with_other_level_as_dim_warns():
         )
 
     xr.testing.assert_equal(da_stack.a, da_aligned.a)
+
+
+@pytest.mark.parametrize("use_datatree", [False, True], ids=["datasets", "datatree"])
+@pytest.mark.parametrize("order", [("AAA", "BBB"), ("BBB", "AAA")], ids=["extra-first", "extra-second"])
+def test_concat_gather_missing_data_vars_error_is_order_independent(
+    use_datatree: bool, order: tuple[str, str]
+):
+    """Mismatched data vars should raise regardless of dataset order."""
+    datasets = {
+        "AAA": _make_site_dataset("AAA", include_inlet_height=True),
+        "BBB": _make_site_dataset("BBB", include_inlet_height=False),
+    }
+    ordered = {key: datasets[key] for key in order}
+
+    with pytest.raises(ValueError, match="inlet_height"):
+        _concat_with_policy(ordered, missing_data_vars="error", use_datatree=use_datatree)
+
+
+@pytest.mark.parametrize("use_datatree", [False, True], ids=["datasets", "datatree"])
+@pytest.mark.parametrize("order", [("AAA", "BBB"), ("BBB", "AAA")], ids=["extra-first", "extra-second"])
+def test_concat_gather_missing_data_vars_drop_warns_and_drops(use_datatree: bool, order: tuple[str, str]):
+    """Drop mode should keep only shared vars and warn once."""
+    datasets = {
+        "AAA": _make_site_dataset("AAA", include_inlet_height=True),
+        "BBB": _make_site_dataset("BBB", include_inlet_height=False),
+    }
+    ordered = {key: datasets[key] for key in order}
+
+    with pytest.warns(UserWarning, match="Dropping data variables.*inlet_height"):
+        result = _concat_with_policy(ordered, missing_data_vars="drop", use_datatree=use_datatree)
+
+    assert set(result.data_vars) == {"mf", "mf_error"}
+    assert "inlet_height" not in result

--- a/tests/test_inversion_inputs.py
+++ b/tests/test_inversion_inputs.py
@@ -202,7 +202,13 @@ def test_inversion_input_hbmcmc_matches_frozen(raw_data_path, inv_inputs_args):
 @pytest.fixture
 def gathered_ds(mhd_and_tac_fp_data) -> xr.Dataset:
     to_concat = {k: v for k, v in mhd_and_tac_fp_data.items() if not k.startswith(".")}
-    return concat_gather_datasets(to_concat, key_dim="site", ragged_dim="time", stack_dim="nmeasure")
+    return concat_gather_datasets(
+        to_concat,
+        key_dim="site",
+        ragged_dim="time",
+        stack_dim="nmeasure",
+        missing_data_vars="drop",
+    )
 
 
 def test_add_site_indicator(gathered_ds):
@@ -221,6 +227,8 @@ def _make_minimal_fp_site(*, mf_base: float, include_inlet_height: bool) -> xr.D
     data_vars = {
         "mf": xr.DataArray(np.array([mf_base, mf_base + 1.0]), dims="time", coords={"time": time}),
         "mf_error": xr.DataArray(np.array([0.1, 0.2]), dims="time", coords={"time": time}),
+        "mf_repeatability": xr.DataArray(np.array([0.05, 0.05]), dims="time", coords={"time": time}),
+        "mf_variability": xr.DataArray(np.array([0.05, 0.15]), dims="time", coords={"time": time}),
         "H": xr.DataArray(
             np.array([[1.0, 2.0], [3.0, 4.0]]),
             dims=("region", "time"),
@@ -247,3 +255,14 @@ def test_make_inv_inputs_drops_non_shared_data_vars():
     assert {"H", "mf", "mf_error", "site_indicator", "site_names", "sigma_freq_index", "min_error"} <= set(
         result.data_vars
     )
+
+
+def test_make_inv_inputs_raises_if_required_var_would_be_dropped():
+    """`make_inv_inputs` should still fail clearly if a required var is not shared."""
+    fp_data = {
+        "AAA": _make_minimal_fp_site(mf_base=10.0, include_inlet_height=False),
+        "BBB": _make_minimal_fp_site(mf_base=20.0, include_inlet_height=False).drop_vars("mf_error"),
+    }
+
+    with pytest.raises(ValueError, match="Required inversion data variables.*mf_error"):
+        make_inv_inputs(fp_data=fp_data, sites=["AAA", "BBB"], min_error=0.0)

--- a/tests/test_inversion_inputs.py
+++ b/tests/test_inversion_inputs.py
@@ -15,7 +15,7 @@ being intentionally refreshed.
 from pathlib import Path
 
 import numpy as np
-from numpy.testing import assert_almost_equal
+import pandas as pd
 import pytest
 import xarray as xr
 
@@ -212,3 +212,38 @@ def test_add_site_indicator(gathered_ds):
     assert list(ds.site_names.values) == ["MHD", "TAC"]
 
     assert np.all(ds.site_names.values[ds.site_indicator.values] == ds.site.values)
+
+
+def _make_minimal_fp_site(*, mf_base: float, include_inlet_height: bool) -> xr.Dataset:
+    """Create a tiny per-site dataset for `make_inv_inputs` tests."""
+    time = xr.DataArray(pd.date_range("2020-01-01", periods=2, freq="1h"), dims="time", name="time")
+    region = xr.DataArray(["r0", "r1"], dims="region", name="region")
+    data_vars = {
+        "mf": xr.DataArray(np.array([mf_base, mf_base + 1.0]), dims="time", coords={"time": time}),
+        "mf_error": xr.DataArray(np.array([0.1, 0.2]), dims="time", coords={"time": time}),
+        "H": xr.DataArray(
+            np.array([[1.0, 2.0], [3.0, 4.0]]),
+            dims=("region", "time"),
+            coords={"region": region, "time": time},
+        ),
+    }
+    if include_inlet_height:
+        data_vars["inlet_height"] = xr.DataArray(np.array([100.0, 100.0]), dims="time", coords={"time": time})
+
+    return xr.Dataset(data_vars)
+
+
+def test_make_inv_inputs_drops_non_shared_data_vars():
+    """`make_inv_inputs` should drop optional non-shared vars before gathering."""
+    fp_data = {
+        "AAA": _make_minimal_fp_site(mf_base=10.0, include_inlet_height=True),
+        "BBB": _make_minimal_fp_site(mf_base=20.0, include_inlet_height=False),
+    }
+
+    with pytest.warns(UserWarning, match="Dropping data variables.*inlet_height"):
+        result = make_inv_inputs(fp_data=fp_data, sites=["AAA", "BBB"], min_error=0.0)
+
+    assert "inlet_height" not in result
+    assert {"H", "mf", "mf_error", "site_indicator", "site_names", "sigma_freq_index", "min_error"} <= set(
+        result.data_vars
+    )


### PR DESCRIPTION
* **Summary of changes**

The `gather_concat_datasets` function that is used to combined scenarios from multiple sites previously raised an error if one site had a data variable that was missing from another site.

This PR adds an option to drop missing variables in this case.

Tests were added to check the new functionality.

This closes #394.



* **Please check if the PR fulfills these requirements**

- [x] Closes #384
- [x] Tests added and passing
- Documentation and tutorials updated/added
- [x] Added an entry to the `CHANGELOG.md` file
- Added any new requirements to `requirements.txt`
