### PR TITLE
Move RHIME model builders into models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Code changes
 
 
+- Moved public RHIME model-builder exports into `openghg_inversions.models` and shared data preparation between `fixedbasisMCMC`, `run_rhime`, and `run_rhime_multisector`. [#399](https://github.com/openghg/openghg_inversions/issues/399), [#425](https://github.com/openghg/openghg_inversions/issues/425)
 - Added modern `run_rhime` and shared-basis `run_rhime_multisector` pipelines, RHIME CLI entry points, RHIME config template, modern result/spec objects, and focused tests for the new public runners. [#398](https://github.com/openghg/openghg_inversions/issues/398)
 - Made concat-gather handling of mismatched site data variables order-independent, added an opt-in drop policy used by `make_inv_inputs`, and added lightweight regression tests for issue #394. [#394](https://github.com/openghg/openghg_inversions/issues/394)
 - Fix bug which was assigninig the wrong times to inversion flux outputs in non-standard cases, such as 3-monthly inversions. [#PR 387](https://github.com/openghg/openghg_inversions/pull/387)

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -28,7 +28,7 @@ import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 import time
-from typing import Literal
+from typing import Literal, cast
 import warnings
 
 import numpy as np
@@ -39,17 +39,11 @@ from openghg.util import split_function_inputs
 import openghg_inversions.hbmcmc.inversion_pymc as mcmc
 from openghg_inversions.models.priors import lognormal_mu_sigma
 from openghg_inversions.utils import ncdf_encoding
-from openghg_inversions.basis import basis_functions_wrapper
-from openghg_inversions.inversion_data import (
-    data_processing_surface_notracer,
-    load_merged_data,
-)
-from openghg_inversions.filters import filtering
+from openghg_inversions.inversion_data import prepare_inversion_data
 from openghg_inversions.postprocessing.inversion_output import (
     InversionOutput,
     make_inv_out_for_fixed_basis_mcmc,
 )
-from openghg_inversions.inversion_inputs import make_inv_inputs
 
 
 def update_log_normal_prior(prior):
@@ -68,61 +62,7 @@ def update_log_normal_prior(prior):
     return prior
 
 
-# ----------------------------------------
-# Preparing inputs
-# ----------------------------------------
-
-
-def _prepare_runtime_inv_inputs(
-    *,
-    fp_data,
-    sites,
-    start_date,
-    bc_freq,
-    sigma_freq,
-    min_error,
-    calculate_min_error,
-    min_error_options,
-) -> xr.Dataset:
-    """Create the dataset consumed by the current inferpymc runtime path.
-
-    Args:
-        fp_data: Forward-model datasets keyed by site name.
-        sites: Sites to include in the inversion inputs.
-        start_date: Inversion start date used when anchoring time-derived
-            indices.
-        bc_freq: Frequency used for BC grouping.
-        sigma_freq: Frequency used for sigma grouping.
-        min_error: Minimum-error configuration passed through to
-            ``make_inv_inputs``.
-        calculate_min_error: Deprecated compatibility argument. When provided,
-            its value overrides ``min_error``.
-        min_error_options: Extra options controlling minimum-error
-            construction.
-
-    Returns:
-        Dataset produced by ``make_inv_inputs`` for the active runtime path.
-    """
-    if calculate_min_error is not None:
-        warnings.warn(
-            "`calculate_min_error` is deprecated. Please use `min_error` to pass the calculation method instead."
-        )
-        min_error = calculate_min_error
-
-    min_error_options = min_error_options or {}
-
-    return make_inv_inputs(
-        fp_data,
-        sites=sites,
-        bc_freq=bc_freq,
-        sigma_freq=sigma_freq,
-        min_error=min_error,
-        min_error_per_site=min_error_options.get("by_site", False),
-        start_date=start_date,
-    )
-
-
-def _extract_post_process_args(inv_inputs: xr.Dataset) -> dict[str, np.ndarray]:
+def _extract_post_process_args(inv_inputs: xr.Dataset) -> dict[str, object]:
     """Extract legacy-shaped postprocessing arrays from inversion inputs.
 
     NOTE: Transitional compatibility bridge. This extracts legacy-shaped arrays
@@ -226,7 +166,7 @@ class _OutputContext:
     species: str
     domain: str
     start_date: str
-    averaging_period: list[str]
+    averaging_period: list[str | None]
     use_bc: bool
     country_file: str | None
     paris_postprocessing_kwargs: dict | None
@@ -291,7 +231,7 @@ def _build_output_context(
     species: str,
     domain: str,
     start_date: str,
-    averaging_period: list[str],
+    averaging_period: list[str | None],
     use_bc: bool,
     country_file: str | None,
     paris_postprocessing_kwargs: dict | None,
@@ -564,7 +504,7 @@ def fixedbasisMCMC(
     species: str,
     sites: list[str],
     domain: str,
-    averaging_period: list[str],
+    averaging_period: list[str | None],
     start_date: str,
     end_date: str,
     outputpath: str,
@@ -620,7 +560,7 @@ def fixedbasisMCMC(
     basis_output_path: str | None = None,
     save_trace: str | Path | bool = False,
     save_inversion_output: str | Path | bool = False,
-    min_error: Literal["percentile", "residual"] | None | float = 0.0,
+    min_error: Literal["percentile", "residual"] | dict[str, float] | None | float = 0.0,
     calculate_min_error: Literal["percentile", "residual"] | None = None,
     min_error_options: dict | None = None,
     output_format: Literal[
@@ -771,164 +711,85 @@ def fixedbasisMCMC(
     else:
         is_column = False
 
-    output_format = _resolve_output_format(
-        output_format,
-        paris_postprocessing=paris_postprocessing,
-        is_column=is_column,
+    output_format = cast(
+        Literal[
+            "hbmcmc",
+            "hbmcmc_postprocessing",
+            "paris",
+            "basic",
+            "merged_data",
+            "inv_out",
+            "mcmc_args",
+            "mcmc_results",
+        ],
+        _resolve_output_format(
+            output_format,
+            paris_postprocessing=paris_postprocessing,
+            is_column=is_column,
+        ),
     )
-
-    rerun_merge = True
-
-    if output_format == "merged_data":
-        reload_merged_data = False
-
-    if reload_merged_data is True and merged_data_dir is not None:
-        try:
-            fp_all = load_merged_data(merged_data_dir, species, start_date, outputname, merged_data_name)
-        except ValueError as e:
-            # couldn't find merged data
-            print(f"{e}, re-running data merge.")
-        else:
-            print("Successfully read in merged data.\n")
-            rerun_merge = False
-
-            # check if sites were dropped when merged data was saved
-            sites_merged = [s for s in fp_all if "." not in s]
-
-            if len(sites) != len(sites_merged):
-                keep_i = [i for i, s in enumerate(sites) if s in sites_merged]
-                dropped_sites = [s for s in sites if s not in sites_merged]
-
-                sites = [s for i, s in enumerate(sites) if i in keep_i]
-                inlet = [s for i, s in enumerate(inlet) if i in keep_i]
-                fp_height = [s for i, s in enumerate(fp_height) if i in keep_i]
-                instrument = [s for i, s in enumerate(instrument) if i in keep_i]
-                max_level = [s for i, s in enumerate(max_level) if i in keep_i]
-                averaging_period = [s for i, s in enumerate(averaging_period) if i in keep_i]
-
-                print(
-                    f"\nDropping {dropped_sites} sites as they are not included in the merged data object.\n"
-                )
-
-    if reload_merged_data is True and merged_data_dir is None:
-        print("Cannot reload merged data without a value for `merged_data_dir`; re-running data merge.")
 
     start_data = time.time()
-
-    # Get datasets for forward simulations
-    if rerun_merge:
-        if not use_tracer:
-            (
-                fp_all,
-                sites,
-                inlet,
-                fp_height,
-                instrument,
-                averaging_period,
-            ) = data_processing_surface_notracer(
-                species=species,
-                sites=sites,
-                domain=domain,
-                averaging_period=averaging_period,
-                start_date=start_date,
-                end_date=end_date,
-                obs_data_level=obs_data_level,
-                platform=platform,
-                met_model=met_model,
-                fp_model=fp_model,
-                fp_height=fp_height,
-                fp_species=fp_species,
-                emissions_name=emissions_name,
-                inlet=inlet,
-                instrument=instrument,
-                max_level=max_level,
-                calibration_scale=calibration_scale,
-                use_bc=use_bc,
-                bc_input=bc_input,
-                bc_store=bc_store,
-                obs_store=obs_store,
-                footprint_store=footprint_store,
-                emissions_store=emissions_store,
-                averagingerror=averaging_error,
-                save_merged_data=save_merged_data,
-                merged_data_name=merged_data_name,
-                merged_data_dir=merged_data_dir,
-                output_name=outputname,
-            )
-
-        elif use_tracer:
-            raise ValueError("Model does not currently include tracer model. Watch this space")
-
-        if output_format == "merged_data":
-            return fp_all  # type: ignore
-
-    # Basis function regions and sensitivity matrices
-    fp_data = basis_functions_wrapper(
-        basis_algorithm=basis_algorithm,
-        nbasis=nbasis,
+    prepared = prepare_inversion_data(
+        species=species,
+        sites=sites,
+        domain=domain,
+        averaging_period=averaging_period,
+        start_date=start_date,
+        end_date=end_date,
+        output_name=outputname,
+        flux_sources=emissions_name,
+        split_by_sectors=False,
+        bc_store=bc_store,
+        obs_store=obs_store,
+        footprint_store=footprint_store,
+        emissions_store=emissions_store,
+        met_model=met_model,
+        fp_model=fp_model,
+        fp_height=fp_height,
+        fp_species=fp_species,
+        inlet=inlet,
+        instrument=instrument,
+        max_level=max_level,
+        calibration_scale=calibration_scale,
+        obs_data_level=obs_data_level,
+        platform=platform,
+        use_tracer=use_tracer,
+        use_bc=use_bc,
         fp_basis_case=fp_basis_case,
-        bc_basis_case=bc_basis_case,
         basis_directory=basis_directory,
+        bc_basis_case=bc_basis_case,
         bc_basis_directory=bc_basis_directory,
         country_directory=country_directory,
-        fp_all=fp_all,
-        use_bc=use_bc,
-        species=species,
-        domain=domain,
-        start_date=start_date,
-        fix_outer_regions=fix_basis_outer_regions,
-        emissions_name=emissions_name,
-        outputname=outputname,
-        output_path=basis_output_path,
-    )
-
-    # Apply named filters to the data
-    if filters is not None:
-        try:
-            fp_data = filtering(fp_data, filters)
-        except ValueError:
-            # possible dask issue, but should be fixed
-            # https://github.com/openghg/openghg_inversions/issues/264
-            #
-            # Apply compute before filtering to avoid dask issue
-            for site in sites:
-                fp_data[site] = fp_data[site].compute()
-            fp_data = filtering(fp_data, filters)
-
-    # check for sites dropped by filtering
-    dropped_sites = []
-    for site in sites:
-        # check if some datasets are empty due to filtering
-        if fp_data[site].time.values.shape[0] == 0:
-            dropped_sites.append(site)
-            del fp_data[site]
-
-    if len(dropped_sites) != 0:
-        sites = [s for s in sites if s not in dropped_sites]
-        print(f"\nDropping {dropped_sites} sites as no data passed the filtering.\n")
-
-    for site in sites:
-        fp_data[site].attrs["Domain"] = domain
-
-    # Inverse models
-    if use_tracer:
-        raise ValueError("Model does not currently include tracer model. Watch this space")
-
-    inv_inputs = _prepare_runtime_inv_inputs(
-        fp_data=fp_data,
-        sites=sites,
-        start_date=start_date,
+        bc_input=bc_input,
+        basis_algorithm=basis_algorithm,
+        nbasis=nbasis,
+        filters=filters,
+        fix_basis_outer_regions=fix_basis_outer_regions,
+        averaging_error=averaging_error,
         bc_freq=bc_freq,
         sigma_freq=sigma_freq,
+        reload_merged_data=False if output_format == "merged_data" else reload_merged_data,
+        save_merged_data=save_merged_data,
+        merged_data_dir=merged_data_dir,
+        merged_data_name=merged_data_name,
+        basis_output_path=basis_output_path,
         min_error=min_error,
         calculate_min_error=calculate_min_error,
         min_error_options=min_error_options,
+        merged_data_only=output_format == "merged_data",
     )
 
-    if np.isnan(inv_inputs.H.values).any():
-        warnings.warn(f"Hx matrix contains {np.isnan(inv_inputs.H.values).flatten().sum()} NaN values")
-    if use_bc and "H_bc" in inv_inputs and np.isnan(inv_inputs.H_bc.values).any():
-        warnings.warn(f"Hbc matrix contains {np.isnan(inv_inputs.H_bc.values).flatten().sum()} NaN values")
+    if output_format == "merged_data":
+        return prepared.fp_all  # type: ignore
+
+    if prepared.fp_data is None or prepared.inv_inputs is None:
+        raise RuntimeError("Fixed-basis data preparation did not produce forward data and model inputs.")
+
+    fp_data = prepared.fp_data
+    inv_inputs = prepared.inv_inputs
+    sites = prepared.sites
+    averaging_period = prepared.averaging_period
 
     # TODO keep this config separate from mcmc_args in the future
     mcmc_config = {
@@ -1171,6 +1032,7 @@ def rerun_output(input_file: str, outputname: str, outputpath: str, verbose: boo
         tune=tune,
         nchain=nchain,
         sigma_per_site=sigma_per_site,
+        emissions_name=None,
         add_offset=add_offset,
         rerun_file=ds_in,
     )

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -24,13 +24,8 @@ from openghg_inversions import convert  # noqa: E402
 from openghg_inversions import utils  # noqa: E402
 from openghg_inversions.hbmcmc.hbmcmc_output import define_output_filename  # noqa: E402
 from openghg_inversions.config.version import code_version  # noqa: E402
-from openghg_inversions.models.components import (  # noqa: E402
-    add_inferpymc_likelihood_component,
-    add_linear_component,
-    add_offset_component,
-    resolve_model_variable,
-)
-from openghg_inversions.models.coords import CoordRegistry, attach_coord_registry  # noqa: E402
+from openghg_inversions.models import build_rhime_model  # noqa: E402
+from openghg_inversions.models.components import resolve_model_variable  # noqa: E402
 from openghg_inversions.models.priors import PriorArgs  # noqa: E402
 from openghg_inversions.inversion_inputs import _compact_integer_index  # noqa: E402
 
@@ -104,7 +99,7 @@ def build_inferpymc_model(
     offset_args: dict | None = None,
     power: dict | float = 1.99,
 ) -> pm.Model:
-    """Build the current component-based inferpymc model.
+    """Compatibility adapter for the standard RHIME model builder.
 
     Args:
         inv_inputs: Canonical inversion-input dataset, usually produced by
@@ -131,7 +126,7 @@ def build_inferpymc_model(
             scaling.
 
     Returns:
-        Built PyMC model for the current inferpymc path.
+        Built PyMC model for the current inferpymc compatibility path.
     """
     xprior, bcprior, sigprior, offsetprior = _prepare_builder_priors(
         xprior=xprior,
@@ -141,58 +136,20 @@ def build_inferpymc_model(
         reparameterise_log_normal=reparameterise_log_normal,
     )
 
-    with pm.Model() as model:
-        attach_coord_registry(model, CoordRegistry())
-        flux_component = add_linear_component(
-            inv_inputs["H"],
-            data_name="hx",
-            prior_args=xprior,
-            var_name="x",
-            output_name="mu",
-            output_dim="nmeasure",
-            compute_deterministic=True,
-        )
-
-        mu_bc = None
-        if use_bc:
-            if "H_bc" not in inv_inputs:
-                raise ValueError("If `use_bc` is True, `inv_inputs` must contain `H_bc`.")
-            bc_component = add_linear_component(
-                inv_inputs["H_bc"],
-                data_name="hbc",
-                prior_args=bcprior,
-                var_name="bc",
-                output_name="mu_bc",
-                output_dim="nmeasure",
-                compute_deterministic=True,
-            )
-            mu_bc = bc_component.output
-
-        offset = None
-        if add_offset:
-            offset_args = offset_args or {}
-            offset = add_offset_component(
-                inv_inputs["site_indicator"],
-                prior_args=offsetprior,
-                output_name="offset",
-                output_dim="nmeasure",
-                **offset_args,
-            )
-
-        add_inferpymc_likelihood_component(
-            inv_inputs,
-            mu=flux_component.output,
-            mu_bc=mu_bc,
-            offset=offset,
-            sigprior=sigprior,
-            power=power,
-            pollution_events_from_obs=pollution_events_from_obs,
-            no_model_error=no_model_error,
-            sigma_per_site=sigma_per_site,
-            output_dim="nmeasure",
-        )
-
-    return model
+    return build_rhime_model(
+        inv_inputs,
+        x_prior=xprior,
+        bc_prior=bcprior,
+        sigma_prior=sigprior,
+        sigma_per_site=sigma_per_site,
+        offset_prior=offsetprior,
+        add_offset=add_offset,
+        use_bc=use_bc,
+        pollution_events_from_obs=pollution_events_from_obs,
+        no_model_error=no_model_error,
+        offset_args=offset_args,
+        power=power,
+    )
 
 
 # ----------------------------------------
@@ -593,7 +550,7 @@ def inferpymc_postprocessouts(
     tune: int,
     nchain: int,
     sigma_per_site: bool,
-    emissions_name: str,
+    emissions_name: list[str] | None,
     bcprior: dict | None = None,
     YBCtrace: np.ndarray | None = None,
     bcouts: np.ndarray | None = None,

--- a/openghg_inversions/inversion_data/__init__.py
+++ b/openghg_inversions/inversion_data/__init__.py
@@ -1,4 +1,11 @@
 from .get_data import data_processing_surface_notracer
+from .preparation import PreparedInversionData, prepare_inversion_data
 from .serialise import load_merged_data, _save_merged_data
 
-__all__ = ["_save_merged_data", "data_processing_surface_notracer", "load_merged_data"]
+__all__ = [
+    "_save_merged_data",
+    "PreparedInversionData",
+    "data_processing_surface_notracer",
+    "load_merged_data",
+    "prepare_inversion_data",
+]

--- a/openghg_inversions/inversion_data/preparation.py
+++ b/openghg_inversions/inversion_data/preparation.py
@@ -1,0 +1,390 @@
+"""Shared runner-level inversion data preparation."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal, cast
+import warnings
+
+import numpy as np
+import xarray as xr
+
+from openghg_inversions.array_ops import get_xr_dummies
+from openghg_inversions.basis import basis_functions_wrapper
+from openghg_inversions.basis.basis_functions import BasisFunctions
+from openghg_inversions.filters import filtering
+from openghg_inversions.inversion_data.get_data import convert_to_list, data_processing_surface_notracer
+from openghg_inversions.inversion_data.serialise import load_merged_data
+from openghg_inversions.inversion_inputs import make_inv_inputs
+
+MinErrorConfig = Literal["percentile", "residual"] | dict[str, float] | None | int | float
+
+
+@dataclass
+class PreparedInversionData:
+    """Data prepared for RHIME-style inversion runners.
+
+    Args:
+        fp_all: Raw merged-data container returned by data gathering or reload.
+        sites: Retained site names after data gathering and filtering.
+        averaging_period: Averaging periods aligned to retained sites.
+        fp_data: Forward-model data after basis functions and filters.
+        inv_inputs: Canonical inversion inputs consumed by model builders.
+        basis: Basis matrix aligned to ``inv_inputs.region``, when requested.
+        flux: Prior flux field from the retained emissions basis object, when
+            basis objects were requested.
+        basis_objects: Basis objects returned by ``basis_functions_wrapper``.
+    """
+
+    fp_all: dict
+    sites: list[str]
+    averaging_period: list[str | None]
+    fp_data: dict | None = None
+    inv_inputs: xr.Dataset | None = None
+    basis: xr.DataArray | None = None
+    flux: xr.DataArray | None = None
+    basis_objects: dict[str, BasisFunctions] = field(default_factory=dict)
+
+
+def _filter_site_aligned_value(value: object, keep_indices: list[int]) -> object:
+    """Filter values that are aligned to the sites list."""
+    if value is None or isinstance(value, str | bytes):
+        return value
+    if not isinstance(value, Sequence):
+        return value
+    return [item for index, item in enumerate(value) if index in keep_indices]
+
+
+def _drop_sites_missing_from_loaded_data(
+    *,
+    fp_all: dict,
+    sites: list[str],
+    inlet: Any,
+    fp_height: Any,
+    instrument: Any,
+    max_level: int | None,
+    averaging_period: list[str | None],
+) -> tuple[list[str], Any, Any, Any, int | None, list[str | None]]:
+    """Align site-level options when loaded merged data lacks requested sites."""
+    sites_merged = [site for site in fp_all if not site.startswith(".")]
+    if all(site in sites_merged for site in sites):
+        return sites, inlet, fp_height, instrument, max_level, list(averaging_period)
+
+    keep_indices = [index for index, site in enumerate(sites) if site in sites_merged]
+    dropped_sites = [site for site in sites if site not in sites_merged]
+    if not keep_indices:
+        raise ValueError(
+            "Loaded merged data does not include any requested sites. "
+            f"Requested sites: {sites}. Available merged-data sites: {sites_merged}."
+        )
+
+    sites = [site for index, site in enumerate(sites) if index in keep_indices]
+    averaging_period = [period for index, period in enumerate(averaging_period) if index in keep_indices]
+
+    print(f"\nDropping {dropped_sites} sites as they are not included in the merged data object.\n")
+    return (
+        sites,
+        _filter_site_aligned_value(inlet, keep_indices),
+        _filter_site_aligned_value(fp_height, keep_indices),
+        _filter_site_aligned_value(instrument, keep_indices),
+        max_level,
+        averaging_period,
+    )
+
+
+def _select_fp_all_sites(fp_all: dict, sites: list[str]) -> dict:
+    """Keep only requested site entries and metadata from a merged-data object."""
+    site_names = set(sites)
+    return {key: value for key, value in fp_all.items() if key.startswith(".") or key in site_names}
+
+
+def _normalise_averaging_period(
+    averaging_period: list[str | None] | str | None, *, nsites: int
+) -> list[str | None]:
+    """Normalize and validate site-aligned averaging periods."""
+    normalized = convert_to_list(averaging_period, length=nsites, name="averaging_period")
+    invalid_periods = [period for period in normalized if period is not None and not isinstance(period, str)]
+    if invalid_periods:
+        raise ValueError(
+            f"`averaging_period` entries must be strings or None. Invalid value(s): {invalid_periods!r}."
+        )
+    return normalized
+
+
+def _make_inv_inputs(
+    *,
+    fp_data: dict,
+    sites: list[str],
+    start_date: str,
+    bc_freq: str | None,
+    sigma_freq: str | None,
+    min_error: MinErrorConfig,
+    calculate_min_error: Literal["percentile", "residual"] | None,
+    min_error_options: dict | None,
+) -> xr.Dataset:
+    """Create canonical inversion inputs with legacy min-error compatibility."""
+    if calculate_min_error is not None:
+        warnings.warn(
+            "`calculate_min_error` is deprecated. Please use `min_error` to pass the calculation method instead.",
+            FutureWarning,
+            stacklevel=3,
+        )
+        min_error = calculate_min_error
+
+    if min_error is None:
+        min_error = 0.0
+    elif isinstance(min_error, int) and not isinstance(min_error, bool):
+        min_error = float(min_error)
+    elif isinstance(min_error, dict):
+        missing_sites = [site for site in sites if site not in min_error]
+        if missing_sites:
+            raise ValueError(
+                "`min_error` dictionaries must include a value for every retained site. "
+                f"Missing site(s): {missing_sites!r}."
+            )
+
+    min_error_options = min_error_options or {}
+    return make_inv_inputs(
+        fp_data,
+        sites=sites,
+        bc_freq=bc_freq,
+        sigma_freq=sigma_freq,
+        min_error=min_error,
+        min_error_per_site=min_error_options.get("by_site", False),
+        start_date=start_date,
+    )
+
+
+def _warn_for_nan_inputs(inv_inputs: xr.Dataset, *, use_bc: bool) -> None:
+    """Warn when prepared sensitivity matrices contain NaN values."""
+    if np.isnan(inv_inputs.H.values).any():
+        warnings.warn(f"H matrix contains {np.isnan(inv_inputs.H.values).flatten().sum()} NaN values")
+    if use_bc and "H_bc" in inv_inputs and np.isnan(inv_inputs.H_bc.values).any():
+        warnings.warn(f"H_bc matrix contains {np.isnan(inv_inputs.H_bc.values).flatten().sum()} NaN values")
+
+
+def prepare_inversion_data(
+    *,
+    species: str,
+    sites: list[str],
+    domain: str,
+    averaging_period: list[str | None] | str | None,
+    start_date: str,
+    end_date: str,
+    output_name: str,
+    flux_sources: list[str] | None,
+    split_by_sectors: bool = False,
+    bc_store: str = "user",
+    obs_store: str = "user",
+    footprint_store: str = "user",
+    emissions_store: str = "user",
+    met_model: Any = None,
+    fp_model: str | None = None,
+    fp_height: Any = None,
+    fp_species: str | None = None,
+    inlet: Any = None,
+    instrument: Any = None,
+    max_level: int | None = None,
+    calibration_scale: str | None = None,
+    obs_data_level: Any = None,
+    platform: Any = None,
+    use_tracer: bool = False,
+    use_bc: bool = True,
+    fp_basis_case: str | None = None,
+    basis_directory: str | None = None,
+    bc_basis_case: str = "NESW",
+    bc_basis_directory: str | Path | None = None,
+    country_directory: str | None = None,
+    bc_input: str | None = None,
+    basis_algorithm: str = "weighted",
+    nbasis: int = 100,
+    filters: Any = None,
+    fix_basis_outer_regions: bool = False,
+    averaging_error: bool = True,
+    bc_freq: str | None = None,
+    sigma_freq: str | None = None,
+    reload_merged_data: bool = False,
+    save_merged_data: bool = False,
+    merged_data_dir: str | None = None,
+    merged_data_name: str | None = None,
+    basis_output_path: str | None = None,
+    min_error: MinErrorConfig = 0.0,
+    calculate_min_error: Literal["percentile", "residual"] | None = None,
+    min_error_options: dict | None = None,
+    return_basis_objects: bool = False,
+    merged_data_only: bool = False,
+) -> PreparedInversionData:
+    """Gather data, apply basis functions and filters, and create inversion inputs.
+
+    This helper owns the runner-level preparation shared by legacy
+    ``fixedbasisMCMC`` and modern RHIME runners. It intentionally does not build
+    PyMC models, sample, or create output products.
+    """
+    if use_tracer:
+        raise ValueError("Tracer inversions are not supported by this RHIME preparation path.")
+    if not sites:
+        raise ValueError("At least one site must be specified for inversion data preparation.")
+
+    averaging_period = _normalise_averaging_period(averaging_period, nsites=len(sites))
+    rerun_merge = True
+    fp_all: dict | None = None
+    if reload_merged_data and merged_data_dir is not None:
+        try:
+            fp_all = load_merged_data(merged_data_dir, species, start_date, output_name, merged_data_name)
+        except ValueError as exc:
+            print(f"{exc}, re-running data merge.")
+        else:
+            print("Successfully read in merged data.\n")
+            fp_all[".split_by_sectors"] = split_by_sectors
+            rerun_merge = False
+            sites, inlet, fp_height, instrument, max_level, averaging_period = (
+                _drop_sites_missing_from_loaded_data(
+                    fp_all=fp_all,
+                    sites=sites,
+                    inlet=inlet,
+                    fp_height=fp_height,
+                    instrument=instrument,
+                    max_level=max_level,
+                    averaging_period=averaging_period,
+                )
+            )
+            fp_all = _select_fp_all_sites(fp_all, sites)
+    elif reload_merged_data:
+        print("Cannot reload merged data without a value for `merged_data_dir`; re-running data merge.")
+
+    if rerun_merge:
+        (
+            fp_all,
+            sites,
+            inlet,
+            fp_height,
+            instrument,
+            averaging_period,
+        ) = data_processing_surface_notracer(
+            species=species,
+            sites=sites,
+            domain=domain,
+            averaging_period=averaging_period,
+            start_date=start_date,
+            end_date=end_date,
+            obs_data_level=obs_data_level,
+            platform=platform,
+            met_model=met_model,
+            fp_model=fp_model,
+            fp_height=fp_height,
+            fp_species=fp_species,
+            emissions_name=flux_sources,
+            inlet=inlet,
+            instrument=instrument,
+            max_level=max_level,
+            calibration_scale=calibration_scale,
+            use_bc=use_bc,
+            bc_input=bc_input,
+            bc_store=bc_store,
+            obs_store=obs_store,
+            footprint_store=footprint_store,
+            emissions_store=emissions_store,
+            split_by_sectors=split_by_sectors,
+            averagingerror=averaging_error,
+            save_merged_data=save_merged_data,
+            merged_data_name=merged_data_name,
+            merged_data_dir=merged_data_dir,
+            output_name=output_name,
+        )
+
+    if fp_all is None:
+        raise RuntimeError("Data preparation did not create or load merged data.")
+    if not sites:
+        raise ValueError("No sites remain after data gathering.")
+
+    if merged_data_only:
+        return PreparedInversionData(
+            fp_all=fp_all,
+            sites=sites,
+            averaging_period=cast(list[str | None], averaging_period),
+        )
+
+    bc_basis_directory_arg = (
+        str(bc_basis_directory) if isinstance(bc_basis_directory, Path) else bc_basis_directory
+    )
+
+    basis_result = basis_functions_wrapper(
+        basis_algorithm=basis_algorithm,
+        nbasis=nbasis,
+        fp_basis_case=fp_basis_case,
+        bc_basis_case=bc_basis_case,
+        basis_directory=basis_directory,
+        bc_basis_directory=bc_basis_directory_arg,
+        country_directory=country_directory,
+        fp_all=fp_all,
+        use_bc=use_bc,
+        species=species,
+        domain=domain,
+        start_date=start_date,
+        fix_outer_regions=fix_basis_outer_regions,
+        emissions_name=flux_sources,
+        outputname=output_name,
+        output_path=basis_output_path,
+        return_basis_objects=return_basis_objects,
+    )
+    if return_basis_objects:
+        fp_data, basis_objects = cast(tuple[dict, dict[str, BasisFunctions]], basis_result)
+    else:
+        fp_data = cast(dict, basis_result)
+        basis_objects = {}
+
+    if filters is not None:
+        try:
+            fp_data = filtering(fp_data, filters)
+        except ValueError:
+            for site in sites:
+                fp_data[site] = fp_data[site].compute()
+            fp_data = filtering(fp_data, filters)
+
+    dropped_sites = []
+    for site in sites:
+        if fp_data[site].time.values.shape[0] == 0:
+            dropped_sites.append(site)
+            del fp_data[site]
+    if dropped_sites:
+        keep_indices = [index for index, site in enumerate(sites) if site not in dropped_sites]
+        if not keep_indices:
+            raise ValueError(f"No sites remain after filtering. Dropped sites: {dropped_sites}.")
+
+        sites = [site for index, site in enumerate(sites) if index in keep_indices]
+        averaging_period = [period for index, period in enumerate(averaging_period) if index in keep_indices]
+        print(f"\nDropping {dropped_sites} sites as no data passed the filtering.\n")
+
+    for site in sites:
+        fp_data[site].attrs["Domain"] = domain
+
+    inv_inputs = _make_inv_inputs(
+        fp_data=fp_data,
+        sites=sites,
+        start_date=start_date,
+        bc_freq=bc_freq,
+        sigma_freq=sigma_freq,
+        min_error=min_error,
+        calculate_min_error=calculate_min_error,
+        min_error_options=min_error_options,
+    )
+    _warn_for_nan_inputs(inv_inputs, use_bc=use_bc)
+
+    basis = None
+    flux = None
+    if return_basis_objects:
+        basis = get_xr_dummies(fp_data[".basis"], cat_dim="region", categories=inv_inputs.region)
+        flux = basis_objects["emissions"].flux
+
+    return PreparedInversionData(
+        fp_all=fp_all,
+        fp_data=fp_data,
+        inv_inputs=inv_inputs,
+        basis=basis,
+        flux=flux,
+        basis_objects=basis_objects,
+        sites=sites,
+        averaging_period=cast(list[str | None], averaging_period),
+    )

--- a/openghg_inversions/models/__init__.py
+++ b/openghg_inversions/models/__init__.py
@@ -16,9 +16,22 @@ from openghg_inversions.models.coords import (
     restore_inferencedata_coords,
 )
 from openghg_inversions.models.priors import parse_prior
+from openghg_inversions.models.rhime import (
+    DEFAULT_BC_PRIOR,
+    DEFAULT_OFFSET_PRIOR,
+    DEFAULT_SIGMA_PRIOR,
+    DEFAULT_X_PRIOR,
+    build_rhime_model,
+    build_rhime_multisector_model,
+    safe_pymc_name,
+)
 
 __all__ = [
     "CoordRegistry",
+    "DEFAULT_BC_PRIOR",
+    "DEFAULT_OFFSET_PRIOR",
+    "DEFAULT_SIGMA_PRIOR",
+    "DEFAULT_X_PRIOR",
     "add_coords",
     "attach_coord_registry",
     "get_coord_registry",
@@ -30,4 +43,7 @@ __all__ = [
     "add_sigma_component",
     "add_offset_component",
     "add_inferpymc_likelihood_component",
+    "build_rhime_model",
+    "build_rhime_multisector_model",
+    "safe_pymc_name",
 ]

--- a/openghg_inversions/rhime.py
+++ b/openghg_inversions/rhime.py
@@ -16,13 +16,10 @@ import pymc as pm
 import xarray as xr
 from openghg.util import split_function_inputs
 
-from openghg_inversions.array_ops import get_xr_dummies, sparse_xr_dot
-from openghg_inversions.basis import basis_functions_wrapper
+from openghg_inversions.array_ops import sparse_xr_dot
 from openghg_inversions.config import config
-from openghg_inversions.filters import filtering
-from openghg_inversions.inversion_data import data_processing_surface_notracer, load_merged_data
-from openghg_inversions.inversion_inputs import make_inv_inputs
-from openghg_inversions.models.rhime import (
+from openghg_inversions.inversion_data import prepare_inversion_data
+from openghg_inversions.models import (
     DEFAULT_X_PRIOR,
     build_rhime_model,
     build_rhime_multisector_model,
@@ -32,6 +29,7 @@ from openghg_inversions.postprocessing.inversion_output import InversionOutput
 from openghg_inversions.utils import ncdf_encoding
 
 OutputFormat = Literal["none", "inv_out", "basic", "paris"]
+MinErrorConfig = Literal["percentile", "residual"] | dict[str, float] | None | int | float
 
 
 @dataclass(frozen=True)
@@ -431,7 +429,7 @@ def _prepare_data(
     species: str,
     sites: list[str],
     domain: str,
-    averaging_period: list[str | None],
+    averaging_period: list[str | None] | str | None,
     start_date: str,
     end_date: str,
     output_name: str,
@@ -471,137 +469,73 @@ def _prepare_data(
     merged_data_dir: str | None = None,
     merged_data_name: str | None = None,
     basis_output_path: str | None = None,
-    min_error: Literal["percentile", "residual"] | None | int | float = 0.0,
+    min_error: MinErrorConfig = 0.0,
     min_error_options: dict | None = None,
 ) -> _PreparedRhimeData:
     """Gather data, apply basis functions, filter observations, and make canonical inputs.
 
-    This is the only RHIME runner stage that should know about the legacy
-    ``fp_all``/``fp_data`` containers. It returns explicit modern objects needed
-    downstream.
+    This delegates the legacy ``fp_all``/``fp_data`` preparation to the shared
+    inversion-data helper and returns the explicit modern objects needed
+    downstream by RHIME.
     """
-    if use_tracer:
-        raise ValueError("RHIME public runners do not support tracer inversions in issue #398.")
-
-    rerun_merge = True
-    if reload_merged_data and merged_data_dir is not None:
-        try:
-            fp_all = load_merged_data(merged_data_dir, species, start_date, output_name, merged_data_name)
-        except ValueError as exc:
-            print(f"{exc}, re-running data merge.")
-        else:
-            fp_all[".split_by_sectors"] = split_by_sectors
-            rerun_merge = False
-    elif reload_merged_data:
-        print("Cannot reload merged data without `merged_data_dir`; re-running data merge.")
-
-    if rerun_merge:
-        (
-            fp_all,
-            sites,
-            inlet,
-            fp_height,
-            instrument,
-            averaging_period,
-        ) = data_processing_surface_notracer(
-            species=species,
-            sites=sites,
-            domain=domain,
-            averaging_period=averaging_period,
-            start_date=start_date,
-            end_date=end_date,
-            obs_data_level=obs_data_level,
-            platform=platform,
-            met_model=met_model,
-            fp_model=fp_model,
-            fp_height=fp_height,
-            fp_species=fp_species,
-            emissions_name=flux_sources,
-            inlet=inlet,
-            instrument=instrument,
-            max_level=max_level,
-            calibration_scale=calibration_scale,
-            use_bc=use_bc,
-            bc_input=bc_input,
-            bc_store=bc_store,
-            obs_store=obs_store,
-            footprint_store=footprint_store,
-            emissions_store=emissions_store,
-            split_by_sectors=split_by_sectors,
-            averagingerror=averaging_error,
-            save_merged_data=save_merged_data,
-            merged_data_name=merged_data_name,
-            merged_data_dir=merged_data_dir,
-            output_name=output_name,
-        )
-
-    fp_data, basis_objects = basis_functions_wrapper(
-        basis_algorithm=basis_algorithm,
-        nbasis=nbasis,
+    prepared = prepare_inversion_data(
+        species=species,
+        sites=sites,
+        domain=domain,
+        averaging_period=averaging_period,
+        start_date=start_date,
+        end_date=end_date,
+        output_name=output_name,
+        flux_sources=flux_sources,
+        split_by_sectors=split_by_sectors,
+        bc_store=bc_store,
+        obs_store=obs_store,
+        footprint_store=footprint_store,
+        emissions_store=emissions_store,
+        met_model=met_model,
+        fp_model=fp_model,
+        fp_height=fp_height,
+        fp_species=fp_species,
+        inlet=inlet,
+        instrument=instrument,
+        max_level=max_level,
+        calibration_scale=calibration_scale,
+        obs_data_level=obs_data_level,
+        platform=platform,
+        use_tracer=use_tracer,
+        use_bc=use_bc,
         fp_basis_case=fp_basis_case,
-        bc_basis_case=bc_basis_case,
         basis_directory=basis_directory,
+        bc_basis_case=bc_basis_case,
         bc_basis_directory=bc_basis_directory,
         country_directory=country_directory,
-        fp_all=fp_all,
-        use_bc=use_bc,
-        species=species,
-        domain=domain,
-        start_date=start_date,
-        fix_outer_regions=fix_basis_outer_regions,
-        emissions_name=flux_sources,
-        outputname=output_name,
-        output_path=basis_output_path,
+        bc_input=bc_input,
+        basis_algorithm=basis_algorithm,
+        nbasis=nbasis,
+        filters=filters,
+        fix_basis_outer_regions=fix_basis_outer_regions,
+        averaging_error=averaging_error,
+        bc_freq=bc_freq,
+        sigma_freq=sigma_freq,
+        reload_merged_data=reload_merged_data,
+        save_merged_data=save_merged_data,
+        merged_data_dir=merged_data_dir,
+        merged_data_name=merged_data_name,
+        basis_output_path=basis_output_path,
+        min_error=min_error,
+        min_error_options=min_error_options,
         return_basis_objects=True,
     )
 
-    if filters is not None:
-        try:
-            fp_data = filtering(fp_data, filters)
-        except ValueError:
-            for site in sites:
-                fp_data[site] = fp_data[site].compute()
-            fp_data = filtering(fp_data, filters)
-
-    dropped_sites = []
-    for site in sites:
-        if fp_data[site].time.values.shape[0] == 0:
-            dropped_sites.append(site)
-            del fp_data[site]
-    if dropped_sites:
-        sites = [site for site in sites if site not in dropped_sites]
-        print(f"\nDropping {dropped_sites} sites as no data passed the filtering.\n")
-
-    for site in sites:
-        fp_data[site].attrs["Domain"] = domain
-
-    min_error_options = min_error_options or {}
-    if isinstance(min_error, int):
-        min_error = float(min_error)
-    inv_inputs = make_inv_inputs(
-        fp_data,
-        sites=sites,
-        bc_freq=bc_freq,
-        sigma_freq=sigma_freq,
-        min_error=min_error,
-        min_error_per_site=min_error_options.get("by_site", False),
-        start_date=start_date,
-    )
-
-    if np.isnan(inv_inputs.H.values).any():
-        warnings.warn(f"H matrix contains {np.isnan(inv_inputs.H.values).flatten().sum()} NaN values")
-    if use_bc and "H_bc" in inv_inputs and np.isnan(inv_inputs.H_bc.values).any():
-        warnings.warn(f"H_bc matrix contains {np.isnan(inv_inputs.H_bc.values).flatten().sum()} NaN values")
-
-    basis = get_xr_dummies(fp_data[".basis"], cat_dim="region", categories=inv_inputs.region)
-    flux = basis_objects["emissions"].flux
+    if prepared.inv_inputs is None or prepared.basis is None or prepared.flux is None:
+        raise RuntimeError("RHIME data preparation did not produce model inputs, basis, and flux.")
 
     return _PreparedRhimeData(
-        inv_inputs=inv_inputs,
-        basis=basis,
-        flux=flux,
-        sites=sites,
-        averaging_period=averaging_period,
+        inv_inputs=prepared.inv_inputs,
+        basis=prepared.basis,
+        flux=prepared.flux,
+        sites=prepared.sites,
+        averaging_period=prepared.averaging_period,
     )
 
 
@@ -978,7 +912,7 @@ def _run_common(
     species = params.pop("species")
     sites = _as_list(params.pop("sites")) or []
     domain = params.pop("domain")
-    averaging_period = _as_list(params.pop("averaging_period")) or []
+    averaging_period = params.pop("averaging_period")
     start_date = params.pop("start_date")
     end_date = params.pop("end_date")
     output_path = params.pop("output_path", None)

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -6,10 +6,16 @@ import pymc as pm
 import pytest
 import xarray as xr
 
+import openghg_inversions.models as models
 import openghg_inversions.rhime as rhime_module
 from openghg_inversions.cli import main
+from openghg_inversions.inversion_data import PreparedInversionData, prepare_inversion_data
+from openghg_inversions.inversion_data.preparation import (
+    _drop_sites_missing_from_loaded_data,
+    _make_inv_inputs,
+)
 from openghg_inversions.inversion_inputs import make_inv_inputs
-from openghg_inversions.models.rhime import (
+from openghg_inversions.models import (
     build_rhime_model,
     build_rhime_multisector_model,
     safe_pymc_name,
@@ -108,6 +114,16 @@ def test_build_rhime_multisector_model_requires_multiple_sectors(
         )
 
 
+def test_models_exports_rhime_builders() -> None:
+    assert models.build_rhime_model is build_rhime_model
+    assert models.build_rhime_multisector_model is build_rhime_multisector_model
+    assert models.safe_pymc_name is safe_pymc_name
+    assert isinstance(models.DEFAULT_X_PRIOR, dict)
+    assert isinstance(models.DEFAULT_BC_PRIOR, dict)
+    assert isinstance(models.DEFAULT_SIGMA_PRIOR, dict)
+    assert isinstance(models.DEFAULT_OFFSET_PRIOR, dict)
+
+
 def test_resolve_flux_sources_prefers_new_name() -> None:
     assert resolve_flux_sources(flux_sources=["new"], emissions_name=["legacy"]) == ["new"]
     assert resolve_flux_sources(emissions_name=["legacy"]) == ["legacy"]
@@ -137,6 +153,460 @@ output_name = "test"
 
     params = params_from_config(config_file)
     assert params["flux_sources"] == ["legacy-source"]
+
+
+def _shared_preparation_args(data_args: dict, flux_sources: list[str]) -> dict:
+    args = data_args.copy()
+    args.pop("emissions_name", None)
+    args.update(
+        {
+            "output_name": "prep_test",
+            "flux_sources": flux_sources,
+            "basis_algorithm": "quadtree",
+            "nbasis": 4,
+            "use_bc": True,
+            "return_basis_objects": True,
+        }
+    )
+    return args
+
+
+def test_prepare_inversion_data_single_sector_reloads_merged_data(
+    tac_ch4_data_args, merged_data_dir, merged_data_file_name
+) -> None:
+    args = _shared_preparation_args(tac_ch4_data_args, tac_ch4_data_args["emissions_name"])
+    args.update(
+        {
+            "reload_merged_data": True,
+            "merged_data_dir": str(merged_data_dir),
+            "merged_data_name": merged_data_file_name,
+        }
+    )
+
+    prepared = prepare_inversion_data(**args)
+
+    assert isinstance(prepared, PreparedInversionData)
+    assert prepared.inv_inputs is not None
+    assert prepared.basis is not None
+    assert prepared.flux is not None
+    assert prepared.sites == ["TAC"]
+    assert "source" not in prepared.inv_inputs["H"].dims
+
+
+def test_prepare_inversion_data_multisector_keeps_source_dimension(tac_ch4_data_args) -> None:
+    flux_sources = ["total-ukghg-edgar7", "total-ukghg-edgar7-shuffled"]
+    args = _shared_preparation_args(tac_ch4_data_args, flux_sources)
+    args["split_by_sectors"] = True
+
+    prepared = prepare_inversion_data(**args)
+
+    assert prepared.inv_inputs is not None
+    assert prepared.flux is not None
+    assert "source" in prepared.inv_inputs["H"].dims
+    assert set(prepared.inv_inputs["H"].coords["source"].values) == set(flux_sources)
+    assert set(prepared.flux.coords["source"].values) == set(flux_sources)
+
+
+def test_loaded_merged_data_alignment_checks_site_membership() -> None:
+    sites, inlet, fp_height, instrument, max_level, averaging_period = _drop_sites_missing_from_loaded_data(
+        fp_all={"TAC": object(), "MHD": object(), ".flux": object()},
+        sites=["TAC", "RGL"],
+        inlet=["185m", "90m"],
+        fp_height=["185m", "90m"],
+        instrument=["inst-1", "inst-2"],
+        max_level=17,
+        averaging_period=["1H", "2H"],
+    )
+
+    assert sites == ["TAC"]
+    assert inlet == ["185m"]
+    assert fp_height == ["185m"]
+    assert instrument == ["inst-1"]
+    assert max_level == 17
+    assert averaging_period == ["1H"]
+
+
+def test_loaded_merged_data_alignment_rejects_no_matching_sites() -> None:
+    with pytest.raises(ValueError, match="does not include any requested sites"):
+        _drop_sites_missing_from_loaded_data(
+            fp_all={"TAC": object(), "MHD": object(), ".flux": object()},
+            sites=["RGL", "BSD"],
+            inlet=["90m", "248m"],
+            fp_height=["90m", "248m"],
+            instrument=["inst-1", "inst-2"],
+            max_level=17,
+            averaging_period=["1H", "2H"],
+        )
+
+
+def test_prepare_inversion_data_prunes_reloaded_merged_data_to_requested_sites(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    captured_fp_all_keys: set[str] = set()
+
+    def fake_load_merged_data(*args: object, **kwargs: object) -> dict:
+        return {
+            "TAC": object(),
+            "MHD": object(),
+            ".flux": object(),
+            ".species": "CH4",
+        }
+
+    def fake_basis_functions_wrapper(**kwargs: object) -> dict:
+        nonlocal captured_fp_all_keys
+        fp_all = kwargs["fp_all"]
+        assert isinstance(fp_all, dict)
+        captured_fp_all_keys = set(fp_all)
+        return {"TAC": xr.Dataset(coords={"time": [0]})}
+
+    def fake_make_inv_inputs(fp_data: dict, sites: list[str], **kwargs: object) -> xr.Dataset:
+        assert sites == ["TAC"]
+        return xr.Dataset({"H": (("region", "nmeasure"), [[1.0]])})
+
+    monkeypatch.setattr(
+        "openghg_inversions.inversion_data.preparation.load_merged_data",
+        fake_load_merged_data,
+    )
+    monkeypatch.setattr(
+        "openghg_inversions.inversion_data.preparation.basis_functions_wrapper",
+        fake_basis_functions_wrapper,
+    )
+    monkeypatch.setattr("openghg_inversions.inversion_data.preparation.make_inv_inputs", fake_make_inv_inputs)
+
+    prepare_inversion_data(
+        species="ch4",
+        sites=["TAC"],
+        domain="EUROPE",
+        averaging_period=["1H"],
+        start_date="2019-01-01",
+        end_date="2019-02-01",
+        output_name="reload_prune",
+        flux_sources=["total-ukghg-edgar7"],
+        reload_merged_data=True,
+        merged_data_dir=str(tmp_path),
+        use_bc=False,
+    )
+
+    assert "TAC" in captured_fp_all_keys
+    assert "MHD" not in captured_fp_all_keys
+    assert {key for key in captured_fp_all_keys if key.startswith(".")} == {
+        ".flux",
+        ".species",
+        ".split_by_sectors",
+    }
+
+
+@pytest.mark.parametrize(
+    ("averaging_period", "expected"),
+    [
+        ("1H", ["1H", "1H"]),
+        (None, [None, None]),
+    ],
+)
+def test_prepare_inversion_data_normalises_averaging_period_to_site_count(
+    monkeypatch: pytest.MonkeyPatch,
+    averaging_period: str | None,
+    expected: list[str | None],
+) -> None:
+    captured_averaging_period: list[str | None] | None = None
+
+    def fake_data_processing_surface_notracer(
+        **kwargs: object,
+    ) -> tuple[dict, list[str], list[str], list[str], list[str], list[str | None]]:
+        nonlocal captured_averaging_period
+        captured_averaging_period = kwargs["averaging_period"]
+        assert isinstance(captured_averaging_period, list)
+        return (
+            {".species": "CH4"},
+            ["TAC", "MHD"],
+            ["185m", "10m"],
+            ["185m", "10m"],
+            ["instrument-1", "instrument-2"],
+            captured_averaging_period,
+        )
+
+    def fake_basis_functions_wrapper(**kwargs: object) -> dict:
+        return {
+            "TAC": xr.Dataset(coords={"time": [0]}),
+            "MHD": xr.Dataset(coords={"time": [0]}),
+        }
+
+    def fake_make_inv_inputs(fp_data: dict, sites: list[str], **kwargs: object) -> xr.Dataset:
+        assert sites == ["TAC", "MHD"]
+        return xr.Dataset({"H": (("region", "nmeasure"), [[1.0, 1.0]])})
+
+    monkeypatch.setattr(
+        "openghg_inversions.inversion_data.preparation.data_processing_surface_notracer",
+        fake_data_processing_surface_notracer,
+    )
+    monkeypatch.setattr(
+        "openghg_inversions.inversion_data.preparation.basis_functions_wrapper",
+        fake_basis_functions_wrapper,
+    )
+    monkeypatch.setattr("openghg_inversions.inversion_data.preparation.make_inv_inputs", fake_make_inv_inputs)
+
+    prepared = prepare_inversion_data(
+        species="ch4",
+        sites=["TAC", "MHD"],
+        domain="EUROPE",
+        averaging_period=averaging_period,
+        start_date="2019-01-01",
+        end_date="2019-02-01",
+        output_name="normalise_avg",
+        flux_sources=["total-ukghg-edgar7"],
+        use_bc=False,
+    )
+
+    assert captured_averaging_period == expected
+    assert prepared.averaging_period == expected
+
+
+def test_prepare_inversion_data_rejects_misaligned_averaging_period_list() -> None:
+    with pytest.raises(ValueError, match="List averaging_period does not have specified length"):
+        prepare_inversion_data(
+            species="ch4",
+            sites=["TAC", "MHD"],
+            domain="EUROPE",
+            averaging_period=["1H"],
+            start_date="2019-01-01",
+            end_date="2019-02-01",
+            output_name="bad_avg",
+            flux_sources=["total-ukghg-edgar7"],
+            use_bc=False,
+        )
+
+
+@pytest.mark.parametrize("averaging_period", [1, ["1H", 2]])
+def test_prepare_inversion_data_rejects_non_string_averaging_period_values(
+    averaging_period: object,
+) -> None:
+    with pytest.raises(ValueError, match="averaging_period"):
+        prepare_inversion_data(
+            species="ch4",
+            sites=["TAC", "MHD"],
+            domain="EUROPE",
+            averaging_period=averaging_period,
+            start_date="2019-01-01",
+            end_date="2019-02-01",
+            output_name="bad_avg_type",
+            flux_sources=["total-ukghg-edgar7"],
+            use_bc=False,
+        )
+
+
+def test_run_rhime_leaves_scalar_averaging_period_for_shared_preparation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_averaging_period: object = None
+    original_signature = rhime_module.inspect.signature(rhime_module._prepare_data)
+
+    def fake_prepare_data(**kwargs: object) -> None:
+        nonlocal captured_averaging_period
+        captured_averaging_period = kwargs["averaging_period"]
+        raise RuntimeError("stop after data argument capture")
+
+    fake_prepare_data.__signature__ = original_signature
+    monkeypatch.setattr(rhime_module, "_prepare_data", fake_prepare_data)
+
+    with pytest.raises(RuntimeError, match="stop after data argument capture"):
+        run_rhime(
+            species="ch4",
+            sites=["TAC", "MHD"],
+            domain="EUROPE",
+            averaging_period="1H",
+            start_date="2019-01-01",
+            end_date="2019-02-01",
+            output_name="avg_scalar",
+            flux_sources=["total-ukghg-edgar7"],
+            output_format="none",
+        )
+
+    assert captured_averaging_period == "1H"
+
+
+def test_prepare_inversion_data_treats_min_error_none_as_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_min_error: object = None
+
+    def fake_data_processing_surface_notracer(
+        **kwargs: object,
+    ) -> tuple[dict, list[str], list[str], list[str], list[str], list[str]]:
+        return (
+            {".species": "CH4"},
+            ["TAC"],
+            ["185m"],
+            ["185m"],
+            ["instrument-1"],
+            ["1H"],
+        )
+
+    def fake_basis_functions_wrapper(**kwargs: object) -> dict:
+        return {"TAC": xr.Dataset(coords={"time": [0]})}
+
+    def fake_make_inv_inputs(fp_data: dict, sites: list[str], **kwargs: object) -> xr.Dataset:
+        nonlocal captured_min_error
+        captured_min_error = kwargs["min_error"]
+        return xr.Dataset({"H": (("region", "nmeasure"), [[1.0]])})
+
+    monkeypatch.setattr(
+        "openghg_inversions.inversion_data.preparation.data_processing_surface_notracer",
+        fake_data_processing_surface_notracer,
+    )
+    monkeypatch.setattr(
+        "openghg_inversions.inversion_data.preparation.basis_functions_wrapper",
+        fake_basis_functions_wrapper,
+    )
+    monkeypatch.setattr("openghg_inversions.inversion_data.preparation.make_inv_inputs", fake_make_inv_inputs)
+
+    prepare_inversion_data(
+        species="ch4",
+        sites=["TAC"],
+        domain="EUROPE",
+        averaging_period=["1H"],
+        start_date="2019-01-01",
+        end_date="2019-02-01",
+        output_name="min_error_none",
+        flux_sources=["total-ukghg-edgar7"],
+        use_bc=False,
+        min_error=None,
+    )
+
+    assert captured_min_error == 0.0
+
+
+def test_prepare_inversion_data_rejects_min_error_dict_missing_retained_site() -> None:
+    with pytest.raises(ValueError, match="MHD"):
+        _make_inv_inputs(
+            fp_data={},
+            sites=["TAC", "MHD"],
+            start_date="2019-01-01",
+            bc_freq=None,
+            sigma_freq=None,
+            min_error={"TAC": 1.0},
+            calculate_min_error=None,
+            min_error_options=None,
+        )
+
+
+def test_calculate_min_error_warning_is_user_visible(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_min_error: object = None
+
+    def fake_make_inv_inputs(fp_data: dict, sites: list[str], **kwargs: object) -> xr.Dataset:
+        nonlocal captured_min_error
+        captured_min_error = kwargs["min_error"]
+        return xr.Dataset({"H": (("region", "nmeasure"), [[1.0]])})
+
+    monkeypatch.setattr("openghg_inversions.inversion_data.preparation.make_inv_inputs", fake_make_inv_inputs)
+
+    with pytest.warns(FutureWarning, match="calculate_min_error"):
+        _make_inv_inputs(
+            fp_data={"TAC": xr.Dataset(coords={"time": [0]})},
+            sites=["TAC"],
+            start_date="2019-01-01",
+            bc_freq=None,
+            sigma_freq=None,
+            min_error=0.0,
+            calculate_min_error="residual",
+            min_error_options=None,
+        )
+
+    assert captured_min_error == "residual"
+
+
+def test_prepare_inversion_data_aligns_averaging_period_after_empty_site_drop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_data_processing_surface_notracer(
+        **kwargs: object,
+    ) -> tuple[dict, list[str], list[str], list[str], list[str], list[str]]:
+        return (
+            {".species": "CH4"},
+            ["TAC", "MHD"],
+            ["185m", "10m"],
+            ["185m", "10m"],
+            ["instrument-1", "instrument-2"],
+            ["1H", "2H"],
+        )
+
+    def fake_basis_functions_wrapper(**kwargs: object) -> dict:
+        return {
+            "TAC": xr.Dataset(coords={"time": [0]}),
+            "MHD": xr.Dataset(coords={"time": []}),
+        }
+
+    def fake_make_inv_inputs(fp_data: dict, sites: list[str], **kwargs: object) -> xr.Dataset:
+        assert sites == ["TAC"]
+        return xr.Dataset({"H": (("region", "nmeasure"), [[1.0]])})
+
+    monkeypatch.setattr(
+        "openghg_inversions.inversion_data.preparation.data_processing_surface_notracer",
+        fake_data_processing_surface_notracer,
+    )
+    monkeypatch.setattr(
+        "openghg_inversions.inversion_data.preparation.basis_functions_wrapper",
+        fake_basis_functions_wrapper,
+    )
+    monkeypatch.setattr("openghg_inversions.inversion_data.preparation.make_inv_inputs", fake_make_inv_inputs)
+
+    prepared = prepare_inversion_data(
+        species="ch4",
+        sites=["TAC", "MHD"],
+        domain="EUROPE",
+        averaging_period=["1H", "2H"],
+        start_date="2019-01-01",
+        end_date="2019-02-01",
+        output_name="filter_drop",
+        flux_sources=["total-ukghg-edgar7"],
+        use_bc=False,
+    )
+
+    assert prepared.sites == ["TAC"]
+    assert prepared.averaging_period == ["1H"]
+
+
+def test_prepare_inversion_data_rejects_all_sites_dropped_by_filtering(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_data_processing_surface_notracer(
+        **kwargs: object,
+    ) -> tuple[dict, list[str], list[str], list[str], list[str], list[str]]:
+        return (
+            {".species": "CH4"},
+            ["TAC", "MHD"],
+            ["185m", "10m"],
+            ["185m", "10m"],
+            ["instrument-1", "instrument-2"],
+            ["1H", "2H"],
+        )
+
+    def fake_basis_functions_wrapper(**kwargs: object) -> dict:
+        return {
+            "TAC": xr.Dataset(coords={"time": []}),
+            "MHD": xr.Dataset(coords={"time": []}),
+        }
+
+    monkeypatch.setattr(
+        "openghg_inversions.inversion_data.preparation.data_processing_surface_notracer",
+        fake_data_processing_surface_notracer,
+    )
+    monkeypatch.setattr(
+        "openghg_inversions.inversion_data.preparation.basis_functions_wrapper",
+        fake_basis_functions_wrapper,
+    )
+
+    with pytest.raises(ValueError, match="No sites remain after filtering"):
+        prepare_inversion_data(
+            species="ch4",
+            sites=["TAC", "MHD"],
+            domain="EUROPE",
+            averaging_period=["1H", "2H"],
+            start_date="2019-01-01",
+            end_date="2019-02-01",
+            output_name="filter_drop",
+            flux_sources=["total-ukghg-edgar7"],
+            use_bc=False,
+        )
 
 
 def test_params_from_config_rejects_unsupported_deprecated_option(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Expose the RHIME model builders, RHIME defaults, and `safe_pymc_name` from `openghg_inversions.models`.
- Convert `build_inferpymc_model` into a compatibility adapter around `build_rhime_model` while preserving legacy prior handling.
- Add shared `prepare_inversion_data` / `PreparedInversionData` and use it from `fixedbasisMCMC`, `run_rhime`, and `run_rhime_multisector`.
- Add focused shared-preparation tests for single-sector reload, multi-sector source handling, dropped-site alignment/fail-fast behavior, site-count normalization of `averaging_period`, and legacy `min_error` handling.

Closes #399
Closes #425

## Follow-up Review Note
- `averaging_period` is now normalized with the existing `convert_to_list` helper, so string values such as `"1H"` are repeated per site rather than split into characters, mismatched list lengths raise clearly, and non-string entries fail at the preparation boundary.
- `run_rhime` now leaves scalar `averaging_period` values for the shared preparation helper instead of converting them to one-element lists too early.
- `min_error=None` is normalized to `0.0` for legacy ini compatibility before calling `make_inv_inputs`; `min_error` dictionaries remain supported and now raise a clear `ValueError` when missing retained sites.
- `calculate_min_error` now emits a visible `FutureWarning` before forwarding to `min_error`.
- The loaded-merged-data site alignment now checks requested-site membership rather than only comparing site counts. This fixes an inherited legacy edge case where equal-length but different requested/loaded site sets could later raise `KeyError`.
- If no requested sites are present in loaded merged data, or all sites are removed by filtering, preparation now raises a clear `ValueError` before reaching `make_inv_inputs`.
- Reloaded merged data is pruned to the retained requested sites plus dot metadata before basis generation and filtering, so extra saved sites cannot influence the active inversion.
- The filtering dropped-site path now filters `averaging_period` alongside `sites`, fixing another inherited legacy alignment issue.
- Opened and updated #427 to track the broader audit of site-aligned inversion metadata after dropped-site handling. Remaining broader work includes centralizing site-aligned metadata, deciding whether public `make_inv_inputs(fp_data, sites=[])` should raise instead of treating `[]` like `None`, and defining the supported `min_error_options` schema.
- The `isinstance(value, str | bytes)` review comment is not applied: PEP 604 union types are valid in `isinstance` on Python 3.10, and this was verified locally.

## Tests
- `uv run pytest tests/test_rhime.py tests/test_inferpymc.py` passed: 56 passed.
- `uv run pytest tests/test_full_inversion.py -k "full_inversion or merged_data"` passed earlier in this PR: 19 passed, 1 deselected.
- `uv run pytest tests/test_rhime.py -k "min_error_none or min_error_dict_missing or calculate_min_error_warning or non_string_averaging_period or scalar_averaging_period or normalises_averaging_period or misaligned_averaging_period or no_matching_sites or all_sites_dropped_by_filtering or prunes_reloaded_merged_data or averaging_period_after_empty_site_drop or loaded_merged_data_alignment or prepare_inversion_data"` passed: 16 passed.
- `uv run ruff check` on touched files passed.
- `uv run ruff format --check` on touched files passed.
- `uv run pyright openghg_inversions/inversion_data/preparation.py` passed.

## Notes
- Full `uv run ruff check openghg_inversions tests` still reports existing unrelated lint issues in older files.
- Full `uv run pyright` still reports the repository's existing type-check baseline errors.