### PR TITLE
Fix shared sigma indexing when site indicators are already registered

### DIFF
--- a/openghg_inversions/models/components.py
+++ b/openghg_inversions/models/components.py
@@ -252,7 +252,8 @@ def add_sigma_component(
         )
 
     site_data = site_indicator if per_site else xr.zeros_like(site_indicator)
-    site_data_var = add_model_data(site_data, "site_indicator")
+    site_data_name = "site_indicator" if per_site else f"{var_name}_site_indicator"
+    site_data_var = add_model_data(site_data.rename(site_data_name), site_data_name)
     freq_data = add_model_data(freq_index.transpose(output_dim), str(freq_index.name))
 
     nsigma_site = int(site_data.max().item()) + 1 if per_site else 1

--- a/tests/models/test_components.py
+++ b/tests/models/test_components.py
@@ -163,6 +163,8 @@ def test_add_sigma_component_supports_explicit_and_derived_freq() -> None:
             per_site=False,
         )
         assert model.named_vars["sigma"].eval().shape[0] == 1
+        assert "site_indicator" not in model.named_vars
+        assert np.array_equal(model.named_vars["sigma_site_indicator"].eval(), np.zeros(4))
         assert "sigma_freq_index" in model.named_vars
 
 

--- a/tests/models/test_components.py
+++ b/tests/models/test_components.py
@@ -211,3 +211,29 @@ def test_add_inferpymc_likelihood_component_adds_epsilon_and_y() -> None:
         )
 
     assert {"epsilon", "y", "sigma"}.issubset(model.named_vars)
+
+
+def test_likelihood_samples_prior_predictive_with_shared_sigma_and_registered_site_indicator() -> None:
+    """Check shared sigma indexing still works after offsets register site data."""
+    ds = _likelihood_dataset()
+
+    with pm.Model(coords={"nmeasure": np.arange(4)}) as model:
+        attach_coord_registry(model, CoordRegistry())
+        mu = pm.Data("mu_input", np.ones(4), dims="nmeasure")
+        mu_bc = pm.Data("mu_bc_input", np.zeros(4), dims="nmeasure")
+        offset = add_offset_component(
+            ds["site_indicator"],
+            prior_args={"pdf": "normal", "mu": 0.0, "sigma": 1.0},
+            output_name="offset",
+        )
+        add_inferpymc_likelihood_component(
+            ds,
+            mu=mu,
+            mu_bc=mu_bc,
+            offset=offset,
+            sigprior={"pdf": "uniform", "lower": 0.1, "upper": 1.0},
+            sigma_per_site=False,
+        )
+
+        assert model.named_vars["sigma"].eval().shape[0] == 1
+        pm.sample_prior_predictive(draws=1, model=model, random_seed=123)


### PR DESCRIPTION
## Summary
- Avoid reusing the existing `site_indicator` model data when `sigma_per_site=False`
- Register a separate zero-valued site index for shared sigma so prior predictive sampling does not index out of bounds
- Add a regression test that covers `add_offset=True` with shared sigma and prior predictive sampling

Closes #421 

## Testing
- `pytest tests/models/test_components.py -k shared_sigma`
- `pytest tests/models/test_components.py`
- `pytest tests/test_inferpymc.py`
- `pytest`
- `black --check` and `ruff check` passed for the touched files