### PR TITLE
Split fixedbasis and RHIME preparation contracts

### DIFF
--- a/openghg_inversions/basis/__init__.py
+++ b/openghg_inversions/basis/__init__.py
@@ -4,6 +4,7 @@ from ._functions import bucketbasisfunction, quadtreebasisfunction, fixed_outer_
 from ._wrapper import (
     basis_functions_wrapper,
     load_basis_functions,
+    make_basis_functions,
 )
 
 __all__ = [
@@ -12,4 +13,5 @@ __all__ = [
     "fixed_outer_regions_basis",
     "basis_functions_wrapper",
     "load_basis_functions",
+    "make_basis_functions",
 ]

--- a/openghg_inversions/basis/_wrapper.py
+++ b/openghg_inversions/basis/_wrapper.py
@@ -1,8 +1,9 @@
 """Functions to calling basis function algorithms and applying basis functions to data."""
 
+from collections.abc import Mapping
 from pathlib import Path
 from time import time
-from typing import Literal
+from typing import Literal, cast
 
 import xarray as xr
 
@@ -14,8 +15,6 @@ from .basis_functions import (
 )
 from ._functions import basis_functions, fixed_outer_regions_basis, basis, openghginv_path
 from ._helpers import apply_basis_functions_sensitivity, bc_sensitivity
-
-BasisArtifactSource = Literal["generated", "datatree", "legacy_flat"]
 
 
 def make_basis_functions(
@@ -40,7 +39,7 @@ def make_basis_functions(
     This helper owns basis artifact generation/loading without applying the
     legacy fixedbasis ``fp_data`` side channels.
     """
-    basis_data_array: xr.DataArray | None = None
+    basis_data_array: xr.DataArray | Mapping[str, xr.DataArray] | None = None
     basis_start = time()
 
     if fp_basis_case is not None:
@@ -85,9 +84,15 @@ def make_basis_functions(
                 "Basis algorithm not recognised. Please use either 'quadtree' or 'weighted', or input a basis function file"
             ) from e
         print(f"Using {basis_function.description} to derive basis functions.")
-        basis_data_array = basis_function.algorithm(
+        basis_candidate = basis_function.algorithm(
             fp_all, start_date, domain, emissions_name, nbasis, country_directory=country_directory
         )
+        if not isinstance(basis_candidate, (xr.DataArray, Mapping)):
+            raise TypeError(
+                f"Basis algorithm {basis_algorithm!r} returned unsupported basis data "
+                f"{type(basis_candidate)!r}."
+            )
+        basis_data_array = cast(xr.DataArray | Mapping[str, xr.DataArray], basis_candidate)
         print("Using generated in-memory basis artifact.")
         basis_functions_object = basis_functions_from_fp_all_flat_basis(
             fp_all=fp_all,
@@ -240,11 +245,7 @@ def basis_functions_wrapper(
     print(f"Computing fp sensitivity took {time() - fp_sens_start}s.")
 
     basis_objects: dict[str, BasisFunctions] = {}
-    needs_basis_object = return_basis_objects or (
-        output_path is not None and basis_output_format == "datatree"
-    )
-
-    if needs_basis_object:
+    if return_basis_objects:
         basis_objects["emissions"] = basis_functions_object
 
     if use_bc is True:

--- a/openghg_inversions/basis/_wrapper.py
+++ b/openghg_inversions/basis/_wrapper.py
@@ -53,7 +53,6 @@ def make_basis_functions(
             basis_case=fp_basis_case,
             basis_directory=basis_directory,
         )
-        basis_data_array = basis_functions_object.flat_basis()
 
     elif basis_algorithm is None:
         raise ValueError("One of `fp_basis_case` or `basis_algorithm` must be specified.")

--- a/openghg_inversions/basis/_wrapper.py
+++ b/openghg_inversions/basis/_wrapper.py
@@ -18,6 +18,115 @@ from ._helpers import apply_basis_functions_sensitivity, bc_sensitivity
 BasisArtifactSource = Literal["generated", "datatree", "legacy_flat"]
 
 
+def make_basis_functions(
+    *,
+    fp_all: dict,
+    species: str,
+    domain: str,
+    start_date: str,
+    emissions_name: list[str] | None,
+    nbasis: int,
+    basis_algorithm: str | None = None,
+    fix_outer_regions: bool = False,
+    fp_basis_case: str | None = None,
+    basis_directory: str | None = None,
+    country_directory: str | None = None,
+    outputname: str | None = None,
+    output_path: str | None = None,
+    basis_output_format: Literal["legacy", "datatree"] = "legacy",
+) -> BasisFunctions:
+    """Create or load retained emissions basis functions.
+
+    This helper owns basis artifact generation/loading without applying the
+    legacy fixedbasis ``fp_data`` side channels.
+    """
+    basis_data_array: xr.DataArray | None = None
+    basis_start = time()
+
+    if fp_basis_case is not None:
+        if basis_algorithm:
+            print(
+                f"Basis algorithm {basis_algorithm} and basis case {fp_basis_case} supplied; using {fp_basis_case}."
+            )
+        basis_functions_object = load_basis_functions(
+            fp_all=fp_all,
+            domain=domain,
+            basis_case=fp_basis_case,
+            basis_directory=basis_directory,
+        )
+        basis_data_array = basis_functions_object.flat_basis()
+
+    elif basis_algorithm is None:
+        raise ValueError("One of `fp_basis_case` or `basis_algorithm` must be specified.")
+
+    elif fix_outer_regions is True:
+        print("Using fixed outer regions for basis functions.")
+        try:
+            basis_data_array = fixed_outer_regions_basis(
+                fp_all, start_date, basis_algorithm, domain, emissions_name, nbasis, country_directory
+            )
+        except KeyError as e:
+            raise ValueError(
+                "Basis algorithm not recognised. Please use either 'quadtree' or 'weighted', or input a basis function file"
+            ) from e
+        print(f"Using InTEM regions with {basis_algorithm} to derive basis functions for inner region.")
+        print("Using generated in-memory basis artifact.")
+        basis_functions_object = basis_functions_from_fp_all_flat_basis(
+            fp_all=fp_all,
+            basis_flat=basis_data_array,
+            metadata={BASIS_ARTIFACT_SOURCE_ATTR: "generated"},
+        )
+
+    else:
+        try:
+            basis_function = basis_functions[basis_algorithm]
+        except KeyError as e:
+            raise ValueError(
+                "Basis algorithm not recognised. Please use either 'quadtree' or 'weighted', or input a basis function file"
+            ) from e
+        print(f"Using {basis_function.description} to derive basis functions.")
+        basis_data_array = basis_function.algorithm(
+            fp_all, start_date, domain, emissions_name, nbasis, country_directory=country_directory
+        )
+        print("Using generated in-memory basis artifact.")
+        basis_functions_object = basis_functions_from_fp_all_flat_basis(
+            fp_all=fp_all,
+            basis_flat=basis_data_array,
+            metadata={BASIS_ARTIFACT_SOURCE_ATTR: "generated"},
+        )
+
+    print(f"Computing basis took {time() - basis_start}s.")
+
+    if output_path is not None and basis_algorithm is not None and fp_basis_case is None:
+        if not isinstance(basis_data_array, xr.DataArray):
+            raise TypeError("Saving generated basis output currently requires a single flat basis DataArray.")
+        if basis_output_format == "legacy":
+            _save_basis(
+                basis=basis_data_array,
+                basis_algorithm=basis_algorithm,
+                output_dir=output_path,
+                domain=domain,
+                species=species,
+                output_name=outputname,
+            )
+        elif basis_output_format == "datatree":
+            _save_basis_datatree(
+                basis_functions=basis_functions_object,
+                basis=basis_data_array,
+                basis_algorithm=basis_algorithm,
+                output_dir=output_path,
+                domain=domain,
+                species=species,
+                output_name=outputname,
+            )
+        else:
+            raise ValueError(
+                f"Unknown basis_output_format '{basis_output_format}'. Expected one of: 'legacy', 'datatree'."
+            )
+
+    return basis_functions_object
+
+
 def basis_functions_wrapper(
     fp_all: dict,
     species: str,
@@ -109,61 +218,22 @@ def basis_functions_wrapper(
     if use_bc is True and bc_basis_case is None:
         raise ValueError("If `use_bc` is True, you must specify `bc_basis_case`.")
 
-    basis_start = time()
-
-    if fp_basis_case is not None:
-        if basis_algorithm:
-            print(
-                f"Basis algorithm {basis_algorithm} and basis case {fp_basis_case} supplied; using {fp_basis_case}."
-            )
-        basis_functions_object = load_basis_functions(
-            fp_all=fp_all,
-            domain=domain,
-            basis_case=fp_basis_case,
-            basis_directory=basis_directory,
-        )
-        basis_data_array = basis_functions_object.flat_basis()
-
-    elif basis_algorithm is None:
-        raise ValueError("One of `fp_basis_case` or `basis_algorithm` must be specified.")
-
-    elif fix_outer_regions is True:
-        print("Using fixed outer regions for basis functions.")
-        try:
-            basis_data_array = fixed_outer_regions_basis(
-                fp_all, start_date, basis_algorithm, domain, emissions_name, nbasis, country_directory
-            )
-        except KeyError as e:
-            raise ValueError(
-                "Basis algorithm not recognised. Please use either 'quadtree' or 'weighted', or input a basis function file"
-            ) from e
-        print(f"Using InTEM regions with {basis_algorithm} to derive basis functions for inner region.")
-        print("Using generated in-memory basis artifact.")
-        basis_functions_object = basis_functions_from_fp_all_flat_basis(
-            fp_all=fp_all,
-            basis_flat=basis_data_array,
-            metadata={BASIS_ARTIFACT_SOURCE_ATTR: "generated"},
-        )
-
-    else:
-        try:
-            basis_function = basis_functions[basis_algorithm]
-        except KeyError as e:
-            raise ValueError(
-                "Basis algorithm not recognised. Please use either 'quadtree' or 'weighted', or input a basis function file"
-            ) from e
-        print(f"Using {basis_function.description} to derive basis functions.")
-        basis_data_array = basis_function.algorithm(
-            fp_all, start_date, domain, emissions_name, nbasis, country_directory=country_directory
-        )
-        print("Using generated in-memory basis artifact.")
-        basis_functions_object = basis_functions_from_fp_all_flat_basis(
-            fp_all=fp_all,
-            basis_flat=basis_data_array,
-            metadata={BASIS_ARTIFACT_SOURCE_ATTR: "generated"},
-        )
-
-    print(f"Computing basis took {time() - basis_start}s.")
+    basis_functions_object = make_basis_functions(
+        fp_all=fp_all,
+        species=species,
+        domain=domain,
+        start_date=start_date,
+        emissions_name=emissions_name,
+        nbasis=nbasis,
+        basis_algorithm=basis_algorithm,
+        fix_outer_regions=fix_outer_regions,
+        fp_basis_case=fp_basis_case,
+        basis_directory=basis_directory,
+        country_directory=country_directory,
+        outputname=outputname,
+        output_path=output_path,
+        basis_output_format=basis_output_format,
+    )
 
     fp_sens_start = time()
     fp_data = apply_basis_functions_sensitivity(fp_all, basis_functions_object)
@@ -186,33 +256,6 @@ def basis_functions_wrapper(
             bc_basis_directory=bc_basis_directory,
         )
         print(f"Computing bc sensitivity took {time() - bc_sens_start}s.")
-
-    if output_path is not None and basis_algorithm is not None and fp_basis_case is None:
-        if not isinstance(basis_data_array, xr.DataArray):
-            raise TypeError("Saving generated basis output currently requires a single flat basis DataArray.")
-        if basis_output_format == "legacy":
-            _save_basis(
-                basis=basis_data_array,
-                basis_algorithm=basis_algorithm,
-                output_dir=output_path,
-                domain=domain,
-                species=species,
-                output_name=outputname,
-            )
-        elif basis_output_format == "datatree":
-            _save_basis_datatree(
-                basis_functions=basis_objects["emissions"],
-                basis=basis_data_array,
-                basis_algorithm=basis_algorithm,
-                output_dir=output_path,
-                domain=domain,
-                species=species,
-                output_name=outputname,
-            )
-        else:
-            raise ValueError(
-                f"Unknown basis_output_format '{basis_output_format}'. Expected one of: 'legacy', 'datatree'."
-            )
 
     if return_basis_objects:
         return fp_data, basis_objects

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -26,7 +26,6 @@ the users OpenGHG config file (default location: ~/.openghg/openghg.conf).
 
 import logging
 from dataclasses import dataclass, field
-from importlib import import_module
 from pathlib import Path
 import time
 from typing import Literal, cast
@@ -35,10 +34,7 @@ import warnings
 import numpy as np
 import xarray as xr
 
-try:
-    split_function_inputs = import_module("openghg.util").split_function_inputs
-except (AttributeError, ImportError):  # pragma: no cover - compatibility with older OpenGHG releases.
-    split_function_inputs = import_module("openghg.util._function_inputs").split_function_inputs
+from openghg.util import split_function_inputs  # pyright: ignore[reportPrivateImportUsage]
 
 import openghg_inversions.hbmcmc.inversion_pymc as mcmc
 from openghg_inversions.models.priors import lognormal_mu_sigma

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -26,6 +26,7 @@ the users OpenGHG config file (default location: ~/.openghg/openghg.conf).
 
 import logging
 from dataclasses import dataclass, field
+from importlib import import_module
 from pathlib import Path
 import time
 from typing import Literal, cast
@@ -34,7 +35,10 @@ import warnings
 import numpy as np
 import xarray as xr
 
-from openghg.util._function_inputs import split_function_inputs
+try:
+    split_function_inputs = import_module("openghg.util").split_function_inputs
+except (AttributeError, ImportError):  # pragma: no cover - compatibility with older OpenGHG releases.
+    split_function_inputs = import_module("openghg.util._function_inputs").split_function_inputs
 
 import openghg_inversions.hbmcmc.inversion_pymc as mcmc
 from openghg_inversions.models.priors import lognormal_mu_sigma

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -97,17 +97,24 @@ def _extract_post_process_args(inv_inputs: xr.Dataset) -> dict[str, object]:
     }
 
 
-def _validate_fixedbasis_prepared_data(prepared: FixedBasisPreparedData) -> None:
-    """Validate the legacy fixedbasis preparation contract before sampling."""
-    if prepared.fp_data is None or prepared.inv_inputs is None:
-        raise RuntimeError("Fixed-basis data preparation did not produce forward data and model inputs.")
+def _require_fixedbasis_inv_inputs(prepared: FixedBasisPreparedData) -> xr.Dataset:
+    """Return prepared model inputs or raise for an invalid fixedbasis contract."""
+    if prepared.inv_inputs is None:
+        raise RuntimeError("Fixed-basis data preparation did not produce model inputs.")
+    return prepared.inv_inputs
 
+
+def _require_fixedbasis_legacy_data(prepared: FixedBasisPreparedData) -> dict:
+    """Return legacy fixedbasis forward data required by postprocessing."""
+    if prepared.fp_data is None:
+        raise RuntimeError("Fixed-basis data preparation did not produce forward data.")
     missing_legacy_keys = [key for key in (".basis", ".flux") if key not in prepared.fp_data]
     if missing_legacy_keys:
         raise RuntimeError(
             "Fixed-basis data preparation did not produce legacy fixed-basis data. "
             f"Missing key(s): {missing_legacy_keys!r}."
         )
+    return prepared.fp_data
 
 
 def _inv_inputs_from_rerun_arrays(
@@ -800,9 +807,7 @@ def fixedbasisMCMC(
     if output_format == "merged_data":
         return prepared.fp_all  # type: ignore
 
-    _validate_fixedbasis_prepared_data(prepared)
-    fp_data = cast(dict, prepared.fp_data)
-    inv_inputs = cast(xr.Dataset, prepared.inv_inputs)
+    inv_inputs = _require_fixedbasis_inv_inputs(prepared)
     sites = prepared.sites
     averaging_period = prepared.averaging_period
 
@@ -827,6 +832,21 @@ def fixedbasisMCMC(
         mcmc_config["bcprior"] = update_log_normal_prior(bcprior)
 
     mcmc_args = mcmc_config.copy()
+    # add any additional kwargs to mcmc_args (these aren't needed for post processing)
+    mcmc_args.update(kwargs)
+    return_mcmc_args = mcmc_args.copy()
+    if return_basis_objects:
+        return_mcmc_args["basis_objects"] = prepared.basis_objects
+
+    end_data = time.time()
+
+    print(f"Data extraction and preparation complete. Time taken = {end_data - start_data:.2f} seconds")
+
+    # for debugging
+    if output_format == "mcmc_args":
+        return return_mcmc_args
+
+    fp_data = _require_fixedbasis_legacy_data(prepared)
     legacy_postprocess_args = _extract_post_process_args(inv_inputs)
 
     legacy_postprocess_args.update(
@@ -853,20 +873,6 @@ def fixedbasisMCMC(
         v = legacy_postprocess_args[k]
         if isinstance(v, np.ndarray) and v.dtype == "float64":
             legacy_postprocess_args[k] = v.astype("float32")
-
-    # add any additional kwargs to mcmc_args (these aren't needed for post processing)
-    mcmc_args.update(kwargs)
-    return_mcmc_args = mcmc_args.copy()
-    if return_basis_objects:
-        return_mcmc_args["basis_objects"] = prepared.basis_objects
-
-    end_data = time.time()
-
-    print(f"Data extraction and preparation complete. Time taken = {end_data - start_data:.2f} seconds")
-
-    # for debugging
-    if output_format == "mcmc_args":
-        return return_mcmc_args
 
     start_inversion = time.time()
 

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -34,12 +34,12 @@ import warnings
 import numpy as np
 import xarray as xr
 
-from openghg.util import split_function_inputs
+from openghg.util._function_inputs import split_function_inputs
 
 import openghg_inversions.hbmcmc.inversion_pymc as mcmc
 from openghg_inversions.models.priors import lognormal_mu_sigma
 from openghg_inversions.utils import ncdf_encoding
-from openghg_inversions.inversion_data import prepare_inversion_data
+from openghg_inversions.inversion_data import FixedBasisPreparedData, prepare_fixedbasis_inversion_data
 from openghg_inversions.postprocessing.inversion_output import (
     InversionOutput,
     make_inv_out_for_fixed_basis_mcmc,
@@ -95,6 +95,19 @@ def _extract_post_process_args(inv_inputs: xr.Dataset) -> dict[str, object]:
         "sigma_freq_index": inv_inputs.sigma_freq_index.values,
         "min_error": inv_inputs.min_error.values,
     }
+
+
+def _validate_fixedbasis_prepared_data(prepared: FixedBasisPreparedData) -> None:
+    """Validate the legacy fixedbasis preparation contract before sampling."""
+    if prepared.fp_data is None or prepared.inv_inputs is None:
+        raise RuntimeError("Fixed-basis data preparation did not produce forward data and model inputs.")
+
+    missing_legacy_keys = [key for key in (".basis", ".flux") if key not in prepared.fp_data]
+    if missing_legacy_keys:
+        raise RuntimeError(
+            "Fixed-basis data preparation did not produce legacy fixed-basis data. "
+            f"Missing key(s): {missing_legacy_keys!r}."
+        )
 
 
 def _inv_inputs_from_rerun_arrays(
@@ -733,7 +746,7 @@ def fixedbasisMCMC(
     )
 
     start_data = time.time()
-    prepared = prepare_inversion_data(
+    prepared = prepare_fixedbasis_inversion_data(
         species=species,
         sites=sites,
         domain=domain,
@@ -787,11 +800,9 @@ def fixedbasisMCMC(
     if output_format == "merged_data":
         return prepared.fp_all  # type: ignore
 
-    if prepared.fp_data is None or prepared.inv_inputs is None:
-        raise RuntimeError("Fixed-basis data preparation did not produce forward data and model inputs.")
-
-    fp_data = prepared.fp_data
-    inv_inputs = prepared.inv_inputs
+    _validate_fixedbasis_prepared_data(prepared)
+    fp_data = cast(dict, prepared.fp_data)
+    inv_inputs = cast(xr.Dataset, prepared.inv_inputs)
     sites = prepared.sites
     averaging_period = prepared.averaging_period
 

--- a/openghg_inversions/inversion_data/__init__.py
+++ b/openghg_inversions/inversion_data/__init__.py
@@ -1,11 +1,18 @@
 from .get_data import data_processing_surface_notracer
-from .preparation import PreparedInversionData, prepare_inversion_data
+from .preparation import (
+    FixedBasisPreparedData,
+    RhimePreparedInputs,
+    prepare_fixedbasis_inversion_data,
+    prepare_rhime_inputs,
+)
 from .serialise import load_merged_data, _save_merged_data
 
 __all__ = [
     "_save_merged_data",
-    "PreparedInversionData",
+    "FixedBasisPreparedData",
+    "RhimePreparedInputs",
     "data_processing_surface_notracer",
     "load_merged_data",
-    "prepare_inversion_data",
+    "prepare_fixedbasis_inversion_data",
+    "prepare_rhime_inputs",
 ]

--- a/openghg_inversions/inversion_data/preparation.py
+++ b/openghg_inversions/inversion_data/preparation.py
@@ -209,19 +209,8 @@ def _prepare_merged_data(
     platform: Any = None,
     use_tracer: bool = False,
     use_bc: bool = True,
-    fp_basis_case: str | None = None,
-    basis_directory: str | None = None,
-    bc_basis_case: str = "NESW",
-    bc_basis_directory: str | Path | None = None,
-    country_directory: str | None = None,
     bc_input: str | None = None,
-    basis_algorithm: str = "weighted",
-    nbasis: int = 100,
-    filters: Any = None,
-    fix_basis_outer_regions: bool = False,
     averaging_error: bool = True,
-    bc_freq: str | None = None,
-    sigma_freq: str | None = None,
     reload_merged_data: bool = False,
     save_merged_data: bool = False,
     merged_data_dir: str | None = None,
@@ -375,8 +364,18 @@ def _rhime_site_data_from_basis_functions(
     for site in sites:
         if fp_data[site].sizes.get("time", 0) == 0:
             continue
-        sensitivity = basis_functions.sensitivity(fp_data[site][fp_x_flux_name])
-        state_dim = "region" if "region" in sensitivity.dims else basis_functions.operator.meta.state_dim
+        fp_x_flux = fp_data[site][fp_x_flux_name]
+        sensitivity = basis_functions.sensitivity(fp_x_flux)
+        state_dims = [dim for dim in sensitivity.dims if dim not in fp_x_flux.dims]
+        if "region" in sensitivity.dims:
+            state_dim = "region"
+        elif len(state_dims) == 1:
+            state_dim = cast(str, state_dims[0])
+        else:
+            raise ValueError(
+                "Could not identify the RHIME sensitivity state dimension from "
+                f"sensitivity dims {sensitivity.dims!r} and fp_x_flux dims {fp_x_flux.dims!r}."
+            )
         if state_dim != "region" and state_dim in sensitivity.dims:
             sensitivity = sensitivity.rename({state_dim: "region"})
             state_dim = "region"

--- a/openghg_inversions/inversion_data/preparation.py
+++ b/openghg_inversions/inversion_data/preparation.py
@@ -11,7 +11,8 @@ import warnings
 import numpy as np
 import xarray as xr
 
-from openghg_inversions.basis import basis_functions_wrapper
+from openghg_inversions.basis import basis_functions_wrapper, make_basis_functions
+from openghg_inversions.basis._helpers import _legacy_multisource_h_if_needed, bc_sensitivity
 from openghg_inversions.basis.basis_functions import BasisFunctions
 from openghg_inversions.filters import filtering
 from openghg_inversions.inversion_data.get_data import convert_to_list, data_processing_surface_notracer
@@ -22,31 +23,46 @@ MinErrorConfig = Literal["percentile", "residual"] | dict[str, float] | None | i
 
 
 @dataclass
-class PreparedInversionData:
-    """Data prepared for RHIME-style inversion runners.
+class FixedBasisPreparedData:
+    """Data prepared for the legacy fixedbasis runner.
 
     Args:
         fp_all: Raw merged-data container returned by data gathering or reload.
-        sites: Retained site names after data gathering and filtering.
-        averaging_period: Averaging periods aligned to retained sites.
         fp_data: Forward-model data after basis functions and filters.
         inv_inputs: Canonical inversion inputs consumed by model builders.
-        basis: Basis matrix aligned to ``inv_inputs.region``, when requested.
-        flux: Prior flux field from the retained emissions basis object, when
-            basis objects were requested.
+        sites: Retained site names after data gathering and filtering.
+        averaging_period: Averaging periods aligned to retained sites.
         basis_objects: Basis objects returned by ``basis_functions_wrapper``.
         basis_artifact_source: Source of the emissions basis artifact.
     """
 
     fp_all: dict
-    sites: list[str]
-    averaging_period: list[str | None]
     fp_data: dict | None = None
     inv_inputs: xr.Dataset | None = None
-    basis: xr.DataArray | None = None
-    flux: xr.DataArray | None = None
+    sites: list[str] = field(default_factory=list)
+    averaging_period: list[str | None] = field(default_factory=list)
     basis_objects: dict[str, BasisFunctions] = field(default_factory=dict)
     basis_artifact_source: str = "generated"
+
+
+@dataclass(frozen=True)
+class RhimePreparedInputs:
+    """Modern RHIME preparation contract."""
+
+    inv_inputs: xr.Dataset
+    basis_functions: BasisFunctions
+    sites: tuple[str, ...]
+    averaging_period: tuple[str | None, ...]
+    basis_artifact_source: str
+
+
+@dataclass
+class _MergedInversionData:
+    """Merged data and site-aligned metadata shared by preparation paths."""
+
+    fp_all: dict
+    sites: list[str]
+    averaging_period: list[str | None]
 
 
 def _filter_site_aligned_value(value: object, keep_indices: list[int]) -> object:
@@ -158,43 +174,6 @@ def _make_inv_inputs(
     )
 
 
-def _legacy_basis_matrix_for_prepared_data(
-    basis_functions: BasisFunctions,
-    *,
-    state_dim: str | None = None,
-    state_coord: xr.DataArray | None = None,
-) -> xr.DataArray:
-    """Legacy adapter returning an explicit basis matrix for prepared data.
-
-    ``PreparedInversionData.basis`` is retained for current RHIME and
-    postprocessing callers that still expect a materialised
-    ``basis(region, lat, lon)`` view. Remove this once issue #429 completes the
-    switch to ``BasisFunctions.sensitivity`` and issue #383 moves output
-    handling onto retained basis objects.
-
-    Args:
-        basis_functions: Retained basis object to expose as an explicit matrix.
-        state_dim: Optional state dimension name expected by the legacy caller.
-        state_coord: Optional state coordinate used to align the output matrix.
-
-    Returns:
-        Basis matrix adapted to the requested legacy state coordinate.
-
-    Raises:
-        ValueError: If ``state_coord`` is unnamed.
-    """
-    basis = basis_functions.operator.basis_matrix
-    current_state_dim = basis_functions.operator.meta.state_dim
-    if state_dim is not None and state_dim != current_state_dim:
-        basis = basis.rename({current_state_dim: state_dim})
-        current_state_dim = state_dim
-    if state_coord is not None:
-        if state_coord.name is None:
-            raise ValueError("state_coord must be named so it can be used for reindexing.")
-        basis = basis.reindex({state_coord.name: state_coord})
-    return basis
-
-
 def _warn_for_nan_inputs(inv_inputs: xr.Dataset, *, use_bc: bool) -> None:
     """Warn when prepared sensitivity matrices contain NaN values."""
     if np.isnan(inv_inputs.H.values).any():
@@ -203,7 +182,7 @@ def _warn_for_nan_inputs(inv_inputs: xr.Dataset, *, use_bc: bool) -> None:
         warnings.warn(f"H_bc matrix contains {np.isnan(inv_inputs.H_bc.values).flatten().sum()} NaN values")
 
 
-def prepare_inversion_data(
+def _prepare_merged_data(
     *,
     species: str,
     sites: list[str],
@@ -247,21 +226,10 @@ def prepare_inversion_data(
     save_merged_data: bool = False,
     merged_data_dir: str | None = None,
     merged_data_name: str | None = None,
-    basis_output_path: str | None = None,
-    min_error: MinErrorConfig = 0.0,
-    calculate_min_error: Literal["percentile", "residual"] | None = None,
-    min_error_options: dict | None = None,
-    return_basis_objects: bool = False,
-    merged_data_only: bool = False,
-) -> PreparedInversionData:
-    """Gather data, apply basis functions and filters, and create inversion inputs.
-
-    This helper owns the runner-level preparation shared by legacy
-    ``fixedbasisMCMC`` and modern RHIME runners. It intentionally does not build
-    PyMC models, sample, or create output products.
-    """
+) -> _MergedInversionData:
+    """Gather or reload merged inversion data and align site metadata."""
     if use_tracer:
-        raise ValueError("Tracer inversions are not supported by this RHIME preparation path.")
+        raise ValueError("Tracer inversions are not supported by this preparation path.")
     if not sites:
         raise ValueError("At least one site must be specified for inversion data preparation.")
 
@@ -337,40 +305,21 @@ def prepare_inversion_data(
     if not sites:
         raise ValueError("No sites remain after data gathering.")
 
-    if merged_data_only:
-        return PreparedInversionData(
-            fp_all=fp_all,
-            sites=sites,
-            averaging_period=cast(list[str | None], averaging_period),
-        )
-
-    bc_basis_directory_arg = (
-        str(bc_basis_directory) if isinstance(bc_basis_directory, Path) else bc_basis_directory
-    )
-
-    basis_result = basis_functions_wrapper(
-        basis_algorithm=basis_algorithm,
-        nbasis=nbasis,
-        fp_basis_case=fp_basis_case,
-        bc_basis_case=bc_basis_case,
-        basis_directory=basis_directory,
-        bc_basis_directory=bc_basis_directory_arg,
-        country_directory=country_directory,
+    return _MergedInversionData(
         fp_all=fp_all,
-        use_bc=use_bc,
-        species=species,
-        domain=domain,
-        start_date=start_date,
-        fix_outer_regions=fix_basis_outer_regions,
-        emissions_name=flux_sources,
-        outputname=output_name,
-        output_path=basis_output_path,
-        return_basis_objects=True,
+        sites=sites,
+        averaging_period=cast(list[str | None], averaging_period),
     )
-    fp_data, prepared_basis_objects = cast(tuple[dict, dict[str, BasisFunctions]], basis_result)
-    basis_source = prepared_basis_objects["emissions"].basis_artifact_source or "generated"
-    basis_objects = prepared_basis_objects if return_basis_objects else {}
 
+
+def _apply_filters_and_drop_empty_sites(
+    *,
+    fp_data: dict,
+    sites: list[str],
+    averaging_period: list[str | None],
+    filters: Any,
+) -> tuple[dict, list[str], list[str | None]]:
+    """Apply filters and keep site-aligned metadata in sync."""
     if filters is not None:
         try:
             fp_data = filtering(fp_data, filters)
@@ -393,12 +342,192 @@ def prepare_inversion_data(
         averaging_period = [period for index, period in enumerate(averaging_period) if index in keep_indices]
         print(f"\nDropping {dropped_sites} sites as no data passed the filtering.\n")
 
+    return fp_data, sites, averaging_period
+
+
+def _set_domain_attrs(fp_data: dict, sites: list[str], domain: str) -> None:
+    """Attach the legacy domain attribute expected by downstream code."""
     for site in sites:
         fp_data[site].attrs["Domain"] = domain
 
+
+def _bc_basis_directory_arg(bc_basis_directory: str | Path | None) -> str | None:
+    """Normalize BC basis directory arguments for legacy helpers."""
+    return str(bc_basis_directory) if isinstance(bc_basis_directory, Path) else bc_basis_directory
+
+
+def _rhime_site_data_from_basis_functions(
+    *,
+    fp_all: dict,
+    basis_functions: BasisFunctions,
+    sites: list[str],
+    domain: str,
+    split_by_sectors: bool,
+    flux_sources: list[str],
+    use_bc: bool,
+    bc_basis_case: str,
+    bc_basis_directory: str | None,
+) -> dict:
+    """Build RHIME site datasets using retained basis functions only."""
+    fp_data = {site: fp_all[site].copy() for site in sites}
+    fp_x_flux_name = "fp_x_flux_sectoral" if split_by_sectors else "fp_x_flux"
+
+    for site in sites:
+        if fp_data[site].sizes.get("time", 0) == 0:
+            continue
+        sensitivity = basis_functions.sensitivity(fp_data[site][fp_x_flux_name])
+        state_dim = "region" if "region" in sensitivity.dims else basis_functions.operator.meta.state_dim
+        if state_dim != "region" and state_dim in sensitivity.dims:
+            sensitivity = sensitivity.rename({state_dim: "region"})
+            state_dim = "region"
+        if split_by_sectors:
+            sensitivity = _legacy_multisource_h_if_needed(
+                sensitivity,
+                state_dim=state_dim,
+                flux_sources=flux_sources,
+            )
+        fp_data[site]["H"] = sensitivity
+
+    if use_bc:
+        fp_data = bc_sensitivity(
+            fp_data,
+            domain=domain,
+            basis_case=bc_basis_case,
+            bc_basis_directory=bc_basis_directory,
+        )
+
+    return fp_data
+
+
+def prepare_fixedbasis_inversion_data(
+    *,
+    species: str,
+    sites: list[str],
+    domain: str,
+    averaging_period: list[str | None] | str | None,
+    start_date: str,
+    end_date: str,
+    output_name: str,
+    flux_sources: list[str] | None,
+    split_by_sectors: bool = False,
+    bc_store: str = "user",
+    obs_store: str = "user",
+    footprint_store: str = "user",
+    emissions_store: str = "user",
+    met_model: Any = None,
+    fp_model: str | None = None,
+    fp_height: Any = None,
+    fp_species: str | None = None,
+    inlet: Any = None,
+    instrument: Any = None,
+    max_level: int | None = None,
+    calibration_scale: str | None = None,
+    obs_data_level: Any = None,
+    platform: Any = None,
+    use_tracer: bool = False,
+    use_bc: bool = True,
+    fp_basis_case: str | None = None,
+    basis_directory: str | None = None,
+    bc_basis_case: str = "NESW",
+    bc_basis_directory: str | Path | None = None,
+    country_directory: str | None = None,
+    bc_input: str | None = None,
+    basis_algorithm: str = "weighted",
+    nbasis: int = 100,
+    filters: Any = None,
+    fix_basis_outer_regions: bool = False,
+    averaging_error: bool = True,
+    bc_freq: str | None = None,
+    sigma_freq: str | None = None,
+    reload_merged_data: bool = False,
+    save_merged_data: bool = False,
+    merged_data_dir: str | None = None,
+    merged_data_name: str | None = None,
+    basis_output_path: str | None = None,
+    min_error: MinErrorConfig = 0.0,
+    calculate_min_error: Literal["percentile", "residual"] | None = None,
+    min_error_options: dict | None = None,
+    return_basis_objects: bool = False,
+    merged_data_only: bool = False,
+) -> FixedBasisPreparedData:
+    """Prepare data for legacy fixedbasisMCMC and its output adapters."""
+    merged = _prepare_merged_data(
+        species=species,
+        sites=sites,
+        domain=domain,
+        averaging_period=averaging_period,
+        start_date=start_date,
+        end_date=end_date,
+        output_name=output_name,
+        flux_sources=flux_sources,
+        split_by_sectors=split_by_sectors,
+        bc_store=bc_store,
+        obs_store=obs_store,
+        footprint_store=footprint_store,
+        emissions_store=emissions_store,
+        met_model=met_model,
+        fp_model=fp_model,
+        fp_height=fp_height,
+        fp_species=fp_species,
+        inlet=inlet,
+        instrument=instrument,
+        max_level=max_level,
+        calibration_scale=calibration_scale,
+        obs_data_level=obs_data_level,
+        platform=platform,
+        use_tracer=use_tracer,
+        use_bc=use_bc,
+        bc_input=bc_input,
+        averaging_error=averaging_error,
+        reload_merged_data=reload_merged_data,
+        save_merged_data=save_merged_data,
+        merged_data_dir=merged_data_dir,
+        merged_data_name=merged_data_name,
+    )
+
+    if merged_data_only:
+        return FixedBasisPreparedData(
+            fp_all=merged.fp_all,
+            sites=merged.sites,
+            averaging_period=merged.averaging_period,
+        )
+
+    bc_basis_directory_arg = _bc_basis_directory_arg(bc_basis_directory)
+
+    basis_result = basis_functions_wrapper(
+        basis_algorithm=basis_algorithm,
+        nbasis=nbasis,
+        fp_basis_case=fp_basis_case,
+        bc_basis_case=bc_basis_case,
+        basis_directory=basis_directory,
+        bc_basis_directory=bc_basis_directory_arg,
+        country_directory=country_directory,
+        fp_all=merged.fp_all,
+        use_bc=use_bc,
+        species=species,
+        domain=domain,
+        start_date=start_date,
+        fix_outer_regions=fix_basis_outer_regions,
+        emissions_name=flux_sources,
+        outputname=output_name,
+        output_path=basis_output_path,
+        return_basis_objects=True,
+    )
+    fp_data, fixedbasis_basis_objects = cast(tuple[dict, dict[str, BasisFunctions]], basis_result)
+    basis_source = fixedbasis_basis_objects["emissions"].basis_artifact_source or "generated"
+    basis_objects = fixedbasis_basis_objects if return_basis_objects else {}
+
+    fp_data, prepared_sites, prepared_averaging_period = _apply_filters_and_drop_empty_sites(
+        fp_data=fp_data,
+        sites=merged.sites,
+        averaging_period=merged.averaging_period,
+        filters=filters,
+    )
+    _set_domain_attrs(fp_data, prepared_sites, domain)
+
     inv_inputs = _make_inv_inputs(
         fp_data=fp_data,
-        sites=sites,
+        sites=prepared_sites,
         start_date=start_date,
         bc_freq=bc_freq,
         sigma_freq=sigma_freq,
@@ -408,25 +537,152 @@ def prepare_inversion_data(
     )
     _warn_for_nan_inputs(inv_inputs, use_bc=use_bc)
 
-    basis = None
-    flux = None
-    if return_basis_objects:
-        emissions_basis = basis_objects["emissions"]
-        basis = _legacy_basis_matrix_for_prepared_data(
-            emissions_basis,
-            state_dim="region",
-            state_coord=inv_inputs.region,
-        )
-        flux = emissions_basis.flux
-
-    return PreparedInversionData(
-        fp_all=fp_all,
+    return FixedBasisPreparedData(
+        fp_all=merged.fp_all,
         fp_data=fp_data,
         inv_inputs=inv_inputs,
-        basis=basis,
-        flux=flux,
         basis_objects=basis_objects,
         basis_artifact_source=basis_source,
+        sites=prepared_sites,
+        averaging_period=prepared_averaging_period,
+    )
+
+
+def prepare_rhime_inputs(
+    *,
+    species: str,
+    sites: list[str],
+    domain: str,
+    averaging_period: list[str | None] | str | None,
+    start_date: str,
+    end_date: str,
+    output_name: str,
+    flux_sources: list[str],
+    split_by_sectors: bool = False,
+    bc_store: str = "user",
+    obs_store: str = "user",
+    footprint_store: str = "user",
+    emissions_store: str = "user",
+    met_model: Any = None,
+    fp_model: str | None = None,
+    fp_height: Any = None,
+    fp_species: str | None = None,
+    inlet: Any = None,
+    instrument: Any = None,
+    max_level: int | None = None,
+    calibration_scale: str | None = None,
+    obs_data_level: Any = None,
+    platform: Any = None,
+    use_tracer: bool = False,
+    use_bc: bool = True,
+    fp_basis_case: str | None = None,
+    basis_directory: str | None = None,
+    bc_basis_case: str = "NESW",
+    bc_basis_directory: str | Path | None = None,
+    country_directory: str | None = None,
+    bc_input: str | None = None,
+    basis_algorithm: str = "weighted",
+    nbasis: int = 100,
+    filters: Any = None,
+    fix_basis_outer_regions: bool = False,
+    averaging_error: bool = True,
+    bc_freq: str | None = None,
+    sigma_freq: str | None = None,
+    reload_merged_data: bool = False,
+    save_merged_data: bool = False,
+    merged_data_dir: str | None = None,
+    merged_data_name: str | None = None,
+    basis_output_path: str | None = None,
+    min_error: MinErrorConfig = 0.0,
+    min_error_options: dict | None = None,
+) -> RhimePreparedInputs:
+    """Prepare modern RHIME inputs without exposing legacy fixedbasis containers."""
+    merged = _prepare_merged_data(
+        species=species,
         sites=sites,
-        averaging_period=cast(list[str | None], averaging_period),
+        domain=domain,
+        averaging_period=averaging_period,
+        start_date=start_date,
+        end_date=end_date,
+        output_name=output_name,
+        flux_sources=flux_sources,
+        split_by_sectors=split_by_sectors,
+        bc_store=bc_store,
+        obs_store=obs_store,
+        footprint_store=footprint_store,
+        emissions_store=emissions_store,
+        met_model=met_model,
+        fp_model=fp_model,
+        fp_height=fp_height,
+        fp_species=fp_species,
+        inlet=inlet,
+        instrument=instrument,
+        max_level=max_level,
+        calibration_scale=calibration_scale,
+        obs_data_level=obs_data_level,
+        platform=platform,
+        use_tracer=use_tracer,
+        use_bc=use_bc,
+        bc_input=bc_input,
+        averaging_error=averaging_error,
+        reload_merged_data=reload_merged_data,
+        save_merged_data=save_merged_data,
+        merged_data_dir=merged_data_dir,
+        merged_data_name=merged_data_name,
+    )
+
+    basis_functions = make_basis_functions(
+        basis_algorithm=basis_algorithm,
+        nbasis=nbasis,
+        fp_basis_case=fp_basis_case,
+        basis_directory=basis_directory,
+        country_directory=country_directory,
+        fp_all=merged.fp_all,
+        species=species,
+        domain=domain,
+        start_date=start_date,
+        fix_outer_regions=fix_basis_outer_regions,
+        emissions_name=flux_sources,
+        outputname=output_name,
+        output_path=basis_output_path,
+    )
+    basis_source = basis_functions.basis_artifact_source or "generated"
+
+    fp_data = _rhime_site_data_from_basis_functions(
+        fp_all=merged.fp_all,
+        basis_functions=basis_functions,
+        sites=merged.sites,
+        domain=domain,
+        split_by_sectors=split_by_sectors,
+        flux_sources=flux_sources,
+        use_bc=use_bc,
+        bc_basis_case=bc_basis_case,
+        bc_basis_directory=_bc_basis_directory_arg(bc_basis_directory),
+    )
+    fp_data, prepared_sites, prepared_averaging_period = _apply_filters_and_drop_empty_sites(
+        fp_data=fp_data,
+        sites=merged.sites,
+        averaging_period=merged.averaging_period,
+        filters=filters,
+    )
+    _set_domain_attrs(fp_data, prepared_sites, domain)
+
+    inv_inputs = _make_inv_inputs(
+        fp_data=fp_data,
+        sites=prepared_sites,
+        start_date=start_date,
+        bc_freq=bc_freq,
+        sigma_freq=sigma_freq,
+        min_error=min_error,
+        calculate_min_error=None,
+        min_error_options=min_error_options,
+    )
+    _warn_for_nan_inputs(inv_inputs, use_bc=use_bc)
+
+    return RhimePreparedInputs(
+        inv_inputs=inv_inputs,
+        basis_functions=basis_functions,
+        basis_artifact_source=basis_source,
+        sites=tuple(prepared_sites),
+        averaging_period=tuple(prepared_averaging_period),
     )

--- a/openghg_inversions/rhime.py
+++ b/openghg_inversions/rhime.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
-from importlib import import_module
 import inspect
 from pathlib import Path
 from typing import Any, Literal, cast
@@ -16,10 +15,7 @@ import numpy as np
 import pymc as pm
 import xarray as xr
 
-try:
-    split_function_inputs = import_module("openghg.util").split_function_inputs
-except (AttributeError, ImportError):  # pragma: no cover - compatibility with older OpenGHG releases.
-    split_function_inputs = import_module("openghg.util._function_inputs").split_function_inputs
+from openghg.util import split_function_inputs  # pyright: ignore[reportPrivateImportUsage]
 
 from openghg_inversions.array_ops import sparse_xr_dot
 from openghg_inversions.basis.basis_functions import BasisFunctions

--- a/openghg_inversions/rhime.py
+++ b/openghg_inversions/rhime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
+from importlib import import_module
 import inspect
 from pathlib import Path
 from typing import Any, Literal, cast
@@ -14,7 +15,11 @@ import arviz as az
 import numpy as np
 import pymc as pm
 import xarray as xr
-from openghg.util._function_inputs import split_function_inputs
+
+try:
+    split_function_inputs = import_module("openghg.util").split_function_inputs
+except (AttributeError, ImportError):  # pragma: no cover - compatibility with older OpenGHG releases.
+    split_function_inputs = import_module("openghg.util._function_inputs").split_function_inputs
 
 from openghg_inversions.array_ops import sparse_xr_dot
 from openghg_inversions.basis.basis_functions import BasisFunctions

--- a/openghg_inversions/rhime.py
+++ b/openghg_inversions/rhime.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 import inspect
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, cast
 import time
 import warnings
 
@@ -14,12 +14,12 @@ import arviz as az
 import numpy as np
 import pymc as pm
 import xarray as xr
-from openghg.util import split_function_inputs
+from openghg.util._function_inputs import split_function_inputs
 
 from openghg_inversions.array_ops import sparse_xr_dot
 from openghg_inversions.basis.basis_functions import BasisFunctions
 from openghg_inversions.config import config
-from openghg_inversions.inversion_data import prepare_inversion_data
+from openghg_inversions.inversion_data import RhimePreparedInputs, prepare_rhime_inputs
 from openghg_inversions.models import (
     DEFAULT_X_PRIOR,
     build_rhime_model,
@@ -144,7 +144,7 @@ class RhimeResult:
         outputs: In-memory derived outputs keyed by output kind.
         model: Built PyMC model.
         inv_out: Modern inversion output object when created.
-        basis_objects: Retained basis objects from shared preparation.
+        basis_functions: Retained emissions basis functions from preparation.
     """
 
     run_spec: RhimeRunSpec
@@ -154,21 +154,9 @@ class RhimeResult:
     idata: az.InferenceData
     output_metadata: dict[str, Any] = field(default_factory=dict)
     outputs: dict[str, Any] = field(default_factory=dict)
-    basis_objects: dict[str, BasisFunctions] = field(default_factory=dict)
+    basis_functions: BasisFunctions | None = None
     model: pm.Model | None = None
     inv_out: InversionOutput | None = None
-
-
-@dataclass
-class _PreparedRhimeData:
-    """Prepared data needed after data gathering, basis application, and filtering."""
-
-    inv_inputs: xr.Dataset
-    basis: xr.DataArray
-    flux: xr.DataArray
-    basis_objects: dict[str, BasisFunctions]
-    sites: list[str]
-    averaging_period: list[str | None]
 
 
 def _as_list(value: str | Sequence[str] | None) -> list[str] | None:
@@ -475,14 +463,13 @@ def _prepare_data(
     basis_output_path: str | None = None,
     min_error: MinErrorConfig = 0.0,
     min_error_options: dict | None = None,
-) -> _PreparedRhimeData:
+) -> RhimePreparedInputs:
     """Gather data, apply basis functions, filter observations, and make canonical inputs.
 
-    This delegates the legacy ``fp_all``/``fp_data`` preparation to the shared
-    inversion-data helper and returns the explicit modern objects needed
-    downstream by RHIME.
+    This returns the explicit modern objects needed downstream by RHIME without
+    exposing fixedbasis ``fp_all``/``fp_data`` containers.
     """
-    prepared = prepare_inversion_data(
+    return prepare_rhime_inputs(
         species=species,
         sites=sites,
         domain=domain,
@@ -528,26 +515,6 @@ def _prepare_data(
         basis_output_path=basis_output_path,
         min_error=min_error,
         min_error_options=min_error_options,
-        return_basis_objects=True,
-    )
-
-    if (
-        prepared.inv_inputs is None
-        or prepared.basis is None
-        or prepared.flux is None
-        or "emissions" not in prepared.basis_objects
-    ):
-        raise RuntimeError(
-            "RHIME data preparation did not produce model inputs, basis, flux, and basis objects."
-        )
-
-    return _PreparedRhimeData(
-        inv_inputs=prepared.inv_inputs,
-        basis=prepared.basis,
-        flux=prepared.flux,
-        basis_objects=prepared.basis_objects,
-        sites=prepared.sites,
-        averaging_period=prepared.averaging_period,
     )
 
 
@@ -633,7 +600,9 @@ def _extend_inferencedata_predictive(
     """Extend an InferenceData object with requested predictive groups."""
     if sample_prior_predictive:
         prior_draws = (
-            trace.posterior.sizes["draw"] if sample_prior_predictive is True else int(sample_prior_predictive)
+            cast(Any, trace).posterior.sizes["draw"]
+            if sample_prior_predictive is True
+            else int(sample_prior_predictive)
         )
         with model:
             trace.extend(pm.sample_prior_predictive(prior_draws, model))
@@ -666,16 +635,19 @@ def _sample(
     idata_kwargs["log_likelihood"] = True
 
     with model:
-        raw_trace = pm.sample(
-            draws=draws,
-            tune=tune,
-            chains=chains,
-            return_inferencedata=True,
-            idata_kwargs=idata_kwargs,
-            **sample_kwargs,
+        raw_trace = cast(
+            az.InferenceData,
+            pm.sample(
+                draws=draws,
+                tune=tune,
+                chains=chains,
+                return_inferencedata=True,
+                idata_kwargs=idata_kwargs,
+                **sample_kwargs,
+            ),
         )
 
-    burned_trace = raw_trace.isel(draw=slice(burn, None))
+    burned_trace = cast(az.InferenceData, raw_trace.isel(draw=slice(burn, None)))
     return _extend_inferencedata_predictive(
         burned_trace,
         model=model,
@@ -684,9 +656,37 @@ def _sample(
     )
 
 
+def _basis_matrix_for_output(
+    basis_functions: BasisFunctions,
+    *,
+    state_dim: str = "region",
+    state_coord: xr.DataArray | None = None,
+) -> xr.DataArray:
+    """Materialise a basis matrix at the RHIME output boundary."""
+    basis = basis_functions.operator.basis_matrix
+    current_state_dim = basis_functions.operator.meta.state_dim
+    if state_dim != current_state_dim:
+        basis = basis.rename({current_state_dim: state_dim})
+    if state_coord is not None:
+        if state_coord.name is None:
+            raise ValueError("state_coord must be named so it can be used for reindexing.")
+        basis = basis.reindex({state_coord.name: state_coord})
+    return basis
+
+
+def _materialise_basis_and_flux_for_output(prepared: RhimePreparedInputs) -> tuple[xr.DataArray, xr.DataArray]:
+    """Return materialised basis/flux arrays for current output adapters."""
+    basis = _basis_matrix_for_output(
+        prepared.basis_functions,
+        state_dim="region",
+        state_coord=prepared.inv_inputs.region,
+    )
+    return basis, prepared.basis_functions.flux
+
+
 def _make_inversion_output(
     *,
-    prepared: _PreparedRhimeData,
+    prepared: RhimePreparedInputs,
     idata: az.InferenceData,
     start_date: str,
     end_date: str,
@@ -701,6 +701,7 @@ def _make_inversion_output(
     ``InversionOutput`` contract.
     """
     inv_inputs = prepared.inv_inputs
+    basis, flux = _materialise_basis_and_flux_for_output(prepared)
     nmeasure = np.arange(inv_inputs.sizes["nmeasure"])
     site_names = (
         inv_inputs["site_names"] if "site_names" in inv_inputs else xr.DataArray(prepared.sites, dims="nsite")
@@ -736,8 +737,8 @@ def _make_inversion_output(
             else None
         ),
         site_indicators=nmeasure_array("site_indicator", inv_inputs["site_indicator"]),
-        flux=prepared.flux,
-        basis=prepared.basis,
+        flux=flux,
+        basis=basis,
         trace=idata,
         site_names=site_names,
         times=nmeasure_array("times", inv_inputs["time"]),
@@ -751,7 +752,7 @@ def _make_inversion_output(
 def _write_standard_outputs(
     *,
     result: RhimeResult,
-    prepared: _PreparedRhimeData,
+    prepared: RhimePreparedInputs,
     country_file: str | None,
 ) -> None:
     """Create and optionally save standard RHIME outputs."""
@@ -840,28 +841,27 @@ def _write_standard_outputs(
 def make_multisector_flux_diagnostics(
     *,
     idata: az.InferenceData,
-    prepared: _PreparedRhimeData,
+    prepared: RhimePreparedInputs,
     model_spec: RhimeModelSpec,
 ) -> xr.Dataset:
     """Create sector-aware posterior flux diagnostics for shared-basis RHIME.
 
     Args:
         idata: InferenceData returned by RHIME sampling.
-        prepared: Prepared RHIME data object containing basis and flux arrays.
+        prepared: Prepared RHIME input object containing retained basis functions.
         model_spec: Model spec containing sector names and variable suffixes.
 
     Returns:
         Dataset containing posterior mean scaling factors, sector posterior flux
         means, and total posterior flux mean.
     """
-    basis = prepared.basis
-    flux = prepared.flux
+    basis, flux = _materialise_basis_and_flux_for_output(prepared)
     posterior_flux = []
     posterior_scaling = []
 
     for sector in model_spec.sectors:
         x_name = f"x_{sector.variable_suffix}"
-        x_mean = idata.posterior[x_name].mean(("chain", "draw"))
+        x_mean = cast(Any, idata).posterior[x_name].mean(("chain", "draw"))
         scale_grid = sparse_xr_dot(basis, x_mean)
         sector_flux = flux.sel(source=sector.flux_source) if "source" in flux.dims else flux
         posterior_scaling.append(scale_grid.expand_dims(sector=[sector.name]))
@@ -876,7 +876,7 @@ def make_multisector_flux_diagnostics(
 def _write_multisector_outputs(
     *,
     result: RhimeResult,
-    prepared: _PreparedRhimeData,
+    prepared: RhimePreparedInputs,
 ) -> None:
     """Create and optionally save shared-basis multi-sector RHIME outputs."""
     diagnostics = make_multisector_flux_diagnostics(
@@ -1065,7 +1065,7 @@ def _run_common(
         inv_inputs=prepared.inv_inputs,
         idata=idata,
         model=model,
-        basis_objects=prepared.basis_objects,
+        basis_functions=prepared.basis_functions,
         output_metadata={"build_and_sample_seconds": time.time() - start_build},
     )
 

--- a/openghg_inversions/rhime.py
+++ b/openghg_inversions/rhime.py
@@ -307,7 +307,7 @@ def _validate_required_params(params: Mapping[str, Any]) -> None:
 
 def _validate_supported_params(params: Mapping[str, Any]) -> None:
     """Raise if normalized run parameters contain unsupported keys."""
-    data_params = set(inspect.signature(_prepare_data).parameters)
+    data_params = set(inspect.signature(prepare_rhime_inputs).parameters)
     runner_params = {
         "x_prior",
         "bc_prior",
@@ -413,108 +413,6 @@ def _save_inferencedata(idata: az.InferenceData, path: str | Path) -> None:
     joined_failures = "\n".join(failures)
     raise RuntimeError(
         f"Could not save RHIME trace to {path}. Tried h5netcdf, ArviZ default, and netcdf4:\n{joined_failures}"
-    )
-
-
-def _prepare_data(
-    *,
-    species: str,
-    sites: list[str],
-    domain: str,
-    averaging_period: list[str | None] | str | None,
-    start_date: str,
-    end_date: str,
-    output_name: str,
-    flux_sources: list[str],
-    split_by_sectors: bool,
-    bc_store: str = "user",
-    obs_store: str = "user",
-    footprint_store: str = "user",
-    emissions_store: str = "user",
-    met_model: list[str | None] | str | None = None,
-    fp_model: str | None = None,
-    fp_height: list[str | None] | str | None = None,
-    fp_species: str | None = None,
-    inlet: list[str | None] | str | None = None,
-    instrument: list[str | None] | str | None = None,
-    max_level: int | None = None,
-    calibration_scale: str | None = None,
-    obs_data_level: list[str | None] | str | None = None,
-    platform: list[str | None] | str | None = None,
-    use_tracer: bool = False,
-    use_bc: bool = True,
-    fp_basis_case: str | None = None,
-    basis_directory: str | None = None,
-    bc_basis_case: str = "NESW",
-    bc_basis_directory: str | None = None,
-    country_directory: str | None = None,
-    bc_input: str | None = None,
-    basis_algorithm: str = "weighted",
-    nbasis: int = 100,
-    filters: None | list | dict[str, list[str] | None] = None,
-    fix_basis_outer_regions: bool = False,
-    averaging_error: bool = True,
-    bc_freq: str | None = None,
-    sigma_freq: str | None = None,
-    reload_merged_data: bool = False,
-    save_merged_data: bool = False,
-    merged_data_dir: str | None = None,
-    merged_data_name: str | None = None,
-    basis_output_path: str | None = None,
-    min_error: MinErrorConfig = 0.0,
-    min_error_options: dict | None = None,
-) -> RhimePreparedInputs:
-    """Gather data, apply basis functions, filter observations, and make canonical inputs.
-
-    This returns the explicit modern objects needed downstream by RHIME without
-    exposing fixedbasis ``fp_all``/``fp_data`` containers.
-    """
-    return prepare_rhime_inputs(
-        species=species,
-        sites=sites,
-        domain=domain,
-        averaging_period=averaging_period,
-        start_date=start_date,
-        end_date=end_date,
-        output_name=output_name,
-        flux_sources=flux_sources,
-        split_by_sectors=split_by_sectors,
-        bc_store=bc_store,
-        obs_store=obs_store,
-        footprint_store=footprint_store,
-        emissions_store=emissions_store,
-        met_model=met_model,
-        fp_model=fp_model,
-        fp_height=fp_height,
-        fp_species=fp_species,
-        inlet=inlet,
-        instrument=instrument,
-        max_level=max_level,
-        calibration_scale=calibration_scale,
-        obs_data_level=obs_data_level,
-        platform=platform,
-        use_tracer=use_tracer,
-        use_bc=use_bc,
-        fp_basis_case=fp_basis_case,
-        basis_directory=basis_directory,
-        bc_basis_case=bc_basis_case,
-        bc_basis_directory=bc_basis_directory,
-        country_directory=country_directory,
-        bc_input=bc_input,
-        basis_algorithm=basis_algorithm,
-        nbasis=nbasis,
-        filters=filters,
-        fix_basis_outer_regions=fix_basis_outer_regions,
-        averaging_error=averaging_error,
-        bc_freq=bc_freq,
-        sigma_freq=sigma_freq,
-        reload_merged_data=reload_merged_data,
-        save_merged_data=save_merged_data,
-        merged_data_dir=merged_data_dir,
-        merged_data_name=merged_data_name,
-        basis_output_path=basis_output_path,
-        min_error=min_error,
-        min_error_options=min_error_options,
     )
 
 
@@ -978,9 +876,9 @@ def _run_common(
             "flux_sources": flux_sources,
             "split_by_sectors": multisector,
         },
-        _prepare_data,
+        prepare_rhime_inputs,
     )
-    prepared = _prepare_data(**data_args)
+    prepared = prepare_rhime_inputs(**data_args)
 
     model_spec = _make_model_spec(
         species=species,

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -1,10 +1,12 @@
 import inspect
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
 
+import openghg_inversions.hbmcmc.hbmcmc as hbmcmc_module
 from openghg_inversions.basis.basis_functions import BasisFunctions
 from openghg_inversions.hbmcmc.hbmcmc import _resolve_output_format, fixedbasisMCMC
 from openghg_inversions.hbmcmc.hbmcmc_output import define_output_filename
@@ -18,6 +20,62 @@ from openghg_inversions.postprocessing.make_paris_outputs import (
     make_paris_outputs,
     paris_flux_output,
 )
+
+
+def _minimal_fixedbasis_inv_inputs() -> xr.Dataset:
+    """Build the smallest fixedbasis inv_inputs dataset used by contract tests."""
+    return xr.Dataset(
+        data_vars={
+            "H": (("region", "nmeasure"), np.array([[0.25]], dtype="float64")),
+            "mf": (("nmeasure",), np.array([1900.0], dtype="float64")),
+            "mf_error": (("nmeasure",), np.array([2.0], dtype="float64")),
+            "mf_repeatability": (("nmeasure",), np.array([1.0], dtype="float64")),
+            "mf_variability": (("nmeasure",), np.array([1.5], dtype="float64")),
+            "site_indicator": (("nmeasure",), np.array([0])),
+            "sigma_freq_index": (("nmeasure",), np.array([0])),
+            "min_error": (("nmeasure",), np.array([0.0], dtype="float64")),
+        },
+        coords={
+            "region": np.array([0]),
+            "nmeasure": np.array([0]),
+            "time": (("nmeasure",), np.array(["2019-01-01T00:00:00"], dtype="datetime64[ns]")),
+        },
+    )
+
+
+def _minimal_fixedbasis_fp_data() -> dict:
+    """Build fixedbasis fp_data with the legacy side-channel keys still required downstream."""
+    lat = np.array([52.0])
+    lon = np.array([1.0])
+    return {
+        ".basis": xr.DataArray(
+            np.array([[0]]),
+            dims=("lat", "lon"),
+            coords={"lat": lat, "lon": lon},
+            name="basis",
+        ),
+        ".flux": {
+            "total": xr.Dataset(
+                {"flux": (("lat", "lon"), np.array([[1.0]], dtype="float32"))},
+                coords={"lat": lat, "lon": lon},
+            )
+        },
+        "TAC": xr.Dataset(coords={"time": np.array(["2019-01-01T00:00:00"], dtype="datetime64[ns]")}),
+    }
+
+
+def _minimal_fixedbasis_prepared_data(**overrides):
+    """Build a prepared-data object using the fixedbasis preparation contract exported by hbmcmc."""
+    defaults = {
+        "fp_all": {"TAC": object(), ".flux": {"total": object()}},
+        "fp_data": _minimal_fixedbasis_fp_data(),
+        "inv_inputs": _minimal_fixedbasis_inv_inputs(),
+        "sites": ["TAC"],
+        "averaging_period": ["1H"],
+        "basis_objects": {"emissions": object()},
+    }
+    defaults.update(overrides)
+    return hbmcmc_module.FixedBasisPreparedData(**defaults)
 
 
 @pytest.fixture
@@ -71,6 +129,155 @@ def test_fixedbasisMCMC_can_return_basis_objects_in_mcmc_args(mcmc_args):
 
     assert isinstance(result["basis_objects"]["emissions"], BasisFunctions)
     assert "basis_objects" not in result["inv_inputs"]
+
+
+def test_fixedbasisMCMC_uses_fixedbasis_preparation_contract_for_mcmc_args(monkeypatch, tmp_path):
+    """The fixedbasis runner consumes the fixedbasis-specific preparation boundary."""
+    prepared = _minimal_fixedbasis_prepared_data()
+    captured_kwargs = {}
+
+    def fake_prepare_fixedbasis_inversion_data(**kwargs):
+        captured_kwargs.update(kwargs)
+        return prepared
+
+    monkeypatch.setattr(
+        hbmcmc_module,
+        "prepare_fixedbasis_inversion_data",
+        fake_prepare_fixedbasis_inversion_data,
+    )
+
+    result = fixedbasisMCMC(
+        species="ch4",
+        sites=["TAC"],
+        domain="EUROPE",
+        averaging_period=["1H"],
+        start_date="2019-01-01",
+        end_date="2019-02-01",
+        outputpath=str(tmp_path),
+        outputname="contract",
+        output_format="mcmc_args",
+        return_basis_objects=True,
+        use_bc=False,
+    )
+
+    assert captured_kwargs["output_name"] == "contract"
+    assert captured_kwargs["split_by_sectors"] is False
+    assert captured_kwargs["return_basis_objects"] is True
+    assert captured_kwargs["merged_data_only"] is False
+    assert result["inv_inputs"] is prepared.inv_inputs
+    assert result["basis_objects"] is prepared.basis_objects
+    assert "basis_objects" not in result["inv_inputs"]
+
+
+def test_fixedbasisMCMC_merged_data_returns_prepared_fp_all(monkeypatch, tmp_path):
+    """The merged-data output remains a preparation-only compatibility path."""
+    fp_all = {"TAC": object(), ".flux": {"total": object()}}
+    prepared = _minimal_fixedbasis_prepared_data(fp_all=fp_all, fp_data=None, inv_inputs=None)
+    captured_kwargs = {}
+
+    def fake_prepare_fixedbasis_inversion_data(**kwargs):
+        captured_kwargs.update(kwargs)
+        return prepared
+
+    monkeypatch.setattr(
+        hbmcmc_module,
+        "prepare_fixedbasis_inversion_data",
+        fake_prepare_fixedbasis_inversion_data,
+    )
+
+    result = fixedbasisMCMC(
+        species="ch4",
+        sites=["TAC"],
+        domain="EUROPE",
+        averaging_period=["1H"],
+        start_date="2019-01-01",
+        end_date="2019-02-01",
+        outputpath=str(tmp_path),
+        outputname="merged",
+        output_format="merged_data",
+        reload_merged_data=True,
+        use_bc=False,
+    )
+
+    assert result is fp_all
+    assert captured_kwargs["merged_data_only"] is True
+    assert captured_kwargs["reload_merged_data"] is False
+
+
+def test_fixedbasisMCMC_hbmcmc_output_uses_legacy_postprocess_path(monkeypatch, tmp_path):
+    """The default hbmcmc output path still consumes legacy postprocessing args."""
+    prepared = _minimal_fixedbasis_prepared_data()
+    captured_inferpymc_args = {}
+
+    def fake_prepare_fixedbasis_inversion_data(**kwargs):
+        return prepared
+
+    def fake_inferpymc(**kwargs):
+        captured_inferpymc_args.update(kwargs)
+        return {
+            "trace": object(),
+            "model": object(),
+            "xouts": np.array([[1.0], [1.1]], dtype="float64"),
+        }
+
+    def fake_inferpymc_postprocessouts(xouts):
+        return xr.Dataset({"xtrace_mean": (("nx",), xouts.mean(axis=0))})
+
+    monkeypatch.setattr(
+        hbmcmc_module,
+        "prepare_fixedbasis_inversion_data",
+        fake_prepare_fixedbasis_inversion_data,
+    )
+    monkeypatch.setattr(hbmcmc_module.mcmc, "inferpymc", fake_inferpymc)
+    monkeypatch.setattr(hbmcmc_module.mcmc, "inferpymc_postprocessouts", fake_inferpymc_postprocessouts)
+
+    result = fixedbasisMCMC(
+        species="ch4",
+        sites=["TAC"],
+        domain="EUROPE",
+        averaging_period=["1H"],
+        start_date="2019-01-01",
+        end_date="2019-02-01",
+        outputpath=str(tmp_path),
+        outputname="legacy",
+        output_format="hbmcmc",
+        use_bc=False,
+    )
+
+    assert captured_inferpymc_args["inv_inputs"] is prepared.inv_inputs
+    assert result["xtrace_mean"].dims == ("nx",)
+    assert result["xtrace_mean"].values.tolist() == [1.05]
+
+
+@pytest.mark.parametrize("missing_key", [".basis", ".flux"])
+def test_fixedbasisMCMC_requires_legacy_fixedbasis_fp_data(monkeypatch, tmp_path, missing_key):
+    """Non-merged fixedbasis outputs require the legacy fp_data side-channel keys."""
+    fp_data = _minimal_fixedbasis_fp_data()
+    del fp_data[missing_key]
+    prepared = _minimal_fixedbasis_prepared_data(fp_data=fp_data)
+
+    def fake_prepare_fixedbasis_inversion_data(**kwargs):
+        return prepared
+
+    monkeypatch.setattr(
+        hbmcmc_module,
+        "prepare_fixedbasis_inversion_data",
+        fake_prepare_fixedbasis_inversion_data,
+    )
+
+    with pytest.raises(RuntimeError, match="legacy fixed-basis data"):
+        fixedbasisMCMC(
+            species="ch4",
+            sites=["TAC"],
+            domain="EUROPE",
+            averaging_period=["1H"],
+            start_date="2019-01-01",
+            end_date="2019-02-01",
+            outputpath=str(tmp_path),
+            outputname="missing",
+            output_format="mcmc_args",
+            use_bc=False,
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -133,7 +133,7 @@ def test_fixedbasisMCMC_can_return_basis_objects_in_mcmc_args(mcmc_args):
 
 def test_fixedbasisMCMC_uses_fixedbasis_preparation_contract_for_mcmc_args(monkeypatch, tmp_path):
     """The fixedbasis runner consumes the fixedbasis-specific preparation boundary."""
-    prepared = _minimal_fixedbasis_prepared_data()
+    prepared = _minimal_fixedbasis_prepared_data(fp_data={})
     captured_kwargs = {}
 
     def fake_prepare_fixedbasis_inversion_data(**kwargs):
@@ -251,7 +251,7 @@ def test_fixedbasisMCMC_hbmcmc_output_uses_legacy_postprocess_path(monkeypatch, 
 
 @pytest.mark.parametrize("missing_key", [".basis", ".flux"])
 def test_fixedbasisMCMC_requires_legacy_fixedbasis_fp_data(monkeypatch, tmp_path, missing_key):
-    """Non-merged fixedbasis outputs require the legacy fp_data side-channel keys."""
+    """Postprocessed fixedbasis outputs require the legacy fp_data side-channel keys."""
     fp_data = _minimal_fixedbasis_fp_data()
     del fp_data[missing_key]
     prepared = _minimal_fixedbasis_prepared_data(fp_data=fp_data)
@@ -275,7 +275,7 @@ def test_fixedbasisMCMC_requires_legacy_fixedbasis_fp_data(monkeypatch, tmp_path
             end_date="2019-02-01",
             outputpath=str(tmp_path),
             outputname="missing",
-            output_format="mcmc_args",
+            output_format="hbmcmc",
             use_bc=False,
         )
 

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -1,20 +1,19 @@
 from __future__ import annotations
 
+from dataclasses import fields
 from pathlib import Path
+from typing import Any, cast
 
+import numpy as np
 import pymc as pm
 import pytest
 import xarray as xr
 
 import openghg_inversions.models as models
+import openghg_inversions.inversion_data.preparation as prep_module
 import openghg_inversions.rhime as rhime_module
-from openghg_inversions.basis.basis_functions import BasisFunctions
+from openghg_inversions.basis.basis_functions import BASIS_ARTIFACT_SOURCE_ATTR, BasisFunctions
 from openghg_inversions.cli import main
-from openghg_inversions.inversion_data import PreparedInversionData, prepare_inversion_data
-from openghg_inversions.inversion_data.preparation import (
-    _drop_sites_missing_from_loaded_data,
-    _make_inv_inputs,
-)
 from openghg_inversions.inversion_inputs import make_inv_inputs
 from openghg_inversions.models import (
     build_rhime_model,
@@ -23,8 +22,10 @@ from openghg_inversions.models import (
 )
 from openghg_inversions.postprocessing.inversion_output import InversionOutput
 from openghg_inversions.rhime import (
+    RhimePreparedInputs,
     RhimeResult,
     params_from_config,
+    prepare_rhime_inputs,
     resolve_flux_sources,
     run_rhime,
     run_rhime_multisector,
@@ -72,7 +73,7 @@ def builder_args() -> dict:
     }
 
 
-def _fake_emissions_basis_objects() -> dict[str, BasisFunctions]:
+def _fake_basis_functions(*, artifact_source: str = "generated") -> BasisFunctions:
     basis = xr.DataArray(
         [[1]],
         dims=("lat", "lon"),
@@ -80,13 +81,80 @@ def _fake_emissions_basis_objects() -> dict[str, BasisFunctions]:
         name="basis",
     )
     flux = xr.ones_like(basis, dtype=float).rename("flux")
-    return {
-        "emissions": BasisFunctions.from_flat_basis(
-            basis_flat=basis,
-            flux=flux,
-            operator_kwargs={"state_dim": "region"},
+    return BasisFunctions.from_flat_basis(
+        basis_flat=basis,
+        flux=flux,
+        operator_kwargs={"state_dim": "region"},
+        metadata={BASIS_ARTIFACT_SOURCE_ATTR: artifact_source},
+    )
+
+
+def _site_dataset(values: list[float] | None = None) -> xr.Dataset:
+    values = values if values is not None else [2.0, 3.0]
+    time = np.array(
+        [f"2019-01-01T{hour:02d}:00:00" for hour in range(len(values))],
+        dtype="datetime64[ns]",
+    )
+    fp_x_flux = xr.DataArray(
+        np.array(values, dtype=float).reshape(len(values), 1, 1),
+        dims=("time", "lat", "lon"),
+        coords={"time": time, "lat": [0.0], "lon": [0.0]},
+        name="fp_x_flux",
+    )
+    return xr.Dataset(
+        {
+            "fp_x_flux": fp_x_flux,
+            "mf": ("time", np.linspace(10.0, 10.0 + len(values) - 1, len(values))),
+            "mf_error": ("time", np.ones(len(values))),
+            "mf_repeatability": ("time", np.full(len(values), 0.5)),
+            "mf_variability": ("time", np.full(len(values), 0.25)),
+        },
+        coords={"time": time},
+    )
+
+
+def _minimal_inv_inputs() -> xr.Dataset:
+    return xr.Dataset(
+        {"H": (("region", "nmeasure"), [[1.0]])},
+        coords={"region": [0], "nmeasure": [0]},
+    )
+
+
+class _SpyBasisFunctions:
+    basis_artifact_source = "datatree"
+
+    def __init__(self, sensitivity: xr.DataArray) -> None:
+        self.sensitivity_calls: list[xr.DataArray] = []
+        self._sensitivity = sensitivity
+
+    @property
+    def flux(self) -> xr.DataArray:
+        raise AssertionError("RHIME preparation should not materialise flux from BasisFunctions.")
+
+    @property
+    def operator(self) -> object:
+        raise AssertionError("RHIME preparation should not materialise a basis matrix.")
+
+    def flat_basis(self) -> xr.DataArray:
+        raise AssertionError("RHIME preparation should not request a flat basis.")
+
+    def sensitivity(self, fp_x_flux: xr.DataArray, fillna: bool = True) -> xr.DataArray:
+        self.sensitivity_calls.append(fp_x_flux)
+        return self._sensitivity
+
+
+class _DynamicSpyBasisFunctions(_SpyBasisFunctions):
+    def __init__(self) -> None:
+        super().__init__(xr.DataArray())
+
+    def sensitivity(self, fp_x_flux: xr.DataArray, fillna: bool = True) -> xr.DataArray:
+        self.sensitivity_calls.append(fp_x_flux)
+        return xr.DataArray(
+            np.ones((1, fp_x_flux.sizes["time"])),
+            dims=("region", "time"),
+            coords={"region": [0], "time": fp_x_flux.time},
+            name="H",
         )
-    }
 
 
 def test_build_rhime_model_contains_expected_variables(
@@ -118,7 +186,9 @@ def test_build_rhime_multisector_model_contains_expected_variables(
         "y",
     }
     assert expected.issubset(model.named_vars)
-    assert len(model.coords["region"]) == multisector_inv_inputs.sizes["region"]
+    region_coord = model.coords["region"]
+    assert region_coord is not None
+    assert len(region_coord) == multisector_inv_inputs.sizes["region"]
 
 
 def test_build_rhime_multisector_model_requires_multiple_sectors(
@@ -173,7 +243,7 @@ output_name = "test"
     assert params["flux_sources"] == ["legacy-source"]
 
 
-def _shared_preparation_args(data_args: dict, flux_sources: list[str]) -> dict:
+def _rhime_preparation_args(data_args: dict, flux_sources: list[str]) -> dict:
     args = data_args.copy()
     args.pop("emissions_name", None)
     args.update(
@@ -183,16 +253,45 @@ def _shared_preparation_args(data_args: dict, flux_sources: list[str]) -> dict:
             "basis_algorithm": "quadtree",
             "nbasis": 4,
             "use_bc": True,
-            "return_basis_objects": True,
         }
     )
     return args
 
 
-def test_prepare_inversion_data_single_sector_reloads_merged_data(
+def test_rhime_prepared_inputs_contract_exposes_only_modern_fields() -> None:
+    expected_fields = [
+        "inv_inputs",
+        "basis_functions",
+        "sites",
+        "averaging_period",
+        "basis_artifact_source",
+    ]
+
+    assert [field.name for field in fields(RhimePreparedInputs)] == expected_fields
+
+    prepared = RhimePreparedInputs(
+        inv_inputs=_minimal_inv_inputs(),
+        basis_functions=_fake_basis_functions(),
+        sites=("TAC",),
+        averaging_period=("1H",),
+        basis_artifact_source="generated",
+    )
+
+    for legacy_attr in (
+        "fp_all",
+        "fp_data",
+        "basis",
+        "flux",
+        "basis_objects",
+        "return_basis_objects",
+    ):
+        assert not hasattr(prepared, legacy_attr)
+
+
+def test_prepare_rhime_inputs_single_sector_reloads_merged_data(
     tac_ch4_data_args, merged_data_dir, merged_data_file_name
 ) -> None:
-    args = _shared_preparation_args(tac_ch4_data_args, tac_ch4_data_args["emissions_name"])
+    args = _rhime_preparation_args(tac_ch4_data_args, tac_ch4_data_args["emissions_name"])
     args.update(
         {
             "reload_merged_data": True,
@@ -201,115 +300,190 @@ def test_prepare_inversion_data_single_sector_reloads_merged_data(
         }
     )
 
-    prepared = prepare_inversion_data(**args)
+    prepared = prepare_rhime_inputs(**args)
 
-    assert isinstance(prepared, PreparedInversionData)
-    assert prepared.inv_inputs is not None
-    assert prepared.basis is not None
-    assert prepared.flux is not None
+    assert isinstance(prepared, RhimePreparedInputs)
     assert prepared.basis_artifact_source == "generated"
-    assert isinstance(prepared.basis_objects["emissions"], BasisFunctions)
-    xr.testing.assert_identical(prepared.flux, prepared.basis_objects["emissions"].flux)
-    assert prepared.sites == ["TAC"]
+    assert isinstance(prepared.basis_functions, BasisFunctions)
+    assert prepared.sites == ("TAC",)
     assert "source" not in prepared.inv_inputs["H"].dims
+    for legacy_attr in ("fp_all", "fp_data", "basis", "flux", "basis_objects"):
+        assert not hasattr(prepared, legacy_attr)
 
 
-def test_prepare_inversion_data_multisector_keeps_source_dimension(tac_ch4_data_args) -> None:
+def test_prepare_rhime_inputs_multisector_keeps_source_dimension(tac_ch4_data_args) -> None:
     flux_sources = ["total-ukghg-edgar7", "total-ukghg-edgar7-shuffled"]
-    args = _shared_preparation_args(tac_ch4_data_args, flux_sources)
+    args = _rhime_preparation_args(tac_ch4_data_args, flux_sources)
     args["split_by_sectors"] = True
 
-    prepared = prepare_inversion_data(**args)
+    prepared = prepare_rhime_inputs(**args)
 
-    assert prepared.inv_inputs is not None
-    assert prepared.flux is not None
     assert prepared.basis_artifact_source == "generated"
-    assert "emissions" in prepared.basis_objects
+    assert isinstance(prepared.basis_functions, BasisFunctions)
     assert "source" in prepared.inv_inputs["H"].dims
     assert set(prepared.inv_inputs["H"].coords["source"].values) == set(flux_sources)
-    assert set(prepared.flux.coords["source"].values) == set(flux_sources)
 
 
-def test_prepare_inversion_data_default_does_not_retain_basis_objects(tac_ch4_data_args) -> None:
-    args = _shared_preparation_args(tac_ch4_data_args, tac_ch4_data_args["emissions_name"])
-    args["return_basis_objects"] = False
-
-    prepared = prepare_inversion_data(**args)
-
-    assert prepared.inv_inputs is not None
-    assert prepared.basis is None
-    assert prepared.flux is None
-    assert prepared.basis_objects == {}
-    assert prepared.basis_artifact_source == "generated"
-
-
-def test_loaded_merged_data_alignment_checks_site_membership() -> None:
-    sites, inlet, fp_height, instrument, max_level, averaging_period = _drop_sites_missing_from_loaded_data(
-        fp_all={"TAC": object(), "MHD": object(), ".flux": object()},
-        sites=["TAC", "RGL"],
-        inlet=["185m", "90m"],
-        fp_height=["185m", "90m"],
-        instrument=["inst-1", "inst-2"],
-        max_level=17,
-        averaging_period=["1H", "2H"],
+def test_prepare_rhime_inputs_uses_basis_sensitivity_without_legacy_side_channels(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    site_data = _site_dataset([2.0])
+    sensitivity = xr.DataArray(
+        [[8.0]],
+        dims=("region", "time"),
+        coords={"region": [0], "time": site_data.time},
+        name="H",
     )
+    basis_functions = _SpyBasisFunctions(sensitivity)
+    captured_fp_data_keys: set[str] = set()
 
-    assert sites == ["TAC"]
-    assert inlet == ["185m"]
-    assert fp_height == ["185m"]
-    assert instrument == ["inst-1"]
-    assert max_level == 17
-    assert averaging_period == ["1H"]
-
-
-def test_loaded_merged_data_alignment_rejects_no_matching_sites() -> None:
-    with pytest.raises(ValueError, match="does not include any requested sites"):
-        _drop_sites_missing_from_loaded_data(
-            fp_all={"TAC": object(), "MHD": object(), ".flux": object()},
-            sites=["RGL", "BSD"],
-            inlet=["90m", "248m"],
-            fp_height=["90m", "248m"],
-            instrument=["inst-1", "inst-2"],
-            max_level=17,
-            averaging_period=["1H", "2H"],
+    def fake_data_processing_surface_notracer(
+        **kwargs: object,
+    ) -> tuple[dict, list[str], list[str], list[str], list[str], list[str]]:
+        return (
+            {"TAC": site_data, ".species": "CH4"},
+            ["TAC"],
+            ["185m"],
+            ["185m"],
+            ["instrument-1"],
+            ["1H"],
         )
 
+    def fake_make_basis_functions(**kwargs: object) -> _SpyBasisFunctions:
+        assert "return_basis_objects" not in kwargs
+        fp_all = kwargs["fp_all"]
+        assert isinstance(fp_all, dict)
+        assert fp_all["TAC"] is site_data
+        return basis_functions
 
-def test_prepare_inversion_data_prunes_reloaded_merged_data_to_requested_sites(
+    def fake_make_inv_inputs(fp_data: dict, sites: list[str], **kwargs: object) -> xr.Dataset:
+        nonlocal captured_fp_data_keys
+        captured_fp_data_keys = set(fp_data)
+        assert sites == ["TAC"]
+        assert set(fp_data) == {"TAC"}
+        xr.testing.assert_identical(fp_data["TAC"]["H"], sensitivity)
+        return _minimal_inv_inputs()
+
+    def forbidden_basis_functions_wrapper(*args: object, **kwargs: object) -> None:
+        raise AssertionError("RHIME preparation should use make_basis_functions and direct sensitivity.")
+
+    monkeypatch.setattr(
+        prep_module,
+        "data_processing_surface_notracer",
+        fake_data_processing_surface_notracer,
+    )
+    monkeypatch.setattr(prep_module, "make_basis_functions", fake_make_basis_functions)
+    monkeypatch.setattr(prep_module, "make_inv_inputs", fake_make_inv_inputs)
+    monkeypatch.setattr(
+        prep_module,
+        "basis_functions_wrapper",
+        forbidden_basis_functions_wrapper,
+        raising=False,
+    )
+
+    prepared = prepare_rhime_inputs(
+        species="ch4",
+        sites=["TAC"],
+        domain="EUROPE",
+        averaging_period=["1H"],
+        start_date="2019-01-01",
+        end_date="2019-02-01",
+        output_name="direct_sensitivity",
+        flux_sources=["total-ukghg-edgar7"],
+        use_bc=False,
+    )
+
+    assert prepared.basis_functions is basis_functions
+    assert prepared.basis_artifact_source == "datatree"
+    assert captured_fp_data_keys == {"TAC"}
+    assert len(basis_functions.sensitivity_calls) == 1
+    xr.testing.assert_identical(basis_functions.sensitivity_calls[0], site_data["fp_x_flux"])
+
+
+def test_prepare_rhime_inputs_matches_direct_sensitivity_inv_inputs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    site_data = _site_dataset([2.0, 3.0])
+    basis_functions = _fake_basis_functions()
+
+    def fake_data_processing_surface_notracer(
+        **kwargs: object,
+    ) -> tuple[dict, list[str], list[str], list[str], list[str], list[str]]:
+        return (
+            {"TAC": site_data, ".species": "CH4"},
+            ["TAC"],
+            ["185m"],
+            ["185m"],
+            ["instrument-1"],
+            ["1H"],
+        )
+
+    def fake_make_basis_functions(**kwargs: object) -> BasisFunctions:
+        return basis_functions
+
+    monkeypatch.setattr(
+        prep_module,
+        "data_processing_surface_notracer",
+        fake_data_processing_surface_notracer,
+    )
+    monkeypatch.setattr(prep_module, "make_basis_functions", fake_make_basis_functions)
+
+    prepared = prepare_rhime_inputs(
+        species="ch4",
+        sites=["TAC"],
+        domain="EUROPE",
+        averaging_period=["1H"],
+        start_date="2019-01-01",
+        end_date="2019-02-01",
+        output_name="equivalence",
+        flux_sources=["total-ukghg-edgar7"],
+        use_bc=False,
+    )
+
+    expected_site_data = site_data.copy()
+    expected_site_data["H"] = basis_functions.sensitivity(expected_site_data["fp_x_flux"])
+    expected_inv_inputs = make_inv_inputs(
+        {"TAC": expected_site_data},
+        sites=["TAC"],
+        bc_freq=None,
+        sigma_freq=None,
+        min_error=0.0,
+        start_date="2019-01-01",
+    )
+
+    xr.testing.assert_identical(prepared.inv_inputs["H"], expected_inv_inputs["H"])
+    xr.testing.assert_identical(prepared.inv_inputs["mf"], expected_inv_inputs["mf"])
+
+
+def test_prepare_rhime_inputs_prunes_reloaded_merged_data_to_requested_sites(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     captured_fp_all_keys: set[str] = set()
 
     def fake_load_merged_data(*args: object, **kwargs: object) -> dict:
         return {
-            "TAC": object(),
-            "MHD": object(),
+            "TAC": _site_dataset([2.0]),
+            "MHD": _site_dataset([3.0]),
             ".flux": object(),
             ".species": "CH4",
         }
 
-    def fake_basis_functions_wrapper(**kwargs: object) -> tuple[dict, dict[str, BasisFunctions]]:
+    def fake_make_basis_functions(**kwargs: object) -> BasisFunctions:
         nonlocal captured_fp_all_keys
         fp_all = kwargs["fp_all"]
         assert isinstance(fp_all, dict)
         captured_fp_all_keys = set(fp_all)
-        return {"TAC": xr.Dataset(coords={"time": [0]})}, _fake_emissions_basis_objects()
+        return _fake_basis_functions()
 
     def fake_make_inv_inputs(fp_data: dict, sites: list[str], **kwargs: object) -> xr.Dataset:
         assert sites == ["TAC"]
-        return xr.Dataset({"H": (("region", "nmeasure"), [[1.0]])})
+        return _minimal_inv_inputs()
 
-    monkeypatch.setattr(
-        "openghg_inversions.inversion_data.preparation.load_merged_data",
-        fake_load_merged_data,
-    )
-    monkeypatch.setattr(
-        "openghg_inversions.inversion_data.preparation.basis_functions_wrapper",
-        fake_basis_functions_wrapper,
-    )
-    monkeypatch.setattr("openghg_inversions.inversion_data.preparation.make_inv_inputs", fake_make_inv_inputs)
+    monkeypatch.setattr(prep_module, "load_merged_data", fake_load_merged_data)
+    monkeypatch.setattr(prep_module, "make_basis_functions", fake_make_basis_functions)
+    monkeypatch.setattr(prep_module, "make_inv_inputs", fake_make_inv_inputs)
 
-    prepare_inversion_data(
+    prepare_rhime_inputs(
         species="ch4",
         sites=["TAC"],
         domain="EUROPE",
@@ -339,21 +513,23 @@ def test_prepare_inversion_data_prunes_reloaded_merged_data_to_requested_sites(
         (None, [None, None]),
     ],
 )
-def test_prepare_inversion_data_normalises_averaging_period_to_site_count(
+def test_prepare_rhime_inputs_normalises_averaging_period_to_site_count(
     monkeypatch: pytest.MonkeyPatch,
     averaging_period: str | None,
     expected: list[str | None],
 ) -> None:
     captured_averaging_period: list[str | None] | None = None
+    site_data = {"TAC": _site_dataset([2.0]), "MHD": _site_dataset([3.0])}
 
     def fake_data_processing_surface_notracer(
         **kwargs: object,
     ) -> tuple[dict, list[str], list[str], list[str], list[str], list[str | None]]:
         nonlocal captured_averaging_period
-        captured_averaging_period = kwargs["averaging_period"]
-        assert isinstance(captured_averaging_period, list)
+        averaging_period_arg = kwargs["averaging_period"]
+        assert isinstance(averaging_period_arg, list)
+        captured_averaging_period = averaging_period_arg
         return (
-            {".species": "CH4"},
+            {**site_data, ".species": "CH4"},
             ["TAC", "MHD"],
             ["185m", "10m"],
             ["185m", "10m"],
@@ -361,30 +537,25 @@ def test_prepare_inversion_data_normalises_averaging_period_to_site_count(
             captured_averaging_period,
         )
 
-    def fake_basis_functions_wrapper(**kwargs: object) -> tuple[dict, dict[str, BasisFunctions]]:
-        return (
-            {
-                "TAC": xr.Dataset(coords={"time": [0]}),
-                "MHD": xr.Dataset(coords={"time": [0]}),
-            },
-            _fake_emissions_basis_objects(),
-        )
+    def fake_make_basis_functions(**kwargs: object) -> _DynamicSpyBasisFunctions:
+        return _DynamicSpyBasisFunctions()
 
     def fake_make_inv_inputs(fp_data: dict, sites: list[str], **kwargs: object) -> xr.Dataset:
         assert sites == ["TAC", "MHD"]
-        return xr.Dataset({"H": (("region", "nmeasure"), [[1.0, 1.0]])})
+        return xr.Dataset(
+            {"H": (("region", "nmeasure"), [[1.0, 1.0]])},
+            coords={"region": [0], "nmeasure": [0, 1]},
+        )
 
     monkeypatch.setattr(
-        "openghg_inversions.inversion_data.preparation.data_processing_surface_notracer",
+        prep_module,
+        "data_processing_surface_notracer",
         fake_data_processing_surface_notracer,
     )
-    monkeypatch.setattr(
-        "openghg_inversions.inversion_data.preparation.basis_functions_wrapper",
-        fake_basis_functions_wrapper,
-    )
-    monkeypatch.setattr("openghg_inversions.inversion_data.preparation.make_inv_inputs", fake_make_inv_inputs)
+    monkeypatch.setattr(prep_module, "make_basis_functions", fake_make_basis_functions)
+    monkeypatch.setattr(prep_module, "make_inv_inputs", fake_make_inv_inputs)
 
-    prepared = prepare_inversion_data(
+    prepared = prepare_rhime_inputs(
         species="ch4",
         sites=["TAC", "MHD"],
         domain="EUROPE",
@@ -397,12 +568,12 @@ def test_prepare_inversion_data_normalises_averaging_period_to_site_count(
     )
 
     assert captured_averaging_period == expected
-    assert prepared.averaging_period == expected
+    assert prepared.averaging_period == tuple(expected)
 
 
-def test_prepare_inversion_data_rejects_misaligned_averaging_period_list() -> None:
+def test_prepare_rhime_inputs_rejects_misaligned_averaging_period_list() -> None:
     with pytest.raises(ValueError, match="List averaging_period does not have specified length"):
-        prepare_inversion_data(
+        prepare_rhime_inputs(
             species="ch4",
             sites=["TAC", "MHD"],
             domain="EUROPE",
@@ -416,15 +587,15 @@ def test_prepare_inversion_data_rejects_misaligned_averaging_period_list() -> No
 
 
 @pytest.mark.parametrize("averaging_period", [1, ["1H", 2]])
-def test_prepare_inversion_data_rejects_non_string_averaging_period_values(
+def test_prepare_rhime_inputs_rejects_non_string_averaging_period_values(
     averaging_period: object,
 ) -> None:
     with pytest.raises(ValueError, match="averaging_period"):
-        prepare_inversion_data(
+        prepare_rhime_inputs(
             species="ch4",
             sites=["TAC", "MHD"],
             domain="EUROPE",
-            averaging_period=averaging_period,
+            averaging_period=cast(Any, averaging_period),
             start_date="2019-01-01",
             end_date="2019-02-01",
             output_name="bad_avg_type",
@@ -437,15 +608,15 @@ def test_run_rhime_leaves_scalar_averaging_period_for_shared_preparation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     captured_averaging_period: object = None
-    original_signature = rhime_module.inspect.signature(rhime_module._prepare_data)
+    original_signature = rhime_module.inspect.signature(rhime_module.prepare_rhime_inputs)
 
-    def fake_prepare_data(**kwargs: object) -> None:
+    def fake_prepare_rhime_inputs(**kwargs: object) -> None:
         nonlocal captured_averaging_period
         captured_averaging_period = kwargs["averaging_period"]
         raise RuntimeError("stop after data argument capture")
 
-    fake_prepare_data.__signature__ = original_signature
-    monkeypatch.setattr(rhime_module, "_prepare_data", fake_prepare_data)
+    setattr(fake_prepare_rhime_inputs, "__signature__", original_signature)
+    monkeypatch.setattr(rhime_module, "prepare_rhime_inputs", fake_prepare_rhime_inputs)
 
     with pytest.raises(RuntimeError, match="stop after data argument capture"):
         run_rhime(
@@ -463,16 +634,17 @@ def test_run_rhime_leaves_scalar_averaging_period_for_shared_preparation(
     assert captured_averaging_period == "1H"
 
 
-def test_prepare_inversion_data_treats_min_error_none_as_default(
+def test_prepare_rhime_inputs_treats_min_error_none_as_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     captured_min_error: object = None
+    site_data = _site_dataset([2.0])
 
     def fake_data_processing_surface_notracer(
         **kwargs: object,
     ) -> tuple[dict, list[str], list[str], list[str], list[str], list[str]]:
         return (
-            {".species": "CH4"},
+            {"TAC": site_data, ".species": "CH4"},
             ["TAC"],
             ["185m"],
             ["185m"],
@@ -480,25 +652,23 @@ def test_prepare_inversion_data_treats_min_error_none_as_default(
             ["1H"],
         )
 
-    def fake_basis_functions_wrapper(**kwargs: object) -> tuple[dict, dict[str, BasisFunctions]]:
-        return {"TAC": xr.Dataset(coords={"time": [0]})}, _fake_emissions_basis_objects()
+    def fake_make_basis_functions(**kwargs: object) -> _DynamicSpyBasisFunctions:
+        return _DynamicSpyBasisFunctions()
 
     def fake_make_inv_inputs(fp_data: dict, sites: list[str], **kwargs: object) -> xr.Dataset:
         nonlocal captured_min_error
         captured_min_error = kwargs["min_error"]
-        return xr.Dataset({"H": (("region", "nmeasure"), [[1.0]])})
+        return _minimal_inv_inputs()
 
     monkeypatch.setattr(
-        "openghg_inversions.inversion_data.preparation.data_processing_surface_notracer",
+        prep_module,
+        "data_processing_surface_notracer",
         fake_data_processing_surface_notracer,
     )
-    monkeypatch.setattr(
-        "openghg_inversions.inversion_data.preparation.basis_functions_wrapper",
-        fake_basis_functions_wrapper,
-    )
-    monkeypatch.setattr("openghg_inversions.inversion_data.preparation.make_inv_inputs", fake_make_inv_inputs)
+    monkeypatch.setattr(prep_module, "make_basis_functions", fake_make_basis_functions)
+    monkeypatch.setattr(prep_module, "make_inv_inputs", fake_make_inv_inputs)
 
-    prepare_inversion_data(
+    prepare_rhime_inputs(
         species="ch4",
         sites=["TAC"],
         domain="EUROPE",
@@ -514,53 +684,16 @@ def test_prepare_inversion_data_treats_min_error_none_as_default(
     assert captured_min_error == 0.0
 
 
-def test_prepare_inversion_data_rejects_min_error_dict_missing_retained_site() -> None:
-    with pytest.raises(ValueError, match="MHD"):
-        _make_inv_inputs(
-            fp_data={},
-            sites=["TAC", "MHD"],
-            start_date="2019-01-01",
-            bc_freq=None,
-            sigma_freq=None,
-            min_error={"TAC": 1.0},
-            calculate_min_error=None,
-            min_error_options=None,
-        )
-
-
-def test_calculate_min_error_warning_is_user_visible(monkeypatch: pytest.MonkeyPatch) -> None:
-    captured_min_error: object = None
-
-    def fake_make_inv_inputs(fp_data: dict, sites: list[str], **kwargs: object) -> xr.Dataset:
-        nonlocal captured_min_error
-        captured_min_error = kwargs["min_error"]
-        return xr.Dataset({"H": (("region", "nmeasure"), [[1.0]])})
-
-    monkeypatch.setattr("openghg_inversions.inversion_data.preparation.make_inv_inputs", fake_make_inv_inputs)
-
-    with pytest.warns(FutureWarning, match="calculate_min_error"):
-        _make_inv_inputs(
-            fp_data={"TAC": xr.Dataset(coords={"time": [0]})},
-            sites=["TAC"],
-            start_date="2019-01-01",
-            bc_freq=None,
-            sigma_freq=None,
-            min_error=0.0,
-            calculate_min_error="residual",
-            min_error_options=None,
-        )
-
-    assert captured_min_error == "residual"
-
-
-def test_prepare_inversion_data_aligns_averaging_period_after_empty_site_drop(
+def test_prepare_rhime_inputs_aligns_averaging_period_after_empty_site_drop(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    site_data = {"TAC": _site_dataset([2.0]), "MHD": _site_dataset([])}
+
     def fake_data_processing_surface_notracer(
         **kwargs: object,
     ) -> tuple[dict, list[str], list[str], list[str], list[str], list[str]]:
         return (
-            {".species": "CH4"},
+            {**site_data, ".species": "CH4"},
             ["TAC", "MHD"],
             ["185m", "10m"],
             ["185m", "10m"],
@@ -568,30 +701,22 @@ def test_prepare_inversion_data_aligns_averaging_period_after_empty_site_drop(
             ["1H", "2H"],
         )
 
-    def fake_basis_functions_wrapper(**kwargs: object) -> tuple[dict, dict[str, BasisFunctions]]:
-        return (
-            {
-                "TAC": xr.Dataset(coords={"time": [0]}),
-                "MHD": xr.Dataset(coords={"time": []}),
-            },
-            _fake_emissions_basis_objects(),
-        )
+    def fake_make_basis_functions(**kwargs: object) -> BasisFunctions:
+        return _fake_basis_functions()
 
     def fake_make_inv_inputs(fp_data: dict, sites: list[str], **kwargs: object) -> xr.Dataset:
         assert sites == ["TAC"]
-        return xr.Dataset({"H": (("region", "nmeasure"), [[1.0]])})
+        return _minimal_inv_inputs()
 
     monkeypatch.setattr(
-        "openghg_inversions.inversion_data.preparation.data_processing_surface_notracer",
+        prep_module,
+        "data_processing_surface_notracer",
         fake_data_processing_surface_notracer,
     )
-    monkeypatch.setattr(
-        "openghg_inversions.inversion_data.preparation.basis_functions_wrapper",
-        fake_basis_functions_wrapper,
-    )
-    monkeypatch.setattr("openghg_inversions.inversion_data.preparation.make_inv_inputs", fake_make_inv_inputs)
+    monkeypatch.setattr(prep_module, "make_basis_functions", fake_make_basis_functions)
+    monkeypatch.setattr(prep_module, "make_inv_inputs", fake_make_inv_inputs)
 
-    prepared = prepare_inversion_data(
+    prepared = prepare_rhime_inputs(
         species="ch4",
         sites=["TAC", "MHD"],
         domain="EUROPE",
@@ -603,18 +728,20 @@ def test_prepare_inversion_data_aligns_averaging_period_after_empty_site_drop(
         use_bc=False,
     )
 
-    assert prepared.sites == ["TAC"]
-    assert prepared.averaging_period == ["1H"]
+    assert prepared.sites == ("TAC",)
+    assert prepared.averaging_period == ("1H",)
 
 
-def test_prepare_inversion_data_rejects_all_sites_dropped_by_filtering(
+def test_prepare_rhime_inputs_rejects_all_sites_dropped_after_sensitivity(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    site_data = {"TAC": _site_dataset([]), "MHD": _site_dataset([])}
+
     def fake_data_processing_surface_notracer(
         **kwargs: object,
     ) -> tuple[dict, list[str], list[str], list[str], list[str], list[str]]:
         return (
-            {".species": "CH4"},
+            {**site_data, ".species": "CH4"},
             ["TAC", "MHD"],
             ["185m", "10m"],
             ["185m", "10m"],
@@ -622,26 +749,18 @@ def test_prepare_inversion_data_rejects_all_sites_dropped_by_filtering(
             ["1H", "2H"],
         )
 
-    def fake_basis_functions_wrapper(**kwargs: object) -> tuple[dict, dict[str, BasisFunctions]]:
-        return (
-            {
-                "TAC": xr.Dataset(coords={"time": []}),
-                "MHD": xr.Dataset(coords={"time": []}),
-            },
-            _fake_emissions_basis_objects(),
-        )
+    def fake_make_basis_functions(**kwargs: object) -> BasisFunctions:
+        return _fake_basis_functions()
 
     monkeypatch.setattr(
-        "openghg_inversions.inversion_data.preparation.data_processing_surface_notracer",
+        prep_module,
+        "data_processing_surface_notracer",
         fake_data_processing_surface_notracer,
     )
-    monkeypatch.setattr(
-        "openghg_inversions.inversion_data.preparation.basis_functions_wrapper",
-        fake_basis_functions_wrapper,
-    )
+    monkeypatch.setattr(prep_module, "make_basis_functions", fake_make_basis_functions)
 
-    with pytest.raises(ValueError, match="No sites remain after filtering"):
-        prepare_inversion_data(
+    with pytest.raises(ValueError, match="No sites remain"):
+        prepare_rhime_inputs(
             species="ch4",
             sites=["TAC", "MHD"],
             domain="EUROPE",
@@ -844,7 +963,7 @@ def test_save_inferencedata_prefers_h5netcdf(tmp_path: Path) -> None:
     idata = FakeInferenceData()
     path = tmp_path / "trace.nc"
 
-    rhime_module._save_inferencedata(idata, path)
+    rhime_module._save_inferencedata(idata, path)  # type: ignore[reportArgumentType]
 
     assert idata.calls == [(str(path), {"engine": "h5netcdf", "compress": True})]
 
@@ -862,7 +981,7 @@ def test_save_inferencedata_falls_back_after_h5netcdf_failure(tmp_path: Path) ->
     idata = FakeInferenceData()
     path = tmp_path / "trace.nc"
 
-    rhime_module._save_inferencedata(idata, path)
+    rhime_module._save_inferencedata(idata, path)  # type: ignore[reportArgumentType]
 
     assert idata.calls == [
         (str(path), {"engine": "h5netcdf", "compress": True}),
@@ -942,9 +1061,11 @@ def test_run_rhime_api_smoke(tac_ch4_data_args, tmp_path: Path) -> None:
     result = run_rhime(**args)
 
     assert isinstance(result, RhimeResult)
-    assert isinstance(result.basis_objects["emissions"], BasisFunctions)
-    assert "x" in result.idata.posterior
-    assert "mu" in result.idata.posterior
+    assert isinstance(result.basis_functions, BasisFunctions)
+    assert not hasattr(result, "basis_objects")
+    posterior = cast(Any, result.idata).posterior
+    assert "x" in posterior
+    assert "mu" in posterior
     assert result.run_spec.split_by_sectors is False
     assert "inversion_output" in result.outputs
     inv_input_long_names = [
@@ -994,10 +1115,12 @@ def test_run_rhime_multisector_api_smoke(tac_ch4_data_args, tmp_path: Path) -> N
     result = run_rhime_multisector(**args)
 
     assert isinstance(result, RhimeResult)
-    assert isinstance(result.basis_objects["emissions"], BasisFunctions)
+    assert isinstance(result.basis_functions, BasisFunctions)
+    assert not hasattr(result, "basis_objects")
     assert result.run_spec.split_by_sectors is True
-    assert "x_total_ukghg_edgar7" in result.idata.posterior
-    assert "x_total_ukghg_edgar7_shuffled" in result.idata.posterior
+    posterior = cast(Any, result.idata).posterior
+    assert "x_total_ukghg_edgar7" in posterior
+    assert "x_total_ukghg_edgar7_shuffled" in posterior
     assert "sector_flux_diagnostics" in result.outputs
 
 

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import fields
 from pathlib import Path
 from typing import Any, cast
 
@@ -259,16 +258,6 @@ def _rhime_preparation_args(data_args: dict, flux_sources: list[str]) -> dict:
 
 
 def test_rhime_prepared_inputs_contract_exposes_only_modern_fields() -> None:
-    expected_fields = [
-        "inv_inputs",
-        "basis_functions",
-        "sites",
-        "averaging_period",
-        "basis_artifact_source",
-    ]
-
-    assert [field.name for field in fields(RhimePreparedInputs)] == expected_fields
-
     prepared = RhimePreparedInputs(
         inv_inputs=_minimal_inv_inputs(),
         basis_functions=_fake_basis_functions(),
@@ -330,10 +319,11 @@ def test_prepare_rhime_inputs_uses_basis_sensitivity_without_legacy_side_channel
     site_data = _site_dataset([2.0])
     sensitivity = xr.DataArray(
         [[8.0]],
-        dims=("region", "time"),
-        coords={"region": [0], "time": site_data.time},
+        dims=("state", "time"),
+        coords={"state": [0], "time": site_data.time},
         name="H",
     )
+    expected_sensitivity = sensitivity.rename({"state": "region"})
     basis_functions = _SpyBasisFunctions(sensitivity)
     captured_fp_data_keys: set[str] = set()
 
@@ -361,7 +351,7 @@ def test_prepare_rhime_inputs_uses_basis_sensitivity_without_legacy_side_channel
         captured_fp_data_keys = set(fp_data)
         assert sites == ["TAC"]
         assert set(fp_data) == {"TAC"}
-        xr.testing.assert_identical(fp_data["TAC"]["H"], sensitivity)
+        xr.testing.assert_identical(fp_data["TAC"]["H"], expected_sensitivity)
         return _minimal_inv_inputs()
 
     def forbidden_basis_functions_wrapper(*args: object, **kwargs: object) -> None:


### PR DESCRIPTION
## Summary
- Delete `PreparedInversionData` and replace the mixed preparation contract with `FixedBasisPreparedData` and frozen `RhimePreparedInputs`.
- Split fixedbasis preparation from RHIME preparation; RHIME now builds `H` directly via `BasisFunctions.sensitivity()` without exposing fixedbasis side channels.
- Keep legacy `.basis` / `.flux` behavior confined to fixedbasis and output/postprocessing boundaries, and simplify review-found cruft after the initial implementation.

Closes #431

## Tests
- `uv run pytest tests/test_rhime.py tests/test_basis_functions.py tests/test_postprocessing.py`
- `uv run ruff check openghg_inversions/inversion_data/preparation.py openghg_inversions/rhime.py openghg_inversions/basis/_wrapper.py openghg_inversions/basis/__init__.py openghg_inversions/hbmcmc/hbmcmc.py tests/test_rhime.py tests/test_postprocessing.py`
- `uv run pyright openghg_inversions/basis/_wrapper.py openghg_inversions/inversion_data/preparation.py openghg_inversions/rhime.py openghg_inversions/hbmcmc/hbmcmc.py`