### PR TITLE
[codex] Prune redundant full inversion tests

### DIFF
--- a/openghg_inversions/inversion_inputs.py
+++ b/openghg_inversions/inversion_inputs.py
@@ -122,23 +122,47 @@ def add_min_error(
 ) -> xr.Dataset:
     """Add min_error to combined Dataset."""
     min_error_data: xr.DataArray | float | np.ndarray
+
+    def site_names_for_min_error() -> list[str]:
+        if "site_names" in ds:
+            return [str(site) for site in ds.site_names.values]
+        if "site" in ds:
+            return [str(site) for site in make_site_names(ds.site).values]
+        return [site for site in fp_data if not site.startswith(".")]
+
+    def site_indicator_for_min_error() -> xr.DataArray:
+        if "site_indicator" in ds:
+            return ds.site_indicator
+        if "site" in ds:
+            return xr_unique_inv(ds.site, sort=False).rename("site_indicator")
+        raise ValueError("Per-site min_error values require site_indicator or site data.")
+
+    def fp_data_for_ds_sites() -> dict[str, Any]:
+        return {site: fp_data[site] for site in site_names_for_min_error()}
+
     if isinstance(min_error, numbers.Real) and not isinstance(min_error, bool):
         min_error_data = float(min_error) * xr.ones_like(ds.mf)
     elif isinstance(min_error, np.ndarray) and min_error.ndim == 0:
         min_error_data = min_error * xr.ones_like(ds.mf)
     elif isinstance(min_error, dict):
-        sites = [k for k in fp_data if not k.startswith(".")]
+        fp_data_for_sites = fp_data_for_ds_sites()
+        sites = list(fp_data_for_sites)
+        missing_sites = [site for site in sites if site not in min_error]
+        if missing_sites:
+            raise ValueError(f"min_error mapping is missing values for site(s): {missing_sites}")
         err_per_site = np.array([min_error[site] for site in sites])
-        min_error_data = xr_setup_min_error(err_per_site, ds.site_indicator)
+        min_error_data = xr_setup_min_error(err_per_site, site_indicator_for_min_error())
     elif min_error == "residual":
-        res_err = residual_error_method(fp_data)
+        fp_data_for_sites = fp_data_for_ds_sites()
+        res_err = residual_error_method(fp_data_for_sites, by_site=min_error_per_site)
         if min_error_per_site:
-            min_error_data = xr_setup_min_error(res_err, ds.site_indicator)
+            min_error_data = xr_setup_min_error(res_err, site_indicator_for_min_error())
         else:
             min_error_data = res_err
     elif min_error == "percentile":
-        perc_err = percentile_error_method(fp_data)
-        min_error_data = xr_setup_min_error(perc_err, ds.site_indicator)
+        fp_data_for_sites = fp_data_for_ds_sites()
+        perc_err = percentile_error_method(fp_data_for_sites)
+        min_error_data = xr_setup_min_error(perc_err, site_indicator_for_min_error())
     else:
         raise ValueError(f"Option '{min_error}' is not valid.")
 

--- a/tests/models/test_components.py
+++ b/tests/models/test_components.py
@@ -196,6 +196,26 @@ def test_add_offset_component_supports_manual_and_derived_freq() -> None:
         assert "offset_freq_indicator" in model.named_vars
 
 
+def test_add_offset_component_drop_first_and_freq_builds_expected_design() -> None:
+    """Check drop-first offsets still build the expected site-period design."""
+    site_indicator = _site_indicator()
+
+    with pm.Model(coords={"nmeasure": np.arange(4)}) as model:
+        attach_coord_registry(model, CoordRegistry())
+        add_offset_component(
+            site_indicator,
+            prior_args={"pdf": "normal", "mu": 0.0, "sigma": 1.0},
+            offset_freq="monthly",
+            output_name="offset",
+            drop_first=True,
+        )
+
+    offset_design = model.named_vars["offset_design"].eval()
+    assert offset_design.shape == (4, 2)
+    np.testing.assert_array_equal(offset_design[:2], np.zeros((2, 2)))
+    np.testing.assert_array_equal(offset_design[2:], np.array([[0, 1], [0, 1]]))
+
+
 def test_add_inferpymc_likelihood_component_adds_epsilon_and_y() -> None:
     """Check the likelihood helper adds epsilon, y, and sigma variables."""
     ds = _likelihood_dataset()
@@ -213,6 +233,49 @@ def test_add_inferpymc_likelihood_component_adds_epsilon_and_y() -> None:
         )
 
     assert {"epsilon", "y", "sigma"}.issubset(model.named_vars)
+
+
+def test_likelihood_no_model_error_uses_observation_error() -> None:
+    """Check no-model-error mode bypasses pollution-event model error."""
+    ds = _likelihood_dataset().copy()
+    ds["min_error"] = xr.full_like(ds["min_error"], 999.0)
+
+    with pm.Model(coords={"nmeasure": np.arange(4)}) as model:
+        attach_coord_registry(model, CoordRegistry())
+        mu = pm.Data("mu_input", np.ones(4), dims="nmeasure")
+        add_inferpymc_likelihood_component(
+            ds,
+            mu=mu,
+            mu_bc=None,
+            sigprior={"pdf": "uniform", "lower": 0.1, "upper": 1.0},
+            no_model_error=True,
+            sigma_per_site=False,
+        )
+
+    np.testing.assert_allclose(model.named_vars["epsilon"].eval(), ds["mf_error"].values)
+
+
+def test_likelihood_pollution_events_from_obs_can_run_without_boundary_conditions() -> None:
+    """Check obs-derived pollution-event scaling does not require BC terms."""
+    ds = _likelihood_dataset().copy()
+    ds["sigma_freq_index"] = xr.zeros_like(ds["sigma_freq_index"])
+
+    with pm.Model(coords={"nmeasure": np.arange(4)}) as model:
+        attach_coord_registry(model, CoordRegistry())
+        mu = pm.Data("mu_input", np.zeros(4), dims="nmeasure")
+        add_inferpymc_likelihood_component(
+            ds,
+            mu=mu,
+            mu_bc=None,
+            sigprior={"pdf": "uniform", "lower": 0.5, "upper": 1.5},
+            pollution_events_from_obs=True,
+            sigma_per_site=False,
+            power=2.0,
+        )
+
+    epsilon = model.named_vars["epsilon"].eval()
+    assert np.all(np.diff(epsilon) > 0)
+    assert "y" in model.named_vars
 
 
 def test_likelihood_samples_prior_predictive_with_shared_sigma_and_registered_site_indicator() -> None:

--- a/tests/test_full_inversion.py
+++ b/tests/test_full_inversion.py
@@ -68,7 +68,9 @@ def satellite_mcmc_args(
     return mcmc_args
 
 
+@pytest.mark.slow
 def test_full_satellite_inversion(satellite_mcmc_args):
+    """Run the satellite/column PARIS path as a slower end-to-end smoke test."""
     satellite_mcmc_args["reload_merged_data"] = False
 
     out = fixedbasisMCMC(**satellite_mcmc_args)
@@ -101,43 +103,10 @@ def test_full_inversion_paris_outputs(mcmc_args):
     assert "Yapost" in out
 
 
-def test_full_inversion_no_model_error(mcmc_args):
-    mcmc_args["no_model_error"] = True
-    fixedbasisMCMC(**mcmc_args)
-
-
 def test_full_inversion_flux_dim_shuffled(mcmc_args):
     mcmc_args["emissions_name"] = ["total-ukghg-edgar7-shuffled"]
     mcmc_args["reload_merged_data"] = False
     fixedbasisMCMC(**mcmc_args)
-
-
-def test_full_inversion_with_min_error_calc(mcmc_args):
-    mcmc_args["min_error"] = "residual"
-    out = fixedbasisMCMC(**mcmc_args)
-
-    assert "min_model_error" in out.attrs
-
-    mcmc_args["min_error"] = "percentile"
-    out = fixedbasisMCMC(**mcmc_args)
-
-    assert "min_model_error" in out.attrs
-
-
-def test_full_inversion_with_min_error_calc_no_bc(mcmc_args):
-    mcmc_args["min_error"] = "residual"
-    mcmc_args["use_bc"] = False
-    out = fixedbasisMCMC(**mcmc_args)
-
-    assert "min_model_error" in out.attrs
-
-
-def test_full_inversion_with_min_error_by_site(mcmc_args):
-    mcmc_args["min_error"] = "residual"
-    mcmc_args["min_error_options"] = {"by_site": True}
-    out = fixedbasisMCMC(**mcmc_args)
-
-    assert "min_model_error" in out.attrs
 
 
 def test_full_inversion_lognormal_infer(mcmc_args):
@@ -150,74 +119,11 @@ def test_full_inversion_lognormal_infer(mcmc_args):
     assert expected_sigma[:4] in out.attrs["Emissions Prior"]
 
 
-def test_full_inversion_lognormal_reparam(mcmc_args):
-    mcmc_args["reparameterise_log_normal"] = True
-    mcmc_args["xprior"] = {"pdf": "lognormal", "mu": 1.0, "sigma": 1.0}
-    fixedbasisMCMC(**mcmc_args)
-
-
-def test_full_inversion_paris_outputs_lognormal_reparam_conflict(mcmc_args):
-    """Check PARIS outputs ignore reparameterized latent-only traces."""
-    mcmc_args["reload_merged_data"] = False
-    mcmc_args["output_format"] = "paris"
-    mcmc_args["reparameterise_log_normal"] = True
-    mcmc_args["xprior"] = {"pdf": "lognormal", "mu": 1.0, "sigma": 1.0}
-
-    out = fixedbasisMCMC(**mcmc_args)
-
-    assert "Yapost" in out
-
-
-def test_full_inversion_min_error(mcmc_args):
-    mcmc_args["min_error"] = 20.0
-    fixedbasisMCMC(**mcmc_args)
-
-
-def test_full_inversion_min_error_numpyro(mcmc_args):
-    mcmc_args["min_error"] = 20.0
-    mcmc_args["nuts_sampler"] = "numpyro"
-    fixedbasisMCMC(**mcmc_args)
-
-
 def test_inversion_if_merged_data_does_not_exist(mcmc_args):
     """Test that inversion runs if reload_merged_data is True, but
     no merged data exists under the default merged data name.
     """
     mcmc_args["merged_data_name"] = None
-    fixedbasisMCMC(**mcmc_args)
-
-
-def test_full_inversion_pollution_events_from_obs(mcmc_args):
-    mcmc_args["pollution_events_from_obs"] = True
-    fixedbasisMCMC(**mcmc_args)
-
-
-def test_full_inversion_min_error_no_bc(mcmc_args):
-    """Test inversion without boundary conditions."""
-    mcmc_args["use_bc"] = False
-    fixedbasisMCMC(**mcmc_args)
-
-
-def test_full_inversion_pollution_events_from_obs_no_bc(mcmc_args):
-    """Test inversion with pollution-event scaling and no boundary conditions."""
-    mcmc_args["pollution_events_from_obs"] = True
-    mcmc_args["use_bc"] = False
-    fixedbasisMCMC(**mcmc_args)
-
-
-def test_full_inversion_two_sites(mcmc_args, mhd_and_tac_ch4_data_args):
-    """Test inversion with two sites and an offset term."""
-    mcmc_args.update(mhd_and_tac_ch4_data_args)
-    mcmc_args["reload_merged_data"] = False
-    mcmc_args["add_offset"] = True
-    mcmc_args["offset_args"] = {"drop_first": True}
-    fixedbasisMCMC(**mcmc_args)
-
-
-def test_full_inversion_offset_args(mcmc_args):
-    """Test full inversion accepts explicit offset arguments through runtime plumbing."""
-    mcmc_args["add_offset"] = True
-    mcmc_args["offset_args"] = {"drop_first": False, "offset_freq": "D"}
     fixedbasisMCMC(**mcmc_args)
 
 

--- a/tests/test_inferpymc.py
+++ b/tests/test_inferpymc.py
@@ -5,6 +5,7 @@ import pymc as pm
 import pytest
 import xarray as xr
 
+import openghg_inversions.hbmcmc.inversion_pymc as inversion_pymc_module
 from openghg_inversions.inversion_inputs import make_inv_inputs
 from openghg_inversions.hbmcmc.inversion_pymc import (
     build_inferpymc_model,
@@ -196,6 +197,45 @@ def test_inferpymc_preserves_legacy_compatibility_outputs(inv_inputs: xr.Dataset
     assert "step2" in result
 
 
+def test_inferpymc_forwards_numpyro_sampler_without_pymc_step(
+    inv_inputs: xr.Dataset, model_args: dict, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The legacy inferpymc adapter does not inject PyMC step methods for numpyro."""
+    captured = {}
+
+    def fake_sample(model: pm.Model, **kwargs):
+        captured["model"] = model
+        captured["sample_kwargs"] = kwargs
+        return object()
+
+    def fake_adapt_legacy_inferpymc_results(**kwargs):
+        captured["adapter_kwargs"] = kwargs
+        return {"ok": True}
+
+    monkeypatch.setattr(inversion_pymc_module, "sample", fake_sample)
+    monkeypatch.setattr(
+        inversion_pymc_module,
+        "_adapt_legacy_inferpymc_results",
+        fake_adapt_legacy_inferpymc_results,
+    )
+
+    result = inferpymc(
+        inv_inputs=inv_inputs,
+        nuts_sampler="numpyro",
+        nit=1,
+        burn=0,
+        tune=0,
+        nchain=1,
+        sampler_kwargs={"random_seed": 123, "compute_convergence_checks": False},
+        **model_args,
+    )
+
+    assert result == {"ok": True}
+    assert captured["sample_kwargs"]["nuts_sampler"] == "numpyro"
+    assert "step" not in captured["sample_kwargs"]
+    assert "step" not in captured["adapter_kwargs"]["sample_kwargs"]
+
+
 def test_build_inferpymc_model_contains_expected_variables(inv_inputs: xr.Dataset, model_args: dict) -> None:
     """The builder adds the core named variables expected by downstream code."""
     model = build_inferpymc_model(inv_inputs, **model_args)
@@ -215,6 +255,37 @@ def test_build_inferpymc_model_contains_expected_variables(inv_inputs: xr.Datase
         "y",
     }
     assert expected_named_vars.issubset(model.named_vars)
+
+
+def test_build_inferpymc_model_with_offset_args_adds_offset_terms(
+    inv_inputs: xr.Dataset, model_args: dict
+) -> None:
+    """Offset args are handled by model construction without a full pipeline run."""
+    args = dict(model_args)
+    args["add_offset"] = True
+    args["offset_args"] = {"drop_first": False, "offset_freq": "D"}
+
+    model = build_inferpymc_model(inv_inputs, **args)
+
+    assert {"offset", "offset_latent", "offset_design", "offset_freq_indicator"}.issubset(
+        model.named_vars
+    )
+
+
+def test_build_inferpymc_model_with_pollution_events_and_no_bc_builds_likelihood(
+    inv_inputs: xr.Dataset, model_args: dict
+) -> None:
+    """Obs-derived pollution-event scaling works without boundary conditions."""
+    args = dict(model_args)
+    args["use_bc"] = False
+    args["pollution_events_from_obs"] = True
+
+    model = build_inferpymc_model(inv_inputs, **args)
+
+    assert {"mu", "sigma", "epsilon", "y"}.issubset(model.named_vars)
+    assert "bc" not in model.named_vars
+    assert "hbc" not in model.named_vars
+    assert "mu_bc" not in model.named_vars
 
 
 def test_restore_inferencedata_coords_helper_restores_multiindex() -> None:

--- a/tests/test_inversion_inputs.py
+++ b/tests/test_inversion_inputs.py
@@ -19,7 +19,12 @@ import pandas as pd
 import pytest
 import xarray as xr
 
-from openghg_inversions.inversion_inputs import add_site_indicator, concat_gather_datasets, make_inv_inputs
+from openghg_inversions.inversion_inputs import (
+    add_min_error,
+    add_site_indicator,
+    concat_gather_datasets,
+    make_inv_inputs,
+)
 
 
 # Helpers for saving result of make_inv_inputs
@@ -226,6 +231,7 @@ def _make_minimal_fp_site(*, mf_base: float, include_inlet_height: bool) -> xr.D
     region = xr.DataArray(["r0", "r1"], dims="region", name="region")
     data_vars = {
         "mf": xr.DataArray(np.array([mf_base, mf_base + 1.0]), dims="time", coords={"time": time}),
+        "mf_mod": xr.DataArray(np.array([mf_base, mf_base + 1.0]), dims="time", coords={"time": time}),
         "mf_error": xr.DataArray(np.array([0.1, 0.2]), dims="time", coords={"time": time}),
         "mf_repeatability": xr.DataArray(np.array([0.05, 0.05]), dims="time", coords={"time": time}),
         "mf_variability": xr.DataArray(np.array([0.05, 0.15]), dims="time", coords={"time": time}),
@@ -278,3 +284,74 @@ def test_make_inv_inputs_accepts_integer_min_error():
     result = make_inv_inputs(fp_data=fp_data, sites=["AAA", "BBB"], min_error=40)
 
     assert np.all(result.min_error.values == 40.0)
+
+
+def test_make_inv_inputs_maps_dict_min_error_by_site():
+    """Site-specific min_error mappings should align onto selected stacked observations."""
+    fp_data = {
+        "AAA": _make_minimal_fp_site(mf_base=10.0, include_inlet_height=False),
+        "BBB": _make_minimal_fp_site(mf_base=20.0, include_inlet_height=False),
+        "CCC": _make_minimal_fp_site(mf_base=30.0, include_inlet_height=False),
+    }
+
+    result = make_inv_inputs(
+        fp_data=fp_data,
+        sites=["AAA", "BBB"],
+        min_error={"AAA": 1.5, "BBB": 2.5},
+    )
+
+    expected = np.where(result.site_indicator.values == 0, 1.5, 2.5)
+    np.testing.assert_allclose(result.min_error.values, expected)
+
+
+def test_add_min_error_can_use_site_coord_without_site_indicator():
+    """Standalone min_error setup can derive site info from a site coordinate."""
+    fp_data = {
+        "AAA": _make_minimal_fp_site(mf_base=10.0, include_inlet_height=False),
+        "BBB": _make_minimal_fp_site(mf_base=20.0, include_inlet_height=False),
+    }
+    ds = xr.Dataset(
+        {"mf": xr.DataArray(np.ones(4), dims="nmeasure")},
+        coords={"site": xr.DataArray(["AAA", "AAA", "BBB", "BBB"], dims="nmeasure")},
+    )
+
+    result = add_min_error(ds, fp_data=fp_data, min_error={"AAA": 1.5, "BBB": 2.5})
+
+    np.testing.assert_allclose(result.min_error.values, [1.5, 1.5, 2.5, 2.5])
+
+
+def test_make_inv_inputs_dict_min_error_missing_site_raises_clear_error():
+    """Site-specific min_error mappings should fail clearly when a selected site is missing."""
+    fp_data = {
+        "AAA": _make_minimal_fp_site(mf_base=10.0, include_inlet_height=False),
+        "BBB": _make_minimal_fp_site(mf_base=20.0, include_inlet_height=False),
+    }
+
+    with pytest.raises(ValueError, match="min_error mapping is missing values.*BBB"):
+        make_inv_inputs(
+            fp_data=fp_data,
+            sites=["AAA", "BBB"],
+            min_error={"AAA": 1.5},
+        )
+
+
+def test_make_inv_inputs_residual_min_error_can_be_site_specific():
+    """Residual min_error values can be calculated per selected site."""
+    fp_data = {
+        "AAA": _make_minimal_fp_site(mf_base=10.0, include_inlet_height=False),
+        "BBB": _make_minimal_fp_site(mf_base=20.0, include_inlet_height=False),
+        "CCC": _make_minimal_fp_site(mf_base=30.0, include_inlet_height=False),
+    }
+    fp_data["AAA"]["mf_mod"] = fp_data["AAA"]["mf"] - xr.DataArray([0.0, 2.0], dims="time")
+    fp_data["BBB"]["mf_mod"] = fp_data["BBB"]["mf"] - xr.DataArray([0.0, 4.0], dims="time")
+    fp_data["CCC"]["mf_mod"] = fp_data["CCC"]["mf"] - xr.DataArray([0.0, 8.0], dims="time")
+
+    result = make_inv_inputs(
+        fp_data=fp_data,
+        sites=["AAA", "BBB"],
+        min_error="residual",
+        min_error_per_site=True,
+    )
+
+    expected = np.where(result.site_indicator.values == 0, 1.0, 2.0)
+    np.testing.assert_allclose(result.min_error.values, expected)


### PR DESCRIPTION
## Summary

- Prune redundant expensive `test_full_inversion.py` variants now covered by lower-level model/input tests.
- Add focused replacement coverage for offset design, no-model-error likelihood behavior, pollution-event scaling without BC, numpyro sampler plumbing, and selected-site `min_error` handling.
- Fix residual and mapped `min_error` handling so per-site values are computed only for sites present in the inversion input dataset, with standalone fallback from `site` and clearer missing-site validation.

## Notes

Rebased onto `devel` after PR #437 merged. This branch intentionally avoids `tests/test_rhime.py`, which was changed in PR #437.

## Validation

- `uv run pytest tests/test_inversion_inputs.py -q --disable-warnings` -> `9 passed, 1 deselected` in `14.29s`
- `uv run pytest tests/models/test_components.py tests/test_inferpymc.py tests/test_inversion_inputs.py tests/test_full_inversion.py -q --disable-warnings --durations=20` -> `40 passed, 3 deselected` in `68.08s`
- `uv run ruff check openghg_inversions/inversion_inputs.py tests/test_inversion_inputs.py`
- Earlier full suite before review-comment fixes: `316 passed, 3 deselected, 6 xfailed` in `184.45s`

`uv run pyright` still reports existing project-wide type errors.