### PR TITLE
Migrate RHIME postprocessing to modern output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## Code changes
 
 
-- Routed standard RHIME `basic` and `paris` postprocessing through modern `InversionOutput` using a narrow postprocessing view, while keeping `LegacyInversionOutput` as the fixedbasis/legacy compatibility carrier. [#435](https://github.com/openghg/openghg_inversions/issues/435)
+- Routed standard RHIME `basic` and `paris` postprocessing through modern `InversionOutput` using a standard single-sector postprocessing view with dataset-based observation inputs and model-managed trace coordinates, while keeping `LegacyInversionOutput` as the fixedbasis/legacy compatibility carrier. [#435](https://github.com/openghg/openghg_inversions/issues/435)
 - Split modern RHIME `InversionOutput` from the legacy-shaped postprocessing carrier, keeping `inferpymc_postprocessouts` on the fixedbasis `output_format="hbmcmc"` path only and using a temporary `LegacyInversionOutput` adapter for RHIME `basic`/`paris` postprocessing. [#401](https://github.com/openghg/openghg_inversions/issues/401)
 - Moved public RHIME model-builder exports into `openghg_inversions.models` and shared data preparation between `fixedbasisMCMC`, `run_rhime`, and `run_rhime_multisector`. [#399](https://github.com/openghg/openghg_inversions/issues/399), [#425](https://github.com/openghg/openghg_inversions/issues/425)
 - Retained `BasisFunctions` objects through shared inversion preparation, RHIME results, and opt-in `fixedbasisMCMC` debug output; DataTree basis artifacts are loaded when available while legacy flat basis artifacts remain supported. [#428](https://github.com/openghg/openghg_inversions/issues/428)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Code changes
 
 
+- Routed standard RHIME `basic` and `paris` postprocessing through modern `InversionOutput` using a narrow postprocessing view, while keeping `LegacyInversionOutput` as the fixedbasis/legacy compatibility carrier. [#435](https://github.com/openghg/openghg_inversions/issues/435)
 - Split modern RHIME `InversionOutput` from the legacy-shaped postprocessing carrier, keeping `inferpymc_postprocessouts` on the fixedbasis `output_format="hbmcmc"` path only and using a temporary `LegacyInversionOutput` adapter for RHIME `basic`/`paris` postprocessing. [#401](https://github.com/openghg/openghg_inversions/issues/401)
 - Moved public RHIME model-builder exports into `openghg_inversions.models` and shared data preparation between `fixedbasisMCMC`, `run_rhime`, and `run_rhime_multisector`. [#399](https://github.com/openghg/openghg_inversions/issues/399), [#425](https://github.com/openghg/openghg_inversions/issues/425)
 - Retained `BasisFunctions` objects through shared inversion preparation, RHIME results, and opt-in `fixedbasisMCMC` debug output; DataTree basis artifacts are loaded when available while legacy flat basis artifacts remain supported. [#428](https://github.com/openghg/openghg_inversions/issues/428)

--- a/docs/plans/clean_up_inversions_refactor.md
+++ b/docs/plans/clean_up_inversions_refactor.md
@@ -168,9 +168,9 @@ model components that consume them.
   `InferenceData`, `inv_inputs`, `BasisFunctions`, metadata, and provenance.
   Do not add fixedbasis `fp_data` or materialised `.basis` side channels to the
   modern object.
-- The current adapter still materialises basis/flux arrays for `basic` and
-  `paris`. Remove that once #435 and #429 let postprocessing consume
-  `BasisFunctions` directly.
+- The #401 adapter still materialised basis/flux arrays for `basic` and
+  `paris`. #435 removes the RHIME use of that adapter; #383/#429 should remove
+  the remaining flat-basis assumptions from postprocessing itself.
 
 ## Review findings for PR #436 / Issue #401
 
@@ -189,7 +189,7 @@ model components that consume them.
   malformed. PR #436 now decodes bytes and skips malformed records safely
   before applying `set_index`.
 
-## Deferred Issue #435 postprocessing consumer migration
+## Issue #435 postprocessing consumer migration target
 
 #435 should move `make_outputs`, `make_paris_outputs`, `countries`,
 `diagnostics`, and `legacy_outputs` off `LegacyInversionOutput` where possible.
@@ -200,13 +200,47 @@ This work links #401, #383, #429, #416, and #381. It should remove the RHIME
 `basic`/`paris` dependency on `LegacyInversionOutput.from_modern_output(...)`
 rather than expanding that adapter.
 
-## Recommended next PR after #436
+## Completed in Current PR / Issue #435
 
-Start with #435 before #383 if only one can be active. #435 should define the
-postprocessing consumer contract around modern `InversionOutput` and remove the
-standard RHIME `basic`/`paris` adapter dependency. That creates the right place
-for #383 to replace legacy flat-basis assumptions with retained
-`BasisFunctions` in flux/country computations.
+- 2026-05-31: #435 / current PR added a narrow
+  `PostprocessingInversionOutput` contract and `ModernPostprocessingOutput`
+  view so postprocessing consumers can derive the existing observation,
+  trace, model-data, basis, and flux conveniences from modern
+  `InversionOutput`.
+- 2026-05-31: #435 / current PR routed standard `run_rhime`
+  `output_format="basic"` and `output_format="paris"` directly through modern
+  `InversionOutput`, removing the RHIME dependency on
+  `LegacyInversionOutput.from_modern_output(...)`.
+- 2026-05-31: #435 / current PR updated `make_outputs`,
+  `make_paris_outputs`, `countries`, and `diagnostics` to consume the narrow
+  postprocessing contract while continuing to accept fixedbasis
+  `LegacyInversionOutput`.
+- 2026-05-31: #435 / current PR kept `legacy_outputs` explicitly
+  `LegacyInversionOutput`-only because it formats fixedbasis/HBMCMC
+  compatibility arrays and still requires legacy `mcmc_results`, sigma
+  indexes, and sensitivity matrices.
+
+## Recorded decisions for Current PR / Issue #435
+
+- Use a narrow helper/view layer rather than making modern `InversionOutput`
+  mimic every legacy attribute or splitting each postprocessing function into
+  many smaller argument bundles.
+- Keep `LegacyInversionOutput.from_modern_output(...)` as an explicit
+  compatibility adapter for callers that request a legacy-shaped carrier, but
+  do not use it on standard RHIME `basic` or `paris` paths.
+- Do not move `inferpymc_postprocessouts` into any RHIME path.
+- Defer operator-backed flux/country reconstruction to #383/#429. This PR
+  still derives the postprocessing basis matrix through retained
+  `BasisFunctions` only to satisfy the current single-sector output contract.
+- Defer sector-aware PARIS totals and sector diagnostics to #405 rather than
+  broadening the standard single-sector postprocessing contract in this PR.
+
+## Recommended next PR after Current PR / Issue #435
+
+#435 defines the postprocessing consumer contract around modern
+`InversionOutput` and removes the standard RHIME `basic`/`paris` adapter
+dependency. That creates the right place for #383 to replace legacy flat-basis
+assumptions with retained `BasisFunctions` in flux/country computations.
 
 After #435, use #383 for the first operator-backed postprocessing slice:
 prefer retained `BasisFunctions.operator.basis_matrix` where available and keep

--- a/docs/plans/clean_up_inversions_refactor.md
+++ b/docs/plans/clean_up_inversions_refactor.md
@@ -202,11 +202,17 @@ rather than expanding that adapter.
 
 ## Completed in Current PR / Issue #435
 
-- 2026-05-31: #435 / current PR added a narrow
-  `PostprocessingInversionOutput` contract and `ModernPostprocessingOutput`
-  view so postprocessing consumers can derive the existing observation,
-  trace, model-data, basis, and flux conveniences from modern
-  `InversionOutput`.
+- 2026-05-31: #435 / current PR added a transitional
+  `StandardPostprocessingOutput` contract and `ModernPostprocessingOutput`
+  view so standard single-sector postprocessing consumers can derive trace,
+  model-data, basis, and flux conveniences from modern `InversionOutput`.
+- 2026-05-31: #435 / current PR changed the modern view to carry observation
+  inputs as one dataset rather than split `obs`/`obs_err`/optional satellite
+  fields. The split fields remain only on `LegacyInversionOutput` for
+  fixedbasis and explicit compatibility callers.
+- 2026-05-31: #435 / current PR restores model-managed coordinates onto RHIME
+  `InferenceData` in `RhimeSampler.sample(...)` using the `models.coords`
+  `CoordRegistry`, after predictive groups are attached.
 - 2026-05-31: #435 / current PR routed standard `run_rhime`
   `output_format="basic"` and `output_format="paris"` directly through modern
   `InversionOutput`, removing the RHIME dependency on
@@ -222,18 +228,28 @@ rather than expanding that adapter.
 
 ## Recorded decisions for Current PR / Issue #435
 
-- Use a narrow helper/view layer rather than making modern `InversionOutput`
-  mimic every legacy attribute or splitting each postprocessing function into
-  many smaller argument bundles.
+- Use a narrow standard single-sector helper/view layer rather than making
+  modern `InversionOutput` mimic every legacy attribute or splitting each
+  postprocessing function into many smaller argument bundles.
+- Treat `StandardPostprocessingOutput` as transitional. It must not become the
+  durable architecture for multisector, multi-species, or inner/outer-domain
+  outputs; those should use smaller product-specific contracts.
 - Keep `LegacyInversionOutput.from_modern_output(...)` as an explicit
   compatibility adapter for callers that request a legacy-shaped carrier, but
   do not use it on standard RHIME `basic` or `paris` paths.
 - Do not move `inferpymc_postprocessouts` into any RHIME path.
+- Do not remove `inferpymc_postprocessouts` in #435 because it is still the
+  default fixedbasis `output_format="hbmcmc"` product. Remove it only after
+  fixedbasis itself is retired.
 - Defer operator-backed flux/country reconstruction to #383/#429. This PR
   still derives the postprocessing basis matrix through retained
   `BasisFunctions` only to satisfy the current single-sector output contract.
 - Defer sector-aware PARIS totals and sector diagnostics to #405 rather than
   broadening the standard single-sector postprocessing contract in this PR.
+- Remove `fixedbasisMCMC` as soon as `run_rhime` can replace it for production
+  scripts. The next compatibility step should add a shim in
+  `hbmcmc/run_hbmcmc.py` so old script invocations and `.ini` config files
+  translate to `run_rhime`, then deprecate and remove the fixedbasis path.
 
 ## Recommended next PR after Current PR / Issue #435
 
@@ -251,6 +267,13 @@ basis reconstruction.
 Track multisector output work under #405. It can proceed after the modern
 postprocessing input contract is clearer, or in parallel if it stays limited to
 sector diagnostics and PARIS-compatible total outputs.
+
+Track fixedbasis removal under #416. The first slice should be a
+`run_hbmcmc.py` compatibility shim that translates legacy config names such as
+`outputpath`, `outputname`, `nit`, and `nchain` to the `run_rhime` API, while
+raising targeted errors for fixedbasis-only output formats. Once old scripts
+can run through `run_rhime`, remove `fixedbasisMCMC` and then remove
+`inferpymc_postprocessouts`.
 
 ## Deferred SemanticModel plan
 

--- a/openghg_inversions/postprocessing/countries.py
+++ b/openghg_inversions/postprocessing/countries.py
@@ -16,7 +16,7 @@ from openghg_inversions import convert, utils
 from openghg_inversions.array_ops import align_sparse_lat_lon, get_xr_dummies, sparse_xr_dot
 from openghg_inversions.utils import get_country_file_path
 from ._country_codes import CountryInfoList
-from .inversion_output import LegacyInversionOutput
+from .inversion_output import PostprocessingInput, as_postprocessing_output
 
 # type for xr.Dataset *or* xr.DataArray
 DataSetOrArray = TypeVar("DataSetOrArray", xr.DataArray, xr.Dataset)
@@ -366,18 +366,20 @@ class Countries:
 
     def get_x_to_country_mat(
         self,
-        inv_out: LegacyInversionOutput,
+        inv_out: PostprocessingInput,
         sparse: bool = False,
     ) -> xr.DataArray:
         """Construct a sparse matrix mapping from x sensitivities to country totals.
 
         Args:
-            inv_out: LegacyInversionOutput object, used to get basis functions and flux.
+            inv_out: Inversion output, used to get basis functions and flux.
             sparse: if True, values of returned DataArray are `sparse.COO` array.
 
         Returns:
             xr.DataArray with coordinate dimensions ("country", "basis_region")
         """
+        inv_out = as_postprocessing_output(inv_out)
+
         # multiply flux and basis and align to country lat/lon
         basis = align_sparse_lat_lon(inv_out.basis, inv_out.flux)
         flux_x_basis = align_sparse_lat_lon(inv_out.flux * basis, self.area_grid)
@@ -420,13 +422,13 @@ class Countries:
 
     def get_country_trace(
         self,
-        inv_out: LegacyInversionOutput,
+        inv_out: PostprocessingInput,
     ) -> xr.Dataset:
         """Calculate trace(s) for total country emissions.
 
         Args:
             species: name of species, e.g. "co2", "ch4", "sf6", etc.
-            inv_out: LegacyInversionOutput
+            inv_out: Inversion output.
 
         Returns:
             xr.Dataset with coordinate dimensions ("country", "draw")
@@ -434,6 +436,7 @@ class Countries:
         TODO: there is a "country unit" conversion in the old code, but it seems to always product
               1.0, based on how it is used in hbmcmc
         """
+        inv_out = as_postprocessing_output(inv_out)
         x_to_country_mat = self.get_x_to_country_mat(inv_out)
         x_trace = inv_out.get_trace_dataset(var_names="x")
 

--- a/openghg_inversions/postprocessing/diagnostics.py
+++ b/openghg_inversions/postprocessing/diagnostics.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
-from openghg_inversions.postprocessing.inversion_output import LegacyInversionOutput
+from openghg_inversions.postprocessing.inversion_output import PostprocessingInput, as_postprocessing_output
 from openghg_inversions.postprocessing.utils import add_suffix, get_parameters
 
 Diagnostic = namedtuple("Diagnostic", ["func", "params"])
@@ -30,7 +30,7 @@ def register_diagnostic(diagnostic: Callable) -> Callable:
 
 @register_diagnostic
 @add_suffix("trace")
-def summary(inv_out: LegacyInversionOutput) -> xr.Dataset:
+def summary(inv_out: PostprocessingInput) -> xr.Dataset:
     """Return diagnostics summary computed by arviz.
 
     Diagnostics reported:
@@ -45,7 +45,7 @@ def summary(inv_out: LegacyInversionOutput) -> xr.Dataset:
           greater than 1. Ideally, all r_hat values should be below 1.01
 
     Args:
-        inv_out: LegacyInversionOutput to summarise.
+        inv_out: Inversion output to summarise.
 
     Returns:
         xr.Dataset: Dataset with diagnostic summary.
@@ -104,7 +104,7 @@ def _r2_by_site(ds: xr.Dataset, report_prior: bool = False) -> xr.Dataset:
 
 
 @register_diagnostic
-def bayes_r2_by_site(inv_out: LegacyInversionOutput, report_prior: bool = False) -> xr.Dataset:
+def bayes_r2_by_site(inv_out: PostprocessingInput, report_prior: bool = False) -> xr.Dataset:
     """Compute Bayesian R2 scores grouped by site.
 
     Scores are computed for posterior predictive traces (compared
@@ -115,7 +115,7 @@ def bayes_r2_by_site(inv_out: LegacyInversionOutput, report_prior: bool = False)
     normalised to always fall between 0 and 1.
 
     Args:
-        inv_out: LegacyInversionOutput object containing obs and trace
+        inv_out: Inversion output containing obs and trace
         report_prior: if True, return prior R2 in addition to posterior R2
 
     Returns:
@@ -123,6 +123,7 @@ def bayes_r2_by_site(inv_out: LegacyInversionOutput, report_prior: bool = False)
             with uncertainties.
 
     """
+    inv_out = as_postprocessing_output(inv_out)
     y_true = inv_out.obs.unstack("nmeasure")
     y_pred = inv_out.get_trace_dataset(var_names="y").unstack("nmeasure")
     ds = xr.merge([y_true, y_pred])
@@ -132,7 +133,7 @@ def bayes_r2_by_site(inv_out: LegacyInversionOutput, report_prior: bool = False)
 
 @register_diagnostic
 def bayes_r2_by_site_resample(
-    inv_out: LegacyInversionOutput, freq: str = "MS", report_prior: bool = False
+    inv_out: PostprocessingInput, freq: str = "MS", report_prior: bool = False
 ) -> xr.Dataset:
     """Compute Bayesian R2 scores grouped by site and time.
 
@@ -144,7 +145,7 @@ def bayes_r2_by_site_resample(
     normalised to always fall between 0 and 1.
 
     Args:
-        inv_out: LegacyInversionOutput object containing obs and trace
+        inv_out: Inversion output containing obs and trace
         freq: frequency to resample to (should be a pandas freq. str that
           can be passed to `xr.Dataset.resample`)
         report_prior: if True, return prior R2 in addition to posterior R2
@@ -154,6 +155,7 @@ def bayes_r2_by_site_resample(
             with uncertainties.
 
     """
+    inv_out = as_postprocessing_output(inv_out)
     y_true = inv_out.obs.unstack("nmeasure")
     y_pred = inv_out.get_trace_dataset(var_names="y").unstack("nmeasure")
     ds = xr.merge([y_true, y_pred])

--- a/openghg_inversions/postprocessing/diagnostics.py
+++ b/openghg_inversions/postprocessing/diagnostics.py
@@ -124,7 +124,7 @@ def bayes_r2_by_site(inv_out: PostprocessingInput, report_prior: bool = False) -
 
     """
     inv_out = as_postprocessing_output(inv_out)
-    y_true = inv_out.obs.unstack("nmeasure")
+    y_true = inv_out.obs_inputs["y_obs"].unstack("nmeasure")
     y_pred = inv_out.get_trace_dataset(var_names="y").unstack("nmeasure")
     ds = xr.merge([y_true, y_pred])
 
@@ -156,7 +156,7 @@ def bayes_r2_by_site_resample(
 
     """
     inv_out = as_postprocessing_output(inv_out)
-    y_true = inv_out.obs.unstack("nmeasure")
+    y_true = inv_out.obs_inputs["y_obs"].unstack("nmeasure")
     y_pred = inv_out.get_trace_dataset(var_names="y").unstack("nmeasure")
     ds = xr.merge([y_true, y_pred])
 

--- a/openghg_inversions/postprocessing/inversion_output.py
+++ b/openghg_inversions/postprocessing/inversion_output.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing_extensions import Self
 from dataclasses import dataclass, field
-from typing import Any, Hashable, Literal, TypeVar, cast
+from typing import Any, Hashable, Literal, Protocol, TypeVar, cast
 import json
 
 import arviz as az
@@ -47,7 +47,9 @@ def _load_json_attr(attrs: dict[Any, Any], key: str) -> dict[str, Any]:
     return payload if isinstance(payload, dict) else {}
 
 
-def _save_datatree(dt: xr.DataTree, output_file: str | Path, output_format: Literal["netcdf", "zarr"] | None) -> None:
+def _save_datatree(
+    dt: xr.DataTree, output_file: str | Path, output_format: Literal["netcdf", "zarr"] | None
+) -> None:
     """Save a DataTree to NetCDF or Zarr, inferring format from the path when needed."""
     output_file = Path(output_file)
 
@@ -76,7 +78,11 @@ def _open_datatree_loaded(file_path: str | Path) -> xr.DataTree:
     open_errors: list[Exception] = []
     for engine in ("h5netcdf", None):
         try:
-            dt = xr.open_datatree(file_path, engine=engine) if engine is not None else xr.open_datatree(file_path)
+            dt = (
+                xr.open_datatree(file_path, engine=engine)
+                if engine is not None
+                else xr.open_datatree(file_path)
+            )
         except (OSError, RuntimeError, ValueError) as exc:
             open_errors.append(exc)
         else:
@@ -93,9 +99,7 @@ def _inferencedata_to_datatree(idata: az.InferenceData) -> xr.DataTree:
 
 def _inferencedata_from_datatree(dt: xr.DataTree) -> az.InferenceData:
     """Convert a DataTree of InferenceData groups back to ArviZ InferenceData."""
-    return cast(Any, az.InferenceData)(
-        **{group: child.to_dataset() for group, child in dt.items()}
-    )
+    return cast(Any, az.InferenceData)(**{group: child.to_dataset() for group, child in dt.items()})
 
 
 def _reset_serialisation_multiindexes(ds: xr.Dataset) -> xr.Dataset:
@@ -446,13 +450,8 @@ class InversionOutput:
         return cls.from_datatree(_open_datatree_loaded(file_path))
 
 
-@dataclass
-class LegacyInversionOutput:
-    """Legacy-shaped postprocessing carrier.
-
-    This is the object consumed by the current ``postprocessing`` submodule. It
-    is distinct from the true legacy ``inferpymc_postprocessouts`` dataset.
-    """
+class PostprocessingInversionOutput(Protocol):
+    """Narrow input contract used by modern postprocessing consumers."""
 
     obs: xr.DataArray
     obs_err: xr.DataArray
@@ -467,30 +466,73 @@ class LegacyInversionOutput:
     end_date: str
     species: str
     domain: str
-    site_names: xr.DataArray | None = None
-    obs_prior_factor: xr.DataArray | None = None
-    obs_prior_upper_level_factor: xr.DataArray | None = None
+    site_names: xr.DataArray | None
+    obs_prior_factor: xr.DataArray | None
+    obs_prior_upper_level_factor: xr.DataArray | None
 
-    def __post_init__(self) -> None:
-        """Check that trace has posterior traces, and fix flux time values."""
+    @property
+    def start_time(self) -> pd.Timestamp: ...
+
+    @property
+    def end_time(self) -> pd.Timestamp: ...
+
+    @property
+    def period_midpoint(self) -> pd.Timestamp: ...
+
+    def nmeasure_to_site_time(self, data: XrDataArrayOrSet) -> XrDataArrayOrSet: ...
+
+    def get_trace_dataset(self, var_names: str | list[str] | None = None) -> xr.Dataset: ...
+
+    def get_model_data(self, var_names: str | list[str] | None = None) -> xr.Dataset: ...
+
+    def get_total_err(self, take_mean: bool = True) -> xr.DataArray: ...
+
+    def get_model_err(self) -> xr.DataArray: ...
+
+    def get_obs_and_errors(self) -> xr.Dataset: ...
+
+    def get_flat_basis(self) -> xr.DataArray: ...
+
+
+PostprocessingInput = InversionOutput | PostprocessingInversionOutput
+
+
+class _PostprocessingOutputMethods:
+    """Shared derived helpers for postprocessing-compatible output views."""
+
+    obs: xr.DataArray
+    obs_err: xr.DataArray
+    obs_repeatability: xr.DataArray
+    obs_variability: xr.DataArray
+    flux: xr.DataArray
+    basis: xr.DataArray
+    trace: az.InferenceData
+    site_indicators: xr.DataArray
+    times: xr.DataArray
+    start_date: str
+    end_date: str
+    species: str
+    domain: str
+    site_names: xr.DataArray | None
+    obs_prior_factor: xr.DataArray | None
+    obs_prior_upper_level_factor: xr.DataArray | None
+    trace_ds: xr.Dataset
+    obs_inputs: xr.Dataset
+
+    def _normalise_postprocessing_inputs(self) -> None:
+        """Normalise raw fields into the shape expected by postprocessing helpers."""
         if not hasattr(self.trace, "posterior"):
             raise ValueError("`trace` InferenceData must have `posterior` traces.")
 
-        # check if flux has time coordinate, and add one if necessary
         if "time" not in self.flux.dims:
             self.flux = self.flux.expand_dims(time=[self.start_time])
 
-        # change "time" dim of flux to "flux_time" to avoid NaNs when merging with obs times
         self.flux = self.flux.rename(time="flux_time")
-
-        # align basis with flux; this is necessary due to an issue with sparse matrices
         self.basis = align_sparse_lat_lon(self.basis, self.flux)
 
-        # if basis has time, make sure it is aligned to flux
         if "time" in self.basis.dims:
             self.basis = self.basis.rename(time="flux_time")
         elif "time" in self.basis.coords:
-            # time not in dims, so just delete the coord
             self.basis = self.basis.drop_vars("time")
 
         self._refresh_derived_datasets()
@@ -507,7 +549,6 @@ class LegacyInversionOutput:
         _add_attributes_to_trace_dataset(trace_ds, self.obs.attrs["units"], obs_long_name)
         self.trace_ds = self.nmeasure_to_site_time(trace_ds)
 
-        # format obs data and errors
         self.obs = self.nmeasure_to_site_time(self.obs.rename("y_obs"))
         self.obs_err = self.nmeasure_to_site_time(self.obs_err.rename("y_obs_error"))
 
@@ -533,76 +574,212 @@ class LegacyInversionOutput:
         ]
         self.obs_inputs = xr.merge([x for x in obs_inputs if x is not None])
 
+    def nmeasure_to_site_time(self, data: XrDataArrayOrSet) -> XrDataArrayOrSet:
+        """Convert `nmeasure` coordinate of dataset to stacked (site, time) coordinate."""
+        return _nmeasure_to_site_time(data, self.site_indicators, self.times, self.site_names)
+
+    def get_trace_dataset(self, var_names: str | list[str] | None = None) -> xr.Dataset:
+        """Return an xarray Dataset containing prior/posterior trace samples."""
+        result = self.trace_ds
+
+        if var_names is not None:
+            result = _filter_trace_data_vars_by_name(result, var_names)
+
+        return result
+
+    def get_model_data(self, var_names: str | list[str] | None = None) -> xr.Dataset:
+        """Return an xarray Dataset containing model input data."""
+        result = convert_idata_to_dataset(self.trace, group_filters=["data"], add_suffix=False)
+        result = self.nmeasure_to_site_time(result)
+
+        if var_names is not None:
+            result = filter_data_vars_by_prefix(result, var_names, sep="")
+
+        return result
+
+    @property
+    def start_time(self) -> pd.Timestamp:
+        """Start date of inversion."""
+        if self.start_date is not None:
+            return pd.to_datetime(self.start_date)
+        return pd.to_datetime(self.times.min().values[0])
+
+    @property
+    def end_time(self) -> pd.Timestamp:
+        """End date of inversion."""
+        if self.end_date is not None:
+            return pd.to_datetime(self.end_date)
+        return pd.to_datetime(self.times.max().values[0])
+
+    @property
+    def period_midpoint(self) -> pd.Timestamp:
+        """Midpoint of inversion period."""
+        return self.start_time + (self.end_time - self.start_time) / 2
+
+    def get_total_err(self, take_mean: bool = True) -> xr.DataArray:
+        """Return the posterior model-data mismatch error."""
+        result = self.get_trace_dataset(var_names="epsilon").epsilon_posterior
+
+        if take_mean:
+            result = result.mean("draw")
+
+        result.attrs["units"] = self.obs.attrs["units"]
+        result.attrs["long_name"] = "total model-data mismatch error"
+
+        return result.rename("total_error")
+
+    def get_model_err(self) -> xr.DataArray:
+        """Return model_error."""
+        total_err = self.get_total_err(take_mean=False)
+        total_obs_err = self.obs_err
+
+        result = np.sqrt(np.maximum(total_err**2 - total_obs_err**2, 0)).mean("draw")  # type: ignore
+        result.attrs["units"] = self.obs.attrs["units"]
+        result.attrs["long_name"] = "inferred model error"
+        return result.rename("model_error")
+
+    def get_obs_and_errors(self) -> xr.Dataset:
+        """Return dataset containing observations and related error terms."""
+        result = xr.merge([self.obs_inputs, self.get_model_err(), self.get_total_err()])
+        result.attrs = {}
+
+        return result
+
+    def get_flat_basis(self) -> xr.DataArray:
+        """Return 2D DataArray encoding basis regions."""
+        if len(self.basis.dims) == 2:
+            return self.basis
+
+        region_dim = next(
+            str(dim) for dim in self.basis.dims if dim not in ["lat", "lon", "latitude", "longitude"]
+        )
+
+        return (self.basis * self.basis[region_dim]).sum(region_dim).as_numpy().rename("basis")
+
+
+def _modern_postprocessing_components(inv_out: InversionOutput) -> dict[str, Any]:
+    """Build postprocessing-compatible fields from modern RHIME output."""
+    inv_inputs = inv_out.inv_inputs
+    basis = inv_out.basis_functions.operator.basis_matrix
+    current_state_dim = inv_out.basis_functions.operator.meta.state_dim
+    if current_state_dim != "region":
+        basis = basis.rename({current_state_dim: "region"})
+    if "region" in inv_inputs.coords:
+        basis = basis.reindex(region=inv_inputs.region)
+
+    nmeasure = np.arange(inv_inputs.sizes["nmeasure"])
+    sites = inv_out.run_metadata.get("sites", [])
+    site_names = (
+        inv_inputs["site_names"]
+        if "site_names" in inv_inputs
+        else xr.DataArray(list(sites), dims="nsite", coords={"nsite": np.arange(len(sites))})
+    )
+    obs_prior_factor = inv_inputs["mf_prior_factor"] if "mf_prior_factor" in inv_inputs else None
+    obs_prior_upper_level_factor = (
+        inv_inputs["mf_prior_upper_level_factor"] if "mf_prior_upper_level_factor" in inv_inputs else None
+    )
+
+    def nmeasure_array(name: str, source: xr.DataArray) -> xr.DataArray:
+        """Create a clean nmeasure DataArray without inherited indexes."""
+        result = xr.DataArray(
+            source.values,
+            dims=["nmeasure"],
+            coords={"nmeasure": nmeasure},
+            name=name,
+        )
+        result.attrs = source.attrs
+        return result
+
+    species = inv_out.species
+    domain = inv_out.domain
+    start_date = inv_out.start_date
+    end_date = inv_out.end_date
+    if species is None or domain is None or start_date is None or end_date is None:
+        raise ValueError(
+            "Modern InversionOutput metadata must include species, domain, start_date, and end_date."
+        )
+
+    return {
+        "obs": nmeasure_array("Yobs", inv_inputs["mf"]),
+        "obs_err": nmeasure_array("Yerror", inv_inputs["mf_error"]),
+        "obs_repeatability": nmeasure_array("Yerror_repeatability", inv_inputs["mf_repeatability"]),
+        "obs_variability": nmeasure_array("Yerror_variability", inv_inputs["mf_variability"]),
+        "obs_prior_factor": (
+            nmeasure_array("Yobs_prior_factor", obs_prior_factor) if obs_prior_factor is not None else None
+        ),
+        "obs_prior_upper_level_factor": (
+            nmeasure_array("Yobs_prior_upper_level_factor", obs_prior_upper_level_factor)
+            if obs_prior_upper_level_factor is not None
+            else None
+        ),
+        "site_indicators": nmeasure_array("site_indicator", inv_inputs["site_indicator"]),
+        "flux": inv_out.basis_functions.flux,
+        "basis": basis,
+        "trace": inv_out.trace,
+        "site_names": site_names,
+        "times": nmeasure_array("times", inv_inputs["time"]),
+        "start_date": start_date,
+        "end_date": end_date,
+        "species": species,
+        "domain": domain,
+    }
+
+
+class ModernPostprocessingOutput(_PostprocessingOutputMethods):
+    """Derived postprocessing view over a modern RHIME InversionOutput."""
+
+    def __init__(self, inv_out: InversionOutput) -> None:
+        self.modern_output = inv_out
+        for name, value in _modern_postprocessing_components(inv_out).items():
+            setattr(self, name, value)
+        self._normalise_postprocessing_inputs()
+
+
+def as_postprocessing_output(inv_out: PostprocessingInput) -> PostprocessingInversionOutput:
+    """Return an object satisfying the postprocessing input contract."""
+    if isinstance(inv_out, InversionOutput):
+        return ModernPostprocessingOutput(inv_out)
+    return inv_out
+
+
+@dataclass
+class LegacyInversionOutput(_PostprocessingOutputMethods):
+    """Legacy-shaped postprocessing carrier.
+
+    This is the object consumed by the current ``postprocessing`` submodule. It
+    is distinct from the true legacy ``inferpymc_postprocessouts`` dataset.
+    """
+
+    obs: xr.DataArray
+    obs_err: xr.DataArray
+    obs_repeatability: xr.DataArray
+    obs_variability: xr.DataArray
+    flux: xr.DataArray
+    basis: xr.DataArray
+    trace: az.InferenceData
+    site_indicators: xr.DataArray
+    times: xr.DataArray
+    start_date: str
+    end_date: str
+    species: str
+    domain: str
+    site_names: xr.DataArray | None = None
+    obs_prior_factor: xr.DataArray | None = None
+    obs_prior_upper_level_factor: xr.DataArray | None = None
+
+    def __post_init__(self) -> None:
+        """Check that trace has posterior traces, and fix flux time values."""
+        self._normalise_postprocessing_inputs()
+
     @classmethod
     def from_modern_output(cls, inv_out: InversionOutput) -> Self:
         """Build the current postprocessing carrier from a modern RHIME output.
 
-        This temporary adapter keeps existing ``basic`` and ``paris``
-        postprocessing available while issue #383/#429 move those consumers onto
-        retained ``BasisFunctions`` directly.
+        This compatibility adapter is retained for callers that explicitly need
+        a legacy-shaped carrier. Standard RHIME postprocessing consumes modern
+        ``InversionOutput`` through ``ModernPostprocessingOutput`` instead.
         """
-        inv_inputs = inv_out.inv_inputs
-        basis = inv_out.basis_functions.operator.basis_matrix
-        current_state_dim = inv_out.basis_functions.operator.meta.state_dim
-        if current_state_dim != "region":
-            basis = basis.rename({current_state_dim: "region"})
-        if "region" in inv_inputs.coords:
-            basis = basis.reindex(region=inv_inputs.region)
-
-        nmeasure = np.arange(inv_inputs.sizes["nmeasure"])
-        sites = inv_out.run_metadata.get("sites", [])
-        site_names = (
-            inv_inputs["site_names"]
-            if "site_names" in inv_inputs
-            else xr.DataArray(list(sites), dims="nsite", coords={"nsite": np.arange(len(sites))})
-        )
-        obs_prior_factor = inv_inputs["mf_prior_factor"] if "mf_prior_factor" in inv_inputs else None
-        obs_prior_upper_level_factor = (
-            inv_inputs["mf_prior_upper_level_factor"] if "mf_prior_upper_level_factor" in inv_inputs else None
-        )
-
-        def nmeasure_array(name: str, source: xr.DataArray) -> xr.DataArray:
-            """Create a clean nmeasure DataArray without inherited indexes."""
-            result = xr.DataArray(
-                source.values,
-                dims=["nmeasure"],
-                coords={"nmeasure": nmeasure},
-                name=name,
-            )
-            result.attrs = source.attrs
-            return result
-
-        species = inv_out.species
-        domain = inv_out.domain
-        start_date = inv_out.start_date
-        end_date = inv_out.end_date
-        if species is None or domain is None or start_date is None or end_date is None:
-            raise ValueError("Modern InversionOutput metadata must include species, domain, start_date, and end_date.")
-
-        return cls(
-            obs=nmeasure_array("Yobs", inv_inputs["mf"]),
-            obs_err=nmeasure_array("Yerror", inv_inputs["mf_error"]),
-            obs_repeatability=nmeasure_array("Yerror_repeatability", inv_inputs["mf_repeatability"]),
-            obs_variability=nmeasure_array("Yerror_variability", inv_inputs["mf_variability"]),
-            obs_prior_factor=(
-                nmeasure_array("Yobs_prior_factor", obs_prior_factor) if obs_prior_factor is not None else None
-            ),
-            obs_prior_upper_level_factor=(
-                nmeasure_array("Yobs_prior_upper_level_factor", obs_prior_upper_level_factor)
-                if obs_prior_upper_level_factor is not None
-                else None
-            ),
-            site_indicators=nmeasure_array("site_indicator", inv_inputs["site_indicator"]),
-            flux=inv_out.basis_functions.flux,
-            basis=basis,
-            trace=inv_out.trace,
-            site_names=site_names,
-            times=nmeasure_array("times", inv_inputs["time"]),
-            start_date=start_date,
-            end_date=end_date,
-            species=species,
-            domain=domain,
-        )
+        return cls(**_modern_postprocessing_components(inv_out))
 
     def __eq__(self, other: Any) -> bool:
         """Check equality between LegacyInversionOutput objects.
@@ -640,157 +817,6 @@ class LegacyInversionOutput:
             self.domain == other.domain,
         ]
         return all(checks)
-
-    def nmeasure_to_site_time(self, data: XrDataArrayOrSet) -> XrDataArrayOrSet:
-        """Convert `nmeasure` coordinate of dataset to stacked (site, time) coordinate.
-
-        Args:
-            data: xr.DataArray or xr.Dataset
-
-        Returns:
-            data with `nmeasure` converted to a stacked (site, time) coordinate.
-
-        """
-        return _nmeasure_to_site_time(data, self.site_indicators, self.times, self.site_names)
-
-    def get_trace_dataset(self, var_names: str | list[str] | None = None) -> xr.Dataset:
-        """Return an xarray Dataset containing a prior/posterior parameter/predictive samples.
-
-        Args:
-            convert_nmeasure: if True, convert `nmeasure` coordinate to multi-index comprising `time` and `site`.
-            var_names: (list of) variables to select. For instance, "x" will return "x_prior" and "x_posterior".
-
-        Returns:
-            xarray Dataset containing a prior/posterior parameter/predictive samples.
-        """
-        result = self.trace_ds
-
-        if var_names is not None:
-            result = _filter_trace_data_vars_by_name(result, var_names)
-
-        return result
-
-    def get_model_data(self, var_names: str | list[str] | None = None) -> xr.Dataset:
-        """Return an xarray Dataset containing the data input to the model.
-
-        This data is captured using `pm.Data`, or when data is observed.
-
-        Args:
-            convert_nmeasure: if True, convert `nmeasure` coordinate to multi-index comprising `time` and `site`.
-            var_names: (list of) variables to select. For instance, "hx" or "min_error"
-
-        Returns:
-            xarray Dataset containing model data
-        """
-        result = convert_idata_to_dataset(self.trace, group_filters=["data"], add_suffix=False)
-        result = self.nmeasure_to_site_time(result)
-
-        if var_names is not None:
-            result = filter_data_vars_by_prefix(result, var_names, sep="")
-
-        return result
-
-    @property
-    def start_time(self) -> pd.Timestamp:
-        """Start date of inversion."""
-        if self.start_date is not None:
-            return pd.to_datetime(self.start_date)
-        return pd.to_datetime(self.times.min().values[0])
-
-    @property
-    def end_time(self) -> pd.Timestamp:
-        """End date of inversion."""
-        if self.end_date is not None:
-            return pd.to_datetime(self.end_date)
-        return pd.to_datetime(self.times.max().values[0])
-
-    @property
-    def period_midpoint(self) -> pd.Timestamp:
-        """Midpoint of inversion period."""
-        return self.start_time + (self.end_time - self.start_time) / 2
-
-    def get_total_err(self, take_mean: bool = True) -> xr.DataArray:
-        """Return the posterior model-data mismatch error.
-
-        This is the variable `epsilon` in the RHIME model. It can be thought of
-        as sqrt(repeatability**2 + variability**2 + model_error**2), although the
-        actual definition is more complicated.
-
-        Args:
-            take_mean: if True, take mean over trace of error term, otherwise
-              return the full trace.
-
-        Returns:
-            xr.DataArray containing total error
-
-        """
-        result = self.get_trace_dataset(var_names="epsilon").epsilon_posterior
-
-        if take_mean:
-            result = result.mean("draw")
-
-        result.attrs["units"] = self.obs.attrs["units"]
-        result.attrs["long_name"] = "total model-data mismatch error"
-
-        return result.rename("total_error")
-
-    def get_model_err(self) -> xr.DataArray:
-        """Return model_error.
-
-        The model error is calculated by subtracting the square of the obs error
-        from the square of the total error, and then taking a square root.
-
-        Returns:
-            xr.DataArray containing model error
-
-        """
-        total_err = self.get_total_err(take_mean=False)
-        total_obs_err = self.obs_err
-
-        result = np.sqrt(np.maximum(total_err**2 - total_obs_err**2, 0)).mean("draw")  # type: ignore
-        result.attrs["units"] = self.obs.attrs["units"]
-        result.attrs["long_name"] = "inferred model error"
-        return result.rename("model_error")
-
-    def get_obs_and_errors(self) -> xr.Dataset:
-        """Return dataset containing observations and related error terms.
-
-        The dataset return contains: obs, obs error (as used by the inversion),
-        obs repeatability and variability, model error, and total error (i.e.
-        the model-data mismatch error).
-
-        Returns:
-            xr.Dataset containing obs and error data
-
-        """
-        result = xr.merge([self.obs_inputs, self.get_model_err(), self.get_total_err()])
-        result.attrs = {}
-
-        return result
-
-    def get_flat_basis(self) -> xr.DataArray:
-        """Return 2D DataArray encoding basis regions.
-
-        The `LegacyInversionOutput.basis` matrix is sparse, with three dimensions: latitude, longitude, and region
-        (which corresponds to a basis function). A sparse matrix cannot be saved directly to disk, or compared
-        with other matrices of this type, and converting directly to a dense matrix could use a very large
-        amount of memory.
-
-        This function converts the basis matrix to a 2D array with latitude and longitude coordinates, and basis
-        regions encoded by numbers in this 2D array.
-
-        Returns:
-            xr.DataArray encoding basis functions, with latitude and longitude coordinates
-
-        """
-        if len(self.basis.dims) == 2:
-            return self.basis
-
-        region_dim = next(
-            str(dim) for dim in self.basis.dims if dim not in ["lat", "lon", "latitude", "longitude"]
-        )
-
-        return (self.basis * self.basis[region_dim]).sum(region_dim).as_numpy().rename("basis")
 
     def to_datatree(self) -> xr.DataTree:
         """Convert LegacyInversionOutput to xarray DataTree.

--- a/openghg_inversions/postprocessing/inversion_output.py
+++ b/openghg_inversions/postprocessing/inversion_output.py
@@ -94,12 +94,16 @@ def _open_datatree_loaded(file_path: str | Path) -> xr.DataTree:
 
 def _inferencedata_to_datatree(idata: az.InferenceData) -> xr.DataTree:
     """Convert an ArviZ InferenceData object to a DataTree."""
-    return xr.DataTree.from_dict({group: idata[group] for group in idata.groups()})
+    return xr.DataTree.from_dict(
+        {group: _reset_serialisation_multiindexes(idata[group]) for group in idata.groups()}
+    )
 
 
 def _inferencedata_from_datatree(dt: xr.DataTree) -> az.InferenceData:
     """Convert a DataTree of InferenceData groups back to ArviZ InferenceData."""
-    return cast(Any, az.InferenceData)(**{group: child.to_dataset() for group, child in dt.items()})
+    return cast(Any, az.InferenceData)(
+        **{group: _restore_serialisation_multiindexes(child.to_dataset()) for group, child in dt.items()}
+    )
 
 
 def _reset_serialisation_multiindexes(ds: xr.Dataset) -> xr.Dataset:
@@ -120,8 +124,8 @@ def _reset_serialisation_multiindexes(ds: xr.Dataset) -> xr.Dataset:
     return result
 
 
-def _restore_inv_inputs_indexes(ds: xr.Dataset) -> xr.Dataset:
-    """Restore RHIME inv_inputs MultiIndexes expanded for serialisation."""
+def _restore_serialisation_multiindexes(ds: xr.Dataset) -> xr.Dataset:
+    """Restore MultiIndexes expanded for DataTree serialisation."""
     raw_multiindex_dims = ds.attrs.get(MULTIINDEX_DIMS_ATTR)
     if raw_multiindex_dims is None:
         return ds
@@ -432,7 +436,7 @@ class InversionOutput:
             raise ValueError(f"Unexpected InversionOutput schema: {schema!r}")
 
         trace = _inferencedata_from_datatree(cast(xr.DataTree, dt["trace"]))
-        inv_inputs = _restore_inv_inputs_indexes(cast(xr.DataTree, dt["inv_inputs"]).to_dataset())
+        inv_inputs = _restore_serialisation_multiindexes(cast(xr.DataTree, dt["inv_inputs"]).to_dataset())
         basis_functions = BasisFunctions.from_datatree(cast(xr.DataTree, dt["basis_functions"]))
         return cls(
             trace=trace,
@@ -450,25 +454,24 @@ class InversionOutput:
         return cls.from_datatree(_open_datatree_loaded(file_path))
 
 
-class PostprocessingInversionOutput(Protocol):
-    """Narrow input contract used by modern postprocessing consumers."""
+class StandardPostprocessingOutput(Protocol):
+    """Single-sector postprocessing view used by current standard outputs.
 
-    obs: xr.DataArray
-    obs_err: xr.DataArray
-    obs_repeatability: xr.DataArray
-    obs_variability: xr.DataArray
+    This protocol describes the transitional interface consumed by ``basic``
+    and ``paris`` postprocessing. It intentionally models a standard
+    single-sector RHIME product and should not be expanded for multisector,
+    multi-species, or inner/outer-domain outputs. Those products should gain
+    smaller, product-specific contracts as they are migrated.
+    """
+
     flux: xr.DataArray
     basis: xr.DataArray
     trace: az.InferenceData
-    site_indicators: xr.DataArray
-    times: xr.DataArray
     start_date: str
     end_date: str
     species: str
     domain: str
-    site_names: xr.DataArray | None
-    obs_prior_factor: xr.DataArray | None
-    obs_prior_upper_level_factor: xr.DataArray | None
+    obs_inputs: xr.Dataset
 
     @property
     def start_time(self) -> pd.Timestamp: ...
@@ -494,28 +497,109 @@ class PostprocessingInversionOutput(Protocol):
     def get_flat_basis(self) -> xr.DataArray: ...
 
 
-PostprocessingInput = InversionOutput | PostprocessingInversionOutput
+PostprocessingInput = InversionOutput | StandardPostprocessingOutput
+
+
+_OBS_INPUT_RENAMES = {
+    "mf": "y_obs",
+    "mf_error": "y_obs_error",
+    "mf_prior_factor": "y_obs_prior_factor",
+    "mf_prior_upper_level_factor": "y_obs_prior_upper_level_factor",
+    "mf_repeatability": "y_obs_repeatability",
+    "mf_variability": "y_obs_variability",
+}
+_REQUIRED_OBS_INPUTS = ("mf", "mf_error", "mf_repeatability", "mf_variability")
+
+
+def _standard_basis_from_basis_functions(
+    basis_functions: BasisFunctions, inv_inputs: xr.Dataset
+) -> xr.DataArray:
+    """Return the flat standard-postprocessing basis from modern basis functions.
+
+    Args:
+        basis_functions: Modern basis-function artifact carried by
+            ``InversionOutput``.
+        inv_inputs: RHIME inversion inputs used to align the basis region
+            coordinate to the model state coordinate.
+
+    Returns:
+        Basis matrix with a ``region`` state dimension for current
+        single-sector postprocessing consumers.
+    """
+    basis = basis_functions.operator.basis_matrix
+    current_state_dim = basis_functions.operator.meta.state_dim
+    if current_state_dim != "region":
+        basis = basis.rename({current_state_dim: "region"})
+    if "region" in inv_inputs.coords:
+        basis = basis.reindex(region=inv_inputs.region)
+    return basis
+
+
+def _modern_observation_inputs(inv_inputs: xr.Dataset) -> xr.Dataset:
+    """Extract the modern observation-input dataset used by postprocessing.
+
+    Args:
+        inv_inputs: RHIME inversion-input dataset.
+
+    Returns:
+        Dataset containing observed mole fraction and uncertainty variables
+        renamed to the postprocessing output names.
+
+    Raises:
+        ValueError: If required observation variables are missing.
+    """
+    missing = [name for name in _REQUIRED_OBS_INPUTS if name not in inv_inputs]
+    if missing:
+        missing_names = ", ".join(missing)
+        raise ValueError(f"Modern InversionOutput.inv_inputs is missing required variables: {missing_names}.")
+
+    available = [name for name in _OBS_INPUT_RENAMES if name in inv_inputs]
+    rename = {name: _OBS_INPUT_RENAMES[name] for name in available}
+    return inv_inputs[available].rename(rename)
+
+
+def _flat_nmeasure_array(name: str, source: xr.DataArray) -> xr.DataArray:
+    """Return a flat legacy-compatible copy of an ``nmeasure`` data array.
+
+    Args:
+        name: Name to assign to the returned array.
+        source: Source array with an ``nmeasure`` dimension.
+
+    Returns:
+        DataArray using integer ``nmeasure`` coordinates and copied attrs.
+    """
+    nmeasure = np.arange(source.sizes["nmeasure"])
+    result = xr.DataArray(
+        source.values,
+        dims=["nmeasure"],
+        coords={"nmeasure": nmeasure},
+        name=name,
+    )
+    result.attrs = source.attrs
+    return result
+
+
+def _has_site_time_nmeasure_index(data: xr.DataArray | xr.Dataset) -> bool:
+    """Return True when ``data`` already has a site/time ``nmeasure`` index."""
+    nmeasure_index = data.indexes.get("nmeasure")
+    return isinstance(nmeasure_index, pd.MultiIndex) and list(nmeasure_index.names) == ["site", "time"]
 
 
 class _PostprocessingOutputMethods:
     """Shared derived helpers for postprocessing-compatible output views."""
 
-    obs: xr.DataArray
-    obs_err: xr.DataArray
-    obs_repeatability: xr.DataArray
-    obs_variability: xr.DataArray
     flux: xr.DataArray
     basis: xr.DataArray
     trace: az.InferenceData
-    site_indicators: xr.DataArray
-    times: xr.DataArray
     start_date: str
     end_date: str
     species: str
     domain: str
     site_names: xr.DataArray | None
-    obs_prior_factor: xr.DataArray | None
-    obs_prior_upper_level_factor: xr.DataArray | None
+    site_indicators: xr.DataArray
+    times: xr.DataArray
+    _site_indicators: xr.DataArray | np.ndarray
+    _times: xr.DataArray | np.ndarray
     trace_ds: xr.Dataset
     obs_inputs: xr.Dataset
 
@@ -538,48 +622,60 @@ class _PostprocessingOutputMethods:
         self._refresh_derived_datasets()
 
     def _refresh_derived_datasets(self) -> None:
-        """Refresh derived datasets cached from trace and observation inputs."""
+        """Refresh derived trace and observation datasets."""
+        self.obs_inputs = self.nmeasure_to_site_time(self.obs_inputs)
+        obs = self.obs_inputs["y_obs"]
+
         trace_ds = convert_idata_to_dataset(self.trace)
 
-        if "longname" in self.obs.attrs:
-            obs_long_name = self.obs.attrs["longname"]
+        if "longname" in obs.attrs:
+            obs_long_name = obs.attrs["longname"]
         else:
-            obs_long_name = self.obs.attrs.get("long_name", "observed_mole_fraction")
+            obs_long_name = obs.attrs.get("long_name", "observed_mole_fraction")
 
-        _add_attributes_to_trace_dataset(trace_ds, self.obs.attrs["units"], obs_long_name)
+        _add_attributes_to_trace_dataset(trace_ds, obs.attrs.get("units", ""), obs_long_name)
         self.trace_ds = self.nmeasure_to_site_time(trace_ds)
 
-        self.obs = self.nmeasure_to_site_time(self.obs.rename("y_obs"))
-        self.obs_err = self.nmeasure_to_site_time(self.obs_err.rename("y_obs_error"))
-
-        if self.obs_prior_factor is not None:
-            self.obs_prior_factor = self.nmeasure_to_site_time(
-                self.obs_prior_factor.rename("y_obs_prior_factor")
-            )
-        if self.obs_prior_upper_level_factor is not None:
-            self.obs_prior_upper_level_factor = self.nmeasure_to_site_time(
-                self.obs_prior_upper_level_factor.rename("y_obs_prior_upper_level_factor")
-            )
-        self.obs_repeatability = self.nmeasure_to_site_time(
-            self.obs_repeatability.rename("y_obs_repeatability")
-        )
-        self.obs_variability = self.nmeasure_to_site_time(self.obs_variability.rename("y_obs_variability"))
-        obs_inputs = [
-            self.obs,
-            self.obs_err,
-            self.obs_prior_factor,
-            self.obs_prior_upper_level_factor,
-            self.obs_repeatability,
-            self.obs_variability,
-        ]
-        self.obs_inputs = xr.merge([x for x in obs_inputs if x is not None])
+    def _site_time_coordinate_inputs(
+        self,
+    ) -> tuple[xr.DataArray | np.ndarray, xr.DataArray | np.ndarray, xr.DataArray | dict | None]:
+        """Return inputs used to build a site/time ``nmeasure`` index."""
+        site_indicators = self._site_indicators if hasattr(self, "_site_indicators") else self.site_indicators
+        times = self._times if hasattr(self, "_times") else self.times
+        site_names = getattr(self, "site_names", None)
+        return site_indicators, times, site_names
 
     def nmeasure_to_site_time(self, data: XrDataArrayOrSet) -> XrDataArrayOrSet:
-        """Convert `nmeasure` coordinate of dataset to stacked (site, time) coordinate."""
-        return _nmeasure_to_site_time(data, self.site_indicators, self.times, self.site_names)
+        """Convert the ``nmeasure`` coordinate to a stacked site/time coordinate.
+
+        Args:
+            data: Dataset or DataArray that may contain an ``nmeasure`` dimension.
+
+        Returns:
+            The input type with an ``nmeasure`` MultiIndex when the dimension is
+            present. Existing site/time indexes are preserved.
+        """
+        if "nmeasure" not in data.dims or _has_site_time_nmeasure_index(data):
+            return data
+
+        if {"site", "time"}.issubset(data.coords) and all(
+            data[coord].dims == ("nmeasure",) for coord in ("site", "time")
+        ):
+            return data.set_index(nmeasure=["site", "time"])
+
+        site_indicators, times, site_names = self._site_time_coordinate_inputs()
+        return _nmeasure_to_site_time(data, site_indicators, times, site_names)
 
     def get_trace_dataset(self, var_names: str | list[str] | None = None) -> xr.Dataset:
-        """Return an xarray Dataset containing prior/posterior trace samples."""
+        """Return prior and posterior trace samples.
+
+        Args:
+            var_names: Optional base variable name or names to select. Names are
+                matched before group suffixes such as ``_posterior``.
+
+        Returns:
+            Dataset containing selected prior/predictive/posterior variables.
+        """
         result = self.trace_ds
 
         if var_names is not None:
@@ -588,7 +684,15 @@ class _PostprocessingOutputMethods:
         return result
 
     def get_model_data(self, var_names: str | list[str] | None = None) -> xr.Dataset:
-        """Return an xarray Dataset containing model input data."""
+        """Return model input data from the ``InferenceData`` constant groups.
+
+        Args:
+            var_names: Optional variable-name prefixes to select.
+
+        Returns:
+            Dataset containing model input variables with restored measurement
+            coordinates when available.
+        """
         result = convert_idata_to_dataset(self.trace, group_filters=["data"], add_suffix=False)
         result = self.nmeasure_to_site_time(result)
 
@@ -617,36 +721,63 @@ class _PostprocessingOutputMethods:
         return self.start_time + (self.end_time - self.start_time) / 2
 
     def get_total_err(self, take_mean: bool = True) -> xr.DataArray:
-        """Return the posterior model-data mismatch error."""
+        """Return the posterior model-data mismatch error.
+
+        This is the variable ``epsilon`` in the RHIME model. It can be thought
+        of as ``sqrt(repeatability**2 + variability**2 + model_error**2)``,
+        although the actual model definition is more complicated.
+
+        Args:
+            take_mean: If True, average over posterior draws. If False, return
+                the full posterior trace.
+
+        Returns:
+            Total model-data mismatch error.
+        """
         result = self.get_trace_dataset(var_names="epsilon").epsilon_posterior
 
         if take_mean:
             result = result.mean("draw")
 
-        result.attrs["units"] = self.obs.attrs["units"]
+        result.attrs["units"] = self.obs_inputs["y_obs"].attrs.get("units", "")
         result.attrs["long_name"] = "total model-data mismatch error"
 
         return result.rename("total_error")
 
     def get_model_err(self) -> xr.DataArray:
-        """Return model_error."""
+        """Return the inferred model-error component.
+
+        Returns:
+            Posterior mean model error after subtracting observation error from
+            total model-data mismatch in quadrature.
+        """
         total_err = self.get_total_err(take_mean=False)
-        total_obs_err = self.obs_err
+        total_obs_err = self.obs_inputs["y_obs_error"]
 
         result = np.sqrt(np.maximum(total_err**2 - total_obs_err**2, 0)).mean("draw")  # type: ignore
-        result.attrs["units"] = self.obs.attrs["units"]
+        result.attrs["units"] = self.obs_inputs["y_obs"].attrs.get("units", "")
         result.attrs["long_name"] = "inferred model error"
         return result.rename("model_error")
 
     def get_obs_and_errors(self) -> xr.Dataset:
-        """Return dataset containing observations and related error terms."""
+        """Return observations and derived uncertainty terms.
+
+        Returns:
+            Dataset containing observed mole fractions, available observation
+            uncertainty inputs, inferred model error, and total model-data
+            mismatch.
+        """
         result = xr.merge([self.obs_inputs, self.get_model_err(), self.get_total_err()])
         result.attrs = {}
 
         return result
 
     def get_flat_basis(self) -> xr.DataArray:
-        """Return 2D DataArray encoding basis regions."""
+        """Return a two-dimensional basis-region map.
+
+        Returns:
+            DataArray encoding the basis region number at each grid cell.
+        """
         if len(self.basis.dims) == 2:
             return self.basis
 
@@ -657,86 +788,67 @@ class _PostprocessingOutputMethods:
         return (self.basis * self.basis[region_dim]).sum(region_dim).as_numpy().rename("basis")
 
 
-def _modern_postprocessing_components(inv_out: InversionOutput) -> dict[str, Any]:
-    """Build postprocessing-compatible fields from modern RHIME output."""
-    inv_inputs = inv_out.inv_inputs
-    basis = inv_out.basis_functions.operator.basis_matrix
-    current_state_dim = inv_out.basis_functions.operator.meta.state_dim
-    if current_state_dim != "region":
-        basis = basis.rename({current_state_dim: "region"})
-    if "region" in inv_inputs.coords:
-        basis = basis.reindex(region=inv_inputs.region)
-
-    nmeasure = np.arange(inv_inputs.sizes["nmeasure"])
-    sites = inv_out.run_metadata.get("sites", [])
-    site_names = (
-        inv_inputs["site_names"]
-        if "site_names" in inv_inputs
-        else xr.DataArray(list(sites), dims="nsite", coords={"nsite": np.arange(len(sites))})
-    )
-    obs_prior_factor = inv_inputs["mf_prior_factor"] if "mf_prior_factor" in inv_inputs else None
-    obs_prior_upper_level_factor = (
-        inv_inputs["mf_prior_upper_level_factor"] if "mf_prior_upper_level_factor" in inv_inputs else None
-    )
-
-    def nmeasure_array(name: str, source: xr.DataArray) -> xr.DataArray:
-        """Create a clean nmeasure DataArray without inherited indexes."""
-        result = xr.DataArray(
-            source.values,
-            dims=["nmeasure"],
-            coords={"nmeasure": nmeasure},
-            name=name,
-        )
-        result.attrs = source.attrs
-        return result
-
-    species = inv_out.species
-    domain = inv_out.domain
-    start_date = inv_out.start_date
-    end_date = inv_out.end_date
-    if species is None or domain is None or start_date is None or end_date is None:
-        raise ValueError(
-            "Modern InversionOutput metadata must include species, domain, start_date, and end_date."
-        )
-
-    return {
-        "obs": nmeasure_array("Yobs", inv_inputs["mf"]),
-        "obs_err": nmeasure_array("Yerror", inv_inputs["mf_error"]),
-        "obs_repeatability": nmeasure_array("Yerror_repeatability", inv_inputs["mf_repeatability"]),
-        "obs_variability": nmeasure_array("Yerror_variability", inv_inputs["mf_variability"]),
-        "obs_prior_factor": (
-            nmeasure_array("Yobs_prior_factor", obs_prior_factor) if obs_prior_factor is not None else None
-        ),
-        "obs_prior_upper_level_factor": (
-            nmeasure_array("Yobs_prior_upper_level_factor", obs_prior_upper_level_factor)
-            if obs_prior_upper_level_factor is not None
-            else None
-        ),
-        "site_indicators": nmeasure_array("site_indicator", inv_inputs["site_indicator"]),
-        "flux": inv_out.basis_functions.flux,
-        "basis": basis,
-        "trace": inv_out.trace,
-        "site_names": site_names,
-        "times": nmeasure_array("times", inv_inputs["time"]),
-        "start_date": start_date,
-        "end_date": end_date,
-        "species": species,
-        "domain": domain,
-    }
-
-
 class ModernPostprocessingOutput(_PostprocessingOutputMethods):
-    """Derived postprocessing view over a modern RHIME InversionOutput."""
+    """Single-sector postprocessing view over modern RHIME output.
+
+    Args:
+        inv_out: Modern RHIME inversion output.
+
+    Attributes:
+        obs_inputs: Observation and observation-error inputs as one dataset.
+        trace: InferenceData containing sampled RHIME variables.
+        basis: Flat standard basis matrix used by transitional output helpers.
+        flux: Prior flux used by current standard output helpers.
+
+    Raises:
+        ValueError: If required modern metadata or observation inputs are
+            missing.
+    """
 
     def __init__(self, inv_out: InversionOutput) -> None:
         self.modern_output = inv_out
-        for name, value in _modern_postprocessing_components(inv_out).items():
-            setattr(self, name, value)
+        inv_inputs = inv_out.inv_inputs
+        if inv_out.run_metadata.get("split_by_sectors"):
+            raise ValueError("Standard postprocessing supports only single-sector RHIME outputs.")
+
+        species = inv_out.species
+        domain = inv_out.domain
+        start_date = inv_out.start_date
+        end_date = inv_out.end_date
+        if species is None or domain is None or start_date is None or end_date is None:
+            raise ValueError(
+                "Modern InversionOutput metadata must include species, domain, start_date, and end_date."
+            )
+
+        sites = inv_out.run_metadata.get("sites", [])
+        self.site_names = (
+            inv_inputs["site_names"]
+            if "site_names" in inv_inputs
+            else xr.DataArray(list(sites), dims="nsite", coords={"nsite": np.arange(len(sites))})
+        )
+        self._site_indicators = inv_inputs["site_indicator"]
+        self._times = inv_inputs["time"]
+        self.obs_inputs = _modern_observation_inputs(inv_inputs)
+        self.flux = inv_out.basis_functions.flux
+        self.basis = _standard_basis_from_basis_functions(inv_out.basis_functions, inv_inputs)
+        self.trace = inv_out.trace
+        self.start_date = start_date
+        self.end_date = end_date
+        self.species = species
+        self.domain = domain
         self._normalise_postprocessing_inputs()
 
 
-def as_postprocessing_output(inv_out: PostprocessingInput) -> PostprocessingInversionOutput:
-    """Return an object satisfying the postprocessing input contract."""
+def as_postprocessing_output(inv_out: PostprocessingInput) -> StandardPostprocessingOutput:
+    """Return the standard single-sector postprocessing view for an output.
+
+    Args:
+        inv_out: Modern ``InversionOutput`` or an object already satisfying the
+            standard postprocessing protocol.
+
+    Returns:
+        Standard single-sector postprocessing view.
+    """
     if isinstance(inv_out, InversionOutput):
         return ModernPostprocessingOutput(inv_out)
     return inv_out
@@ -768,8 +880,42 @@ class LegacyInversionOutput(_PostprocessingOutputMethods):
     obs_prior_upper_level_factor: xr.DataArray | None = None
 
     def __post_init__(self) -> None:
-        """Check that trace has posterior traces, and fix flux time values."""
+        """Check trace contents and derive standard postprocessing datasets."""
+        self.obs_inputs = xr.merge(
+            [
+                data
+                for data in (
+                    self.obs.rename("y_obs"),
+                    self.obs_err.rename("y_obs_error"),
+                    (
+                        self.obs_prior_factor.rename("y_obs_prior_factor")
+                        if self.obs_prior_factor is not None
+                        else None
+                    ),
+                    (
+                        self.obs_prior_upper_level_factor.rename("y_obs_prior_upper_level_factor")
+                        if self.obs_prior_upper_level_factor is not None
+                        else None
+                    ),
+                    self.obs_repeatability.rename("y_obs_repeatability"),
+                    self.obs_variability.rename("y_obs_variability"),
+                )
+                if data is not None
+            ]
+        )
         self._normalise_postprocessing_inputs()
+        self.obs = self.obs_inputs["y_obs"]
+        self.obs_err = self.obs_inputs["y_obs_error"]
+        self.obs_repeatability = self.obs_inputs["y_obs_repeatability"]
+        self.obs_variability = self.obs_inputs["y_obs_variability"]
+        self.obs_prior_factor = (
+            self.obs_inputs["y_obs_prior_factor"] if "y_obs_prior_factor" in self.obs_inputs else None
+        )
+        self.obs_prior_upper_level_factor = (
+            self.obs_inputs["y_obs_prior_upper_level_factor"]
+            if "y_obs_prior_upper_level_factor" in self.obs_inputs
+            else None
+        )
 
     @classmethod
     def from_modern_output(cls, inv_out: InversionOutput) -> Self:
@@ -779,7 +925,51 @@ class LegacyInversionOutput(_PostprocessingOutputMethods):
         a legacy-shaped carrier. Standard RHIME postprocessing consumes modern
         ``InversionOutput`` through ``ModernPostprocessingOutput`` instead.
         """
-        return cls(**_modern_postprocessing_components(inv_out))
+        inv_inputs = inv_out.inv_inputs
+        species = inv_out.species
+        domain = inv_out.domain
+        start_date = inv_out.start_date
+        end_date = inv_out.end_date
+        if species is None or domain is None or start_date is None or end_date is None:
+            raise ValueError(
+                "Modern InversionOutput metadata must include species, domain, start_date, and end_date."
+            )
+
+        sites = inv_out.run_metadata.get("sites", [])
+        site_names = (
+            inv_inputs["site_names"]
+            if "site_names" in inv_inputs
+            else xr.DataArray(list(sites), dims="nsite", coords={"nsite": np.arange(len(sites))})
+        )
+
+        return cls(
+            obs=_flat_nmeasure_array("Yobs", inv_inputs["mf"]),
+            obs_err=_flat_nmeasure_array("Yerror", inv_inputs["mf_error"]),
+            obs_repeatability=_flat_nmeasure_array("Yerror_repeatability", inv_inputs["mf_repeatability"]),
+            obs_variability=_flat_nmeasure_array("Yerror_variability", inv_inputs["mf_variability"]),
+            obs_prior_factor=(
+                _flat_nmeasure_array("Yobs_prior_factor", inv_inputs["mf_prior_factor"])
+                if "mf_prior_factor" in inv_inputs
+                else None
+            ),
+            obs_prior_upper_level_factor=(
+                _flat_nmeasure_array(
+                    "Yobs_prior_upper_level_factor", inv_inputs["mf_prior_upper_level_factor"]
+                )
+                if "mf_prior_upper_level_factor" in inv_inputs
+                else None
+            ),
+            flux=inv_out.basis_functions.flux,
+            basis=_standard_basis_from_basis_functions(inv_out.basis_functions, inv_inputs),
+            trace=inv_out.trace,
+            site_indicators=_flat_nmeasure_array("site_indicator", inv_inputs["site_indicator"]),
+            times=_flat_nmeasure_array("times", inv_inputs["time"]),
+            site_names=site_names,
+            start_date=start_date,
+            end_date=end_date,
+            species=species,
+            domain=domain,
+        )
 
     def __eq__(self, other: Any) -> bool:
         """Check equality between LegacyInversionOutput objects.

--- a/openghg_inversions/postprocessing/make_outputs.py
+++ b/openghg_inversions/postprocessing/make_outputs.py
@@ -1,17 +1,20 @@
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal, cast
 
 import xarray as xr
 
 from openghg_inversions.array_ops import sparse_xr_dot
 from openghg_inversions.postprocessing.countries import Countries, paris_regions_dict
-from openghg_inversions.postprocessing.inversion_output import LegacyInversionOutput
+from openghg_inversions.postprocessing.inversion_output import (
+    PostprocessingInput,
+    as_postprocessing_output,
+)
 from openghg_inversions.postprocessing.stats import calculate_stats
 from openghg_inversions.postprocessing.utils import rename_by_replacement
 
 
 def make_flux_outputs(
-    inv_out: LegacyInversionOutput,
+    inv_out: PostprocessingInput,
     stats: list[str] | None = None,
     stats_args: dict | None = None,
     include_scale_factors: bool = True,
@@ -20,7 +23,7 @@ def make_flux_outputs(
     """Return dataset of stats for fluxes and scaling factors.
 
     Args:
-        inv_out: LegacyInversionOutput containing MCMC traces.
+        inv_out: Inversion output containing MCMC traces.
         stats: List of stats to use. If None, the default for
             calculate_stats is used, which is "mean" and "quantiles". See the
             postprocessing.stats submodule for more options.
@@ -42,6 +45,7 @@ def make_flux_outputs(
         xr.Dataset with computed flux stats.
 
     """
+    inv_out = as_postprocessing_output(inv_out)
     trace = inv_out.get_trace_dataset(var_names="x")
 
     if stats_args is None:
@@ -98,7 +102,7 @@ def flatten_post_prior(ds: xr.Dataset) -> xr.Dataset:
     ds_list = []
     dvs_list = []
     for coord, when in [("post", "posterior"), ("prior", "prior")]:
-        dvs = [str(dv) for dv in ds.data_vars if when in dv]
+        dvs = [str(dv) for dv in ds.data_vars if when in str(dv)]
         dvs_list.extend(dvs)
         # select either "posterior" or "prior" vars, remove those from the variable names
         # then add "post" or "prior" as a coordinate for the dimension "when"
@@ -149,7 +153,7 @@ def sort_data_vars(ds: xr.Dataset) -> xr.Dataset:
 
 
 def make_concentration_outputs(
-    inv_out: LegacyInversionOutput,
+    inv_out: PostprocessingInput,
     stats: list[str] | None = None,
     stats_args: dict | None = None,
     combine_bc_and_offset: bool = False,
@@ -157,7 +161,7 @@ def make_concentration_outputs(
     """Return dataset of stats for concentrations.
 
     Args:
-        inv_out: LegacyInversionOutput containing MCMC traces.
+        inv_out: Inversion output containing MCMC traces.
         stats: List of stats to use. If None, the default for
             calculate_stats is used, which is "mean" and "quantiles". See the
             postprocessing.stats submodule for more options.
@@ -175,12 +179,14 @@ def make_concentration_outputs(
         xr.Dataset with computed flux stats.
 
     """
+    inv_out = as_postprocessing_output(inv_out)
     conc_vars = ["y"]
+    posterior = cast(Any, inv_out.trace).posterior
 
-    if "mu_bc" in inv_out.trace.posterior:
+    if "mu_bc" in posterior:
         conc_vars.append("mu_bc")
 
-    if "offset" in inv_out.trace.posterior:
+    if "offset" in posterior:
         conc_vars.append("offset")
 
     trace = inv_out.get_trace_dataset(var_names=conc_vars)
@@ -212,7 +218,7 @@ def make_concentration_outputs(
 
 
 def make_country_outputs(
-    inv_out: LegacyInversionOutput,
+    inv_out: PostprocessingInput,
     country_file: str | Path | None = None,
     country_regions: str | Path | dict[str, list[str]] | Literal["paris"] | None = None,
     stats: list[str] | None = None,
@@ -222,9 +228,9 @@ def make_country_outputs(
     """Calculate country emission stats.
 
     Args:
-        inv_out: LegacyInversionOutput containing MCMC traces.
+        inv_out: Inversion output containing MCMC traces.
         country_file: Path to country definition file. If None, the default
-            country file location and the domain of the LegacyInversionOutput will be used
+            country file location and the domain of the inversion output will be used
             to try to find a suitable country file.
         country_regions: Dict mapping country region names (e.g. "BENELUX") to a
             list of (country codes) of the countries comprising that regions (e.g.
@@ -247,6 +253,7 @@ def make_country_outputs(
         xr.Dataset containing statistics for the specified countries and regions.
 
     """
+    inv_out = as_postprocessing_output(inv_out)
     drop_missing_regions = False
 
     if country_regions == "paris":
@@ -275,7 +282,7 @@ def make_country_outputs(
 
 
 def basic_output(
-    inv_out: LegacyInversionOutput,
+    inv_out: PostprocessingInput,
     country_file: str | Path | None = None,
     country_regions: str | Path | dict[str, list[str]] | Literal["paris"] | None = None,
     stats: list[str] | None = None,
@@ -287,7 +294,7 @@ def basic_output(
     to create the model, like "H matrices" and the flux used.
 
     Args:
-        inv_out: LegacyInversionOutput to process
+        inv_out: inversion output to process
         country_file: path to country file
         country_regions: optional country regions to use. If "paris" is passed,
         then the PARIS regions will be used.
@@ -300,23 +307,31 @@ def basic_output(
         totals.
 
     """
-    obs_and_errs = inv_out.get_obs_and_errors()
-    conc_outs = make_concentration_outputs(inv_out, stats=stats, stats_args=stats_args)
-    flux_outs = make_flux_outputs(inv_out, stats=stats, stats_args=stats_args)
+    postprocessing_inv_out = as_postprocessing_output(inv_out)
+    obs_and_errs = postprocessing_inv_out.get_obs_and_errors()
+    conc_outs = make_concentration_outputs(postprocessing_inv_out, stats=stats, stats_args=stats_args)
+    flux_outs = make_flux_outputs(postprocessing_inv_out, stats=stats, stats_args=stats_args)
     country_outs = make_country_outputs(
-        inv_out,
+        postprocessing_inv_out,
         country_file=country_file,
         country_regions=country_regions,
         stats=stats,
         stats_args=stats_args,
     )
 
-    model_data = inv_out.get_model_data(var_names=["hx", "hbc", "min_error"]).rename(
+    model_data = postprocessing_inv_out.get_model_data(var_names=["hx", "hbc", "min_error"]).rename(
         {"hx": "Hx", "hbc": "Hbc", "min_error": "min_model_error"}
     )
 
     result = xr.merge(
-        [obs_and_errs, conc_outs, flux_outs, country_outs, model_data, inv_out.get_flat_basis()]
+        [
+            obs_and_errs,
+            conc_outs,
+            flux_outs,
+            country_outs,
+            model_data,
+            postprocessing_inv_out.get_flat_basis(),
+        ]
     )
 
     for dv in result.data_vars:

--- a/openghg_inversions/postprocessing/make_paris_outputs.py
+++ b/openghg_inversions/postprocessing/make_paris_outputs.py
@@ -6,12 +6,13 @@ from typing import Any, Literal
 import pandas as pd
 import xarray as xr
 
-from openghg.util import timestamp_now
+from openghg.util._time import timestamp_now
 from openghg_inversions.config.version import code_version
 from openghg_inversions.postprocessing.countries import Countries
 from openghg_inversions.postprocessing.inversion_output import (
-    LegacyInversionOutput,
+    PostprocessingInput,
     make_inv_out_from_rhime_outputs,
+    as_postprocessing_output,
 )
 from openghg_inversions.postprocessing.make_outputs import (
     make_concentration_outputs,
@@ -133,12 +134,13 @@ def shift_measurement_time_to_midpoint(ds: xr.Dataset, period: str = "4h") -> xr
 
 
 def paris_concentration_outputs(
-    inv_out: LegacyInversionOutput, report_mode: bool = False, obs_avg_period: str = "4h"
+    inv_out: PostprocessingInput, report_mode: bool = False, obs_avg_period: str = "4h"
 ) -> xr.Dataset:
     """Create PARIS concentration outputs.
 
     TODO: add offset
     """
+    inv_out = as_postprocessing_output(inv_out)
     stats = ["kde_mode", "quantiles"] if report_mode else ["mean", "quantiles"]
 
     stats_args = {"quantiles__quantiles": [0.159, 0.841]}
@@ -155,13 +157,11 @@ def paris_concentration_outputs(
         "total_error": "uYtotal",
     }
     filtered_rename_map = {k: v for k, v in rename_map.items() if k in existing_vars}
-    obs_and_errs = (
-        obs_and_errs_raw
-        .rename(filtered_rename_map)
-        .drop_vars("y_obs_error")
-    )
+    obs_and_errs = obs_and_errs_raw.rename(filtered_rename_map).drop_vars("y_obs_error")
 
-    conc_outputs = make_concentration_outputs(inv_out, stats, stats_args, combine_bc_and_offset=True).unstack("nmeasure")
+    conc_outputs = make_concentration_outputs(inv_out, stats, stats_args, combine_bc_and_offset=True).unstack(
+        "nmeasure"
+    )
 
     # rename to match PARIS concentrations template
     def renamer(name: str) -> str:
@@ -276,13 +276,14 @@ def _flux_interval_midpoints(
 
 
 def paris_flux_output(
-    inv_out: LegacyInversionOutput,
+    inv_out: PostprocessingInput,
     country_file: str | Path | None = None,
     time_point: Literal["start", "midpoint"] = "midpoint",
     report_mode: bool = False,
     inversion_grid: bool = True,
-    flux_frequency: Literal["monthly", "yearly"] | str = "yearly"
+    flux_frequency: Literal["monthly", "yearly"] | str = "yearly",
 ) -> xr.Dataset:
+    inv_out = as_postprocessing_output(inv_out)
     stats = ["kde_mode", "quantiles"] if report_mode else ["mean", "quantiles"]
 
     stats_args = {"quantiles__quantiles": [0.159, 0.841]}
@@ -302,14 +303,12 @@ def paris_flux_output(
         country_regions="paris",
         stats=stats,
         stats_args=stats_args,
-        country_code="alpha3"
+        country_code="alpha3",
     )
     country_outs = country_outs * 1e-3  # convert g/yr to kg/yr
 
     # add country mask
-    countries = Countries.from_file(
-        country_file=country_file, country_code="alpha3", domain=inv_out.domain
-    )
+    countries = Countries.from_file(country_file=country_file, country_code="alpha3", domain=inv_out.domain)
 
     country_fraction = countries.matrix.as_numpy().rename("country_fraction")
 
@@ -359,7 +358,7 @@ def paris_flux_output(
             return ds
 
     result = (
-        xr.merge([flux_outs, country_outs, country_fraction.reindex_like(flux_outs)], join='outer')
+        xr.merge([flux_outs, country_outs, country_fraction.reindex_like(flux_outs)], join="outer")
         .rename(dim_rename_dict)
         .pipe(time_func)
         .pipe(convert_time_to_unix_epoch, "1d")
@@ -455,14 +454,15 @@ def infer_flux_frequency(flux: xr.DataArray) -> str:
 
 
 def make_paris_outputs(
-    inv_out: LegacyInversionOutput,
+    inv_out: PostprocessingInput,
     country_file: str | Path | None = None,
     time_point: Literal["start", "midpoint"] = "midpoint",
     report_mode: bool = False,
     inversion_grid: bool = True,
     obs_avg_period: str = "4h",
-    domain: str | None = None
+    domain: str | None = None,
 ) -> tuple[xr.Dataset, xr.Dataset]:
+    inv_out = as_postprocessing_output(inv_out)
     # infer flux frequency
     flux_frequency = infer_flux_frequency(inv_out.flux)
     conc_outs = paris_concentration_outputs(inv_out, report_mode=report_mode, obs_avg_period=obs_avg_period)
@@ -472,7 +472,7 @@ def make_paris_outputs(
         country_file=country_file,
         inversion_grid=inversion_grid,
         time_point=time_point,
-        flux_frequency=flux_frequency
+        flux_frequency=flux_frequency,
     )
 
     return flux_outs, conc_outs

--- a/openghg_inversions/postprocessing/make_paris_outputs.py
+++ b/openghg_inversions/postprocessing/make_paris_outputs.py
@@ -6,7 +6,7 @@ from typing import Any, Literal
 import pandas as pd
 import xarray as xr
 
-from openghg.util._time import timestamp_now
+from openghg.util import timestamp_now  # pyright: ignore[reportPrivateImportUsage]
 from openghg_inversions.config.version import code_version
 from openghg_inversions.postprocessing.countries import Countries
 from openghg_inversions.postprocessing.inversion_output import (

--- a/openghg_inversions/postprocessing/make_paris_outputs.py
+++ b/openghg_inversions/postprocessing/make_paris_outputs.py
@@ -192,7 +192,7 @@ def paris_concentration_outputs(
 
     conc_attrs = get_data_var_attrs(conc_template_path)
 
-    units = float(inv_out.obs.attrs["units"].split(" ")[0])  # e.g. get 1e-12 from "1e-12 mol/mol"
+    units = float(obs_and_errs_raw["y_obs"].attrs["units"].split(" ")[0])
 
     common_rename_dict = {"site": "nsite"}
 

--- a/openghg_inversions/rhime/outputs.py
+++ b/openghg_inversions/rhime/outputs.py
@@ -12,7 +12,7 @@ import xarray as xr
 from openghg_inversions.array_ops import sparse_xr_dot
 from openghg_inversions.inversion_data import RhimePreparedInputs
 from openghg_inversions.models import RhimeModelSpec
-from openghg_inversions.postprocessing.inversion_output import InversionOutput, LegacyInversionOutput
+from openghg_inversions.postprocessing.inversion_output import InversionOutput
 from openghg_inversions.rhime.specs import RhimeOutputSpec, RhimeRunSpec
 from openghg_inversions.utils import ncdf_encoding
 
@@ -176,18 +176,16 @@ def make_standard_output_bundle(
     if output_spec.output_format == "basic":
         from openghg_inversions.postprocessing.make_outputs import basic_output
 
-        legacy_inv_out = LegacyInversionOutput.from_modern_output(inv_out)
-        output_metadata["postprocessing_input_contract"] = "legacy_adapter"
-        outputs["basic"] = basic_output(legacy_inv_out, country_file=country_file)
+        output_metadata["postprocessing_input_contract"] = "modern_view"
+        outputs["basic"] = basic_output(inv_out, country_file=country_file)
     elif output_spec.output_format == "paris":
         from openghg_inversions.postprocessing.make_paris_outputs import make_paris_outputs
 
-        legacy_inv_out = LegacyInversionOutput.from_modern_output(inv_out)
-        output_metadata["postprocessing_input_contract"] = "legacy_adapter"
+        output_metadata["postprocessing_input_contract"] = "modern_view"
         obs_avg_period = prepared.averaging_period[0] or "0h"
         kwargs = output_spec.paris_postprocessing_kwargs or {}
         flux_outs, conc_outs = make_paris_outputs(
-            legacy_inv_out,
+            inv_out,
             country_file=country_file,
             domain=model_spec.domain,
             obs_avg_period=obs_avg_period,

--- a/openghg_inversions/rhime/outputs.py
+++ b/openghg_inversions/rhime/outputs.py
@@ -12,7 +12,10 @@ import xarray as xr
 from openghg_inversions.array_ops import sparse_xr_dot
 from openghg_inversions.inversion_data import RhimePreparedInputs
 from openghg_inversions.models import RhimeModelSpec
-from openghg_inversions.postprocessing.inversion_output import InversionOutput
+from openghg_inversions.postprocessing.inversion_output import (
+    InversionOutput,
+    _reset_serialisation_multiindexes,
+)
 from openghg_inversions.rhime.specs import RhimeOutputSpec, RhimeRunSpec
 from openghg_inversions.utils import ncdf_encoding
 
@@ -54,6 +57,11 @@ def _define_output_filename(
 
 def _save_inferencedata(idata: az.InferenceData, path: str | Path) -> None:
     """Save InferenceData, preferring the h5netcdf backend with fallbacks."""
+    if isinstance(idata, az.InferenceData):
+        idata = cast(Any, az.InferenceData)(
+            **{group: _reset_serialisation_multiindexes(idata[group]) for group in idata.groups()}
+        )
+
     failures = []
     for engine in ("h5netcdf", None, "netcdf4"):
         try:
@@ -176,12 +184,12 @@ def make_standard_output_bundle(
     if output_spec.output_format == "basic":
         from openghg_inversions.postprocessing.make_outputs import basic_output
 
-        output_metadata["postprocessing_input_contract"] = "modern_view"
+        output_metadata["postprocessing_input_contract"] = "standard_single_sector_modern_view"
         outputs["basic"] = basic_output(inv_out, country_file=country_file)
     elif output_spec.output_format == "paris":
         from openghg_inversions.postprocessing.make_paris_outputs import make_paris_outputs
 
-        output_metadata["postprocessing_input_contract"] = "modern_view"
+        output_metadata["postprocessing_input_contract"] = "standard_single_sector_modern_view"
         obs_avg_period = prepared.averaging_period[0] or "0h"
         kwargs = output_spec.paris_postprocessing_kwargs or {}
         flux_outs, conc_outs = make_paris_outputs(

--- a/openghg_inversions/rhime/sampling.py
+++ b/openghg_inversions/rhime/sampling.py
@@ -8,6 +8,8 @@ from typing import Any, Literal, cast
 import arviz as az
 import pymc as pm
 
+from openghg_inversions.models.coords import get_coord_registry, restore_inferencedata_coords
+
 NutsSampler = Literal["pymc", "nutpie", "numpyro", "blackjax"]
 
 
@@ -133,7 +135,11 @@ class RhimeSampler:
             )
 
         trace = cast(az.InferenceData, raw_trace.isel(draw=slice(self.burn, None)))
-        return self._extend_predictive(trace, model=model)
+        trace = self._extend_predictive(trace, model=model)
+        registry = get_coord_registry(model)
+        if registry is not None:
+            trace = restore_inferencedata_coords(trace, registry)
+        return trace
 
     def _extend_predictive(self, trace: az.InferenceData, *, model: pm.Model) -> az.InferenceData:
         """Extend sampled trace with configured predictive groups."""

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -106,6 +106,25 @@ def _fake_basis_functions(*, artifact_source: str = "generated") -> BasisFunctio
     )
 
 
+def _fake_basis_functions_matching_country_grid(country_file: Path) -> BasisFunctions:
+    """Build a one-region basis artifact on the grid of a test country file."""
+    country_grid = xr.open_dataset(country_file)
+    basis = xr.DataArray(
+        np.ones((country_grid.sizes["lat"], country_grid.sizes["lon"]), dtype=int),
+        dims=("lat", "lon"),
+        coords={"lat": country_grid.lat, "lon": country_grid.lon},
+        name="basis",
+    )
+    flux = xr.ones_like(basis, dtype=float).rename("flux")
+    flux.attrs["units"] = "mol/m2/s"
+    return BasisFunctions.from_flat_basis(
+        basis_flat=basis,
+        flux=flux,
+        operator_kwargs={"state_dim": "region"},
+        metadata={BASIS_ARTIFACT_SOURCE_ATTR: "country-grid-test"},
+    )
+
+
 def _site_dataset(values: list[float] | None = None) -> xr.Dataset:
     """Build a minimal site dataset with footprint-times-flux values."""
     values = values if values is not None else [2.0, 3.0]
@@ -195,6 +214,59 @@ def _minimal_output_idata() -> az.InferenceData:
         posterior={"x": np.ones((1, 1, 1))},
         coords={"region": [0]},
         dims={"x": ["region"]},
+    )
+
+
+def _postprocessing_output_idata() -> az.InferenceData:
+    """Build a small complete trace for modern postprocessing smoke tests."""
+    coords = {"region": [0], "nmeasure": [0]}
+    return az.from_dict(
+        posterior={
+            "x": np.ones((1, 3, 1)),
+            "epsilon": np.full((1, 3, 1), 2.0),
+            "mu_bc": np.full((1, 3, 1), 0.1),
+        },
+        prior={
+            "x": np.full((1, 3, 1), 0.8),
+            "mu_bc": np.full((1, 3, 1), 0.05),
+        },
+        posterior_predictive={"y": np.full((1, 3, 1), 10.0)},
+        prior_predictive={"y": np.full((1, 3, 1), 9.0)},
+        constant_data={
+            "hx": np.ones(1),
+            "hbc": np.full(1, 0.1),
+            "min_error": np.zeros(1),
+        },
+        coords=coords,
+        dims={
+            "x": ["region"],
+            "epsilon": ["nmeasure"],
+            "mu_bc": ["nmeasure"],
+            "y": ["nmeasure"],
+            "hx": ["nmeasure"],
+            "hbc": ["nmeasure"],
+            "min_error": ["nmeasure"],
+        },
+    )
+
+
+def _modern_postprocessing_inv_out(country_file: Path) -> InversionOutput:
+    """Build a modern output with enough groups for real postprocessing helpers."""
+    inv_inputs = _minimal_output_inv_inputs()
+    for var_name in ("mf", "mf_error", "mf_repeatability", "mf_variability"):
+        inv_inputs[var_name].attrs["units"] = "1e-09 mol/mol"
+
+    return InversionOutput(
+        trace=_postprocessing_output_idata(),
+        inv_inputs=inv_inputs,
+        basis_functions=_fake_basis_functions_matching_country_grid(country_file),
+        run_metadata={
+            "start_date": "2019-01-01",
+            "end_date": "2019-01-02",
+            "sites": ["TAC"],
+            "split_by_sectors": False,
+        },
+        model_metadata={"species": "ch4", "domain": "EUROPE"},
     )
 
 
@@ -688,6 +760,65 @@ def test_rhime_sampler_runs_pymc_sampling_and_predictive_steps(
         "random_seed": 42,
     }
     assert fake_idata.extensions == ["prior", "posterior"]
+
+
+def test_rhime_sampler_restores_registered_coords_after_predictive_steps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RhimeSampler restores model-managed coordinates after predictive groups are attached."""
+
+    class FakePosterior:
+        sizes = {"draw": 2}
+
+    class FakeInferenceData:
+        posterior = FakePosterior()
+
+        def __init__(self) -> None:
+            self.extensions: list[str] = []
+
+        def isel(self, **kwargs: Any) -> "FakeInferenceData":
+            return self
+
+        def extend(self, other: str) -> None:
+            self.extensions.append(other)
+
+    fake_idata = FakeInferenceData()
+    calls: list[tuple[FakeInferenceData, models.CoordRegistry, list[str]]] = []
+
+    def fake_sample(**kwargs: Any) -> FakeInferenceData:
+        return fake_idata
+
+    def fake_prior_predictive(draws: int, model: pm.Model) -> str:
+        return "prior"
+
+    def fake_posterior_predictive(trace: Any, **kwargs: Any) -> str:
+        return "posterior"
+
+    def fake_restore(trace: FakeInferenceData, registry: models.CoordRegistry) -> FakeInferenceData:
+        calls.append((trace, registry, list(trace.extensions)))
+        return trace
+
+    monkeypatch.setattr("openghg_inversions.rhime.sampling.pm.sample", fake_sample)
+    monkeypatch.setattr(
+        "openghg_inversions.rhime.sampling.pm.sample_prior_predictive",
+        fake_prior_predictive,
+    )
+    monkeypatch.setattr(
+        "openghg_inversions.rhime.sampling.pm.sample_posterior_predictive",
+        fake_posterior_predictive,
+    )
+    monkeypatch.setattr("openghg_inversions.rhime.sampling.restore_inferencedata_coords", fake_restore)
+
+    model = pm.Model()
+    registry = models.CoordRegistry(
+        original_coords={"nmeasure": pd.MultiIndex.from_arrays([["TAC"], pd.to_datetime(["2019-01-01"])])}
+    )
+    models.attach_coord_registry(model, registry)
+
+    result = RhimeSampler(draws=2, chains=1, tune=0).sample(model)
+
+    assert result is fake_idata
+    assert calls == [(fake_idata, registry, ["prior", "posterior"])]
 
 
 def test_params_from_config_maps_legacy_emissions_name(tmp_path: Path) -> None:
@@ -1802,6 +1933,51 @@ def test_modern_inversion_output_restores_bytes_multiindex_metadata() -> None:
     xr.testing.assert_identical(reloaded.inv_inputs, inv_inputs)
 
 
+def test_modern_inversion_output_roundtrips_trace_multiindex() -> None:
+    """Modern output serialization preserves restored trace measurement coordinates."""
+    model_spec, output_spec, run_spec = _minimal_output_specs()
+    nmeasure_index = pd.MultiIndex.from_arrays(
+        [["TAC"], pd.to_datetime(["2019-01-01"])],
+        names=["site", "time"],
+    )
+    posterior = xr.Dataset(
+        {"x": (("chain", "draw", "region"), np.ones((1, 1, 1)))},
+        coords={"chain": [0], "draw": [0], "region": [0]},
+    )
+    posterior_predictive = xr.Dataset(
+        {"y": (("chain", "draw", "nmeasure"), np.ones((1, 1, 1)))},
+        coords={
+            "chain": [0],
+            "draw": [0],
+            **xr.Coordinates.from_pandas_multiindex(nmeasure_index, "nmeasure"),
+        },
+    )
+    prepared = RhimePreparedInputs(
+        inv_inputs=_minimal_output_inv_inputs(),
+        basis_functions=_fake_basis_functions(artifact_source="unit-test"),
+        sites=("TAC",),
+        averaging_period=("1h",),
+        basis_artifact_source="unit-test",
+    )
+    bundle = rhime_outputs.make_standard_output_bundle(
+        output_spec=output_spec,
+        run_spec=run_spec,
+        model_spec=model_spec,
+        idata=az.InferenceData(posterior=posterior, posterior_predictive=posterior_predictive),
+        prepared=prepared,
+        country_file=None,
+    )
+    assert bundle.inv_out is not None
+
+    reloaded = InversionOutput.from_datatree(bundle.inv_out.to_datatree())
+
+    reloaded_posterior_predictive = cast(Any, reloaded.trace).posterior_predictive
+    index = reloaded_posterior_predictive.indexes["nmeasure"]
+    assert isinstance(index, pd.MultiIndex)
+    assert index.names == ["site", "time"]
+    xr.testing.assert_identical(reloaded_posterior_predictive["y"], posterior_predictive["y"])
+
+
 @pytest.mark.parametrize(
     "raw_multiindex_dims",
     [
@@ -1894,6 +2070,121 @@ def test_modern_postprocessing_view_supports_flux_outputs() -> None:
     xr.testing.assert_allclose(modern_flux, legacy_flux)
 
 
+def test_modern_postprocessing_view_keeps_observations_as_dataset() -> None:
+    """Modern postprocessing avoids the split observation fields retained by the legacy carrier."""
+    from openghg_inversions.postprocessing.inversion_output import (
+        ModernPostprocessingOutput,
+        as_postprocessing_output,
+    )
+
+    model_spec, output_spec, run_spec = _minimal_output_specs()
+    inv_inputs = _minimal_output_inv_inputs()
+    inv_inputs["mf_prior_factor"] = ("nmeasure", [0.2])
+    inv_inputs["mf_prior_upper_level_factor"] = ("nmeasure", [0.3])
+    prepared = RhimePreparedInputs(
+        inv_inputs=inv_inputs,
+        basis_functions=_fake_basis_functions(),
+        sites=("TAC",),
+        averaging_period=("1h",),
+        basis_artifact_source="generated",
+    )
+    bundle = rhime_outputs.make_standard_output_bundle(
+        output_spec=output_spec,
+        run_spec=run_spec,
+        model_spec=model_spec,
+        idata=_minimal_output_idata(),
+        prepared=prepared,
+        country_file=None,
+    )
+    assert bundle.inv_out is not None
+
+    modern_view = as_postprocessing_output(bundle.inv_out)
+
+    assert isinstance(modern_view, ModernPostprocessingOutput)
+    assert not hasattr(modern_view, "obs")
+    assert not hasattr(modern_view, "obs_err")
+    assert set(modern_view.obs_inputs.data_vars) == {
+        "y_obs",
+        "y_obs_error",
+        "y_obs_prior_factor",
+        "y_obs_prior_upper_level_factor",
+        "y_obs_repeatability",
+        "y_obs_variability",
+    }
+    assert isinstance(modern_view.obs_inputs.indexes["nmeasure"], pd.MultiIndex)
+    assert modern_view.obs_inputs.indexes["nmeasure"].names == ["site", "time"]
+
+
+def test_standard_postprocessing_view_rejects_multisector_outputs() -> None:
+    """Standard postprocessing does not silently accept multisector modern outputs."""
+    from openghg_inversions.postprocessing.inversion_output import as_postprocessing_output
+
+    inv_out = InversionOutput(
+        trace=_minimal_output_idata(),
+        inv_inputs=_minimal_output_inv_inputs(),
+        basis_functions=_fake_basis_functions(),
+        run_metadata={
+            "start_date": "2019-01-01",
+            "end_date": "2019-01-02",
+            "sites": ["TAC"],
+            "split_by_sectors": True,
+        },
+        model_metadata={"species": "ch4", "domain": "EUROPE"},
+    )
+
+    with pytest.raises(ValueError, match="single-sector"):
+        as_postprocessing_output(inv_out)
+
+
+def test_basic_output_processes_modern_output_without_legacy_adapter(
+    monkeypatch: pytest.MonkeyPatch,
+    europe_country_file: Path,
+) -> None:
+    """Real basic postprocessing accepts modern output without legacy conversion."""
+    from openghg_inversions.postprocessing.make_outputs import basic_output
+
+    def fail_from_modern_output(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("basic_output must not call LegacyInversionOutput.from_modern_output")
+
+    monkeypatch.setattr(LegacyInversionOutput, "from_modern_output", fail_from_modern_output)
+
+    outputs = basic_output(
+        _modern_postprocessing_inv_out(europe_country_file), country_file=europe_country_file
+    )
+
+    assert "y_obs" in outputs
+    assert "model_error" in outputs
+    assert "y_posterior_predictive_mean" in outputs
+    assert "flux_posterior_mean" in outputs
+    assert "country_posterior_mean" in outputs
+
+
+def test_paris_output_processes_modern_output_without_legacy_adapter(
+    monkeypatch: pytest.MonkeyPatch,
+    europe_country_file: Path,
+) -> None:
+    """Real PARIS postprocessing accepts modern output without legacy conversion."""
+    from openghg_inversions.postprocessing.make_paris_outputs import make_paris_outputs
+
+    def fail_from_modern_output(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("make_paris_outputs must not call LegacyInversionOutput.from_modern_output")
+
+    monkeypatch.setattr(LegacyInversionOutput, "from_modern_output", fail_from_modern_output)
+
+    flux_outputs, conc_outputs = make_paris_outputs(
+        _modern_postprocessing_inv_out(europe_country_file),
+        country_file=europe_country_file,
+        obs_avg_period="1h",
+        domain="europe",
+        inversion_grid=False,
+    )
+
+    assert "Yobs" in conc_outputs
+    assert "Yapost" in conc_outputs
+    assert "flux_total_posterior" in flux_outputs
+    assert "country_flux_total_posterior" in flux_outputs
+
+
 def test_standard_basic_output_uses_modern_postprocessing_without_legacy_adapter(monkeypatch) -> None:
     """RHIME basic postprocessing consumes modern output without legacy adapters."""
     model_spec, output_spec, run_spec = _minimal_output_specs(output_format="basic")
@@ -1934,7 +2225,7 @@ def test_standard_basic_output_uses_modern_postprocessing_without_legacy_adapter
     assert captured["inv_out"] is bundle.inv_out
     assert captured["country_file"] == "countries.json"
     assert bundle.output_metadata["inversion_output_contract"] == "modern"
-    assert bundle.output_metadata["postprocessing_input_contract"] == "modern_view"
+    assert bundle.output_metadata["postprocessing_input_contract"] == "standard_single_sector_modern_view"
     assert "basic" in bundle.outputs
 
 
@@ -1991,7 +2282,7 @@ def test_standard_paris_output_uses_modern_postprocessing_without_legacy_adapter
     assert captured["domain"] == "EUROPE"
     assert captured["obs_avg_period"] == "1h"
     assert bundle.output_metadata["inversion_output_contract"] == "modern"
-    assert bundle.output_metadata["postprocessing_input_contract"] == "modern_view"
+    assert bundle.output_metadata["postprocessing_input_contract"] == "standard_single_sector_modern_view"
     assert "paris_flux" in bundle.outputs
     assert "paris_concentration" in bundle.outputs
 
@@ -2031,6 +2322,31 @@ def test_save_inferencedata_falls_back_after_h5netcdf_failure(tmp_path: Path) ->
         (str(path), {"engine": "h5netcdf", "compress": True}),
         (str(path), {"compress": True}),
     ]
+
+
+def test_save_inferencedata_resets_multiindex_coords(tmp_path: Path) -> None:
+    """Standalone trace saving handles restored scientific measurement coordinates."""
+    nmeasure_index = pd.MultiIndex.from_arrays(
+        [["TAC"], pd.to_datetime(["2019-01-01"])],
+        names=["site", "time"],
+    )
+    posterior_predictive = xr.Dataset(
+        {"y": (("chain", "draw", "nmeasure"), np.ones((1, 1, 1)))},
+        coords={
+            "chain": [0],
+            "draw": [0],
+            **xr.Coordinates.from_pandas_multiindex(nmeasure_index, "nmeasure"),
+        },
+    )
+    path = tmp_path / "trace.nc"
+
+    rhime_outputs._save_inferencedata(az.InferenceData(posterior_predictive=posterior_predictive), path)
+    reloaded = az.from_netcdf(path)
+
+    reloaded_posterior_predictive = cast(Any, reloaded).posterior_predictive
+    assert "site" in reloaded_posterior_predictive.coords
+    assert "time" in reloaded_posterior_predictive.coords
+    assert not isinstance(reloaded_posterior_predictive.indexes.get("nmeasure"), pd.MultiIndex)
 
 
 def test_supported_parameter_validation_accepts_sigma_per_site(tmp_path: Path) -> None:

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -157,9 +157,9 @@ def _minimal_output_inv_inputs() -> xr.Dataset:
     return inv_inputs
 
 
-def _minimal_output_specs(output_format: rhime_specs.OutputFormat = "inv_out") -> tuple[
-    RhimeModelSpec, RhimeOutputSpec, RhimeRunSpec
-]:
+def _minimal_output_specs(
+    output_format: rhime_specs.OutputFormat = "inv_out",
+) -> tuple[RhimeModelSpec, RhimeOutputSpec, RhimeRunSpec]:
     """Build minimal RHIME specs for output helper tests."""
     model_spec = RhimeModelSpec(
         species="ch4",
@@ -1844,8 +1844,58 @@ def test_modern_inversion_output_ignores_malformed_multiindex_metadata(raw_multi
     assert not isinstance(reloaded.inv_inputs.indexes.get("nmeasure"), pd.MultiIndex)
 
 
-def test_standard_basic_output_uses_legacy_adapter_without_inferpymc(monkeypatch) -> None:
-    """RHIME basic postprocessing adapts modern output without using inferpymc legacy postprocess."""
+def test_modern_postprocessing_view_supports_flux_outputs() -> None:
+    """Modern InversionOutput can feed postprocessing without becoming LegacyInversionOutput."""
+    from openghg_inversions.postprocessing.inversion_output import (
+        ModernPostprocessingOutput,
+        as_postprocessing_output,
+    )
+    from openghg_inversions.postprocessing.make_outputs import make_flux_outputs
+
+    model_spec, output_spec, run_spec = _minimal_output_specs()
+    prepared = RhimePreparedInputs(
+        inv_inputs=_minimal_output_inv_inputs(),
+        basis_functions=_fake_basis_functions(),
+        sites=("TAC",),
+        averaging_period=("1h",),
+        basis_artifact_source="generated",
+    )
+    bundle = rhime_outputs.make_standard_output_bundle(
+        output_spec=output_spec,
+        run_spec=run_spec,
+        model_spec=model_spec,
+        idata=az.from_dict(
+            posterior={"x": np.ones((1, 2, 1))},
+            prior={"x": np.ones((1, 2, 1))},
+            coords={"region": [0]},
+            dims={"x": ["region"]},
+        ),
+        prepared=prepared,
+        country_file=None,
+    )
+    assert bundle.inv_out is not None
+
+    modern_view = as_postprocessing_output(bundle.inv_out)
+    assert isinstance(modern_view, ModernPostprocessingOutput)
+    assert not isinstance(modern_view, LegacyInversionOutput)
+
+    modern_flux = make_flux_outputs(
+        bundle.inv_out,
+        include_scale_factors=False,
+        report_flux_on_inversion_grid=False,
+    )
+    legacy_flux = make_flux_outputs(
+        LegacyInversionOutput.from_modern_output(bundle.inv_out),
+        include_scale_factors=False,
+        report_flux_on_inversion_grid=False,
+    )
+
+    assert "flux_posterior_mean" in modern_flux
+    xr.testing.assert_allclose(modern_flux, legacy_flux)
+
+
+def test_standard_basic_output_uses_modern_postprocessing_without_legacy_adapter(monkeypatch) -> None:
+    """RHIME basic postprocessing consumes modern output without legacy adapters."""
     model_spec, output_spec, run_spec = _minimal_output_specs(output_format="basic")
     prepared = RhimePreparedInputs(
         inv_inputs=_minimal_output_inv_inputs(),
@@ -1859,12 +1909,16 @@ def test_standard_basic_output_uses_legacy_adapter_without_inferpymc(monkeypatch
     def fail_inferpymc_postprocessouts(**kwargs: Any) -> None:
         raise AssertionError("run_rhime output helpers must not call inferpymc_postprocessouts")
 
-    def fake_basic_output(inv_out: LegacyInversionOutput, country_file: str | None = None) -> xr.Dataset:
+    def fail_from_modern_output(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("run_rhime basic output must not call LegacyInversionOutput.from_modern_output")
+
+    def fake_basic_output(inv_out: InversionOutput, country_file: str | None = None) -> xr.Dataset:
         captured["inv_out"] = inv_out
         captured["country_file"] = country_file
         return xr.Dataset({"ok": ((), 1)})
 
     monkeypatch.setattr(legacy_mcmc, "inferpymc_postprocessouts", fail_inferpymc_postprocessouts)
+    monkeypatch.setattr(LegacyInversionOutput, "from_modern_output", fail_from_modern_output)
     monkeypatch.setattr("openghg_inversions.postprocessing.make_outputs.basic_output", fake_basic_output)
 
     bundle = rhime_outputs.make_standard_output_bundle(
@@ -1877,15 +1931,15 @@ def test_standard_basic_output_uses_legacy_adapter_without_inferpymc(monkeypatch
     )
 
     assert isinstance(bundle.inv_out, InversionOutput)
-    assert isinstance(captured["inv_out"], LegacyInversionOutput)
+    assert captured["inv_out"] is bundle.inv_out
     assert captured["country_file"] == "countries.json"
     assert bundle.output_metadata["inversion_output_contract"] == "modern"
-    assert bundle.output_metadata["postprocessing_input_contract"] == "legacy_adapter"
+    assert bundle.output_metadata["postprocessing_input_contract"] == "modern_view"
     assert "basic" in bundle.outputs
 
 
-def test_standard_paris_output_uses_legacy_adapter_without_inferpymc(monkeypatch) -> None:
-    """RHIME PARIS postprocessing adapts modern output without using inferpymc legacy postprocess."""
+def test_standard_paris_output_uses_modern_postprocessing_without_legacy_adapter(monkeypatch) -> None:
+    """RHIME PARIS postprocessing consumes modern output without legacy adapters."""
     model_spec, output_spec, run_spec = _minimal_output_specs(output_format="paris")
     prepared = RhimePreparedInputs(
         inv_inputs=_minimal_output_inv_inputs(),
@@ -1899,8 +1953,11 @@ def test_standard_paris_output_uses_legacy_adapter_without_inferpymc(monkeypatch
     def fail_inferpymc_postprocessouts(**kwargs: Any) -> None:
         raise AssertionError("run_rhime output helpers must not call inferpymc_postprocessouts")
 
+    def fail_from_modern_output(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("run_rhime PARIS output must not call LegacyInversionOutput.from_modern_output")
+
     def fake_make_paris_outputs(
-        inv_out: LegacyInversionOutput,
+        inv_out: InversionOutput,
         country_file: str | None = None,
         domain: str | None = None,
         obs_avg_period: str = "4h",
@@ -1913,6 +1970,7 @@ def test_standard_paris_output_uses_legacy_adapter_without_inferpymc(monkeypatch
         return xr.Dataset({"flux": ((), 1)}), xr.Dataset({"conc": ((), 1)})
 
     monkeypatch.setattr(legacy_mcmc, "inferpymc_postprocessouts", fail_inferpymc_postprocessouts)
+    monkeypatch.setattr(LegacyInversionOutput, "from_modern_output", fail_from_modern_output)
     monkeypatch.setattr(
         "openghg_inversions.postprocessing.make_paris_outputs.make_paris_outputs",
         fake_make_paris_outputs,
@@ -1928,12 +1986,12 @@ def test_standard_paris_output_uses_legacy_adapter_without_inferpymc(monkeypatch
     )
 
     assert isinstance(bundle.inv_out, InversionOutput)
-    assert isinstance(captured["inv_out"], LegacyInversionOutput)
+    assert captured["inv_out"] is bundle.inv_out
     assert captured["country_file"] == "countries.json"
     assert captured["domain"] == "EUROPE"
     assert captured["obs_avg_period"] == "1h"
     assert bundle.output_metadata["inversion_output_contract"] == "modern"
-    assert bundle.output_metadata["postprocessing_input_contract"] == "legacy_adapter"
+    assert bundle.output_metadata["postprocessing_input_contract"] == "modern_view"
     assert "paris_flux" in bundle.outputs
     assert "paris_concentration" in bundle.outputs
 


### PR DESCRIPTION
* **Summary of changes**

Migrate standard RHIME postprocessing consumers off the temporary `LegacyInversionOutput.from_modern_output(...)` bridge introduced in #401 / PR #436:

- Add a transitional `StandardPostprocessingOutput` contract plus `ModernPostprocessingOutput` view over modern `InversionOutput` for standard single-sector outputs.
- Keep modern observation inputs as one `obs_inputs` dataset instead of re-splitting `obs`, `obs_err`, repeatability/variability, and optional satellite prior-factor arrays on the modern path.
- Restore RHIME `InferenceData` coordinates from the model `CoordRegistry` in `RhimeSampler.sample(...)`, after predictive groups are attached, and reset/restore MultiIndexes at modern output serialization boundaries.
- Route `run_rhime(output_format="basic")` and `run_rhime(output_format="paris")` through modern `InversionOutput` directly.
- Update `make_outputs`, `make_paris_outputs`, `countries`, and `diagnostics` to accept the modern standard postprocessing path while continuing to accept fixedbasis `LegacyInversionOutput`.
- Keep `legacy_outputs` isolated to fixedbasis/HBMCMC compatibility output generation.
- Update the cleanup planning note and changelog for #435, including the next `run_hbmcmc.py` shim step toward removing `fixedbasisMCMC`.

Closes #435.

Relationship to #401/#436: this removes the standard RHIME `basic`/`paris` use of the temporary legacy adapter added in PR #436, while keeping the explicit legacy compatibility adapter available for callers that need a legacy-shaped carrier.

Deferred follow-ups: #383/#429 should replace the remaining flat-basis/postprocessing assumptions with retained/operator-backed `BasisFunctions`; #405 should handle sector-aware RHIME outputs and PARIS-compatible total outputs; #416 should add the `run_hbmcmc.py` compatibility shim, then remove `fixedbasisMCMC` and finally `inferpymc_postprocessouts`.

* **Please check if the PR fulfills these requirements**

- [x] Closes #435
- [x] Tests added and passing
- [x] Documentation and tutorials updated/added
- [x] Added an entry to the `CHANGELOG.md` file
- [x] Added any new requirements to `requirements.txt` (not needed)

Tests/checks run:

- `uv run pytest tests/test_rhime.py tests/test_postprocessing.py tests/postprocessing/test_diagnostics.py tests/postprocessing/test_legacy_outputs.py` (120 passed)
- `uv run ruff check openghg_inversions/postprocessing/inversion_output.py openghg_inversions/postprocessing/diagnostics.py openghg_inversions/postprocessing/make_paris_outputs.py openghg_inversions/postprocessing/make_outputs.py openghg_inversions/postprocessing/countries.py openghg_inversions/rhime/sampling.py openghg_inversions/rhime/outputs.py tests/test_rhime.py`
- `uv run ruff format --check openghg_inversions/postprocessing/inversion_output.py openghg_inversions/postprocessing/diagnostics.py openghg_inversions/postprocessing/make_paris_outputs.py openghg_inversions/postprocessing/make_outputs.py openghg_inversions/postprocessing/countries.py openghg_inversions/rhime/sampling.py openghg_inversions/rhime/outputs.py tests/test_rhime.py`
- `uv run pyright openghg_inversions/postprocessing/inversion_output.py openghg_inversions/postprocessing/diagnostics.py openghg_inversions/postprocessing/make_paris_outputs.py openghg_inversions/postprocessing/make_outputs.py openghg_inversions/postprocessing/countries.py openghg_inversions/rhime/sampling.py openghg_inversions/rhime/outputs.py tests/test_rhime.py`
- `uv run sphinx-build --keep-going -b html docs docs/_build/html` (build succeeded with existing autodoc/static-path warnings about `openghg.analyse._utils` and missing `_static`)