### PR TITLE
Split RHIME output from fixedbasis legacy output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Code changes
 
 
+- Split modern RHIME `InversionOutput` from the legacy-shaped postprocessing carrier, keeping `inferpymc_postprocessouts` on the fixedbasis `output_format="hbmcmc"` path only and using a temporary `LegacyInversionOutput` adapter for RHIME `basic`/`paris` postprocessing. [#401](https://github.com/openghg/openghg_inversions/issues/401)
 - Moved public RHIME model-builder exports into `openghg_inversions.models` and shared data preparation between `fixedbasisMCMC`, `run_rhime`, and `run_rhime_multisector`. [#399](https://github.com/openghg/openghg_inversions/issues/399), [#425](https://github.com/openghg/openghg_inversions/issues/425)
 - Retained `BasisFunctions` objects through shared inversion preparation, RHIME results, and opt-in `fixedbasisMCMC` debug output; DataTree basis artifacts are loaded when available while legacy flat basis artifacts remain supported. [#428](https://github.com/openghg/openghg_inversions/issues/428)
 - Added modern `run_rhime` and shared-basis `run_rhime_multisector` pipelines, RHIME CLI entry points, RHIME config template, modern result/spec objects, and focused tests for the new public runners. [#398](https://github.com/openghg/openghg_inversions/issues/398)

--- a/docs/plans/clean_up_inversions_refactor.md
+++ b/docs/plans/clean_up_inversions_refactor.md
@@ -112,26 +112,26 @@ functions, and inversion input construction. A future `RhimeDataSpec` or
 `sigma_freq`, `bc_freq`, and related model-input concerns moving closer to the
 model components that consume them.
 
-## Completed in PR #TBD / Issue #401
+## Completed in PR #436 / Issue #401
 
-- 2026-05-31: #401 / PR #TBD renamed the current postprocessing carrier to
+- 2026-05-31: #401 / PR #436 renamed the current postprocessing carrier to
   `LegacyInversionOutput` and reserved `InversionOutput` for the modern RHIME
   result contract.
-- 2026-05-31: #401 / PR #TBD added modern `InversionOutput` save/load support
+- 2026-05-31: #401 / PR #436 added modern `InversionOutput` save/load support
   for `InferenceData`, canonical `inv_inputs`, retained `BasisFunctions`, run
   metadata, model metadata, output metadata, and provenance.
-- 2026-05-31: #401 / PR #TBD routed fixedbasis output explicitly:
+- 2026-05-31: #401 / PR #436 routed fixedbasis output explicitly:
   `output_format="hbmcmc"` remains the only path that calls
   `inferpymc_postprocessouts`, while `hbmcmc_postprocessing`, `basic`, `paris`,
   and `inv_out` use `LegacyInversionOutput`.
-- 2026-05-31: #401 / PR #TBD routed standard `run_rhime` output explicitly:
+- 2026-05-31: #401 / PR #436 routed standard `run_rhime` output explicitly:
   `inv_out` saves and returns modern `InversionOutput`, while `basic` and
   `paris` build a temporary `LegacyInversionOutput` adapter for the existing
   postprocessing functions.
-- 2026-05-31: #401 / PR #TBD opened #435 to migrate postprocessing consumers to
+- 2026-05-31: #401 / PR #436 opened #435 to migrate postprocessing consumers to
   modern `InversionOutput`.
 
-## Recorded decisions for PR #TBD / Issue #401
+## Recorded decisions for PR #436 / Issue #401
 
 - The true legacy output remains `inferpymc_postprocessouts` in
   `hbmcmc.inversion_pymc`. It should stay legacy/fixedbasis-only and should not
@@ -146,7 +146,7 @@ model components that consume them.
 - #401 does not migrate `postprocessing` consumers to modern `InversionOutput`.
   That is deferred to #435.
 
-## Current PR #TBD / Issue #401 cleanup notes
+## Current PR #436 / Issue #401 cleanup notes
 
 - Keep `inferpymc_postprocessouts` isolated to
   `fixedbasisMCMC(output_format="hbmcmc")`.

--- a/docs/plans/clean_up_inversions_refactor.md
+++ b/docs/plans/clean_up_inversions_refactor.md
@@ -21,6 +21,9 @@ version, which partially negates the benefit of keeping it as the main route.
 - #401: use to separate `LegacyInversionOutput` from modern `InversionOutput`.
 - #435: migrate postprocessing consumers from `LegacyInversionOutput` to the
   modern `InversionOutput`; opened as the follow-up from #401.
+- #405: complete sector-aware RHIME outputs and PARIS-compatible total outputs.
+  PR #436 makes multisector runs carry modern `InversionOutput`, but sector
+  diagnostics and PARIS totals are still transitional.
 - #429: keep as operator-backed output/postprocessing, but make it depend on
   the preparation split.
 - #416: should become active sooner; classify/deprecate `fixedbasisMCMC`,
@@ -128,8 +131,14 @@ model components that consume them.
   `inv_out` saves and returns modern `InversionOutput`, while `basic` and
   `paris` build a temporary `LegacyInversionOutput` adapter for the existing
   postprocessing functions.
+- 2026-05-31: #401 / PR #436 made non-`none` multisector RHIME output bundles
+  carry the same modern `InversionOutput` contract while leaving their
+  sector-flux diagnostics as a transitional output product.
 - 2026-05-31: #401 / PR #436 opened #435 to migrate postprocessing consumers to
   modern `InversionOutput`.
+- 2026-05-31: #401 / PR #436 hardened modern `InversionOutput` load handling
+  for serialized MultiIndex metadata by accepting bytes attrs and ignoring
+  malformed index metadata instead of failing load.
 
 ## Recorded decisions for PR #436 / Issue #401
 
@@ -143,6 +152,9 @@ model components that consume them.
   `inv_out` output.
 - `LegacyInversionOutput.from_modern_output(...)` is the only temporary bridge
   for standard RHIME `basic` and `paris` output modes in #401.
+- Multisector RHIME should also expose modern `InversionOutput` for `inv_out`.
+  The remaining multisector gap is not the durable run artifact but the
+  sector-aware postprocessing/PARIS output contract, which belongs to #405.
 - #401 does not migrate `postprocessing` consumers to modern `InversionOutput`.
   That is deferred to #435.
 
@@ -160,6 +172,23 @@ model components that consume them.
   `paris`. Remove that once #435 and #429 let postprocessing consume
   `BasisFunctions` directly.
 
+## Review findings for PR #436 / Issue #401
+
+- Architecture review found the standard #401 split sound: modern
+  `InversionOutput` owns `InferenceData`, `inv_inputs`, `BasisFunctions`, and
+  metadata; `LegacyInversionOutput` remains the temporary postprocessing
+  carrier; and `inferpymc_postprocessouts` stays fixedbasis-only.
+- Architecture review flagged multisector `inv_out` as the only boundary risk:
+  `run_rhime_multisector` originally returned sector diagnostics but did not
+  set `result.inv_out`. PR #436 now builds the modern `InversionOutput` for
+  non-`none` multisector bundles as well.
+- The multisector output product itself remains transitional. #405 should turn
+  the current `sector_flux_diagnostics` product into documented sector-aware
+  outputs and PARIS-compatible total outputs.
+- Copilot review found that serialized MultiIndex metadata could be bytes or
+  malformed. PR #436 now decodes bytes and skips malformed records safely
+  before applying `set_index`.
+
 ## Deferred Issue #435 postprocessing consumer migration
 
 #435 should move `make_outputs`, `make_paris_outputs`, `countries`,
@@ -170,6 +199,24 @@ model components that consume them.
 This work links #401, #383, #429, #416, and #381. It should remove the RHIME
 `basic`/`paris` dependency on `LegacyInversionOutput.from_modern_output(...)`
 rather than expanding that adapter.
+
+## Recommended next PR after #436
+
+Start with #435 before #383 if only one can be active. #435 should define the
+postprocessing consumer contract around modern `InversionOutput` and remove the
+standard RHIME `basic`/`paris` adapter dependency. That creates the right place
+for #383 to replace legacy flat-basis assumptions with retained
+`BasisFunctions` in flux/country computations.
+
+After #435, use #383 for the first operator-backed postprocessing slice:
+prefer retained `BasisFunctions.operator.basis_matrix` where available and keep
+legacy basis reconstruction as fallback. #429 should then make the
+operator-backed path primary and define the deprecation policy for legacy
+basis reconstruction.
+
+Track multisector output work under #405. It can proceed after the modern
+postprocessing input contract is clearer, or in parallel if it stays limited to
+sector diagnostics and PARIS-compatible total outputs.
 
 ## Deferred SemanticModel plan
 

--- a/docs/plans/clean_up_inversions_refactor.md
+++ b/docs/plans/clean_up_inversions_refactor.md
@@ -19,6 +19,8 @@ version, which partially negates the benefit of keeping it as the main route.
   in modern path." Legacy reconstruction from `fp_data[".basis"]` should remain
   only in compatibility adapters.
 - #401: use to separate `LegacyInversionOutput` from modern `InversionOutput`.
+- #435: migrate postprocessing consumers from `LegacyInversionOutput` to the
+  modern `InversionOutput`; opened as the follow-up from #401.
 - #429: keep as operator-backed output/postprocessing, but make it depend on
   the preparation split.
 - #416: should become active sooner; classify/deprecate `fixedbasisMCMC`,
@@ -26,10 +28,10 @@ version, which partially negates the benefit of keeping it as the main route.
 - #415: serializable RHIME bundle should serialize `RhimePreparedInputs`
   artifacts, not `fp_data`.
 
-Prep split note: #431 is the dependency that should make `RhimePreparedInputs`
-consume RHIME specs and keep `fp_data`, `fp_all`, flat `.basis`, materialised
-basis arrays, and optional basis-object side channels out of the modern
-contract.
+Prep split note: #431 was closed by #433. That dependency moved
+`RhimePreparedInputs` toward consuming RHIME specs and keeping `fp_data`,
+`fp_all`, flat `.basis`, materialised basis arrays, and optional basis-object
+side channels out of the modern contract.
 
 ## Completed in PR #434 / Issue #400
 
@@ -103,11 +105,71 @@ PR #434 / Issue #400 should not introduce `RhimeDataSpec`. The current
 function construction, and `make_inv_inputs` concerns, so a one-piece data spec
 would mostly mirror the INI template rather than clarify the architecture.
 
-Track the future split under #431. That work should break preparation into
-smaller contracts for data gathering, filtering, basis functions, and inversion
-input construction. A future `RhimeDataSpec` or `RequiredDataPlan` can then be
-introduced at the right boundary, with `sigma_freq`, `bc_freq`, and related
-model-input concerns moving closer to the model components that consume them.
+#431 was closed by #433. Any remaining preparation split should break
+preparation into smaller contracts for data gathering, filtering, basis
+functions, and inversion input construction. A future `RhimeDataSpec` or
+`RequiredDataPlan` can then be introduced at the right boundary, with
+`sigma_freq`, `bc_freq`, and related model-input concerns moving closer to the
+model components that consume them.
+
+## Completed in PR #TBD / Issue #401
+
+- 2026-05-31: #401 / PR #TBD renamed the current postprocessing carrier to
+  `LegacyInversionOutput` and reserved `InversionOutput` for the modern RHIME
+  result contract.
+- 2026-05-31: #401 / PR #TBD added modern `InversionOutput` save/load support
+  for `InferenceData`, canonical `inv_inputs`, retained `BasisFunctions`, run
+  metadata, model metadata, output metadata, and provenance.
+- 2026-05-31: #401 / PR #TBD routed fixedbasis output explicitly:
+  `output_format="hbmcmc"` remains the only path that calls
+  `inferpymc_postprocessouts`, while `hbmcmc_postprocessing`, `basic`, `paris`,
+  and `inv_out` use `LegacyInversionOutput`.
+- 2026-05-31: #401 / PR #TBD routed standard `run_rhime` output explicitly:
+  `inv_out` saves and returns modern `InversionOutput`, while `basic` and
+  `paris` build a temporary `LegacyInversionOutput` adapter for the existing
+  postprocessing functions.
+- 2026-05-31: #401 / PR #TBD opened #435 to migrate postprocessing consumers to
+  modern `InversionOutput`.
+
+## Recorded decisions for PR #TBD / Issue #401
+
+- The true legacy output remains `inferpymc_postprocessouts` in
+  `hbmcmc.inversion_pymc`. It should stay legacy/fixedbasis-only and should not
+  appear in modern RHIME output construction.
+- `LegacyInversionOutput` is the legacy-shaped postprocessing carrier, not the
+  true legacy `inferpymc_postprocessouts` output object.
+- Modern `InversionOutput` keeps retained `BasisFunctions` and canonical
+  `inv_inputs`; it does not materialise flat basis/flux arrays for RHIME
+  `inv_out` output.
+- `LegacyInversionOutput.from_modern_output(...)` is the only temporary bridge
+  for standard RHIME `basic` and `paris` output modes in #401.
+- #401 does not migrate `postprocessing` consumers to modern `InversionOutput`.
+  That is deferred to #435.
+
+## Current PR #TBD / Issue #401 cleanup notes
+
+- Keep `inferpymc_postprocessouts` isolated to
+  `fixedbasisMCMC(output_format="hbmcmc")`.
+- Keep current `postprocessing` functions typed against
+  `LegacyInversionOutput` until #435 changes their input contract.
+- Keep modern RHIME save/load serialization focused on durable artifacts:
+  `InferenceData`, `inv_inputs`, `BasisFunctions`, metadata, and provenance.
+  Do not add fixedbasis `fp_data` or materialised `.basis` side channels to the
+  modern object.
+- The current adapter still materialises basis/flux arrays for `basic` and
+  `paris`. Remove that once #435 and #429 let postprocessing consume
+  `BasisFunctions` directly.
+
+## Deferred Issue #435 postprocessing consumer migration
+
+#435 should move `make_outputs`, `make_paris_outputs`, `countries`,
+`diagnostics`, and `legacy_outputs` off `LegacyInversionOutput` where possible.
+`LegacyInversionOutput` should become an adapter over modern output, while
+`legacy_outputs` remains isolated to fixedbasis/HBMCMC compatibility output.
+
+This work links #401, #383, #429, #416, and #381. It should remove the RHIME
+`basic`/`paris` dependency on `LegacyInversionOutput.from_modern_output(...)`
+rather than expanding that adapter.
 
 ## Deferred SemanticModel plan
 

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -41,7 +41,7 @@ from openghg_inversions.models.priors import lognormal_mu_sigma
 from openghg_inversions.utils import ncdf_encoding
 from openghg_inversions.inversion_data import FixedBasisPreparedData, prepare_fixedbasis_inversion_data
 from openghg_inversions.postprocessing.inversion_output import (
-    InversionOutput,
+    LegacyInversionOutput,
     make_inv_out_for_fixed_basis_mcmc,
 )
 
@@ -194,7 +194,7 @@ class _OutputContext:
     mcmc_args: dict
     mcmc_results: dict
     inv_out_args: dict
-    inv_out: InversionOutput | None = None
+    inv_out: LegacyInversionOutput | None = None
     paths: dict[str, Path] = field(default_factory=dict)
 
 
@@ -276,11 +276,11 @@ def _build_output_context(
         country_file: Optional country definition file passed to postprocessing.
         paris_postprocessing_kwargs: Optional keyword arguments for PARIS output creation.
         save_trace: Trace save setting passed to ``fixedbasisMCMC``.
-        save_inversion_output: InversionOutput save setting passed to ``fixedbasisMCMC``.
+        save_inversion_output: LegacyInversionOutput save setting passed to ``fixedbasisMCMC``.
         legacy_postprocess_args: Legacy postprocessing argument dictionary built during inversion setup.
         mcmc_args: Arguments passed to ``mcmc.inferpymc``.
         mcmc_results: Raw sampler results from ``mcmc.inferpymc``.
-        inv_out_args: Arguments needed to build ``InversionOutput``.
+        inv_out_args: Arguments needed to build ``LegacyInversionOutput``.
 
     Returns:
         _OutputContext: Context object for final output handling.
@@ -369,8 +369,8 @@ def _build_inv_out_args(
     return inv_out_args
 
 
-def _get_inversion_output(context: _OutputContext) -> InversionOutput:
-    """Build and cache the InversionOutput object for output handling."""
+def _get_inversion_output(context: _OutputContext) -> LegacyInversionOutput:
+    """Build and cache the LegacyInversionOutput object for output handling."""
     if context.inv_out is None:
         context.inv_out = make_inv_out_for_fixed_basis_mcmc(**context.inv_out_args)
     return context.inv_out
@@ -399,7 +399,7 @@ def _handle_core_output_artifacts(context: _OutputContext) -> None:
         _get_inversion_output(context).save(inversion_output_path)
 
 
-def _finalize_output(context: _OutputContext) -> xr.Dataset | dict | InversionOutput:
+def _finalize_output(context: _OutputContext) -> xr.Dataset | dict | LegacyInversionOutput:
     """Dispatch the final output path for a completed inversion run."""
     if context.output_format == "mcmc_results":
         return context.mcmc_results
@@ -598,7 +598,7 @@ def fixedbasisMCMC(
     power: dict | float = 1.99,
     return_basis_objects: bool = False,
     **kwargs,
-) -> xr.Dataset | dict | InversionOutput:
+) -> xr.Dataset | dict | LegacyInversionOutput:
     """Script to run hierarchical Bayesian MCMC (RHIME) for inference of emissions.
 
     Uses PyMC to solve the inverse problem. Saves an output from the inversion code
@@ -713,7 +713,7 @@ def fixedbasisMCMC(
             - "hbmcmc_postprocessing": return legacy-style output format, computed using functions from the
               `postprocessing` submodule
             - "merged_data": return `fp_all` dictionary, no further processing and inversion *not* run
-            - "inv_out": return `InversionOutput` object
+            - "inv_out": return `LegacyInversionOutput` object
             - "basic": return basic output created by new `postprocessing` submodule
             - "paris": return flux and concentration datasets with PARIS formatting; these are also saved
               as netCDF files in the directory `outputpath`
@@ -934,8 +934,8 @@ def rerun_output(input_file: str, outputname: str, outputpath: str, verbose: boo
         over the inversion period and so will not be identical to the
         original a priori flux, if it varies over the inversion period.
 
-    TODO: update this function to use `InversionOutput` (and possibly an ini file) as its inputs.
-    This may require updating `InversionOutput` to hold more model metadata.
+    TODO: update this function to use `LegacyInversionOutput` (and possibly an ini file) as its inputs.
+    This may require updating `LegacyInversionOutput` to hold more model metadata.
     """
 
     def isFloat(string):

--- a/openghg_inversions/postprocessing/countries.py
+++ b/openghg_inversions/postprocessing/countries.py
@@ -16,7 +16,7 @@ from openghg_inversions import convert, utils
 from openghg_inversions.array_ops import align_sparse_lat_lon, get_xr_dummies, sparse_xr_dot
 from openghg_inversions.utils import get_country_file_path
 from ._country_codes import CountryInfoList
-from .inversion_output import InversionOutput
+from .inversion_output import LegacyInversionOutput
 
 # type for xr.Dataset *or* xr.DataArray
 DataSetOrArray = TypeVar("DataSetOrArray", xr.DataArray, xr.Dataset)
@@ -366,13 +366,13 @@ class Countries:
 
     def get_x_to_country_mat(
         self,
-        inv_out: InversionOutput,
+        inv_out: LegacyInversionOutput,
         sparse: bool = False,
     ) -> xr.DataArray:
         """Construct a sparse matrix mapping from x sensitivities to country totals.
 
         Args:
-            inv_out: InversionOutput object, used to get basis functions and flux.
+            inv_out: LegacyInversionOutput object, used to get basis functions and flux.
             sparse: if True, values of returned DataArray are `sparse.COO` array.
 
         Returns:
@@ -420,13 +420,13 @@ class Countries:
 
     def get_country_trace(
         self,
-        inv_out: InversionOutput,
+        inv_out: LegacyInversionOutput,
     ) -> xr.Dataset:
         """Calculate trace(s) for total country emissions.
 
         Args:
             species: name of species, e.g. "co2", "ch4", "sf6", etc.
-            inv_out: InversionOutput
+            inv_out: LegacyInversionOutput
 
         Returns:
             xr.Dataset with coordinate dimensions ("country", "draw")

--- a/openghg_inversions/postprocessing/diagnostics.py
+++ b/openghg_inversions/postprocessing/diagnostics.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
-from openghg_inversions.postprocessing.inversion_output import InversionOutput
+from openghg_inversions.postprocessing.inversion_output import LegacyInversionOutput
 from openghg_inversions.postprocessing.utils import add_suffix, get_parameters
 
 Diagnostic = namedtuple("Diagnostic", ["func", "params"])
@@ -30,7 +30,7 @@ def register_diagnostic(diagnostic: Callable) -> Callable:
 
 @register_diagnostic
 @add_suffix("trace")
-def summary(inv_out: InversionOutput) -> xr.Dataset:
+def summary(inv_out: LegacyInversionOutput) -> xr.Dataset:
     """Return diagnostics summary computed by arviz.
 
     Diagnostics reported:
@@ -45,7 +45,7 @@ def summary(inv_out: InversionOutput) -> xr.Dataset:
           greater than 1. Ideally, all r_hat values should be below 1.01
 
     Args:
-        inv_out: InversionOutput to summarise.
+        inv_out: LegacyInversionOutput to summarise.
 
     Returns:
         xr.Dataset: Dataset with diagnostic summary.
@@ -104,7 +104,7 @@ def _r2_by_site(ds: xr.Dataset, report_prior: bool = False) -> xr.Dataset:
 
 
 @register_diagnostic
-def bayes_r2_by_site(inv_out: InversionOutput, report_prior: bool = False) -> xr.Dataset:
+def bayes_r2_by_site(inv_out: LegacyInversionOutput, report_prior: bool = False) -> xr.Dataset:
     """Compute Bayesian R2 scores grouped by site.
 
     Scores are computed for posterior predictive traces (compared
@@ -115,7 +115,7 @@ def bayes_r2_by_site(inv_out: InversionOutput, report_prior: bool = False) -> xr
     normalised to always fall between 0 and 1.
 
     Args:
-        inv_out: InversionOutput object containing obs and trace
+        inv_out: LegacyInversionOutput object containing obs and trace
         report_prior: if True, return prior R2 in addition to posterior R2
 
     Returns:
@@ -132,7 +132,7 @@ def bayes_r2_by_site(inv_out: InversionOutput, report_prior: bool = False) -> xr
 
 @register_diagnostic
 def bayes_r2_by_site_resample(
-    inv_out: InversionOutput, freq: str = "MS", report_prior: bool = False
+    inv_out: LegacyInversionOutput, freq: str = "MS", report_prior: bool = False
 ) -> xr.Dataset:
     """Compute Bayesian R2 scores grouped by site and time.
 
@@ -144,7 +144,7 @@ def bayes_r2_by_site_resample(
     normalised to always fall between 0 and 1.
 
     Args:
-        inv_out: InversionOutput object containing obs and trace
+        inv_out: LegacyInversionOutput object containing obs and trace
         freq: frequency to resample to (should be a pandas freq. str that
           can be passed to `xr.Dataset.resample`)
         report_prior: if True, return prior R2 in addition to posterior R2

--- a/openghg_inversions/postprocessing/inversion_output.py
+++ b/openghg_inversions/postprocessing/inversion_output.py
@@ -34,10 +34,17 @@ def _load_json_attr(attrs: dict[Any, Any], key: str) -> dict[str, Any]:
     if raw is None:
         return {}
     if isinstance(raw, bytes):
-        raw = raw.decode()
+        try:
+            raw = raw.decode()
+        except UnicodeDecodeError:
+            return {}
     if not isinstance(raw, str):
         return {}
-    return json.loads(raw)
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    return payload if isinstance(payload, dict) else {}
 
 
 def _save_datatree(dt: xr.DataTree, output_file: str | Path, output_format: Literal["netcdf", "zarr"] | None) -> None:

--- a/openghg_inversions/postprocessing/inversion_output.py
+++ b/openghg_inversions/postprocessing/inversion_output.py
@@ -1,7 +1,8 @@
 from pathlib import Path
 from typing_extensions import Self
-from dataclasses import dataclass
-from typing import Any, Hashable, Literal, TypeVar
+from dataclasses import dataclass, field
+from typing import Any, Hashable, Literal, TypeVar, cast
+import json
 
 import arviz as az
 import numpy as np
@@ -9,6 +10,121 @@ import pandas as pd
 import xarray as xr
 
 from openghg_inversions.array_ops import get_xr_dummies, align_sparse_lat_lon
+from openghg_inversions.basis.basis_functions import BasisFunctions
+
+
+MODERN_INVERSION_OUTPUT_SCHEMA = "openghg_inversions.inversion_output"
+LEGACY_INVERSION_OUTPUT_SCHEMA = "openghg_inversions.legacy_inversion_output"
+MULTIINDEX_DIMS_ATTR = "openghg_inversions:multiindex_dims"
+
+
+def _json_default(value: object) -> str:
+    """JSON fallback for metadata values stored on output artifacts."""
+    return str(value)
+
+
+def _json_attr(value: dict[str, Any]) -> str:
+    """Encode output metadata for xarray attrs."""
+    return json.dumps(value, default=_json_default)
+
+
+def _load_json_attr(attrs: dict[Any, Any], key: str) -> dict[str, Any]:
+    """Decode optional JSON metadata from xarray attrs."""
+    raw = attrs.get(key)
+    if raw is None:
+        return {}
+    if isinstance(raw, bytes):
+        raw = raw.decode()
+    if not isinstance(raw, str):
+        return {}
+    return json.loads(raw)
+
+
+def _save_datatree(dt: xr.DataTree, output_file: str | Path, output_format: Literal["netcdf", "zarr"] | None) -> None:
+    """Save a DataTree to NetCDF or Zarr, inferring format from the path when needed."""
+    output_file = Path(output_file)
+
+    if output_format is None:
+        try:
+            output_format = {".nc": "netcdf", ".zarr": "zarr"}[output_file.suffix]  # type: ignore
+        except KeyError:
+            raise ValueError(
+                f"Output file {output_file} does not end in '.nc' or '.zarr'; please specify `output_format`."
+            )
+
+    if output_format == "netcdf":
+        if output_file.suffix != ".nc":
+            output_file = output_file.with_suffix(".nc")
+        dt.to_netcdf(output_file)
+    elif output_format == "zarr":
+        if output_file.suffix != ".zarr":
+            output_file = output_file.with_suffix(".zarr")
+        dt.to_zarr(output_file)
+    else:
+        raise ValueError(f"Unsupported output_format: {output_format!r}")
+
+
+def _open_datatree_loaded(file_path: str | Path) -> xr.DataTree:
+    """Open and load a DataTree artifact with the same engine fallback as legacy outputs."""
+    open_errors: list[Exception] = []
+    for engine in ("h5netcdf", None):
+        try:
+            dt = xr.open_datatree(file_path, engine=engine) if engine is not None else xr.open_datatree(file_path)
+        except (OSError, RuntimeError, ValueError) as exc:
+            open_errors.append(exc)
+        else:
+            with dt:
+                return dt.load()
+
+    raise open_errors[-1]
+
+
+def _inferencedata_to_datatree(idata: az.InferenceData) -> xr.DataTree:
+    """Convert an ArviZ InferenceData object to a DataTree."""
+    return xr.DataTree.from_dict({group: idata[group] for group in idata.groups()})
+
+
+def _inferencedata_from_datatree(dt: xr.DataTree) -> az.InferenceData:
+    """Convert a DataTree of InferenceData groups back to ArviZ InferenceData."""
+    return cast(Any, az.InferenceData)(
+        **{group: child.to_dataset() for group, child in dt.items()}
+    )
+
+
+def _reset_serialisation_multiindexes(ds: xr.Dataset) -> xr.Dataset:
+    """Expand xarray MultiIndexes before DataTree serialisation."""
+    result = ds
+    multiindex_dims: list[dict[str, object]] = []
+    for dim, index in ds.indexes.items():
+        if dim in result.dims and isinstance(index, pd.MultiIndex):
+            level_names = list(index.names)
+            if any(name is None for name in level_names):
+                raise ValueError(f"Cannot serialise unnamed MultiIndex levels for dimension {dim!r}.")
+            result = result.reset_index(dim)
+            multiindex_dims.append({"dim": str(dim), "levels": [str(name) for name in level_names]})
+    if multiindex_dims:
+        result = result.copy()
+        result.attrs = dict(result.attrs)
+        result.attrs[MULTIINDEX_DIMS_ATTR] = json.dumps({"dims": multiindex_dims})
+    return result
+
+
+def _restore_inv_inputs_indexes(ds: xr.Dataset) -> xr.Dataset:
+    """Restore RHIME inv_inputs MultiIndexes expanded for serialisation."""
+    raw_multiindex_dims = ds.attrs.get(MULTIINDEX_DIMS_ATTR)
+    if raw_multiindex_dims is None:
+        return ds
+
+    result = ds.copy()
+    result.attrs = dict(result.attrs)
+    del result.attrs[MULTIINDEX_DIMS_ATTR]
+    records = json.loads(raw_multiindex_dims)["dims"]
+    for record in records:
+        dim = record["dim"]
+        levels = record["levels"]
+        if dim in result.dims and all(level in result and result[level].dims == (dim,) for level in levels):
+            result = result.set_index({dim: levels})
+    return result
 
 
 def filter_data_vars_by_prefix(
@@ -212,7 +328,101 @@ def _nmeasure_to_site_time(
 
 @dataclass
 class InversionOutput:
-    """Outputs of inversion needed for post-processing."""
+    """Modern RHIME inversion output contract.
+
+    This object carries the runtime artifacts needed to reproduce and extend
+    RHIME outputs without exposing fixedbasis ``fp_data`` or legacy
+    ``inferpymc_postprocessouts`` dictionaries.
+    """
+
+    trace: az.InferenceData
+    inv_inputs: xr.Dataset
+    basis_functions: BasisFunctions
+    run_metadata: dict[str, Any] = field(default_factory=dict)
+    model_metadata: dict[str, Any] = field(default_factory=dict)
+    output_metadata: dict[str, Any] = field(default_factory=dict)
+    provenance: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def start_date(self) -> str | None:
+        """Inversion start date from run metadata."""
+        value = self.run_metadata.get("start_date")
+        return None if value is None else str(value)
+
+    @property
+    def end_date(self) -> str | None:
+        """Inversion end date from run metadata."""
+        value = self.run_metadata.get("end_date")
+        return None if value is None else str(value)
+
+    @property
+    def species(self) -> str | None:
+        """Species name from model metadata."""
+        value = self.model_metadata.get("species")
+        return None if value is None else str(value)
+
+    @property
+    def domain(self) -> str | None:
+        """Domain name from model metadata."""
+        value = self.model_metadata.get("domain")
+        return None if value is None else str(value)
+
+    def to_datatree(self) -> xr.DataTree:
+        """Convert the modern output to a serialisable DataTree."""
+        dt = xr.DataTree.from_dict(
+            {
+                "trace": _inferencedata_to_datatree(self.trace),
+                "inv_inputs": xr.DataTree(_reset_serialisation_multiindexes(self.inv_inputs)),
+                "basis_functions": self.basis_functions.to_datatree(),
+            }
+        )
+        dt.attrs = {
+            "schema": MODERN_INVERSION_OUTPUT_SCHEMA,
+            "schema_version": 1,
+            "run_metadata": _json_attr(self.run_metadata),
+            "model_metadata": _json_attr(self.model_metadata),
+            "output_metadata": _json_attr(self.output_metadata),
+            "provenance": _json_attr(self.provenance),
+        }
+        return dt
+
+    def save(self, output_file: str | Path, output_format: Literal["netcdf", "zarr"] | None = None) -> None:
+        """Save modern InversionOutput to NetCDF or Zarr."""
+        _save_datatree(self.to_datatree(), output_file, output_format)
+
+    @classmethod
+    def from_datatree(cls, dt: xr.DataTree) -> Self:
+        """Construct a modern InversionOutput from a serialised DataTree."""
+        schema = dt.attrs.get("schema")
+        if schema is not None and schema != MODERN_INVERSION_OUTPUT_SCHEMA:
+            raise ValueError(f"Unexpected InversionOutput schema: {schema!r}")
+
+        trace = _inferencedata_from_datatree(cast(xr.DataTree, dt["trace"]))
+        inv_inputs = _restore_inv_inputs_indexes(cast(xr.DataTree, dt["inv_inputs"]).to_dataset())
+        basis_functions = BasisFunctions.from_datatree(cast(xr.DataTree, dt["basis_functions"]))
+        return cls(
+            trace=trace,
+            inv_inputs=inv_inputs,
+            basis_functions=basis_functions,
+            run_metadata=_load_json_attr(dt.attrs, "run_metadata"),
+            model_metadata=_load_json_attr(dt.attrs, "model_metadata"),
+            output_metadata=_load_json_attr(dt.attrs, "output_metadata"),
+            provenance=_load_json_attr(dt.attrs, "provenance"),
+        )
+
+    @classmethod
+    def load(cls, file_path: str | Path) -> Self:
+        """Load a modern InversionOutput artifact."""
+        return cls.from_datatree(_open_datatree_loaded(file_path))
+
+
+@dataclass
+class LegacyInversionOutput:
+    """Legacy-shaped postprocessing carrier.
+
+    This is the object consumed by the current ``postprocessing`` submodule. It
+    is distinct from the true legacy ``inferpymc_postprocessouts`` dataset.
+    """
 
     obs: xr.DataArray
     obs_err: xr.DataArray
@@ -293,8 +503,79 @@ class InversionOutput:
         ]
         self.obs_inputs = xr.merge([x for x in obs_inputs if x is not None])
 
+    @classmethod
+    def from_modern_output(cls, inv_out: InversionOutput) -> Self:
+        """Build the current postprocessing carrier from a modern RHIME output.
+
+        This temporary adapter keeps existing ``basic`` and ``paris``
+        postprocessing available while issue #383/#429 move those consumers onto
+        retained ``BasisFunctions`` directly.
+        """
+        inv_inputs = inv_out.inv_inputs
+        basis = inv_out.basis_functions.operator.basis_matrix
+        current_state_dim = inv_out.basis_functions.operator.meta.state_dim
+        if current_state_dim != "region":
+            basis = basis.rename({current_state_dim: "region"})
+        if "region" in inv_inputs.coords:
+            basis = basis.reindex(region=inv_inputs.region)
+
+        nmeasure = np.arange(inv_inputs.sizes["nmeasure"])
+        sites = inv_out.run_metadata.get("sites", [])
+        site_names = (
+            inv_inputs["site_names"]
+            if "site_names" in inv_inputs
+            else xr.DataArray(list(sites), dims="nsite", coords={"nsite": np.arange(len(sites))})
+        )
+        obs_prior_factor = inv_inputs["mf_prior_factor"] if "mf_prior_factor" in inv_inputs else None
+        obs_prior_upper_level_factor = (
+            inv_inputs["mf_prior_upper_level_factor"] if "mf_prior_upper_level_factor" in inv_inputs else None
+        )
+
+        def nmeasure_array(name: str, source: xr.DataArray) -> xr.DataArray:
+            """Create a clean nmeasure DataArray without inherited indexes."""
+            result = xr.DataArray(
+                source.values,
+                dims=["nmeasure"],
+                coords={"nmeasure": nmeasure},
+                name=name,
+            )
+            result.attrs = source.attrs
+            return result
+
+        species = inv_out.species
+        domain = inv_out.domain
+        start_date = inv_out.start_date
+        end_date = inv_out.end_date
+        if species is None or domain is None or start_date is None or end_date is None:
+            raise ValueError("Modern InversionOutput metadata must include species, domain, start_date, and end_date.")
+
+        return cls(
+            obs=nmeasure_array("Yobs", inv_inputs["mf"]),
+            obs_err=nmeasure_array("Yerror", inv_inputs["mf_error"]),
+            obs_repeatability=nmeasure_array("Yerror_repeatability", inv_inputs["mf_repeatability"]),
+            obs_variability=nmeasure_array("Yerror_variability", inv_inputs["mf_variability"]),
+            obs_prior_factor=(
+                nmeasure_array("Yobs_prior_factor", obs_prior_factor) if obs_prior_factor is not None else None
+            ),
+            obs_prior_upper_level_factor=(
+                nmeasure_array("Yobs_prior_upper_level_factor", obs_prior_upper_level_factor)
+                if obs_prior_upper_level_factor is not None
+                else None
+            ),
+            site_indicators=nmeasure_array("site_indicator", inv_inputs["site_indicator"]),
+            flux=inv_out.basis_functions.flux,
+            basis=basis,
+            trace=inv_out.trace,
+            site_names=site_names,
+            times=nmeasure_array("times", inv_inputs["time"]),
+            start_date=start_date,
+            end_date=end_date,
+            species=species,
+            domain=domain,
+        )
+
     def __eq__(self, other: Any) -> bool:
-        """Check equality between InversionOutput objects.
+        """Check equality between LegacyInversionOutput objects.
 
         The `dataclass` default `__eq__` method doesn't work because the
         `.basis` attribute is a sparse matrix, which causes problems when
@@ -309,7 +590,7 @@ class InversionOutput:
 
         Raises:
             NotImplementedError: if equality is tested with an object that is
-              not InversionOutput.
+              not LegacyInversionOutput.
 
         """
         if not isinstance(other, self.__class__):
@@ -460,7 +741,7 @@ class InversionOutput:
     def get_flat_basis(self) -> xr.DataArray:
         """Return 2D DataArray encoding basis regions.
 
-        The `InversionOutput.basis` matrix is sparse, with three dimensions: latitude, longitude, and region
+        The `LegacyInversionOutput.basis` matrix is sparse, with three dimensions: latitude, longitude, and region
         (which corresponds to a basis function). A sparse matrix cannot be saved directly to disk, or compared
         with other matrices of this type, and converting directly to a dense matrix could use a very large
         amount of memory.
@@ -482,7 +763,7 @@ class InversionOutput:
         return (self.basis * self.basis[region_dim]).sum(region_dim).as_numpy().rename("basis")
 
     def to_datatree(self) -> xr.DataTree:
-        """Convert InversionOutput to xarray DataTree.
+        """Convert LegacyInversionOutput to xarray DataTree.
 
         The output of this method can be saved to netCDF or zarr.
 
@@ -505,13 +786,15 @@ class InversionOutput:
         ]
         to_merge = [x for x in to_merge if x is not None]
         dt_dict = {
-            "trace": xr.DataTree.from_dict({group: ds for group, ds in self.trace.items()}),
+            "trace": _inferencedata_to_datatree(self.trace),
             "obs_and_errors": xr.merge(to_merge).reset_index("nmeasure"),
             "basis": self.get_flat_basis().to_dataset(),
             "flux": self.flux.rename(flux_time="time").rename("flux").to_dataset(),
         }
         dt = xr.DataTree.from_dict(dt_dict)
         dt.attrs = {
+            "schema": LEGACY_INVERSION_OUTPUT_SCHEMA,
+            "schema_version": 1,
             "start_date": str(self.start_date),
             "end_date": str(self.end_date),
             "species": self.species,
@@ -520,13 +803,13 @@ class InversionOutput:
         return dt
 
     def save(self, output_file: str | Path, output_format: Literal["netcdf", "zarr"] | None = None) -> None:
-        """Save InversionOutput to netCDF or Zarr.
+        """Save LegacyInversionOutput to netCDF or Zarr.
 
-        There is a corresponding `load` method to recover the InversionOutput
+        There is a corresponding `load` method to recover the LegacyInversionOutput
         from a saved version.
 
         Args:
-            output_file: path to file where the InversionOutput should be saved
+            output_file: path to file where the LegacyInversionOutput should be saved
             output_format: format to save to; if `None`, this will be inferred by the
               extension of `output_file`
 
@@ -535,39 +818,25 @@ class InversionOutput:
               from the output file extension.
 
         """
-        output_file = Path(output_file)
-
-        if output_format is None:
-            try:
-                output_format = {".nc": "netcdf", ".zarr": "zarr"}[output_file.suffix]  # type: ignore
-            except KeyError:
-                raise ValueError(
-                    f"Output file {output_file} does not end in '.nc' or '.zarr'; please specify `output_format`."
-                )
-
-        if output_format == "netcdf":
-            if output_file.suffix != ".nc":
-                output_file = Path(output_file.stem + ".nc")
-            self.to_datatree().to_netcdf(output_file)
-
-        if output_format == "zarr":
-            if output_file.suffix != ".zarr":
-                output_file = Path(output_file.stem + ".zarr")
-            self.to_datatree().to_zarr(output_file)
+        _save_datatree(self.to_datatree(), output_file, output_format)
 
     @classmethod
     def from_datatree(cls: type[Self], dt: xr.DataTree) -> Self:
-        """Construct InversionOutput from serialised InversionOutput xr.DataTree.
+        """Construct LegacyInversionOutput from serialised DataTree.
 
         This method is the inverse of `to_datatree`.
 
         Args:
-            dt: xr.DataTree constructed using `InversionOutput.to_datatree`
+            dt: xr.DataTree constructed using `LegacyInversionOutput.to_datatree`
 
         Returns:
-            InversionOutput: reconstructed from datatree
+            LegacyInversionOutput: reconstructed from datatree
 
         """
+        schema = dt.attrs.get("schema")
+        if schema is not None and schema != LEGACY_INVERSION_OUTPUT_SCHEMA:
+            raise ValueError(f"Unexpected LegacyInversionOutput schema: {schema!r}")
+
         obs_and_errs_ds = dt.obs_and_errors.to_dataset().drop_vars(["site", "time"])
         obs_and_errs = dict(obs_and_errs_ds)
         obs_and_errs = {
@@ -579,51 +848,48 @@ class InversionOutput:
             "species": dt.attrs.get("species"),
             "domain": dt.attrs.get("domain"),
         }
+        if any(value is None for value in inv_info.values()):
+            raise ValueError("LegacyInversionOutput DataTree is missing required inversion metadata.")
         basis_dim = "nx" if "nx" in dt.trace.posterior.coords else "region"
         basis = get_xr_dummies(
             dt.basis.basis,
             cat_dim=basis_dim,
             categories=dt.trace.posterior[basis_dim],
         )
-        trace = az.InferenceData(**{group: val.to_dataset() for group, val in dt.trace.items()})
+        trace = _inferencedata_from_datatree(dt.trace)
         return cls(
-            **obs_and_errs,
+            obs=obs_and_errs["obs"],
+            obs_err=obs_and_errs["obs_err"],
+            obs_repeatability=obs_and_errs["obs_repeatability"],
+            obs_variability=obs_and_errs["obs_variability"],
+            obs_prior_factor=obs_and_errs.get("obs_prior_factor"),
+            obs_prior_upper_level_factor=obs_and_errs.get("obs_prior_upper_level_factor"),
             flux=dt.flux.flux,
             basis=basis,
             trace=trace,
             site_indicators=dt.obs_and_errors.site,
             times=dt.obs_and_errors.time,
-            **inv_info,
+            start_date=str(inv_info["start_date"]),
+            end_date=str(inv_info["end_date"]),
+            species=str(inv_info["species"]),
+            domain=str(inv_info["domain"]),
         )
 
     @classmethod
     def load(cls: type[Self], file_path: str | Path) -> Self:
-        """Load InversionOutput from file.
+        """Load LegacyInversionOutput from file.
 
-        Use this to load `InversionOutput` that was previously saved using
-        `InversionOutput.save`.
+        Use this to load `LegacyInversionOutput` that was previously saved using
+        `LegacyInversionOutput.save`.
 
         Args:
-            file_path: path to saved InversionOutput
+            file_path: path to saved LegacyInversionOutput
 
         Returns:
-            InversionOutput loaded from saved file
+            LegacyInversionOutput loaded from saved file
 
         """
-        open_errors: list[Exception] = []
-        for engine in ("h5netcdf", None):
-            try:
-                dt = (
-                    xr.open_datatree(file_path, engine=engine)
-                    if engine is not None
-                    else xr.open_datatree(file_path)
-                )
-            except (OSError, RuntimeError, ValueError) as exc:
-                open_errors.append(exc)
-            else:
-                return cls.from_datatree(dt)
-
-        raise open_errors[-1]
+        return cls.from_datatree(_open_datatree_loaded(file_path))
 
 
 def make_inv_out_for_fixed_basis_mcmc(
@@ -642,8 +908,8 @@ def make_inv_out_for_fixed_basis_mcmc(
     domain: str,
     obs_prior_factor: np.ndarray | None = None,
     obs_prior_upper_level_factor: np.ndarray | None = None,
-) -> InversionOutput:
-    """Create InversionOutput in `fixedbasisMCMC`."""
+) -> LegacyInversionOutput:
+    """Create LegacyInversionOutput in `fixedbasisMCMC`."""
     nmeasure = np.arange(len(Y))
     y_obs = xr.DataArray(Y, dims=["nmeasure"], coords={"nmeasure": nmeasure}, name="Yobs")
     times = xr.DataArray(Ytime, dims=["nmeasure"], coords={"nmeasure": nmeasure}, name="times")
@@ -688,7 +954,8 @@ def make_inv_out_for_fixed_basis_mcmc(
     try:
         flux = scenarios[0].flux_stacked
     except AttributeError:
-        flux = next(iter(fp_data[".flux"].values())).data
+        flux_source = next(iter(fp_data[".flux"].values()))
+        flux = getattr(flux_source, "data", flux_source)
 
     # TODO: this only works if there is one flux used (or if multiple, but ModelScenario stacks them)
     if isinstance(flux, xr.Dataset):
@@ -707,10 +974,12 @@ def make_inv_out_for_fixed_basis_mcmc(
     for scenario in scenarios:
         if not ("mf_prior_factor" in scenario and "mf_prior_upper_level_factor" in scenario):
             continue
-        y_obs_prior_factor.attrs = scenario.mf_prior_factor.attrs
-        y_obs_prior_upper_level_factor.attrs = scenario.mf_prior_upper_level_factor.attrs
+        if y_obs_prior_factor is not None:
+            y_obs_prior_factor.attrs = scenario.mf_prior_factor.attrs
+        if y_obs_prior_upper_level_factor is not None:
+            y_obs_prior_upper_level_factor.attrs = scenario.mf_prior_upper_level_factor.attrs
 
-    return InversionOutput(
+    return LegacyInversionOutput(
         obs=y_obs,
         obs_err=y_error,
         obs_prior_factor=y_obs_prior_factor,
@@ -779,7 +1048,7 @@ def _clean_rhime_output(ds: xr.Dataset) -> xr.Dataset:
     ]
 
     if "Yobs_prior_factor" in ds.data_vars or "Yobs_prior_upper_level_factor" in ds.data_vars:
-        data_vars.append(["Yobs_prior_factor", "Yobs_prior_upper_level_factor"])
+        data_vars.extend(["Yobs_prior_factor", "Yobs_prior_upper_level_factor"])
     if use_bc:
         data_vars.extend(["bc", "bcsensitivity"])
 
@@ -802,7 +1071,7 @@ def _make_idata_from_rhime_outs(rhime_out_ds: xr.Dataset) -> az.InferenceData:
 
 def make_inv_out_from_rhime_outputs(
     ds: xr.Dataset, species: str, domain: str, start_date: str | None = None, end_date: str | None = None
-) -> InversionOutput:
+) -> LegacyInversionOutput:
     """Create inversion output from RHIME outputs.
 
     This can be used to re-run flux and country total outputs using the PARIS postprocessing.
@@ -814,12 +1083,12 @@ def make_inv_out_from_rhime_outputs(
     site_indicators = ds_clean.siteindicator
     basis = get_xr_dummies(ds_clean.basisfunctions, cat_dim="nx", categories=ds_clean.nx.values)
 
-    start_date = start_date or ds_clean.Ytime.min().values
-    end_date = end_date or ds_clean.Ytime.max().values
+    start_date = str(start_date or ds_clean.Ytime.min().values)
+    end_date = str(end_date or ds_clean.Ytime.max().values)
 
     trace = _make_idata_from_rhime_outs(ds_clean)
 
-    return InversionOutput(
+    return LegacyInversionOutput(
         obs=ds_clean.Yobs,
         obs_err=ds_clean.Yerror,
         obs_prior_factor=getattr(ds_clean, "Yobs_prior_factor", None),

--- a/openghg_inversions/postprocessing/inversion_output.py
+++ b/openghg_inversions/postprocessing/inversion_output.py
@@ -118,10 +118,33 @@ def _restore_inv_inputs_indexes(ds: xr.Dataset) -> xr.Dataset:
     result = ds.copy()
     result.attrs = dict(result.attrs)
     del result.attrs[MULTIINDEX_DIMS_ATTR]
-    records = json.loads(raw_multiindex_dims)["dims"]
+
+    if isinstance(raw_multiindex_dims, bytes):
+        try:
+            raw_multiindex_dims = raw_multiindex_dims.decode()
+        except UnicodeDecodeError:
+            return result
+    if not isinstance(raw_multiindex_dims, str):
+        return result
+
+    try:
+        payload = json.loads(raw_multiindex_dims)
+    except json.JSONDecodeError:
+        return result
+
+    records = payload.get("dims") if isinstance(payload, dict) else None
+    if not isinstance(records, list):
+        return result
+
     for record in records:
-        dim = record["dim"]
-        levels = record["levels"]
+        if not isinstance(record, dict):
+            continue
+        dim = record.get("dim")
+        levels = record.get("levels")
+        if not isinstance(dim, str) or not isinstance(levels, list):
+            continue
+        if not all(isinstance(level, str) for level in levels):
+            continue
         if dim in result.dims and all(level in result and result[level].dims == (dim,) for level in levels):
             result = result.set_index({dim: levels})
     return result

--- a/openghg_inversions/postprocessing/legacy_outputs.py
+++ b/openghg_inversions/postprocessing/legacy_outputs.py
@@ -8,7 +8,7 @@ import numpy as np
 import xarray as xr
 
 from openghg_inversions import utils
-from openghg_inversions.postprocessing.inversion_output import InversionOutput
+from openghg_inversions.postprocessing.inversion_output import LegacyInversionOutput
 from openghg_inversions.postprocessing.make_outputs import (
     make_concentration_outputs,
     make_country_outputs,
@@ -232,7 +232,7 @@ def _flatten_nmeasure_for_legacy(data: xr.DataArray) -> xr.DataArray:
 
 
 def make_legacy_hbmcmc_output(
-    inv_out: InversionOutput,
+    inv_out: LegacyInversionOutput,
     mcmc_results: dict,
     sigma_freq_index: np.ndarray | xr.DataArray,
     Hx: np.ndarray | xr.DataArray,

--- a/openghg_inversions/postprocessing/make_outputs.py
+++ b/openghg_inversions/postprocessing/make_outputs.py
@@ -5,13 +5,13 @@ import xarray as xr
 
 from openghg_inversions.array_ops import sparse_xr_dot
 from openghg_inversions.postprocessing.countries import Countries, paris_regions_dict
-from openghg_inversions.postprocessing.inversion_output import InversionOutput
+from openghg_inversions.postprocessing.inversion_output import LegacyInversionOutput
 from openghg_inversions.postprocessing.stats import calculate_stats
 from openghg_inversions.postprocessing.utils import rename_by_replacement
 
 
 def make_flux_outputs(
-    inv_out: InversionOutput,
+    inv_out: LegacyInversionOutput,
     stats: list[str] | None = None,
     stats_args: dict | None = None,
     include_scale_factors: bool = True,
@@ -20,7 +20,7 @@ def make_flux_outputs(
     """Return dataset of stats for fluxes and scaling factors.
 
     Args:
-        inv_out: InversionOutput containing MCMC traces.
+        inv_out: LegacyInversionOutput containing MCMC traces.
         stats: List of stats to use. If None, the default for
             calculate_stats is used, which is "mean" and "quantiles". See the
             postprocessing.stats submodule for more options.
@@ -149,7 +149,7 @@ def sort_data_vars(ds: xr.Dataset) -> xr.Dataset:
 
 
 def make_concentration_outputs(
-    inv_out: InversionOutput,
+    inv_out: LegacyInversionOutput,
     stats: list[str] | None = None,
     stats_args: dict | None = None,
     combine_bc_and_offset: bool = False,
@@ -157,7 +157,7 @@ def make_concentration_outputs(
     """Return dataset of stats for concentrations.
 
     Args:
-        inv_out: InversionOutput containing MCMC traces.
+        inv_out: LegacyInversionOutput containing MCMC traces.
         stats: List of stats to use. If None, the default for
             calculate_stats is used, which is "mean" and "quantiles". See the
             postprocessing.stats submodule for more options.
@@ -212,7 +212,7 @@ def make_concentration_outputs(
 
 
 def make_country_outputs(
-    inv_out: InversionOutput,
+    inv_out: LegacyInversionOutput,
     country_file: str | Path | None = None,
     country_regions: str | Path | dict[str, list[str]] | Literal["paris"] | None = None,
     stats: list[str] | None = None,
@@ -222,9 +222,9 @@ def make_country_outputs(
     """Calculate country emission stats.
 
     Args:
-        inv_out: InversionOutput containing MCMC traces.
+        inv_out: LegacyInversionOutput containing MCMC traces.
         country_file: Path to country definition file. If None, the default
-            country file location and the domain of the InversionOutput will be used
+            country file location and the domain of the LegacyInversionOutput will be used
             to try to find a suitable country file.
         country_regions: Dict mapping country region names (e.g. "BENELUX") to a
             list of (country codes) of the countries comprising that regions (e.g.
@@ -275,7 +275,7 @@ def make_country_outputs(
 
 
 def basic_output(
-    inv_out: InversionOutput,
+    inv_out: LegacyInversionOutput,
     country_file: str | Path | None = None,
     country_regions: str | Path | dict[str, list[str]] | Literal["paris"] | None = None,
     stats: list[str] | None = None,
@@ -287,7 +287,7 @@ def basic_output(
     to create the model, like "H matrices" and the flux used.
 
     Args:
-        inv_out: InversionOutput to process
+        inv_out: LegacyInversionOutput to process
         country_file: path to country file
         country_regions: optional country regions to use. If "paris" is passed,
         then the PARIS regions will be used.

--- a/openghg_inversions/postprocessing/make_paris_outputs.py
+++ b/openghg_inversions/postprocessing/make_paris_outputs.py
@@ -10,7 +10,7 @@ from openghg.util import timestamp_now
 from openghg_inversions.config.version import code_version
 from openghg_inversions.postprocessing.countries import Countries
 from openghg_inversions.postprocessing.inversion_output import (
-    InversionOutput,
+    LegacyInversionOutput,
     make_inv_out_from_rhime_outputs,
 )
 from openghg_inversions.postprocessing.make_outputs import (
@@ -19,7 +19,6 @@ from openghg_inversions.postprocessing.make_outputs import (
     make_country_outputs,
 )
 from openghg_inversions.postprocessing.stats import stats_functions
-from openghg_inversions.utils import get_country_file_path
 
 
 # path to `paris_formatting` submodule
@@ -134,7 +133,7 @@ def shift_measurement_time_to_midpoint(ds: xr.Dataset, period: str = "4h") -> xr
 
 
 def paris_concentration_outputs(
-    inv_out: InversionOutput, report_mode: bool = False, obs_avg_period: str = "4h"
+    inv_out: LegacyInversionOutput, report_mode: bool = False, obs_avg_period: str = "4h"
 ) -> xr.Dataset:
     """Create PARIS concentration outputs.
 
@@ -277,7 +276,7 @@ def _flux_interval_midpoints(
 
 
 def paris_flux_output(
-    inv_out: InversionOutput,
+    inv_out: LegacyInversionOutput,
     country_file: str | Path | None = None,
     time_point: Literal["start", "midpoint"] = "midpoint",
     report_mode: bool = False,
@@ -456,7 +455,7 @@ def infer_flux_frequency(flux: xr.DataArray) -> str:
 
 
 def make_paris_outputs(
-    inv_out: InversionOutput,
+    inv_out: LegacyInversionOutput,
     country_file: str | Path | None = None,
     time_point: Literal["start", "midpoint"] = "midpoint",
     report_mode: bool = False,

--- a/openghg_inversions/rhime/outputs.py
+++ b/openghg_inversions/rhime/outputs.py
@@ -2,18 +2,17 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, cast
 
 import arviz as az
-import numpy as np
 import xarray as xr
 
 from openghg_inversions.array_ops import sparse_xr_dot
 from openghg_inversions.inversion_data import RhimePreparedInputs
 from openghg_inversions.models import RhimeModelSpec
-from openghg_inversions.postprocessing.inversion_output import InversionOutput
+from openghg_inversions.postprocessing.inversion_output import InversionOutput, LegacyInversionOutput
 from openghg_inversions.rhime.specs import RhimeOutputSpec, RhimeRunSpec
 from openghg_inversions.utils import ncdf_encoding
 
@@ -97,66 +96,35 @@ def _make_inversion_output(
     *,
     prepared: RhimePreparedInputs,
     idata: az.InferenceData,
-    start_date: str,
-    end_date: str,
-    species: str,
-    domain: str,
+    run_spec: RhimeRunSpec,
+    model_spec: RhimeModelSpec,
+    output_spec: RhimeOutputSpec,
 ) -> InversionOutput:
-    """Create an InversionOutput directly from RHIME inputs and InferenceData.
-
-    This is a transitional direct constructor for the modern RHIME path. It is
-    deliberately not routed through the fixed-basis/inferpymc legacy adapter.
-    This should be refactored when issue #401 defines the modern
-    ``InversionOutput`` contract.
-    """
-    inv_inputs = prepared.inv_inputs
-    basis, flux = _materialise_basis_and_flux_for_output(prepared)
-    nmeasure = np.arange(inv_inputs.sizes["nmeasure"])
-    site_names = (
-        inv_inputs["site_names"]
-        if "site_names" in inv_inputs
-        else xr.DataArray(list(prepared.sites), dims="nsite")
-    )
-
-    obs_prior_factor = inv_inputs["mf_prior_factor"] if "mf_prior_factor" in inv_inputs else None
-    obs_prior_upper_level_factor = (
-        inv_inputs["mf_prior_upper_level_factor"] if "mf_prior_upper_level_factor" in inv_inputs else None
-    )
-
-    def nmeasure_array(name: str, source: xr.DataArray) -> xr.DataArray:
-        """Create a clean nmeasure DataArray without inherited MultiIndex coords."""
-        result = xr.DataArray(
-            source.values,
-            dims=["nmeasure"],
-            coords={"nmeasure": nmeasure},
-            name=name,
-        )
-        result.attrs = source.attrs
-        return result
-
+    """Create the modern RHIME InversionOutput without fixedbasis legacy adapters."""
     return InversionOutput(
-        obs=nmeasure_array("Yobs", inv_inputs["mf"]),
-        obs_err=nmeasure_array("Yerror", inv_inputs["mf_error"]),
-        obs_repeatability=nmeasure_array("Yerror_repeatability", inv_inputs["mf_repeatability"]),
-        obs_variability=nmeasure_array("Yerror_variability", inv_inputs["mf_variability"]),
-        obs_prior_factor=(
-            nmeasure_array("Yobs_prior_factor", obs_prior_factor) if obs_prior_factor is not None else None
-        ),
-        obs_prior_upper_level_factor=(
-            nmeasure_array("Yobs_prior_upper_level_factor", obs_prior_upper_level_factor)
-            if obs_prior_upper_level_factor is not None
-            else None
-        ),
-        site_indicators=nmeasure_array("site_indicator", inv_inputs["site_indicator"]),
-        flux=flux,
-        basis=basis,
+        inv_inputs=prepared.inv_inputs,
+        basis_functions=prepared.basis_functions,
         trace=idata,
-        site_names=site_names,
-        times=nmeasure_array("times", inv_inputs["time"]),
-        start_date=start_date,
-        end_date=end_date,
-        species=species,
-        domain=domain,
+        run_metadata={
+            "start_date": run_spec.start_date,
+            "end_date": run_spec.end_date,
+            "sites": list(run_spec.sites),
+            "averaging_period": list(run_spec.averaging_period),
+            "split_by_sectors": run_spec.split_by_sectors,
+            "basis_artifact_source": prepared.basis_artifact_source,
+        },
+        model_metadata=asdict(model_spec),
+        output_metadata={
+            "output_format": output_spec.output_format,
+            "output_path": output_spec.output_path,
+            "output_name": output_spec.output_name,
+            "save_trace": output_spec.save_trace,
+            "save_inversion_output": output_spec.save_inversion_output,
+        },
+        provenance={
+            "contract": "modern_rhime_inversion_output",
+            "compatibility_issue": "401",
+        },
     )
 
 
@@ -178,12 +146,12 @@ def make_standard_output_bundle(
     inv_out = _make_inversion_output(
         prepared=prepared,
         idata=idata,
-        start_date=run_spec.start_date,
-        end_date=run_spec.end_date,
-        species=model_spec.species,
-        domain=model_spec.domain,
+        run_spec=run_spec,
+        model_spec=model_spec,
+        output_spec=output_spec,
     )
     outputs["inversion_output"] = inv_out
+    output_metadata["inversion_output_contract"] = "modern"
 
     trace_path = _resolve_output_path(
         output_spec.save_trace,
@@ -208,14 +176,18 @@ def make_standard_output_bundle(
     if output_spec.output_format == "basic":
         from openghg_inversions.postprocessing.make_outputs import basic_output
 
-        outputs["basic"] = basic_output(inv_out, country_file=country_file)
+        legacy_inv_out = LegacyInversionOutput.from_modern_output(inv_out)
+        output_metadata["postprocessing_input_contract"] = "legacy_adapter"
+        outputs["basic"] = basic_output(legacy_inv_out, country_file=country_file)
     elif output_spec.output_format == "paris":
         from openghg_inversions.postprocessing.make_paris_outputs import make_paris_outputs
 
+        legacy_inv_out = LegacyInversionOutput.from_modern_output(inv_out)
+        output_metadata["postprocessing_input_contract"] = "legacy_adapter"
         obs_avg_period = prepared.averaging_period[0] or "0h"
         kwargs = output_spec.paris_postprocessing_kwargs or {}
         flux_outs, conc_outs = make_paris_outputs(
-            inv_out,
+            legacy_inv_out,
             country_file=country_file,
             domain=model_spec.domain,
             obs_avg_period=obs_avg_period,

--- a/openghg_inversions/rhime/outputs.py
+++ b/openghg_inversions/rhime/outputs.py
@@ -274,6 +274,7 @@ def make_multisector_output_bundle(
     prepared: RhimePreparedInputs,
 ) -> RhimeOutputBundle:
     """Create and optionally save transitional multi-sector RHIME outputs."""
+    inv_out = None
     diagnostics = _make_multisector_flux_diagnostics(
         idata=idata,
         prepared=prepared,
@@ -281,6 +282,26 @@ def make_multisector_output_bundle(
     )
     outputs: dict[str, Any] = {"sector_flux_diagnostics": diagnostics}
     output_metadata: dict[str, Any] = {}
+    if output_spec.output_format != "none":
+        inv_out = _make_inversion_output(
+            prepared=prepared,
+            idata=idata,
+            run_spec=run_spec,
+            model_spec=model_spec,
+            output_spec=output_spec,
+        )
+        outputs["inversion_output"] = inv_out
+        output_metadata["inversion_output_contract"] = "modern"
+
+        inv_out_path = _resolve_output_path(
+            output_spec.save_inversion_output,
+            output_spec.output_path,
+            f"{output_spec.output_name}{run_spec.start_date}_inversion_output.nc",
+        )
+        if inv_out_path is not None:
+            inv_out_path.parent.mkdir(parents=True, exist_ok=True)
+            inv_out.save(inv_out_path)
+            output_metadata["inversion_output_path"] = str(inv_out_path)
 
     if output_spec.output_format == "paris":
         output_metadata["paris_note"] = (
@@ -296,4 +317,4 @@ def make_multisector_output_bundle(
         diagnostics.to_netcdf(diagnostics_path, mode="w", encoding=ncdf_encoding(diagnostics))
         output_metadata["sector_flux_diagnostics_path"] = str(diagnostics_path)
 
-    return RhimeOutputBundle(outputs=outputs, output_metadata=output_metadata)
+    return RhimeOutputBundle(inv_out=inv_out, outputs=outputs, output_metadata=output_metadata)

--- a/openghg_inversions/rhime/specs.py
+++ b/openghg_inversions/rhime/specs.py
@@ -94,8 +94,8 @@ def validate_output_path_settings(
         return
     if save_trace is True:
         raise ValueError("`output_path` is required when `save_trace=True`.")
-    if not multisector and save_inversion_output is True:
-        raise ValueError("`output_path` is required when saving the standard RHIME InversionOutput.")
+    if save_inversion_output is True:
+        raise ValueError("`output_path` is required when saving the RHIME InversionOutput.")
 
 
 def make_output_spec(

--- a/tests/postprocessing/test_diagnostics.py
+++ b/tests/postprocessing/test_diagnostics.py
@@ -1,12 +1,12 @@
 import pytest
 
 from openghg_inversions.postprocessing.diagnostics import summary
-from openghg_inversions.postprocessing.inversion_output import InversionOutput
+from openghg_inversions.postprocessing.inversion_output import LegacyInversionOutput
 
 
 @pytest.fixture
 def inv_out(raw_data_path):
-    return InversionOutput.load(raw_data_path / "inversion_output.nc")
+    return LegacyInversionOutput.load(raw_data_path / "inversion_output.nc")
 
 
 def test_summary(inv_out):

--- a/tests/postprocessing/test_legacy_outputs.py
+++ b/tests/postprocessing/test_legacy_outputs.py
@@ -3,7 +3,7 @@ import pandas as pd
 import xarray as xr
 
 from openghg_inversions import utils
-from openghg_inversions.postprocessing.inversion_output import InversionOutput
+from openghg_inversions.postprocessing.inversion_output import LegacyInversionOutput
 from openghg_inversions.postprocessing.legacy_outputs import (
     _compute_apriori_flux,
     make_legacy_hbmcmc_output,
@@ -13,7 +13,7 @@ from openghg_inversions.postprocessing.legacy_outputs import (
 def test_make_legacy_hbmcmc_output_handles_mixed_nmeasure_indexes(raw_data_path, europe_country_file):
     """Legacy output generation tolerates flattened nmeasure-only indexes."""
     legacy = xr.open_dataset(raw_data_path / "standard_rhime_outs.nc")
-    inv_out = InversionOutput.load(raw_data_path / "inversion_output.nc")
+    inv_out = LegacyInversionOutput.load(raw_data_path / "inversion_output.nc")
     inv_out.times = xr.DataArray(
         inv_out.times.values,
         dims=["nmeasure"],
@@ -107,7 +107,7 @@ def test_compute_apriori_flux_handles_multi_year_flux_time():
 def test_make_legacy_hbmcmc_output_only_sets_convergence_when_present(raw_data_path, europe_country_file):
     """Legacy outputs omit convergence metadata when it is not supplied."""
     with xr.open_dataset(raw_data_path / "standard_rhime_outs.nc") as legacy:
-        inv_out = InversionOutput.load(raw_data_path / "inversion_output.nc")
+        inv_out = LegacyInversionOutput.load(raw_data_path / "inversion_output.nc")
 
         compat = make_legacy_hbmcmc_output(
             inv_out=inv_out,

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -1,6 +1,7 @@
 import inspect
 from pathlib import Path
 
+import arviz as az
 import numpy as np
 import pandas as pd
 import pytest
@@ -10,7 +11,7 @@ import openghg_inversions.hbmcmc.hbmcmc as hbmcmc_module
 from openghg_inversions.basis.basis_functions import BasisFunctions
 from openghg_inversions.hbmcmc.hbmcmc import _resolve_output_format, fixedbasisMCMC
 from openghg_inversions.hbmcmc.hbmcmc_output import define_output_filename
-from openghg_inversions.postprocessing.inversion_output import InversionOutput
+from openghg_inversions.postprocessing.inversion_output import LegacyInversionOutput
 from openghg_inversions.postprocessing.legacy_outputs import make_legacy_hbmcmc_output
 from openghg_inversions.postprocessing.make_outputs import basic_output, make_country_outputs
 
@@ -60,7 +61,15 @@ def _minimal_fixedbasis_fp_data() -> dict:
                 coords={"lat": lat, "lon": lon},
             )
         },
-        "TAC": xr.Dataset(coords={"time": np.array(["2019-01-01T00:00:00"], dtype="datetime64[ns]")}),
+        "TAC": xr.Dataset(
+            {
+                "mf": ("time", np.array([1900.0], dtype="float64"), {"units": "1e-09 mol/mol"}),
+                "mf_error": ("time", np.array([2.0], dtype="float64"), {"units": "1e-09 mol/mol"}),
+                "mf_repeatability": ("time", np.array([1.0], dtype="float64"), {"units": "1e-09 mol/mol"}),
+                "mf_variability": ("time", np.array([1.5], dtype="float64"), {"units": "1e-09 mol/mol"}),
+            },
+            coords={"time": np.array(["2019-01-01T00:00:00"], dtype="datetime64[ns]")},
+        ),
     }
 
 
@@ -103,12 +112,12 @@ def mcmc_args(tmp_path, tac_ch4_data_args, merged_data_dir, merged_data_file_nam
 
 @pytest.fixture(scope="module")
 def inv_out(raw_data_path):
-    return InversionOutput.load(raw_data_path / "inversion_output.nc")
+    return LegacyInversionOutput.load(raw_data_path / "inversion_output.nc")
 
 
 @pytest.fixture(scope="module")
 def inv_out_eastasia(raw_data_path):
-    return InversionOutput.load(raw_data_path / "inversion_output_EASTASIA.nc")
+    return LegacyInversionOutput.load(raw_data_path / "inversion_output_EASTASIA.nc")
 
 
 def test_fixedbasisMCMC_return_basis_objects_preserves_positional_output_format():
@@ -247,6 +256,51 @@ def test_fixedbasisMCMC_hbmcmc_output_uses_legacy_postprocess_path(monkeypatch, 
     assert captured_inferpymc_args["inv_inputs"] is prepared.inv_inputs
     assert result["xtrace_mean"].dims == ("nx",)
     assert result["xtrace_mean"].values.tolist() == [1.05]
+
+
+def test_fixedbasisMCMC_inv_out_returns_legacy_without_inferpymc_postprocess(monkeypatch, tmp_path):
+    """The fixedbasis inv_out path builds LegacyInversionOutput without legacy output postprocessing."""
+    prepared = _minimal_fixedbasis_prepared_data()
+
+    def fake_prepare_fixedbasis_inversion_data(**kwargs):
+        return prepared
+
+    def fake_inferpymc(**kwargs):
+        return {
+            "trace": az.from_dict(
+                posterior={"x": np.ones((1, 1, 1))},
+                coords={"nx": [0]},
+                dims={"x": ["nx"]},
+            ),
+            "model": object(),
+            "xouts": np.array([[1.0]], dtype="float64"),
+        }
+
+    def fail_inferpymc_postprocessouts(**kwargs):
+        raise AssertionError("output_format='inv_out' must not call inferpymc_postprocessouts")
+
+    monkeypatch.setattr(
+        hbmcmc_module,
+        "prepare_fixedbasis_inversion_data",
+        fake_prepare_fixedbasis_inversion_data,
+    )
+    monkeypatch.setattr(hbmcmc_module.mcmc, "inferpymc", fake_inferpymc)
+    monkeypatch.setattr(hbmcmc_module.mcmc, "inferpymc_postprocessouts", fail_inferpymc_postprocessouts)
+
+    result = fixedbasisMCMC(
+        species="ch4",
+        sites=["TAC"],
+        domain="EUROPE",
+        averaging_period=["1H"],
+        start_date="2019-01-01",
+        end_date="2019-02-01",
+        outputpath=str(tmp_path),
+        outputname="inv-out",
+        output_format="inv_out",
+        use_bc=False,
+    )
+
+    assert isinstance(result, LegacyInversionOutput)
 
 
 @pytest.mark.parametrize("missing_key", [".basis", ".flux"])
@@ -484,7 +538,8 @@ def test_save_inversion_output(mcmc_args, tmpdir):
     mcmc_args["output_format"] = "inv_out"
     inv_out = fixedbasisMCMC(**mcmc_args)
 
-    inv_out_reloaded = InversionOutput.load(tmpdir / "inv_out.nc")
+    assert isinstance(inv_out, LegacyInversionOutput)
+    inv_out_reloaded = LegacyInversionOutput.load(tmpdir / "inv_out.nc")
 
     assert inv_out == inv_out_reloaded
 
@@ -608,7 +663,7 @@ def test_inv_out_and_trace_outputs_preserve_downstream_dims_and_custom_paths(mcm
 def test_hbmcmc_postprocessing_output_matches_legacy_core_fields(raw_data_path, europe_country_file):
     """Regression test for deterministic prior concentration terms in legacy-compatible output."""
     with xr.open_dataset(raw_data_path / "standard_rhime_outs.nc") as legacy:
-        inv_out = InversionOutput.load(raw_data_path / "inversion_output.nc")
+        inv_out = LegacyInversionOutput.load(raw_data_path / "inversion_output.nc")
         compat = make_legacy_hbmcmc_output(
             inv_out=inv_out,
             mcmc_results={

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -12,6 +12,7 @@ import xarray as xr
 
 import openghg_inversions.models as models
 import openghg_inversions.models.rhime as rhime_models_module
+import openghg_inversions.hbmcmc.inversion_pymc as legacy_mcmc
 import openghg_inversions.rhime as rhime_public
 import openghg_inversions.rhime.params as rhime_params
 import openghg_inversions.rhime.outputs as rhime_outputs
@@ -30,7 +31,7 @@ from openghg_inversions.models import (
     build_rhime_multisector_model_from_spec,
     safe_pymc_name,
 )
-from openghg_inversions.postprocessing.inversion_output import InversionOutput
+from openghg_inversions.postprocessing.inversion_output import InversionOutput, LegacyInversionOutput
 from openghg_inversions.rhime import (
     RhimeModelSpec,
     RhimeOutputSpec,
@@ -152,6 +153,47 @@ def _minimal_output_inv_inputs() -> xr.Dataset:
     )
     inv_inputs["mf"].attrs["units"] = "ppm"
     return inv_inputs
+
+
+def _minimal_output_specs(output_format: rhime_specs.OutputFormat = "inv_out") -> tuple[
+    RhimeModelSpec, RhimeOutputSpec, RhimeRunSpec
+]:
+    """Build minimal RHIME specs for output helper tests."""
+    model_spec = RhimeModelSpec(
+        species="ch4",
+        domain="EUROPE",
+        sectors=(
+            SectorSpec(
+                name="FF",
+                flux_source="ff-inventory",
+                x_prior={"pdf": "normal", "mu": 1.0, "sigma": 0.2},
+                variable_suffix="ff",
+            ),
+        ),
+    )
+    output_spec = RhimeOutputSpec(
+        output_format=output_format,
+        output_name="test",
+        save_inversion_output=False,
+    )
+    run_spec = RhimeRunSpec(
+        "2019-01-01",
+        "2019-01-02",
+        ("TAC",),
+        ("1h",),
+        model_spec,
+        output_spec,
+    )
+    return model_spec, output_spec, run_spec
+
+
+def _minimal_output_idata() -> az.InferenceData:
+    """Build a minimal posterior trace with one region."""
+    return az.from_dict(
+        posterior={"x": np.ones((1, 1, 1))},
+        coords={"region": [0]},
+        dims={"x": ["region"]},
+    )
 
 
 class _SpyBasisFunctions:
@@ -1605,31 +1647,7 @@ def test_make_output_spec_validates_trace_save_path() -> None:
 
 
 def test_make_standard_output_bundle_returns_outputs_without_mutating_result() -> None:
-    model_spec = RhimeModelSpec(
-        species="ch4",
-        domain="EUROPE",
-        sectors=(
-            SectorSpec(
-                name="FF",
-                flux_source="ff-inventory",
-                x_prior={"pdf": "normal", "mu": 1.0, "sigma": 0.2},
-                variable_suffix="ff",
-            ),
-        ),
-    )
-    output_spec = RhimeOutputSpec(
-        output_format="inv_out",
-        output_name="test",
-        save_inversion_output=False,
-    )
-    run_spec = RhimeRunSpec(
-        "2019-01-01",
-        "2019-01-02",
-        ("TAC",),
-        ("1h",),
-        model_spec,
-        output_spec,
-    )
+    model_spec, output_spec, run_spec = _minimal_output_specs()
     prepared = RhimePreparedInputs(
         inv_inputs=_minimal_output_inv_inputs(),
         basis_functions=_fake_basis_functions(),
@@ -1642,14 +1660,145 @@ def test_make_standard_output_bundle_returns_outputs_without_mutating_result() -
         output_spec=output_spec,
         run_spec=run_spec,
         model_spec=model_spec,
-        idata=az.from_dict(posterior={"x": np.ones((1, 1))}),
+        idata=_minimal_output_idata(),
         prepared=prepared,
         country_file=None,
     )
 
     assert isinstance(bundle.inv_out, InversionOutput)
     assert bundle.outputs == {"inversion_output": bundle.inv_out}
-    assert bundle.output_metadata == {}
+    assert bundle.output_metadata == {"inversion_output_contract": "modern"}
+
+
+def test_modern_inversion_output_save_load_roundtrip(tmp_path: Path) -> None:
+    """Modern RHIME InversionOutput preserves retained inputs, basis, and metadata."""
+    model_spec, output_spec, run_spec = _minimal_output_specs()
+    prepared = RhimePreparedInputs(
+        inv_inputs=_minimal_output_inv_inputs(),
+        basis_functions=_fake_basis_functions(artifact_source="unit-test"),
+        sites=("TAC",),
+        averaging_period=("1h",),
+        basis_artifact_source="unit-test",
+    )
+    bundle = rhime_outputs.make_standard_output_bundle(
+        output_spec=output_spec,
+        run_spec=run_spec,
+        model_spec=model_spec,
+        idata=_minimal_output_idata(),
+        prepared=prepared,
+        country_file=None,
+    )
+    assert bundle.inv_out is not None
+
+    output_file = tmp_path / "modern_inv_out.nc"
+    bundle.inv_out.save(output_file)
+    reloaded = InversionOutput.load(output_file)
+
+    assert reloaded.species == "ch4"
+    assert reloaded.domain == "EUROPE"
+    assert reloaded.start_date == "2019-01-01"
+    assert reloaded.run_metadata["basis_artifact_source"] == "unit-test"
+    assert reloaded.output_metadata["output_format"] == "inv_out"
+    xr.testing.assert_identical(reloaded.inv_inputs, prepared.inv_inputs)
+    xr.testing.assert_identical(reloaded.basis_functions.flux, prepared.basis_functions.flux)
+    xr.testing.assert_equal(
+        reloaded.basis_functions.operator.basis_matrix,
+        prepared.basis_functions.operator.basis_matrix,
+    )
+
+
+def test_standard_basic_output_uses_legacy_adapter_without_inferpymc(monkeypatch) -> None:
+    """RHIME basic postprocessing adapts modern output without using inferpymc legacy postprocess."""
+    model_spec, output_spec, run_spec = _minimal_output_specs(output_format="basic")
+    prepared = RhimePreparedInputs(
+        inv_inputs=_minimal_output_inv_inputs(),
+        basis_functions=_fake_basis_functions(),
+        sites=("TAC",),
+        averaging_period=("1h",),
+        basis_artifact_source="generated",
+    )
+    captured: dict[str, Any] = {}
+
+    def fail_inferpymc_postprocessouts(**kwargs: Any) -> None:
+        raise AssertionError("run_rhime output helpers must not call inferpymc_postprocessouts")
+
+    def fake_basic_output(inv_out: LegacyInversionOutput, country_file: str | None = None) -> xr.Dataset:
+        captured["inv_out"] = inv_out
+        captured["country_file"] = country_file
+        return xr.Dataset({"ok": ((), 1)})
+
+    monkeypatch.setattr(legacy_mcmc, "inferpymc_postprocessouts", fail_inferpymc_postprocessouts)
+    monkeypatch.setattr("openghg_inversions.postprocessing.make_outputs.basic_output", fake_basic_output)
+
+    bundle = rhime_outputs.make_standard_output_bundle(
+        output_spec=output_spec,
+        run_spec=run_spec,
+        model_spec=model_spec,
+        idata=_minimal_output_idata(),
+        prepared=prepared,
+        country_file="countries.json",
+    )
+
+    assert isinstance(bundle.inv_out, InversionOutput)
+    assert isinstance(captured["inv_out"], LegacyInversionOutput)
+    assert captured["country_file"] == "countries.json"
+    assert bundle.output_metadata["inversion_output_contract"] == "modern"
+    assert bundle.output_metadata["postprocessing_input_contract"] == "legacy_adapter"
+    assert "basic" in bundle.outputs
+
+
+def test_standard_paris_output_uses_legacy_adapter_without_inferpymc(monkeypatch) -> None:
+    """RHIME PARIS postprocessing adapts modern output without using inferpymc legacy postprocess."""
+    model_spec, output_spec, run_spec = _minimal_output_specs(output_format="paris")
+    prepared = RhimePreparedInputs(
+        inv_inputs=_minimal_output_inv_inputs(),
+        basis_functions=_fake_basis_functions(),
+        sites=("TAC",),
+        averaging_period=("1h",),
+        basis_artifact_source="generated",
+    )
+    captured: dict[str, Any] = {}
+
+    def fail_inferpymc_postprocessouts(**kwargs: Any) -> None:
+        raise AssertionError("run_rhime output helpers must not call inferpymc_postprocessouts")
+
+    def fake_make_paris_outputs(
+        inv_out: LegacyInversionOutput,
+        country_file: str | None = None,
+        domain: str | None = None,
+        obs_avg_period: str = "4h",
+        **kwargs: Any,
+    ) -> tuple[xr.Dataset, xr.Dataset]:
+        captured["inv_out"] = inv_out
+        captured["country_file"] = country_file
+        captured["domain"] = domain
+        captured["obs_avg_period"] = obs_avg_period
+        return xr.Dataset({"flux": ((), 1)}), xr.Dataset({"conc": ((), 1)})
+
+    monkeypatch.setattr(legacy_mcmc, "inferpymc_postprocessouts", fail_inferpymc_postprocessouts)
+    monkeypatch.setattr(
+        "openghg_inversions.postprocessing.make_paris_outputs.make_paris_outputs",
+        fake_make_paris_outputs,
+    )
+
+    bundle = rhime_outputs.make_standard_output_bundle(
+        output_spec=output_spec,
+        run_spec=run_spec,
+        model_spec=model_spec,
+        idata=_minimal_output_idata(),
+        prepared=prepared,
+        country_file="countries.json",
+    )
+
+    assert isinstance(bundle.inv_out, InversionOutput)
+    assert isinstance(captured["inv_out"], LegacyInversionOutput)
+    assert captured["country_file"] == "countries.json"
+    assert captured["domain"] == "EUROPE"
+    assert captured["obs_avg_period"] == "1h"
+    assert bundle.output_metadata["inversion_output_contract"] == "modern"
+    assert bundle.output_metadata["postprocessing_input_contract"] == "legacy_adapter"
+    assert "paris_flux" in bundle.outputs
+    assert "paris_concentration" in bundle.outputs
 
 
 def test_save_inferencedata_prefers_h5netcdf(tmp_path: Path) -> None:
@@ -1771,6 +1920,8 @@ def test_run_rhime_api_smoke(tac_ch4_data_args, tmp_path: Path) -> None:
     assert "mu" in posterior
     assert result.run_spec.split_by_sectors is False
     assert "inversion_output" in result.outputs
+    assert isinstance(result.inv_out, InversionOutput)
+    assert result.output_metadata["inversion_output_contract"] == "modern"
     inv_input_long_names = [
         result.inv_inputs.mf.attrs.get("long_name", ""),
         result.inv_inputs.mf_error.attrs.get("long_name", ""),
@@ -1782,11 +1933,14 @@ def test_run_rhime_api_smoke(tac_ch4_data_args, tmp_path: Path) -> None:
     assert output_file.exists()
     reloaded = InversionOutput.load(output_file)
     assert reloaded.species == "ch4"
+    assert reloaded.domain == args["domain"]
+    assert isinstance(reloaded.basis_functions, BasisFunctions)
+    xr.testing.assert_identical(reloaded.inv_inputs, result.inv_inputs)
     obs_long_names = [
-        reloaded.obs.attrs.get("long_name", ""),
-        reloaded.obs_err.attrs.get("long_name", ""),
-        reloaded.obs_repeatability.attrs.get("long_name", ""),
-        reloaded.obs_variability.attrs.get("long_name", ""),
+        reloaded.inv_inputs.mf.attrs.get("long_name", ""),
+        reloaded.inv_inputs.mf_error.attrs.get("long_name", ""),
+        reloaded.inv_inputs.mf_repeatability.attrs.get("long_name", ""),
+        reloaded.inv_inputs.mf_variability.attrs.get("long_name", ""),
     ]
     assert all("number_of_observations" not in long_name for long_name in obs_long_names)
 

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -1670,6 +1670,64 @@ def test_make_standard_output_bundle_returns_outputs_without_mutating_result() -
     assert bundle.output_metadata == {"inversion_output_contract": "modern"}
 
 
+def test_make_multisector_output_bundle_returns_modern_inv_out() -> None:
+    """Multi-sector RHIME outputs retain the same modern inversion-output contract."""
+    sectors = (
+        SectorSpec(
+            name="FF",
+            flux_source="ff-inventory",
+            x_prior={"pdf": "normal", "mu": 1.0, "sigma": 0.2},
+            variable_suffix="ff",
+        ),
+        SectorSpec(
+            name="Ocean",
+            flux_source="ocean-inventory",
+            x_prior={"pdf": "normal", "mu": 1.0, "sigma": 0.2},
+            variable_suffix="ocean",
+        ),
+    )
+    model_spec = RhimeModelSpec(species="ch4", domain="EUROPE", sectors=sectors)
+    output_spec = RhimeOutputSpec(output_format="inv_out", output_name="test", save_inversion_output=False)
+    run_spec = RhimeRunSpec(
+        "2019-01-01",
+        "2019-01-02",
+        ("TAC",),
+        ("1h",),
+        model_spec,
+        output_spec,
+        split_by_sectors=True,
+    )
+    prepared = RhimePreparedInputs(
+        inv_inputs=_minimal_output_inv_inputs(),
+        basis_functions=_fake_basis_functions(),
+        sites=("TAC",),
+        averaging_period=("1h",),
+        basis_artifact_source="generated",
+    )
+    idata = az.from_dict(
+        posterior={
+            "x_ff": np.ones((1, 1, 1)),
+            "x_ocean": np.ones((1, 1, 1)),
+        },
+        coords={"region": [0]},
+        dims={"x_ff": ["region"], "x_ocean": ["region"]},
+    )
+
+    bundle = rhime_outputs.make_multisector_output_bundle(
+        output_spec=output_spec,
+        run_spec=run_spec,
+        model_spec=model_spec,
+        idata=idata,
+        prepared=prepared,
+    )
+
+    assert isinstance(bundle.inv_out, InversionOutput)
+    assert bundle.inv_out.run_metadata["split_by_sectors"] is True
+    assert bundle.output_metadata["inversion_output_contract"] == "modern"
+    assert "sector_flux_diagnostics" in bundle.outputs
+    assert bundle.outputs["inversion_output"] is bundle.inv_out
+
+
 def test_modern_inversion_output_save_load_roundtrip(tmp_path: Path) -> None:
     """Modern RHIME InversionOutput preserves retained inputs, basis, and metadata."""
     model_spec, output_spec, run_spec = _minimal_output_specs()

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -6,6 +6,7 @@ from typing import Any, cast
 
 import numpy as np
 import arviz as az
+import pandas as pd
 import pymc as pm
 import pytest
 import xarray as xr
@@ -13,6 +14,7 @@ import xarray as xr
 import openghg_inversions.models as models
 import openghg_inversions.models.rhime as rhime_models_module
 import openghg_inversions.hbmcmc.inversion_pymc as legacy_mcmc
+import openghg_inversions.postprocessing.inversion_output as inversion_output_module
 import openghg_inversions.rhime as rhime_public
 import openghg_inversions.rhime.params as rhime_params
 import openghg_inversions.rhime.outputs as rhime_outputs
@@ -1763,6 +1765,83 @@ def test_modern_inversion_output_save_load_roundtrip(tmp_path: Path) -> None:
         reloaded.basis_functions.operator.basis_matrix,
         prepared.basis_functions.operator.basis_matrix,
     )
+
+
+def test_modern_inversion_output_restores_bytes_multiindex_metadata() -> None:
+    """Modern output loading accepts bytes-encoded MultiIndex metadata."""
+    model_spec, output_spec, run_spec = _minimal_output_specs()
+    inv_inputs = _minimal_output_inv_inputs().assign_coords(site=("nmeasure", ["TAC"]))
+    inv_inputs = inv_inputs.set_index(nmeasure=["site", "time"])
+    prepared = RhimePreparedInputs(
+        inv_inputs=inv_inputs,
+        basis_functions=_fake_basis_functions(artifact_source="unit-test"),
+        sites=("TAC",),
+        averaging_period=("1h",),
+        basis_artifact_source="unit-test",
+    )
+    bundle = rhime_outputs.make_standard_output_bundle(
+        output_spec=output_spec,
+        run_spec=run_spec,
+        model_spec=model_spec,
+        idata=_minimal_output_idata(),
+        prepared=prepared,
+        country_file=None,
+    )
+    assert bundle.inv_out is not None
+
+    dt = bundle.inv_out.to_datatree()
+    inv_inputs_dt = dt["inv_inputs"]
+    inv_inputs_dt.attrs[inversion_output_module.MULTIINDEX_DIMS_ATTR] = inv_inputs_dt.attrs[
+        inversion_output_module.MULTIINDEX_DIMS_ATTR
+    ].encode()
+
+    reloaded = InversionOutput.from_datatree(dt)
+
+    assert isinstance(reloaded.inv_inputs.indexes["nmeasure"], pd.MultiIndex)
+    assert reloaded.inv_inputs.indexes["nmeasure"].names == ["site", "time"]
+    xr.testing.assert_identical(reloaded.inv_inputs, inv_inputs)
+
+
+@pytest.mark.parametrize(
+    "raw_multiindex_dims",
+    [
+        b"not-json",
+        '{"dims": "not-a-list"}',
+        '{"dims": [{"dim": "nmeasure", "levels": "site"}]}',
+        '{"dims": [{"dim": "nmeasure", "levels": ["missing"]}]}',
+    ],
+)
+def test_modern_inversion_output_ignores_malformed_multiindex_metadata(raw_multiindex_dims: object) -> None:
+    """Malformed MultiIndex metadata should not break modern output loading."""
+    model_spec, output_spec, run_spec = _minimal_output_specs()
+    inv_inputs = _minimal_output_inv_inputs().assign_coords(site=("nmeasure", ["TAC"]))
+    inv_inputs = inv_inputs.set_index(nmeasure=["site", "time"])
+    prepared = RhimePreparedInputs(
+        inv_inputs=inv_inputs,
+        basis_functions=_fake_basis_functions(artifact_source="unit-test"),
+        sites=("TAC",),
+        averaging_period=("1h",),
+        basis_artifact_source="unit-test",
+    )
+    bundle = rhime_outputs.make_standard_output_bundle(
+        output_spec=output_spec,
+        run_spec=run_spec,
+        model_spec=model_spec,
+        idata=_minimal_output_idata(),
+        prepared=prepared,
+        country_file=None,
+    )
+    assert bundle.inv_out is not None
+
+    dt = bundle.inv_out.to_datatree()
+    dt["inv_inputs"].attrs[inversion_output_module.MULTIINDEX_DIMS_ATTR] = raw_multiindex_dims
+
+    reloaded = InversionOutput.from_datatree(dt)
+
+    assert inversion_output_module.MULTIINDEX_DIMS_ATTR not in reloaded.inv_inputs.attrs
+    assert "site" in reloaded.inv_inputs
+    assert "time" in reloaded.inv_inputs
+    assert not isinstance(reloaded.inv_inputs.indexes.get("nmeasure"), pd.MultiIndex)
 
 
 def test_standard_basic_output_uses_legacy_adapter_without_inferpymc(monkeypatch) -> None:


### PR DESCRIPTION
* **Summary of changes**

Split the modern RHIME output contract from the legacy-shaped postprocessing carrier:

- Reserve `InversionOutput` for modern RHIME artifacts: `InferenceData`, canonical `inv_inputs`, retained `BasisFunctions`, metadata, and provenance.
- Rename the current postprocessing carrier to `LegacyInversionOutput`, keeping its current save/load schema and helper methods for existing postprocessing consumers.
- Keep `inferpymc_postprocessouts` on the fixedbasis `output_format="hbmcmc"` path only.
- Route `run_rhime` and `run_rhime_multisector` `inv_out` outputs through the modern `InversionOutput`; adapt standard RHIME `basic`/`paris` to `LegacyInversionOutput` temporarily.
- Add follow-up issue #435 for migrating postprocessing consumers to modern `InversionOutput`.

Closes #401.

Deferred follow-up: #435.

* **Please check if the PR fulfills these requirements**

- [x] Closes #401
- [x] Tests added and passing
- [x] Documentation and tutorials updated/added
- [x] Added an entry to the `CHANGELOG.md` file
- [x] Added any new requirements to `requirements.txt` (not needed)

Tests/checks run:

- `uv run pytest tests/test_rhime.py tests/test_postprocessing.py tests/postprocessing/test_legacy_outputs.py tests/postprocessing/test_diagnostics.py` (107 passed)
- `uv run ruff check openghg_inversions/postprocessing/inversion_output.py openghg_inversions/rhime/outputs.py openghg_inversions/rhime/specs.py openghg_inversions/hbmcmc/hbmcmc.py openghg_inversions/postprocessing/countries.py openghg_inversions/postprocessing/diagnostics.py openghg_inversions/postprocessing/legacy_outputs.py openghg_inversions/postprocessing/make_outputs.py openghg_inversions/postprocessing/make_paris_outputs.py tests/test_rhime.py tests/test_postprocessing.py tests/postprocessing/test_legacy_outputs.py tests/postprocessing/test_diagnostics.py`
- `uv run pyright openghg_inversions/postprocessing/inversion_output.py openghg_inversions/rhime/outputs.py openghg_inversions/rhime/specs.py openghg_inversions/hbmcmc/hbmcmc.py`
- `uv run sphinx-build -b html docs docs/_build/html` (build succeeded with existing autodoc/static-path warnings)