### PR TITLE
fix persisting bug about flux timestamps

### DIFF
--- a/openghg_inversions/postprocessing/make_paris_outputs.py
+++ b/openghg_inversions/postprocessing/make_paris_outputs.py
@@ -260,12 +260,17 @@ def _flux_interval_midpoints(
         inv_end: End of the inversion period.
 
     Returns:
-        List of midpoint timestamps, one per flux interval.
+        List of midpoint timestamps, one per flux interval (only for periods overlapping the inversion period).
     """
-    return [
-        max(ft, inv_start) + (min(ft + flux_period, inv_end) - max(ft, inv_start)) / 2
-        for ft in flux_times
-    ]
+    midpoints = []
+    for ft in flux_times:
+        overlap_start = max(ft, inv_start)
+        overlap_end = min(ft + flux_period, inv_end)
+        # Only include midpoint if there is valid overlap
+        if overlap_end > overlap_start:
+            midpoint = overlap_start + (overlap_end - overlap_start) / 2
+            midpoints.append(midpoint)
+    return midpoints
 
 
 def paris_flux_output(
@@ -345,7 +350,15 @@ def paris_flux_output(
         def time_func(ds):
             flux_times = pd.to_datetime(ds.time.values)
             midpoints = _flux_interval_midpoints(flux_times, flux_period, inv_start, inv_end)
-            return ds.assign_coords(time=midpoints)
+            # Find which time indices have valid overlap (those included in midpoints)
+            valid_indices = []
+            for i, ft in enumerate(flux_times):
+                overlap_start = max(ft, inv_start)
+                overlap_end = min(ft + flux_period, inv_end)
+                if overlap_end > overlap_start:
+                    valid_indices.append(i)
+            # Select only the valid time indices and assign the midpoints
+            return ds.isel(time=valid_indices).assign_coords(time=midpoints)
     else:
 
         def time_func(ds):

--- a/openghg_inversions/postprocessing/make_paris_outputs.py
+++ b/openghg_inversions/postprocessing/make_paris_outputs.py
@@ -241,7 +241,7 @@ def _flux_interval_midpoints(
     flux_period: pd.DateOffset | pd.Timedelta,
     inv_start: pd.Timestamp,
     inv_end: pd.Timestamp,
-) -> list[pd.Timestamp]:
+) -> tuple[list[pd.Timestamp], list[int]]:
     """Compute output timestamps as midpoints of each flux interval clipped to the inversion period.
 
     For each flux interval [ft, ft + flux_period], the output timestamp is the
@@ -260,17 +260,20 @@ def _flux_interval_midpoints(
         inv_end: End of the inversion period.
 
     Returns:
-        List of midpoint timestamps, one per flux interval (only for periods overlapping the inversion period).
+        Tuple of (midpoint_timestamps, valid_time_indices). Both lists contain
+        one entry per flux interval that overlaps the inversion period.
     """
     midpoints = []
-    for ft in flux_times:
+    valid_indices = []
+    for i, ft in enumerate(flux_times):
         overlap_start = max(ft, inv_start)
         overlap_end = min(ft + flux_period, inv_end)
-        # Only include midpoint if there is valid overlap
+        # Only include if there is valid overlap
         if overlap_end > overlap_start:
             midpoint = overlap_start + (overlap_end - overlap_start) / 2
             midpoints.append(midpoint)
-    return midpoints
+            valid_indices.append(i)
+    return midpoints, valid_indices
 
 
 def paris_flux_output(
@@ -349,15 +352,7 @@ def paris_flux_output(
 
         def time_func(ds):
             flux_times = pd.to_datetime(ds.time.values)
-            midpoints = _flux_interval_midpoints(flux_times, flux_period, inv_start, inv_end)
-            # Find which time indices have valid overlap (those included in midpoints)
-            valid_indices = []
-            for i, ft in enumerate(flux_times):
-                overlap_start = max(ft, inv_start)
-                overlap_end = min(ft + flux_period, inv_end)
-                if overlap_end > overlap_start:
-                    valid_indices.append(i)
-            # Select only the valid time indices and assign the midpoints
+            midpoints, valid_indices = _flux_interval_midpoints(flux_times, flux_period, inv_start, inv_end)
             return ds.isel(time=valid_indices).assign_coords(time=midpoints)
     else:
 

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -110,8 +110,36 @@ def inv_out_eastasia(raw_data_path):
 )
 def test_flux_interval_midpoints(flux_times, flux_period, inv_start, inv_end, expected):
     """Check midpoint timestamps are computed from the flux/inversion period overlap."""
-    result = _flux_interval_midpoints(flux_times, flux_period, inv_start, inv_end)
-    assert result == expected
+    midpoints, valid_indices = _flux_interval_midpoints(flux_times, flux_period, inv_start, inv_end)
+    assert midpoints == expected
+    # Also verify that valid_indices are correct (0-indexed positions in flux_times
+    # of the flux periods that overlap the inversion period)
+    assert len(valid_indices) == len(expected)
+    assert valid_indices == list(range(len(expected)))  # For these test cases, all flux times have overlap
+
+
+def test_flux_interval_midpoints_with_non_overlapping_times():
+    """Test that non-overlapping flux times are correctly filtered out.
+    
+    This test verifies the fix for the bug where all 13 flux times (2012-2024)
+    were being written to output even when the inversion period was only 2023-2024.
+    """
+    # Flux times spanning 2012-2024 (yearly intervals)
+    flux_times = [pd.Timestamp(f"{year}-01-01") for year in range(2012, 2025)]  # 13 times
+    flux_period = pd.DateOffset(years=1)
+    inv_start = pd.Timestamp("2023-01-01")
+    inv_end = pd.Timestamp("2024-01-01")
+    
+    midpoints, valid_indices = _flux_interval_midpoints(flux_times, flux_period, inv_start, inv_end)
+    
+    # Only the 2023 flux interval (index 11) overlaps with the inversion period
+    assert len(midpoints) == 1
+    assert len(valid_indices) == 1
+    assert valid_indices[0] == 11  # 2023 is at index 11 (year 2012 = 0, ..., 2023 = 11)
+    
+    # The midpoint should be the midpoint of 2023-01-01 to 2024-01-01
+    expected_midpoint = pd.Timestamp("2023-01-01") + (pd.Timestamp("2024-01-01") - pd.Timestamp("2023-01-01")) / 2
+    assert midpoints[0] == expected_midpoint
 
 
 def test_paris_flux_output_timestamp(inv_out, europe_country_file):


### PR DESCRIPTION
Updated the flux postprocessing code to actually filter the data according to the correct timestamps, which wasn't happening before. I don't think this will have materially impacted too many inversions, but it's worth checking for erroneous timestamps in anything you've run in the last week or so @supriyamantri 


* **Please check if the PR fulfills these requirements**

- [x] Closes #417 
- [x] Tests added and passing
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry to the `CHANGELOG.md` file
- [ ] Added any new requirements to `requirements.txt`
