### PR TITLE
Route `fixedbasisMCMC` through new RHIME models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@
   `fixedbasisMCMC` behavior as available from release 0.6 or earlier.
   Country-file loading in modern country and legacy-format
   postprocessing now falls back to direct HDF5 reads when h5netcdf dimension-scale
-  decoding fails on cluster nodes. [#416](https://github.com/openghg/openghg_inversions/issues/416)
+  decoding fails on cluster nodes, and floating legacy-format output variables
+  are written as `float32` to avoid footprint-alignment upcasts.
+  [#416](https://github.com/openghg/openghg_inversions/issues/416)
 - Routed modern RHIME and fixedbasis postprocessing through modern `InversionOutput` semantics, retained `BasisFunctions` / `BasisOperator` products, variable-role lookups, and product-local capability checks; removed the transitional postprocessing protocol/view layer and deleted `LegacyInversionOutput` plus the dead legacy inversion-output builder helpers. [#383](https://github.com/openghg/openghg_inversions/issues/383)
 - Migrated standard RHIME `basic` and `paris` postprocessing toward modern `InversionOutput` as an intermediate step before the final #383 product-local postprocessing contract. [#435](https://github.com/openghg/openghg_inversions/issues/435)
 - Introduced the temporary modern/legacy output split and modern `InversionOutput` serialization; the transitional `LegacyInversionOutput` carrier was removed by #383. [#401](https://github.com/openghg/openghg_inversions/issues/401)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@
   are produced from modern `InversionOutput`, legacy KDE mode statistics now
   handle all-NaN and partially-NaN rows without dropping every draw, and user
   docs mark historical `fixedbasisMCMC` behavior as available from release 0.6
-  or earlier. [#416](https://github.com/openghg/openghg_inversions/issues/416)
+  or earlier. Country-file loading in modern country and legacy-format
+  postprocessing now falls back to direct HDF5 reads when h5netcdf dimension-scale
+  decoding fails on cluster nodes. [#416](https://github.com/openghg/openghg_inversions/issues/416)
 - Routed modern RHIME and fixedbasis postprocessing through modern `InversionOutput` semantics, retained `BasisFunctions` / `BasisOperator` products, variable-role lookups, and product-local capability checks; removed the transitional postprocessing protocol/view layer and deleted `LegacyInversionOutput` plus the dead legacy inversion-output builder helpers. [#383](https://github.com/openghg/openghg_inversions/issues/383)
 - Migrated standard RHIME `basic` and `paris` postprocessing toward modern `InversionOutput` as an intermediate step before the final #383 product-local postprocessing contract. [#435](https://github.com/openghg/openghg_inversions/issues/435)
 - Introduced the temporary modern/legacy output split and modern `InversionOutput` serialization; the transitional `LegacyInversionOutput` carrier was removed by #383. [#401](https://github.com/openghg/openghg_inversions/issues/401)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@
   `hbmcmc` / `hbmcmc_postprocessing` output requests to it, and made
   `run_hbmcmc.py` translate fixedbasis-style configs into `run_rhime` calls while
   preserving legacy output filenames. The shim now validates translated arguments
-  before copying configs, old HBMCMC output attrs are produced from modern
-  `InversionOutput`, and user docs mark historical `fixedbasisMCMC` behavior as
-  available from release 0.6 or earlier. [#416](https://github.com/openghg/openghg_inversions/issues/416)
+  before copying configs, translates deprecated `calculate_min_error` and
+  `reparameterise_log_normal` options where possible, old HBMCMC output attrs
+  are produced from modern `InversionOutput`, and user docs mark historical
+  `fixedbasisMCMC` behavior as available from release 0.6 or earlier. [#416](https://github.com/openghg/openghg_inversions/issues/416)
 - Routed modern RHIME and fixedbasis postprocessing through modern `InversionOutput` semantics, retained `BasisFunctions` / `BasisOperator` products, variable-role lookups, and product-local capability checks; removed the transitional postprocessing protocol/view layer and deleted `LegacyInversionOutput` plus the dead legacy inversion-output builder helpers. [#383](https://github.com/openghg/openghg_inversions/issues/383)
 - Migrated standard RHIME `basic` and `paris` postprocessing toward modern `InversionOutput` as an intermediate step before the final #383 product-local postprocessing contract. [#435](https://github.com/openghg/openghg_inversions/issues/435)
 - Introduced the temporary modern/legacy output split and modern `InversionOutput` serialization; the transitional `LegacyInversionOutput` carrier was removed by #383. [#401](https://github.com/openghg/openghg_inversions/issues/401)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@
   before copying configs, translates deprecated `calculate_min_error` and
   `reparameterise_log_normal` options where possible, old HBMCMC output attrs
   are produced from modern `InversionOutput`, legacy KDE mode statistics now
-  handle all-NaN and partially-NaN rows without dropping every draw, and user
-  docs mark historical `fixedbasisMCMC` behavior as available from release 0.6
-  or earlier. Country-file loading in modern country and legacy-format
+  handle all-NaN and partially-NaN rows without dropping every draw, derived
+  RHIME products no longer save large `InversionOutput` sidecars unless
+  `save_inversion_output` is requested, and user docs mark historical
+  `fixedbasisMCMC` behavior as available from release 0.6 or earlier.
+  Country-file loading in modern country and legacy-format
   postprocessing now falls back to direct HDF5 reads when h5netcdf dimension-scale
   decoding fails on cluster nodes. [#416](https://github.com/openghg/openghg_inversions/issues/416)
 - Routed modern RHIME and fixedbasis postprocessing through modern `InversionOutput` semantics, retained `BasisFunctions` / `BasisOperator` products, variable-role lookups, and product-local capability checks; removed the transitional postprocessing protocol/view layer and deleted `LegacyInversionOutput` plus the dead legacy inversion-output builder helpers. [#383](https://github.com/openghg/openghg_inversions/issues/383)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@
 ## Code changes
 
 
+- Added a modern `output_format="legacy"` compatibility product, routed deprecated
+  `hbmcmc` / `hbmcmc_postprocessing` output requests to it, and made
+  `run_hbmcmc.py` translate fixedbasis-style configs into `run_rhime` calls while
+  preserving legacy output filenames. [#416](https://github.com/openghg/openghg_inversions/issues/416)
 - Routed modern RHIME and fixedbasis postprocessing through modern `InversionOutput` semantics, retained `BasisFunctions` / `BasisOperator` products, variable-role lookups, and product-local capability checks; removed the transitional postprocessing protocol/view layer and deleted `LegacyInversionOutput` plus the dead legacy inversion-output builder helpers. [#383](https://github.com/openghg/openghg_inversions/issues/383)
-- Routed standard RHIME `basic` and `paris` postprocessing through modern `InversionOutput` using a standard single-sector postprocessing view with dataset-based observation inputs and model-managed trace coordinates, while keeping `LegacyInversionOutput` as the fixedbasis/legacy compatibility carrier. [#435](https://github.com/openghg/openghg_inversions/issues/435)
-- Split modern RHIME `InversionOutput` from the legacy-shaped postprocessing carrier, keeping `inferpymc_postprocessouts` on the fixedbasis `output_format="hbmcmc"` path only and using a temporary `LegacyInversionOutput` adapter for RHIME `basic`/`paris` postprocessing. [#401](https://github.com/openghg/openghg_inversions/issues/401)
+- Migrated standard RHIME `basic` and `paris` postprocessing toward modern `InversionOutput` as an intermediate step before the final #383 product-local postprocessing contract. [#435](https://github.com/openghg/openghg_inversions/issues/435)
+- Introduced the temporary modern/legacy output split and modern `InversionOutput` serialization; the transitional `LegacyInversionOutput` carrier was removed by #383. [#401](https://github.com/openghg/openghg_inversions/issues/401)
 - Moved public RHIME model-builder exports into `openghg_inversions.models` and shared data preparation between `fixedbasisMCMC`, `run_rhime`, and `run_rhime_multisector`. [#399](https://github.com/openghg/openghg_inversions/issues/399), [#425](https://github.com/openghg/openghg_inversions/issues/425)
 - Retained `BasisFunctions` objects through shared inversion preparation, RHIME results, and opt-in `fixedbasisMCMC` debug output; DataTree basis artifacts are loaded when available while legacy flat basis artifacts remain supported. [#428](https://github.com/openghg/openghg_inversions/issues/428)
 - Added modern `run_rhime` and shared-basis `run_rhime_multisector` pipelines, RHIME CLI entry points, RHIME config template, modern result/spec objects, and focused tests for the new public runners. [#398](https://github.com/openghg/openghg_inversions/issues/398)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@
   preserving legacy output filenames. The shim now validates translated arguments
   before copying configs, translates deprecated `calculate_min_error` and
   `reparameterise_log_normal` options where possible, old HBMCMC output attrs
-  are produced from modern `InversionOutput`, and user docs mark historical
-  `fixedbasisMCMC` behavior as available from release 0.6 or earlier. [#416](https://github.com/openghg/openghg_inversions/issues/416)
+  are produced from modern `InversionOutput`, legacy KDE mode statistics now
+  handle all-NaN and partially-NaN rows without dropping every draw, and user
+  docs mark historical `fixedbasisMCMC` behavior as available from release 0.6
+  or earlier. [#416](https://github.com/openghg/openghg_inversions/issues/416)
 - Routed modern RHIME and fixedbasis postprocessing through modern `InversionOutput` semantics, retained `BasisFunctions` / `BasisOperator` products, variable-role lookups, and product-local capability checks; removed the transitional postprocessing protocol/view layer and deleted `LegacyInversionOutput` plus the dead legacy inversion-output builder helpers. [#383](https://github.com/openghg/openghg_inversions/issues/383)
 - Migrated standard RHIME `basic` and `paris` postprocessing toward modern `InversionOutput` as an intermediate step before the final #383 product-local postprocessing contract. [#435](https://github.com/openghg/openghg_inversions/issues/435)
 - Introduced the temporary modern/legacy output split and modern `InversionOutput` serialization; the transitional `LegacyInversionOutput` carrier was removed by #383. [#401](https://github.com/openghg/openghg_inversions/issues/401)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@
 - Added a modern `output_format="legacy"` compatibility product, routed deprecated
   `hbmcmc` / `hbmcmc_postprocessing` output requests to it, and made
   `run_hbmcmc.py` translate fixedbasis-style configs into `run_rhime` calls while
-  preserving legacy output filenames. [#416](https://github.com/openghg/openghg_inversions/issues/416)
+  preserving legacy output filenames. The shim now validates translated arguments
+  before copying configs, old HBMCMC output attrs are produced from modern
+  `InversionOutput`, and user docs mark historical `fixedbasisMCMC` behavior as
+  available from release 0.6 or earlier. [#416](https://github.com/openghg/openghg_inversions/issues/416)
 - Routed modern RHIME and fixedbasis postprocessing through modern `InversionOutput` semantics, retained `BasisFunctions` / `BasisOperator` products, variable-role lookups, and product-local capability checks; removed the transitional postprocessing protocol/view layer and deleted `LegacyInversionOutput` plus the dead legacy inversion-output builder helpers. [#383](https://github.com/openghg/openghg_inversions/issues/383)
 - Migrated standard RHIME `basic` and `paris` postprocessing toward modern `InversionOutput` as an intermediate step before the final #383 product-local postprocessing contract. [#435](https://github.com/openghg/openghg_inversions/issues/435)
 - Introduced the temporary modern/legacy output split and modern `InversionOutput` serialization; the transitional `LegacyInversionOutput` carrier was removed by #383. [#401](https://github.com/openghg/openghg_inversions/issues/401)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,10 @@
   the historical fixedbasis-style file contract. RHIME and the `run_hbmcmc.py`
   compatibility shim now emit grep-friendly `TIMING ... seconds=... maxrss_kb=...`
   lines for setup, preparation, sampling, postprocessing, and output writes so
-  batch logs can identify runtime regressions.
+  batch logs can identify runtime regressions. Modern RHIME model imports also
+  apply the same PyTensor `floatX=float32` default as the historical
+  fixedbasis PyMC path, avoiding accidental float64 sampling after the
+  `run_hbmcmc.py` route switch.
   [#416](https://github.com/openghg/openghg_inversions/issues/416)
 - Routed modern RHIME and fixedbasis postprocessing through modern `InversionOutput` semantics, retained `BasisFunctions` / `BasisOperator` products, variable-role lookups, and product-local capability checks; removed the transitional postprocessing protocol/view layer and deleted `LegacyInversionOutput` plus the dead legacy inversion-output builder helpers. [#383](https://github.com/openghg/openghg_inversions/issues/383)
 - Migrated standard RHIME `basic` and `paris` postprocessing toward modern `InversionOutput` as an intermediate step before the final #383 product-local postprocessing contract. [#435](https://github.com/openghg/openghg_inversions/issues/435)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,9 @@
   Country-file loading in modern country and legacy-format
   postprocessing now falls back to direct HDF5 reads when h5netcdf dimension-scale
   decoding fails on cluster nodes, and floating legacy-format output variables
-  are written as `float32` to avoid footprint-alignment upcasts.
+  are written as `float32` to avoid footprint-alignment upcasts. Modern PARIS
+  compatibility outputs also cast floating data variables to `float32` to match
+  the historical fixedbasis-style file contract.
   [#416](https://github.com/openghg/openghg_inversions/issues/416)
 - Routed modern RHIME and fixedbasis postprocessing through modern `InversionOutput` semantics, retained `BasisFunctions` / `BasisOperator` products, variable-role lookups, and product-local capability checks; removed the transitional postprocessing protocol/view layer and deleted `LegacyInversionOutput` plus the dead legacy inversion-output builder helpers. [#383](https://github.com/openghg/openghg_inversions/issues/383)
 - Migrated standard RHIME `basic` and `paris` postprocessing toward modern `InversionOutput` as an intermediate step before the final #383 product-local postprocessing contract. [#435](https://github.com/openghg/openghg_inversions/issues/435)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,11 @@
   compatibility outputs also cast floating data variables to `float32` to match
   the historical fixedbasis-style file contract. RHIME and the `run_hbmcmc.py`
   compatibility shim now emit grep-friendly `TIMING ... seconds=... maxrss_kb=...`
-  lines for setup, preparation, sampling, postprocessing, and output writes so
-  batch logs can identify runtime regressions. Modern RHIME model imports also
-  apply the same PyTensor `floatX=float32` default as the historical
-  fixedbasis PyMC path, avoiding accidental float64 sampling after the
-  `run_hbmcmc.py` route switch.
+  lines for setup, preparation, sampling, sampler statistics, postprocessing,
+  and output writes so batch logs can identify runtime regressions. Modern
+  RHIME model imports also apply the same PyTensor `floatX=float32` default as
+  the historical fixedbasis PyMC path, avoiding accidental float64 sampling
+  after the `run_hbmcmc.py` route switch.
   [#416](https://github.com/openghg/openghg_inversions/issues/416)
 - Routed modern RHIME and fixedbasis postprocessing through modern `InversionOutput` semantics, retained `BasisFunctions` / `BasisOperator` products, variable-role lookups, and product-local capability checks; removed the transitional postprocessing protocol/view layer and deleted `LegacyInversionOutput` plus the dead legacy inversion-output builder helpers. [#383](https://github.com/openghg/openghg_inversions/issues/383)
 - Migrated standard RHIME `basic` and `paris` postprocessing toward modern `InversionOutput` as an intermediate step before the final #383 product-local postprocessing contract. [#435](https://github.com/openghg/openghg_inversions/issues/435)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,10 @@
   decoding fails on cluster nodes, and floating legacy-format output variables
   are written as `float32` to avoid footprint-alignment upcasts. Modern PARIS
   compatibility outputs also cast floating data variables to `float32` to match
-  the historical fixedbasis-style file contract.
+  the historical fixedbasis-style file contract. RHIME and the `run_hbmcmc.py`
+  compatibility shim now emit grep-friendly `TIMING ... seconds=... maxrss_kb=...`
+  lines for setup, preparation, sampling, postprocessing, and output writes so
+  batch logs can identify runtime regressions.
   [#416](https://github.com/openghg/openghg_inversions/issues/416)
 - Routed modern RHIME and fixedbasis postprocessing through modern `InversionOutput` semantics, retained `BasisFunctions` / `BasisOperator` products, variable-role lookups, and product-local capability checks; removed the transitional postprocessing protocol/view layer and deleted `LegacyInversionOutput` plus the dead legacy inversion-output builder helpers. [#383](https://github.com/openghg/openghg_inversions/issues/383)
 - Migrated standard RHIME `basic` and `paris` postprocessing toward modern `InversionOutput` as an intermediate step before the final #383 product-local postprocessing contract. [#435](https://github.com/openghg/openghg_inversions/issues/435)

--- a/README.md
+++ b/README.md
@@ -220,12 +220,15 @@ RHIME terminology:
 
 New runs should use `openghg-inversions run-rhime` or the Python
 `run_rhime(...)` API above. The historical `run_hbmcmc.py` script remains as a
-compatibility wrapper for old fixedbasis-style INI files: it translates legacy
-names such as `outputpath`, `outputname`, `nit`, `nchain`, `verbose`, and
-`sampler_kwargs` to modern RHIME names and then calls `run_rhime(...)`.
+compatibility wrapper for old fixedbasis-style INI files: it translates
+supported legacy names and options to modern RHIME arguments and then calls
+`run_rhime(...)`.
 This branch is no longer preserving the exact historical fixedbasisMCMC /
 inferpymc passthrough behaviour. Use release `0.6` or earlier if you need the
 old fixedbasis implementation.
+
+Direct `fixedbasisMCMC(...)` calls are a temporary legacy Python path, not a
+wrapper around `run_rhime(...)`. New work should not target that API.
 
 The old output names `hbmcmc` and `hbmcmc_postprocessing` are deprecated
 aliases for the modern `legacy` output format. The compatibility wrapper keeps

--- a/README.md
+++ b/README.md
@@ -223,6 +223,9 @@ New runs should use `openghg-inversions run-rhime` or the Python
 compatibility wrapper for old fixedbasis-style INI files: it translates legacy
 names such as `outputpath`, `outputname`, `nit`, `nchain`, `verbose`, and
 `sampler_kwargs` to modern RHIME names and then calls `run_rhime(...)`.
+This branch is no longer preserving the exact historical fixedbasisMCMC /
+inferpymc passthrough behaviour. Use release `0.6` or earlier if you need the
+old fixedbasis implementation.
 
 The old output names `hbmcmc` and `hbmcmc_postprocessing` are deprecated
 aliases for the modern `legacy` output format. The compatibility wrapper keeps
@@ -265,7 +268,7 @@ the inversion period, and you pass an `ini` file using the flag `-c`.
 In addition, you can pass the output path using the flag `--output-path`; this is useful if your SLURM script
 uses different output locations for different array jobs.
 
-You can also pass arbitrary keyword arguments to `run_hbmcmc.py` using the `--kwargs` flag.
+You can also pass supported RHIME-compatible keyword arguments to `run_hbmcmc.py` using the `--kwargs` flag.
 For instance:
 
 ``` bash
@@ -273,7 +276,9 @@ python run_hbmcmc.py "2019-01-01" "2019-02-01" -c "example.ini" --kwargs '{"aver
 ```
 It is crucial that you enclose the dictionary in single quotes, otherwise the command line will split the dictionary on white space.
 
-Again, this can be used to change the arguments passed to an inversion on the fly (say, in a SLURM script).
+Again, this can be used to change supported inversion arguments on the fly (say, in a SLURM script).
+Unsupported fixedbasis-only options now raise targeted errors instead of being
+passed through to `inferpymc`.
 
 The format of the dictionary inside single quotes must be JSON, because the value of `kwargs` is parsed using `json.loads`.
 Python translates JSON according to [this table](https://docs.python.org/3/library/json.html#encoders-and-decoders).
@@ -287,7 +292,10 @@ The following sections detail some parameters that enable/specify optional behav
 
 ##### Parameters for `fixedbasisMCMC`
 
-This is not a comprehensive list (see the docstring for `fixedbasisMCMC` in the [hbmcmc module](openghg_inversions/hbmcmc/hbmcmc.py) for more arguments).
+These are compatibility-era notes for old fixedbasis-style workflows, not the
+recommended interface for new runs. New configs should use the RHIME vocabulary
+above. See the docstring for `fixedbasisMCMC` in the [hbmcmc module](openghg_inversions/hbmcmc/hbmcmc.py)
+for the current compatibility arguments.
 
 
 Arguments affecting the data using in the inversion:
@@ -326,9 +334,12 @@ Arguments affecting the output of the inversion:
 
 ##### Parameters for `inferpymc`
 
-As mentioned above, any keyword argument passed to `fixedbasisMCMC` (either by an `ini` file or from `--kwargs` on the command line) that is not recognised by `fixedbasisMCMC` is passed on to `inferpymc`.
+In release `0.6` and earlier, unrecognised `fixedbasisMCMC` keyword arguments
+were passed through to `inferpymc`. Current compatibility paths validate
+RHIME-compatible options instead. The argument routing design is being cleaned
+up as part of the fixedbasis retirement work.
 
-These parameters include:
+Historical inferpymc-era parameters included:
 - `min_error`: a non-negative float value specifying a lower bound for the model-measurement mismatch error (i.e. the error on (y - y_mod)).
 - `nuts_sampler`: a string, which defaults to `"pymc"`. The other option is `"numpyro"`, which will the [JAX](https://jax.readthedocs.io/en/latest/index.html) accelerated sampler from [Numpyro](https://num.pyro.ai/en/stable/index.html); this tends to be significantly faster than the NUTS sampler built into PyMC.
 - `pollution_events_from_obs`: Determines whether the model error is calculated as a fraction of:

--- a/README.md
+++ b/README.md
@@ -216,15 +216,21 @@ RHIME terminology:
 - `tracer`: additional species used to constrain the primary species through linked forward models.
 - `emissions_name`: legacy compatibility spelling only; use `flux_sources` in new RHIME configs.
 
-### Legacy HBMCMC Parameter Passing
+### Legacy HBMCMC Compatibility
 
-Keyword arguments are propagated as follows:
-1. any key-value pair in an `ini` file or passed via the `--kwargs` flag is passed to the MCMC function as a keyword argument. (Currently, `fixedbasisMCMC` is the only available MCMC function)
-2. any keyword argument not recognised by the MCMC function (i.e. `fixedbasisMCMC`) is passed to the function `inferpymc` in `hbmcmc.inversion_pymc`, which is the function that creates and samples from the RHIME model.
+New runs should use `openghg-inversions run-rhime` or the Python
+`run_rhime(...)` API above. The historical `run_hbmcmc.py` script remains as a
+compatibility wrapper for old fixedbasis-style INI files: it translates legacy
+names such as `outputpath`, `outputname`, `nit`, `nchain`, `verbose`, and
+`sampler_kwargs` to modern RHIME names and then calls `run_rhime(...)`.
 
-Thus you can pass arguments to either `fixedbasisMCMC` or `inferpymc`, but all of these arguments will be specified in the `ini` file (or command line).
+The old output names `hbmcmc` and `hbmcmc_postprocessing` are deprecated
+aliases for the modern `legacy` output format. The compatibility wrapper keeps
+the old HBMCMC filename convention for these outputs; direct `run_rhime` calls
+use RHIME filenames unless configured otherwise.
 
-Let's look at these two steps in detail.
+The compatibility entry point still accepts the old INI layout and command-line
+overrides.
 
 #### Ways of passing arguments to the inversion
 
@@ -241,14 +247,15 @@ fix_basis_outer_regions = True
 use_bc = True
 nuts_sampler = "numpyro"
 save_trace = False
-calculate_min_error = "percentile"
+min_error = "percentile"
 pollution_events_from_obs = True
-reparameterise_log_normal = True
+reparameterise_log_normal = False
 sampler_kwargs = {"target_accept": 0.99}
 ```
 
-These will be passed to the MCMC function (e.g. `fixedbasisMCMC`) as keyword arguments.
-Any argument in `fixedbasisMCMC` can be specified in an `ini` file this way.
+These options are read from the old file layout and translated where a modern
+RHIME equivalent exists. Fixedbasis-only options that are enabled and no longer
+have a RHIME equivalent raise a targeted error.
 
 ##### Passing options at the command line
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -91,8 +91,8 @@ Summary
 ## Method 1: python script or notebook
 
 New scripts should call `run_rhime` from `openghg_inversions.rhime`.
-`fixedbasisMCMC` remains only as a legacy compatibility entry point for old
-fixedbasis-style Python workflows.
+`fixedbasisMCMC` remains only as a temporary direct legacy Python path, not as
+the RHIME-backed compatibility route.
 It no longer preserves the exact historical `fixedbasisMCMC` / `inferpymc`
 passthrough behaviour; use release `0.6` or earlier if you need the old
 fixedbasis implementation.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -93,6 +93,9 @@ Summary
 New scripts should call `run_rhime` from `openghg_inversions.rhime`.
 `fixedbasisMCMC` remains only as a legacy compatibility entry point for old
 fixedbasis-style Python workflows.
+It no longer preserves the exact historical `fixedbasisMCMC` / `inferpymc`
+passthrough behaviour; use release `0.6` or earlier if you need the old
+fixedbasis implementation.
 
 
 <a id="org6a59239"></a>
@@ -100,7 +103,7 @@ fixedbasis-style Python workflows.
 ## Method 2: ini file
 
 -   Create a `.ini` file based on the templates in `openghg_inversions/config/templates`. (NOTE: these need to be updated.)
--   Activate a Pixi, conda, or venv environment with inversions installed, and call `python <path to openghg_inversions>/openghg_inversions/hbmcmc/run_hbmcmc.py -c somefile.ini` for old fixedbasis-style INI files. The script now translates those configs and runs the modern `run_rhime` pathway. New INI files should use `openghg-inversions run-rhime` and the RHIME config vocabulary.
+-   Activate a Pixi, conda, or venv environment with inversions installed, and call `python <path to openghg_inversions>/openghg_inversions/hbmcmc/run_hbmcmc.py -c somefile.ini` for old fixedbasis-style INI files. The script now translates those configs and runs the modern `run_rhime` pathway. New INI files should use `openghg-inversions run-rhime` and the RHIME config vocabulary. Unsupported fixedbasis-only options now raise targeted errors instead of being passed through to `inferpymc`.
 -   A sample `.ini` script is at the bottom of this document.
 
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -90,7 +90,9 @@ Summary
 
 ## Method 1: python script or notebook
 
-Assuming you have the necessary data, you just need to run the `fixedbasisMCMC` function from `hbmcmc.py` in `openghg_inversions.hbmbmc`.
+New scripts should call `run_rhime` from `openghg_inversions.rhime`.
+`fixedbasisMCMC` remains only as a legacy compatibility entry point for old
+fixedbasis-style Python workflows.
 
 
 <a id="org6a59239"></a>
@@ -98,7 +100,7 @@ Assuming you have the necessary data, you just need to run the `fixedbasisMCMC` 
 ## Method 2: ini file
 
 -   Create a `.ini` file based on the templates in `openghg_inversions/config/templates`. (NOTE: these need to be updated.)
--   Activate a Pixi, conda, or venv environment with inversions installed, and call `python <path to openghg_inversions>/openghg_inversions/hbmcmc/run_hbmcmc.py -c somefile.ini`
+-   Activate a Pixi, conda, or venv environment with inversions installed, and call `python <path to openghg_inversions>/openghg_inversions/hbmcmc/run_hbmcmc.py -c somefile.ini` for old fixedbasis-style INI files. The script now translates those configs and runs the modern `run_rhime` pathway. New INI files should use `openghg-inversions run-rhime` and the RHIME config vocabulary.
 -   A sample `.ini` script is at the bottom of this document.
 
 
@@ -330,7 +332,7 @@ outputname = 'ch4_TAC_test'  ; (required)
 
 # Description of HBMCMC output file
 
-The output of `run_hbmcmc` (and `fixedbasisMCMC`) is an xarray Dataset with the following variables and attributes:
+The legacy compatibility output from `run_hbmcmc` (and `fixedbasisMCMC(output_format="legacy")`) is an xarray Dataset with the following variables and attributes:
 
 HMCMC output data variables:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,10 @@ OpenGHG Inversions Documentation
 
 OpenGHG Inversions is a Python package that is being developed as part of the [OpenGHG project](https://openghg.org) with the aim of merging the data-processing and simulation modelling capabilities of OpenGHG with the atmospheric Bayesian inverse models developed by the Atmospheric Chemistry Research Group (ACRG) at the University of Bristol, UK.
 
+OpenGHG Inversions now uses RHIME as the modern runner for regional inversion
+workflows. The older fixedbasis/HBMCMC entry points remain only as
+compatibility context while existing scripts are migrated.
+
 Currently, OpenGHG Inversions includes the following regional inversion models:
 
 - Hierarchical Bayesian Markov Chain Monte Carlo (HBMCMC) model (as described in Ganesan et al., 2014, _ACP_)

--- a/docs/plans/clean_up_inversions_refactor.md
+++ b/docs/plans/clean_up_inversions_refactor.md
@@ -38,6 +38,63 @@ version, which partially negates the benefit of keeping it as the main route.
   PR #436 makes multisector runs carry modern `InversionOutput`, but sector
   diagnostics and PARIS totals are still transitional.
 
+## Documentation requirements before broad user docs
+
+After the fixedbasis/RHIME transition merges, user-facing documentation should
+orient users around this route:
+
+- Existing fixedbasis-style INI and SLURM workflows may continue to call
+  `openghg_inversions/hbmcmc/run_hbmcmc.py`, but that script is now a
+  compatibility wrapper. It translates supported legacy config names to the
+  modern `run_rhime` API, keeps the legacy filename convention, and writes
+  compatibility outputs through the modern `legacy` formatter.
+- New scripts, notebooks, and config files should use
+  `openghg_inversions.rhime.run_rhime(...)`,
+  `openghg_inversions.rhime.run_rhime_multisector(...)`, or
+  `openghg-inversions run-rhime`, with RHIME vocabulary such as
+  `flux_sources`, `sector_sources`, `draws`, `chains`, `output_path`, and
+  `output_name`.
+- `fixedbasisMCMC`, `inferpymc`, and direct legacy passthrough behavior should
+  be documented only as compatibility/deprecation context, not as the normal
+  path for new users.
+
+Before expanding broad user docs, keep a concise maintainer-facing map of the
+modern responsibilities:
+
+- `openghg_inversions.rhime.__init__`: public RHIME re-export surface.
+- `openghg_inversions.rhime.runner`: orchestration; normalize setup, prepare
+  inputs, build the model, sample, and dispatch outputs.
+- `openghg_inversions.rhime.params`: config/API parameter loading, legacy alias
+  handling, scalar coercion, and validation before spec construction.
+- `openghg_inversions.rhime.specs`: run/output specs and output-format
+  validation.
+- `openghg_inversions.rhime.sampling`: executable PyMC sampler settings and
+  predictive sampling.
+- `openghg_inversions.rhime.outputs`: construction, saving, and compatibility
+  formatting of RHIME output bundles.
+- `openghg_inversions.models.rhime`: RHIME PyMC builders plus the current
+  `RhimeModelSpec` and `SectorSpec`.
+- `openghg_inversions.inversion_data.preparation`: data gathering/filtering,
+  basis construction, and `RhimePreparedInputs`.
+- `openghg_inversions.postprocessing.*`: product-specific output schemas and
+  capability checks over modern `InversionOutput`.
+
+Document current workarounds explicitly rather than hiding them. In particular,
+`RhimeModelSpec` and `SectorSpec` currently live under
+`openghg_inversions.models` beside the concrete RHIME builders. That is
+intentional for the near-term dependency direction,
+`openghg_inversions.rhime -> openghg_inversions.models`, and should remain
+until a `SemanticModel` or equivalent abstract model-spec contract makes
+dependency inversion useful. Do not move these specs solely for cosmetic
+package layout before that abstraction exists.
+
+Broad user documentation should wait until the compatibility/refactor surface
+is simpler: remove or quarantine dead fixedbasis/inferpymc paths, settle the
+operator-backed postprocessing boundary, clarify sector-aware output support,
+and then rewrite examples around the modern RHIME API and config template.
+Until then, make only small orientation updates that prevent users from
+choosing the legacy route for new work.
+
 # Issue #400 model specs and terminology
 
 ## Completed in PR #434 / Issue #400
@@ -355,9 +412,9 @@ sector diagnostics and PARIS-compatible total outputs.
 Track fixedbasis removal under #416. The first slice is a `run_hbmcmc.py`
 compatibility shim that translates legacy config names such as `outputpath`,
 `outputname`, `nit`, and `nchain` to the `run_rhime` API, routes old
-`hbmcmc` / `hbmcmc_postprocessing` output requests to `legacy`, and rejects
-enabled fixedbasis-only options. Once old scripts can run through `run_rhime`,
-remove `fixedbasisMCMC`, then remove `inferpymc` and
+`hbmcmc` / `hbmcmc_postprocessing` output requests to `legacy`, and translates
+legacy options that have modern equivalents. Once old scripts can run through
+`run_rhime`, remove `fixedbasisMCMC`, then remove `inferpymc` and
 `inferpymc_postprocessouts`.
 
 # Issue #416 Fixedbasis transition and legacy adapter removal
@@ -370,10 +427,14 @@ review.
 
 ## Required short-term behavior
 
-- `fixedbasisMCMC` may remain as a compatibility entrypoint while #416 is
-  active, but it should keep only the operational contract that current users
-  need: same inputs in, successful run, and matching `output_format="paris"`
-  and legacy-format products.
+- `run_hbmcmc.py` is the active fixedbasis-style compatibility route. It should
+  translate old INI/SLURM workflows to `run_rhime` and keep the practical old
+  outputs working through `output_format="legacy"`, `output_format="paris"`,
+  and modern `InversionOutput`.
+- `fixedbasisMCMC` is no longer the script/config compatibility route. It may
+  remain temporarily as a direct Python legacy path only while tests and users
+  finish moving to `run_hbmcmc.py` -> `run_rhime`; treat it as dead code
+  pending removal rather than investing in new compatibility behavior there.
 - `legacy` is the modern compatibility output name. Deprecated
   `hbmcmc` and `hbmcmc_postprocessing` output requests should resolve to
   `legacy`.
@@ -393,8 +454,10 @@ review.
   names to it.
 - Done in #416 first slice: add a `run_hbmcmc.py` compatibility shim that reads
   old fixedbasis-style INI files, translates legacy names (`outputpath`,
-  `outputname`, `nit`, `nchain`, `verbose`, `sampler_kwargs`) to modern RHIME
-  names, accepts and removes `mcmc_type="fixed_basis"`, and calls `run_rhime`.
+  `outputname`, `nit`, `nchain`, `verbose`, `sampler_kwargs`,
+  `calculate_min_error`, `reparameterise_log_normal`) to modern RHIME names or
+  prior dictionaries, accepts and removes `mcmc_type="fixed_basis"`, and calls
+  `run_rhime`.
 - Done in #416 first slice: keep old fixedbasis filename conventions for
   outputs created via `run_hbmcmc.py`; direct `run_rhime` keeps RHIME filenames
   unless explicitly given the compatibility filename convention.

--- a/docs/plans/clean_up_inversions_refactor.md
+++ b/docs/plans/clean_up_inversions_refactor.md
@@ -20,15 +20,18 @@ version, which partially negates the benefit of keeping it as the main route.
 - [x] #401: use to separate `LegacyInversionOutput` from modern `InversionOutput`.
 - [x] #435: migrate postprocessing consumers from `LegacyInversionOutput` to the
   modern `InversionOutput`; opened as the follow-up from #401.
-- [ ] #383: revise toward "postprocessing consumes `BasisFunctions`, no `fp_data`
+- [x] #383: revise toward "postprocessing consumes `BasisFunctions`, no `fp_data`
   in modern path." Standard postprocessing should consume modern
   `InversionOutput` through product-neutral semantic accessors; old-format
   HBMCMC output may remain only as a dataset formatter over modern
   postprocessing results.
 - [ ] #429: keep as operator-backed output/postprocessing, but make it depend on
   the preparation split.
-- [ ] #416: should become active sooner; classify/deprecate `fixedbasisMCMC`,
-  `inferpymc`, `inferpymc_postprocessouts`, and hbmcmc helpers.
+- [ ] #416: first compatibility slice active; route fixedbasis-style
+  `run_hbmcmc.py` configs and deprecated HBMCMC output names to `run_rhime`
+  and the modern `legacy` formatter, then classify/deprecate the remaining
+  `fixedbasisMCMC`, `inferpymc`, `inferpymc_postprocessouts`, and hbmcmc
+  helpers.
 - [ ] #415: serializable RHIME bundle should serialize `RhimePreparedInputs`
   artifacts, not `fp_data`.
 - [ ] #405: complete sector-aware RHIME outputs and PARIS-compatible total outputs.
@@ -95,6 +98,12 @@ version, which partially negates the benefit of keeping it as the main route.
   validation for the later YAML/semantic-IR work.
 
 # Issue #401 Introduce `LegacyInversionOutput` and keep `InversionOutput` modern
+
+Historical note: #401 and #435 record intermediate architecture that has now
+been superseded. The current contract is the #383 / PR #439 state, plus the
+#416 first slice below: modern postprocessing consumes `InversionOutput`
+directly, `LegacyInversionOutput` is removed, and `inferpymc_postprocessouts`
+is no longer a normal output-dispatch target.
 
 ## Completed in PR #436 / Issue #401
 
@@ -256,43 +265,43 @@ layer. The modern postprocessing contract is `InversionOutput` plus retained
 `BasisFunctions`; product-specific modules own output names, legacy-format
 renames, and PARIS formatting.
 
-## Completed in Current PR / Issue #383
+## Completed in PR #439 / Issue #383
 
-- 2026-05-31: #383 / current PR added private operator-backed postprocessing
+- 2026-05-31: #383 / PR #439 added private operator-backed postprocessing
   helpers for standard single-sector flux and country products.
-- 2026-05-31: #383 / current PR routed modern `make_flux_outputs`, country
+- 2026-05-31: #383 / PR #439 routed modern `make_flux_outputs`, country
   totals, and PARIS flux outputs through retained `BasisFunctions` /
   `BasisOperator` data when a modern `InversionOutput` is supplied.
-- 2026-06-01: #383 / current PR moved fixedbasis `basic`, `paris`,
+- 2026-06-01: #383 / PR #439 moved fixedbasis `basic`, `paris`,
   `hbmcmc_postprocessing`, `inv_out`, and saved inversion-output handling onto
   modern `InversionOutput` backed by retained `BasisFunctions`, while keeping
   the true legacy `hbmcmc` formatter isolated.
-- 2026-06-01: #383 / current PR removed the transitional
+- 2026-06-01: #383 / PR #439 removed the transitional
   `StandardPostprocessingOutput` / `PostprocessingInput` /
   `ModernPostprocessingOutput` layer and did not replace it with public
   `standard_*` free functions. Product helpers consume modern
   `InversionOutput` directly.
-- 2026-06-01: #383 / current PR added product-neutral `InversionOutput`
+- 2026-06-01: #383 / PR #439 added product-neutral `InversionOutput`
   semantics for current postprocessing needs: period metadata, prior flux,
   site names, variable-role lookup, and canonical `input_dataset(...)`,
   `trace_dataset(...)`, and `model_data(...)` accessors. Product modules own
   their own single-sector/multisector validation.
-- 2026-06-01: #383 / current PR removed `LegacyInversionOutput`,
+- 2026-06-01: #383 / PR #439 removed `LegacyInversionOutput`,
   `make_inv_out_for_fixed_basis_mcmc(...)`, and the old RHIME-output
   reprocessing helpers. The remaining old-format `hbmcmc_postprocessing`
   product is a formatter over modern `InversionOutput`, not a separate
   inversion-output carrier.
-- 2026-06-01: #383 / current PR made fixedbasis sampling restore model-managed
+- 2026-06-01: #383 / PR #439 made fixedbasis sampling restore model-managed
   coordinates onto `InferenceData` and canonicalize fixedbasis trace dims back
   to the modern `BasisFunctions.operator.meta.state_dim` before constructing
   `InversionOutput`.
-- 2026-06-01: #383 / current PR added a module-level design note to
+- 2026-06-01: #383 / PR #439 added a module-level design note to
   `postprocessing/inversion_output.py` documenting that `InversionOutput` is a
   modern product-neutral carrier, product formatters own output schemas and
   capability checks, variable roles are a temporary bridge, and generic
   DataTree/MultiIndex serialization helpers should move to utilities later.
 
-## Recorded decisions for Current PR / Issue #383
+## Recorded decisions for PR #439 / Issue #383
 
 - Keep operator-backed flux/country reconstruction as internal postprocessing
   implementation detail for now. The public input is the modern
@@ -309,8 +318,8 @@ renames, and PARIS formatting.
   an `InversionOutput.require_single_sector(...)` method.
 - Keep output-name mapping inside product modules: `make_outputs.py` maps to
   `y_obs`, `model_error`, `Hx`, and `basis`; `make_paris_outputs.py` maps to
-  PARIS names and attrs; `legacy_outputs.py` maps to `inferpymc_postprocessouts`
-  style names.
+  PARIS names and attrs; `legacy_outputs.py` maps to legacy-format HBMCMC-style
+  names.
 - Do not reconstruct site/time coordinates in postprocessing. Model sampling
   and fixedbasis construction must restore valid `nmeasure=(site, time)`
   coordinates before product helpers run, and products should fail clearly if
@@ -343,11 +352,12 @@ Track multisector output work under #405. It can proceed after the modern
 postprocessing input contract is clearer, or in parallel if it stays limited to
 sector diagnostics and PARIS-compatible total outputs.
 
-Track fixedbasis removal under #416. The first slice should be a
-`run_hbmcmc.py` compatibility shim that translates legacy config names such as
-`outputpath`, `outputname`, `nit`, and `nchain` to the `run_rhime` API, while
-raising targeted errors for fixedbasis-only output formats. Once old scripts
-can run through `run_rhime`, remove `fixedbasisMCMC` and then remove
+Track fixedbasis removal under #416. The first slice is a `run_hbmcmc.py`
+compatibility shim that translates legacy config names such as `outputpath`,
+`outputname`, `nit`, and `nchain` to the `run_rhime` API, routes old
+`hbmcmc` / `hbmcmc_postprocessing` output requests to `legacy`, and rejects
+enabled fixedbasis-only options. Once old scripts can run through `run_rhime`,
+remove `fixedbasisMCMC`, then remove `inferpymc` and
 `inferpymc_postprocessouts`.
 
 # Issue #416 Fixedbasis transition and legacy adapter removal
@@ -363,17 +373,36 @@ review.
 - `fixedbasisMCMC` may remain as a compatibility entrypoint while #416 is
   active, but it should keep only the operational contract that current users
   need: same inputs in, successful run, and matching `output_format="paris"`
-  products.
+  and legacy-format products.
+- `legacy` is the modern compatibility output name. Deprecated
+  `hbmcmc` and `hbmcmc_postprocessing` output requests should resolve to
+  `legacy`.
 - Saved legacy inversion-output compatibility and direct legacy carrier return
   behavior are not strategic compatibility goals. #383 removes that carrier
   once fixedbasis postprocessing can construct modern `InversionOutput`.
-- `inferpymc_postprocessouts` should not remain the compatibility target.
-  `postprocessing/legacy_outputs.py` exists so the old-format dataset can be
-  produced from the modern postprocessing path by renaming variables and
-  arranging dimensions, then `inferpymc_postprocessouts` can be deleted.
+- `inferpymc_postprocessouts` should not remain the compatibility target or a
+  normal output-dispatch path. `postprocessing/legacy_outputs.py` exists so the
+  old-format dataset can be produced from modern `InversionOutput` by deriving
+  trace, sensitivity, frequency-index, and product fields internally; then
+  `inferpymc_postprocessouts` can be deleted.
 
 ## Preferred #416 implementation direction
 
+- Done in #416 first slice: add `output_format="legacy"` to RHIME single-sector
+  output dispatch and route deprecated `hbmcmc` / `hbmcmc_postprocessing`
+  names to it.
+- Done in #416 first slice: add a `run_hbmcmc.py` compatibility shim that reads
+  old fixedbasis-style INI files, translates legacy names (`outputpath`,
+  `outputname`, `nit`, `nchain`, `verbose`, `sampler_kwargs`) to modern RHIME
+  names, accepts and removes `mcmc_type="fixed_basis"`, and calls `run_rhime`.
+- Done in #416 first slice: keep old fixedbasis filename conventions for
+  outputs created via `run_hbmcmc.py`; direct `run_rhime` keeps RHIME filenames
+  unless explicitly given the compatibility filename convention.
+- Done in #416 first slice: refactor
+  `postprocessing.legacy_outputs.make_legacy_hbmcmc_output(...)` to consume
+  modern `InversionOutput` directly and derive `Hx`, `Hbc`,
+  `sigma_freq_index`, `xtrace`, `sigtrace`, `bctrace`, and convergence without
+  an inferpymc-shaped `mcmc_results` adapter.
 - Done in #383: pipe retained `BasisFunctions` through `FixedBasisPreparedData`
   for fixedbasis output modes after data preparation, construct modern
   `InversionOutput` from canonical `inv_inputs`, retained
@@ -394,12 +423,25 @@ review.
 - Done in #383: remove flat-basis fallback branches from modern flux/country
   postprocessing helpers.
 - Remove `inferpymc_postprocessouts` after old-format output parity is covered
-  by `postprocessing/legacy_outputs.py` using modern postprocessing inputs.
-- Remove `fixedbasisMCMC` once the #416 compatibility shim can run current
-  fixedbasis-style scripts through `run_rhime`.
+  by `postprocessing/legacy_outputs.py` using modern postprocessing inputs. No
+  normal RHIME/fixedbasis output dispatch should call it after the #416 first
+  slice.
+- Remove or quarantine direct `inferpymc` sampling once `fixedbasisMCMC` is no
+  longer needed as a Python compatibility entrypoint.
+- Remove `fixedbasisMCMC` once the #416 compatibility shim has enough
+  fixedbasis-style script parity coverage through `run_rhime`.
 
 ## Tests needed before removal
 
+- Done in #416 first slice: shim tests prove old config names route to
+  `run_rhime` with modern arguments and legacy filename convention.
+- Done in #416 first slice: alias tests prove `hbmcmc`,
+  `hbmcmc_postprocessing`, and `legacy` select the modern legacy formatter.
+- Done in #416 first slice: legacy formatter tests prove no `mcmc_results`,
+  `inferpymc_postprocessouts`, or `fp_data` are needed.
+- Done in #416 first slice: RHIME output-bundle tests prove
+  `output_format="legacy"` passes modern `InversionOutput` to the formatter and
+  writes the expected legacy file.
 - A focused fixedbasis compatibility test that proves the same fixedbasis input
   still runs and produces PARIS flux/concentration outputs matching the current
   behavior.

--- a/docs/plans/clean_up_inversions_refactor.md
+++ b/docs/plans/clean_up_inversions_refactor.md
@@ -501,6 +501,13 @@ review.
   longer needed as a Python compatibility entrypoint.
 - Remove `fixedbasisMCMC` once the #416 compatibility shim has enough
   fixedbasis-style script parity coverage through `run_rhime`.
+- Track and resolve `InversionOutput` storage policy in
+  [#465](https://github.com/openghg/openghg_inversions/issues/465). Derived
+  products should not silently save large `inv_out` sidecars; trace saves
+  should avoid persisted deterministic variables where they can be recreated
+  from latent variables, model specs, and retained model components; any future
+  Zarr-based storage needs to account for strict inode limits on shared
+  workspaces.
 - Delete or quarantine dead compatibility code as it loses callers:
   `legacy_postprocess_args` provenance plumbing in `fixedbasisMCMC`,
   `rerun_output(...)` replay through `inferpymc_postprocessouts`, old

--- a/docs/plans/clean_up_inversions_refactor.md
+++ b/docs/plans/clean_up_inversions_refactor.md
@@ -398,11 +398,19 @@ review.
 - Done in #416 first slice: keep old fixedbasis filename conventions for
   outputs created via `run_hbmcmc.py`; direct `run_rhime` keeps RHIME filenames
   unless explicitly given the compatibility filename convention.
+- Done in #416 first slice: make `run_hbmcmc.py` validate the translated RHIME
+  arguments before copying configs or creating output directories, and force
+  the legacy filename convention from that shim even if a caller supplies a
+  direct RHIME filename override.
 - Done in #416 first slice: refactor
   `postprocessing.legacy_outputs.make_legacy_hbmcmc_output(...)` to consume
   modern `InversionOutput` directly and derive `Hx`, `Hbc`,
   `sigma_freq_index`, `xtrace`, `sigtrace`, `bctrace`, and convergence without
   an inferpymc-shaped `mcmc_results` adapter.
+- Done in #416 first slice: preserve the old legacy-output metadata attributes
+  needed by fixedbasis workflows (`Emissions Prior`, sampler counts, sigma
+  settings, and related prior attrs) without passing `mcmc_results` or `fp_data`
+  into the formatter.
 - Done in #383: pipe retained `BasisFunctions` through `FixedBasisPreparedData`
   for fixedbasis output modes after data preparation, construct modern
   `InversionOutput` from canonical `inv_inputs`, retained
@@ -430,6 +438,19 @@ review.
   longer needed as a Python compatibility entrypoint.
 - Remove `fixedbasisMCMC` once the #416 compatibility shim has enough
   fixedbasis-style script parity coverage through `run_rhime`.
+- Delete or quarantine dead compatibility code as it loses callers:
+  `legacy_postprocess_args` provenance plumbing in `fixedbasisMCMC`,
+  `rerun_output(...)` replay through `inferpymc_postprocessouts`, old
+  `inferpymc` result adapters used only to shape `mcmc_results`, and
+  compatibility-era README/API sections that describe direct `inferpymc`
+  passthrough.
+- Design a replacement for legacy flat `**kwargs` / INI argument routing before
+  widening the shim. The historical behavior passed unrecognised
+  `fixedbasisMCMC` kwargs to `inferpymc`, which made ownership of options
+  unclear. Current RHIME compatibility paths validate supported options and
+  reject unsupported keys. Future config work should use explicit namespaces
+  such as data/model/sampler/output/postprocessing, or another similarly clear
+  routing scheme, rather than restoring arbitrary passthrough.
 
 ## Tests needed before removal
 

--- a/docs/usage/getting_started.rst
+++ b/docs/usage/getting_started.rst
@@ -109,6 +109,9 @@ Method 1: python script or notebook
 New scripts should call ``run_rhime`` from ``openghg_inversions.rhime``.
 ``fixedbasisMCMC`` remains only as a legacy compatibility entry point for old
 fixedbasis-style Python workflows.
+It no longer preserves the exact historical ``fixedbasisMCMC`` / ``inferpymc``
+passthrough behaviour; use release ``0.6`` or earlier if you need the old
+fixedbasis implementation.
 
 Method 2: ini file
 ~~~~~~~~~~~~~~~~~~
@@ -121,6 +124,8 @@ Method 2: ini file
   for old fixedbasis-style INI files. The script now translates those configs
   and runs the modern ``run_rhime`` pathway. New INI files should use
   ``openghg-inversions run-rhime`` and the RHIME config vocabulary.
+  Unsupported fixedbasis-only options now raise targeted errors instead of
+  being passed through to ``inferpymc``.
 - A sample ``.ini`` script is at the bottom of this document.
 
 Method 3: as a job on Blue Pebble

--- a/docs/usage/getting_started.rst
+++ b/docs/usage/getting_started.rst
@@ -107,8 +107,8 @@ Method 1: python script or notebook
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 New scripts should call ``run_rhime`` from ``openghg_inversions.rhime``.
-``fixedbasisMCMC`` remains only as a legacy compatibility entry point for old
-fixedbasis-style Python workflows.
+``fixedbasisMCMC`` remains only as a temporary direct legacy Python path, not
+as the RHIME-backed compatibility route.
 It no longer preserves the exact historical ``fixedbasisMCMC`` / ``inferpymc``
 passthrough behaviour; use release ``0.6`` or earlier if you need the old
 fixedbasis implementation.

--- a/docs/usage/getting_started.rst
+++ b/docs/usage/getting_started.rst
@@ -106,9 +106,9 @@ How do you run an inversion?
 Method 1: python script or notebook
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Assuming you have the necessary data, you just need to run the
-``fixedbasisMCMC`` function from ``hbmcmc.py`` in
-``openghg_inversions.hbmbmc``.
+New scripts should call ``run_rhime`` from ``openghg_inversions.rhime``.
+``fixedbasisMCMC`` remains only as a legacy compatibility entry point for old
+fixedbasis-style Python workflows.
 
 Method 2: ini file
 ~~~~~~~~~~~~~~~~~~
@@ -118,6 +118,9 @@ Method 2: ini file
 - Activate a Pixi, conda, or venv environment with inversions installed, and
   call
   ``python <path to openghg_inversions>/openghg_inversions/hbmcmc/run_hbmcmc.py -c my_inversion.ini``
+  for old fixedbasis-style INI files. The script now translates those configs
+  and runs the modern ``run_rhime`` pathway. New INI files should use
+  ``openghg-inversions run-rhime`` and the RHIME config vocabulary.
 - A sample ``.ini`` script is at the bottom of this document.
 
 Method 3: as a job on Blue Pebble
@@ -420,9 +423,9 @@ The following file, ``my_hbmcmc_inputs.ini`` can be used to run an
 
    [MCMC.OUTPUT]
    ; Format of output
-   ; See docs for openghg_inversions.hbmcmc.hbmcmc.fixedbasisMCMC
-   ; for full list of options
-   output_format = "hbmcmc"  ; default option, but "paris" tends to be used more
+   ; "legacy" writes the old HBMCMC-compatible output through modern RHIME.
+   ; Deprecated aliases "hbmcmc" and "hbmcmc_postprocessing" are accepted.
+   output_format = "legacy"
 
    ; Details of where to write the output
    ; outputpath (str) - directory to write output
@@ -434,8 +437,9 @@ The following file, ``my_hbmcmc_inputs.ini`` can be used to run an
 Description of HBMCMC output file
 ---------------------------------
 
-The output of ``run_hbmcmc`` (and ``fixedbasisMCMC``) is an xarray
-Dataset with the following variables and attributes:
+The legacy compatibility output from ``run_hbmcmc`` (and
+``fixedbasisMCMC(output_format="legacy")``) is an xarray Dataset with the
+following variables and attributes:
 
 HMCMC output data variables:
 

--- a/docs/usage/rhime.rst
+++ b/docs/usage/rhime.rst
@@ -136,3 +136,6 @@ and ``hbmcmc_postprocessing`` are accepted as aliases for ``legacy``.
 files. It translates legacy option names to the modern ``run_rhime`` API and
 uses the legacy filename convention. New scripts and new configs should use
 ``openghg-inversions run-rhime`` or ``run_rhime(...)`` directly.
+This compatibility route no longer preserves the exact historical
+``fixedbasisMCMC`` / ``inferpymc`` passthrough behaviour. Use release ``0.6`` or
+earlier if you need the old fixedbasis implementation.

--- a/docs/usage/rhime.rst
+++ b/docs/usage/rhime.rst
@@ -123,3 +123,16 @@ are not the same strings as the OpenGHG source values.
        "TER": {"pdf": "normal", "mu": 1.0, "sigma": 0.5},
        "ocean": {"pdf": "lognormal", "mean": 1.0, "stdev": 1.0}
    }
+
+Output Formats
+--------------
+
+Standard single-sector RHIME supports ``inv_out``, ``basic``, ``paris``, and
+``legacy`` output formats. ``legacy`` writes the old HBMCMC-compatible NetCDF
+product from the modern ``InversionOutput``. The deprecated names ``hbmcmc``
+and ``hbmcmc_postprocessing`` are accepted as aliases for ``legacy``.
+
+``run_hbmcmc.py`` is now a compatibility wrapper for old fixedbasis-style INI
+files. It translates legacy option names to the modern ``run_rhime`` API and
+uses the legacy filename convention. New scripts and new configs should use
+``openghg-inversions run-rhime`` or ``run_rhime(...)`` directly.

--- a/docs/usage/rhime.rst
+++ b/docs/usage/rhime.rst
@@ -139,3 +139,5 @@ uses the legacy filename convention. New scripts and new configs should use
 This compatibility route no longer preserves the exact historical
 ``fixedbasisMCMC`` / ``inferpymc`` passthrough behaviour. Use release ``0.6`` or
 earlier if you need the old fixedbasis implementation.
+Direct ``fixedbasisMCMC(...)`` calls are a temporary legacy Python path, not a
+wrapper around ``run_rhime(...)``.

--- a/openghg_inversions/_country_file.py
+++ b/openghg_inversions/_country_file.py
@@ -5,20 +5,68 @@ from __future__ import annotations
 import warnings
 from collections.abc import Iterable
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
+import numpy as np
 import xarray as xr
 
-CountryFileEngine = Literal["default", "h5netcdf"]
+CountryFileEngine = Literal["default", "h5netcdf", "h5py"]
 
-COUNTRY_FILE_ENGINE_ORDER: tuple[CountryFileEngine, ...] = ("default", "h5netcdf")
+COUNTRY_FILE_ENGINE_ORDER: tuple[CountryFileEngine, ...] = ("default", "h5netcdf", "h5py")
 COUNTRY_FILE_SELECTED_ENGINE_ATTR = "_openghg_inversions_country_file_engine"
 
 
+def _read_h5py_dataset(data: Any) -> np.ndarray:
+    """Read a h5py dataset, decoding string arrays when needed."""
+    if data.dtype.kind in {"O", "S"}:
+        try:
+            return np.asarray(data.asstr()[()])
+        except (AttributeError, TypeError):
+            return np.asarray(data[()]).astype(str)
+    return np.asarray(data[()])
+
+
+def _load_country_dataset_with_h5py(country_file_path: Path) -> xr.Dataset:
+    """Load required country-file fields without xarray/HDF5 scale decoding."""
+    import h5py
+
+    with h5py.File(country_file_path, "r") as country_file:
+        for name in ("lat", "lon", "name"):
+            if name not in country_file:
+                raise ValueError(f"Country file {country_file_path} is missing required variable {name!r}.")
+
+        country_var = (
+            "country" if "country" in country_file else "region" if "region" in country_file else None
+        )
+        if country_var is None:
+            raise ValueError(
+                f"Country file {country_file_path} must contain either a 'country' or 'region' variable."
+            )
+
+        lat = _read_h5py_dataset(country_file["lat"])
+        lon = _read_h5py_dataset(country_file["lon"])
+        country = _read_h5py_dataset(country_file[country_var])
+        country_names = _read_h5py_dataset(country_file["name"]).astype(str)
+
+        data_vars: dict[str, tuple[tuple[str, ...], np.ndarray]] = {
+            "country": (("lat", "lon"), country),
+            "name": (("ncountries",), country_names),
+        }
+        if "country_code" in country_file:
+            data_vars["country_code"] = (
+                ("ncountries",),
+                _read_h5py_dataset(country_file["country_code"]).astype(str),
+            )
+
+    return xr.Dataset(data_vars=data_vars, coords={"lat": lat, "lon": lon})
+
+
 def _open_country_dataset(path: Path, engine: CountryFileEngine) -> xr.Dataset:
-    """Open a country-file dataset using a named xarray engine."""
+    """Open a country-file dataset using a named backend path."""
     if engine == "default":
         return xr.open_dataset(path)
+    if engine == "h5py":
+        return _load_country_dataset_with_h5py(path)
 
     return xr.open_dataset(path, engine=engine)
 
@@ -27,16 +75,23 @@ def _format_failures(failures: list[tuple[CountryFileEngine, BaseException]]) ->
     return "; ".join(f"{engine}: {type(error).__name__}: {error}" for engine, error in failures)
 
 
+def _fallback_label(engine: CountryFileEngine) -> str:
+    if engine == "h5py":
+        return "direct HDF5 reader"
+    return "xarray engine"
+
+
 def load_country_dataset(
     country_file: str | Path,
     engines: Iterable[CountryFileEngine] = COUNTRY_FILE_ENGINE_ORDER,
 ) -> xr.Dataset:
-    """Open and load a country file with a fallback for HDF5 backend issues.
+    """Open and load a country file with fallbacks for HDF5 backend issues.
 
     Args:
         country_file: NetCDF country file path.
-        engines: Ordered xarray backend labels to try. ``"default"`` uses xarray's
-            engine selection; any other value is passed as ``engine=...``.
+        engines: Ordered backend labels to try. ``"default"`` uses xarray's
+            engine selection, ``"h5netcdf"`` passes ``engine="h5netcdf"`` to
+            xarray, and ``"h5py"`` uses a direct minimal HDF5 reader.
 
     Returns:
         Loaded xarray Dataset with its file handle closed.
@@ -49,16 +104,20 @@ def load_country_dataset(
 
     for engine in engines:
         try:
-            with _open_country_dataset(path, engine) as dataset:
+            dataset = _open_country_dataset(path, engine)
+            try:
                 loaded = dataset.load()
+            finally:
+                dataset.close()
         except Exception as error:
             failures.append((engine, error))
             continue
 
         if failures:
             warnings.warn(
-                "Falling back to xarray engine "
-                f"{engine!r} for country file {path} after {_format_failures(failures)}",
+                "Falling back to "
+                f"{_fallback_label(engine)} {engine!r} for country file {path} "
+                f"after {_format_failures(failures)}",
                 RuntimeWarning,
                 stacklevel=2,
             )

--- a/openghg_inversions/_pymc_config.py
+++ b/openghg_inversions/_pymc_config.py
@@ -1,0 +1,14 @@
+"""Shared PyMC/PyTensor runtime configuration."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+
+def configure_pytensor() -> None:
+    """Apply OpenGHG Inversions PyTensor defaults before importing PyMC."""
+    import pytensor
+
+    config = cast(Any, pytensor).config
+    config.floatX = "float32"
+    config.warn_float64 = "warn"

--- a/openghg_inversions/_timing.py
+++ b/openghg_inversions/_timing.py
@@ -1,0 +1,59 @@
+"""Small helpers for grep-friendly runtime instrumentation."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from time import perf_counter
+from typing import Any, Iterator
+import resource
+import sys
+
+
+def _maxrss_kb() -> int:
+    """Return peak resident set size in KiB where available."""
+    maxrss = int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
+    if sys.platform == "darwin":
+        return maxrss // 1024
+    return maxrss
+
+
+def _format_value(value: Any) -> str:
+    """Format a timing field value without spaces."""
+    if isinstance(value, float):
+        return f"{value:.6f}"
+    if isinstance(value, bool):
+        return str(value).lower()
+    if value is None:
+        return "none"
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return ",".join(_format_value(item) for item in value)
+    return str(value).replace(" ", "_")
+
+
+def log_timing(label: str, seconds: float, **fields: Any) -> None:
+    """Print one grep-friendly timing line."""
+    field_text = " ".join(
+        f"{name}={_format_value(value)}" for name, value in fields.items() if value is not None
+    )
+    suffix = f" {field_text}" if field_text else ""
+    print(f"TIMING {label} seconds={seconds:.6f} maxrss_kb={_maxrss_kb()}{suffix}")
+
+
+def timer_start() -> float:
+    """Return a timestamp for later ``log_timing`` calls."""
+    return perf_counter()
+
+
+def timer_seconds(start: float) -> float:
+    """Return elapsed seconds since ``start``."""
+    return perf_counter() - start
+
+
+@contextmanager
+def timed(label: str, **fields: Any) -> Iterator[None]:
+    """Context manager that logs elapsed time for a code block."""
+    start = timer_start()
+    try:
+        yield
+    finally:
+        log_timing(label, timer_seconds(start), **fields)

--- a/openghg_inversions/basis/operators.py
+++ b/openghg_inversions/basis/operators.py
@@ -386,7 +386,7 @@ class BucketBasisOperator(BasisOperator):
             region_labels: Policy for the output state coordinate labels:
                 - `"range0"`: `0..N-1` (legacy-friendly)
                 - `"range1"`: `1..N`
-                - `"basis_values"`: use the unique positive labels found in `basis_flat`.
+                - `"basis_values"`: use the ordered non-negative labels found in `basis_flat`.
             chunks: Optional chunking to apply to the basis matrix.
         """
         meta = meta or BasisMeta()
@@ -432,25 +432,37 @@ class BucketBasisOperator(BasisOperator):
             `mat` with an updated state coordinate.
 
         Notes:
-            This assumes `get_xr_dummies` orders categories in ascending order of the
-            unique positive labels in `basis_flat`.
+            This assumes `get_xr_dummies` orders categories in ascending order
+            of the unique labels in `basis_flat`. Both one-based basis labels
+            (`1..N`) and zero-based legacy output labels (`0..N-1`) are
+            accepted.
         """
-        # Determine basis label values present (assume positive ints, often 1..N)
         labels = np.unique(self.basis_flat.values.astype(int))
-        labels = labels[labels > 0]
-        n = len(labels)
+        positive_labels = labels[labels > 0]
+        non_negative_labels = labels[labels >= 0]
+        n = mat.sizes[self.meta.state_dim]
+
+        if len(positive_labels) == n:
+            basis_value_labels = positive_labels
+        elif len(non_negative_labels) == n:
+            basis_value_labels = non_negative_labels
+        else:
+            raise ValueError(
+                "Basis labels must be one-based positive values or zero-based non-negative values; "
+                f"got labels {labels.tolist()} for {n} dummy columns."
+            )
 
         if self.region_labels == "range0":
             coord = np.arange(n, dtype=int)
         elif self.region_labels == "range1":
             coord = np.arange(1, n + 1, dtype=int)
         elif self.region_labels == "basis_values":
-            coord = labels.astype(int)
+            coord = basis_value_labels.astype(int)
         else:
             raise ValueError(f"Unknown region_labels policy: {self.region_labels}")
 
         # Assign coordinate. Important: this assumes get_xr_dummies created state columns
-        # ordered by sorted unique labels > 0. If that assumption changes, we must reindex.
+        # ordered by sorted unique labels. If that assumption changes, we must reindex.
         return mat.assign_coords({self.meta.state_dim: coord})
 
     # ---- DataTree IO ----

--- a/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_satellite_template.ini
+++ b/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_satellite_template.ini
@@ -178,12 +178,13 @@ nchain = 4
 ; save_trace (bool): If True, the arviz InferenceData output from sampling will be saved to the output path of
 ;                    the inversion, with a file name of the form f"{outputname}{start_data}_trace.nc.
 ;                    Alternatively, you can pass a path (including filename), and that path will be used.
-; calculate_min_error: legacy-only deprecated option. The run_hbmcmc compatibility shim rejects enabled
-;                      values; use `min_error` and `min_error_options` instead.
+; calculate_min_error: deprecated legacy spelling. The run_hbmcmc compatibility shim translates
+;                      "residual" or "percentile" to `min_error`; prefer `min_error` directly.
 ; pollution_events_from_obs (bool): Determines whether the model error is calculated as a fraction of:
 ;                                   - the measured enhancement above the modelled baseline (if True)
 ;                                   - the prior modelled enhancement (if False)
-; reparameterise_log_normal (bool): legacy-only option. Leave False for the run_hbmcmc compatibility shim.
+; reparameterise_log_normal (bool): deprecated legacy spelling. If True, the shim sets
+;                                   `reparameterise=True` in lognormal emissions/BC priors.
 averaging_error = False
 min_error = 0.0
 fix_basis_outer_regions = False

--- a/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_satellite_template.ini
+++ b/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_satellite_template.ini
@@ -178,14 +178,12 @@ nchain = 4
 ; save_trace (bool): If True, the arviz InferenceData output from sampling will be saved to the output path of
 ;                    the inversion, with a file name of the form f"{outputname}{start_data}_trace.nc.
 ;                    Alternatively, you can pass a path (including filename), and that path will be used.
-; calculate_min_error: computes min_error on the fly using the "residual error method" or a method based on percentiles.
-;                      values can be: "residual", "percentile", None. If value is None, then value passed to `min_error`
-;                      is used.
+; calculate_min_error: legacy-only deprecated option. The run_hbmcmc compatibility shim rejects enabled
+;                      values; use `min_error` and `min_error_options` instead.
 ; pollution_events_from_obs (bool): Determines whether the model error is calculated as a fraction of:
 ;                                   - the measured enhancement above the modelled baseline (if True)
 ;                                   - the prior modelled enhancement (if False)
-; reparameterise_log_normal (bool): If True, rewrite log normal prior samples as a function of standard normal samples.
-;                                   This may reduce divergences when sampling.
+; reparameterise_log_normal (bool): legacy-only option. Leave False for the run_hbmcmc compatibility shim.
 averaging_error = False
 min_error = 0.0
 fix_basis_outer_regions = False
@@ -201,6 +199,8 @@ reparameterise_log_normal = False
 ; Details of where to write the output
 ; outputpath (str): Directory to write output
 ; outputname (str): Unique identifier for output/run name.
+; output_format (str): Optional. Defaults to "legacy". Deprecated aliases "hbmcmc"
+;                      and "hbmcmc_postprocessing" also route to "legacy".
 
 #outputpath = "/group/chemistry/acrg/ES/"  ; (required)
 outputpath = "/user/work/vq21425/openghg_inversions"  ; (required)

--- a/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template.ini
+++ b/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template.ini
@@ -200,14 +200,12 @@ nchain = 2
 ; save_trace (bool): If True, the arviz InferenceData output from sampling will be saved to the output path of
 ;                    the inversion, with a file name of the form f"{outputname}{start_data}_trace.nc.
 ;                    Alternatively, you can pass a path (including filename), and that path will be used.
-; calculate_min_error: computes min_error on the fly using the "residual error method" or a method based on percentiles.
-;                      values can be: "residual", "percentile", None. If value is None, then value passed to `min_error`
-;                      is used.
+; calculate_min_error: legacy-only deprecated option. The run_hbmcmc compatibility shim rejects enabled
+;                      values; use `min_error` and `min_error_options` instead.
 ; pollution_events_from_obs (bool): Determines whether the model error is calculated as a fraction of:
 ;                                   - the measured enhancement above the modelled baseline (if True)
 ;                                   - the prior modelled enhancement (if False)
-; reparameterise_log_normal (bool): If True, rewrite log normal prior samples as a function of standard normal samples.
-;                                   This may reduce divergences when sampling.
+; reparameterise_log_normal (bool): legacy-only option. Leave False for the run_hbmcmc compatibility shim.
 ; sampler_kwargs (dict): Kwargs to pass to the sampler (e.g. sampler_kwargs = {'target_accept': 0.99})
 
 averaging_error = True
@@ -223,6 +221,8 @@ no_model_error = False
 ; Details of where to write the output
 ; outputpath (str): Directory to write output
 ; outputname (str): Unique identifier for output/run name.
+; output_format (str): Optional. Defaults to "legacy". Deprecated aliases "hbmcmc"
+;                      and "hbmcmc_postprocessing" also route to "legacy".
 
 outputpath = " "  ; (required)
 outputname = " "  ; (required)

--- a/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template.ini
+++ b/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template.ini
@@ -200,12 +200,13 @@ nchain = 2
 ; save_trace (bool): If True, the arviz InferenceData output from sampling will be saved to the output path of
 ;                    the inversion, with a file name of the form f"{outputname}{start_data}_trace.nc.
 ;                    Alternatively, you can pass a path (including filename), and that path will be used.
-; calculate_min_error: legacy-only deprecated option. The run_hbmcmc compatibility shim rejects enabled
-;                      values; use `min_error` and `min_error_options` instead.
+; calculate_min_error: deprecated legacy spelling. The run_hbmcmc compatibility shim translates
+;                      "residual" or "percentile" to `min_error`; prefer `min_error` directly.
 ; pollution_events_from_obs (bool): Determines whether the model error is calculated as a fraction of:
 ;                                   - the measured enhancement above the modelled baseline (if True)
 ;                                   - the prior modelled enhancement (if False)
-; reparameterise_log_normal (bool): legacy-only option. Leave False for the run_hbmcmc compatibility shim.
+; reparameterise_log_normal (bool): deprecated legacy spelling. If True, the shim sets
+;                                   `reparameterise=True` in lognormal emissions/BC priors.
 ; sampler_kwargs (dict): Kwargs to pass to the sampler (e.g. sampler_kwargs = {'target_accept': 0.99})
 
 averaging_error = True

--- a/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template_example.ini
+++ b/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template_example.ini
@@ -171,14 +171,12 @@ nchain = 4
 ; save_trace (bool): If True, the arviz InferenceData output from sampling will be saved to the output path of
 ;                    the inversion, with a file name of the form f"{outputname}{start_data}_trace.nc.
 ;                    Alternatively, you can pass a path (including filename), and that path will be used.
-; calculate_min_error: computes min_error on the fly using the "residual error method" or a method based on percentiles.
-;                      values can be: "residual", "percentile", None. If value is None, then value passed to `min_error`
-;                      is used.
+; calculate_min_error: legacy-only deprecated option. The run_hbmcmc compatibility shim rejects enabled
+;                      values; use `min_error` and `min_error_options` instead.
 ; pollution_events_from_obs (bool): Determines whether the model error is calculated as a fraction of:
 ;                                   - the measured enhancement above the modelled baseline (if True)
 ;                                   - the prior modelled enhancement (if False)
-; reparameterise_log_normal (bool): If True, rewrite log normal prior samples as a function of standard normal samples.
-;                                   This may reduce divergences when sampling.
+; reparameterise_log_normal (bool): legacy-only option. Leave False for the run_hbmcmc compatibility shim.
 ; sampler_kwargs (dict): Kwargs to pass to the sampler (e.g. sampler_kwargs = {'target_accept': 0.99})
 
 averaging_error = True
@@ -196,6 +194,8 @@ reparameterise_log_normal = False
 ; Details of where to write the output
 ; outputpath (str): Directory to write output
 ; outputname (str): Unique identifier for output/run name.
+; output_format (str): Optional. Defaults to "legacy". Deprecated aliases "hbmcmc"
+;                      and "hbmcmc_postprocessing" also route to "legacy".
 
 outputpath = "/group/chemistry/acrg/ES/"  ; (required)
 outputname = "my_first_rhime_inversion"  ; (required)

--- a/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template_example.ini
+++ b/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template_example.ini
@@ -171,12 +171,13 @@ nchain = 4
 ; save_trace (bool): If True, the arviz InferenceData output from sampling will be saved to the output path of
 ;                    the inversion, with a file name of the form f"{outputname}{start_data}_trace.nc.
 ;                    Alternatively, you can pass a path (including filename), and that path will be used.
-; calculate_min_error: legacy-only deprecated option. The run_hbmcmc compatibility shim rejects enabled
-;                      values; use `min_error` and `min_error_options` instead.
+; calculate_min_error: deprecated legacy spelling. The run_hbmcmc compatibility shim translates
+;                      "residual" or "percentile" to `min_error`; prefer `min_error` directly.
 ; pollution_events_from_obs (bool): Determines whether the model error is calculated as a fraction of:
 ;                                   - the measured enhancement above the modelled baseline (if True)
 ;                                   - the prior modelled enhancement (if False)
-; reparameterise_log_normal (bool): legacy-only option. Leave False for the run_hbmcmc compatibility shim.
+; reparameterise_log_normal (bool): deprecated legacy spelling. If True, the shim sets
+;                                   `reparameterise=True` in lognormal emissions/BC priors.
 ; sampler_kwargs (dict): Kwargs to pass to the sampler (e.g. sampler_kwargs = {'target_accept': 0.99})
 
 averaging_error = True

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -35,8 +35,6 @@ import arviz as az
 import numpy as np
 import xarray as xr
 
-from openghg.util import split_function_inputs  # pyright: ignore[reportPrivateImportUsage]
-
 import openghg_inversions.hbmcmc.inversion_pymc as mcmc
 from openghg_inversions.basis.basis_functions import BasisFunctions
 from openghg_inversions.models.priors import lognormal_mu_sigma
@@ -254,11 +252,13 @@ def _resolve_output_format(
         )
 
     resolved_output_format = output_format.lower()
-
-    if resolved_output_format == "hbmcmc" and is_column:
-        raise ValueError(
-            "Cannot use output_format 'hbmcmc' when column-based measurements are included. Please choose another output_format."
+    if resolved_output_format in {"hbmcmc", "hbmcmc_postprocessing"}:
+        warnings.warn(
+            f"output_format={resolved_output_format!r} is deprecated; use output_format='legacy' instead.",
+            UserWarning,
+            stacklevel=2,
         )
+        resolved_output_format = "legacy"
 
     return resolved_output_format
 
@@ -432,18 +432,6 @@ def _get_inversion_output(context: _OutputContext) -> InversionOutput:
     return context.inv_out
 
 
-def _prepare_legacy_hbmcmc_postprocess_args(context: _OutputContext) -> dict:
-    """Prepare the legacy argument bag for ``inferpymc_postprocessouts``."""
-    legacy_postprocess_args = context.legacy_postprocess_args.copy()
-    legacy_postprocess_args.update(context.mcmc_args)
-    del legacy_postprocess_args["inv_inputs"]
-    del legacy_postprocess_args["nit"]
-    del legacy_postprocess_args["verbose"]
-    del legacy_postprocess_args["offset_args"]
-    del legacy_postprocess_args["power"]
-    return legacy_postprocess_args
-
-
 def _handle_core_output_artifacts(context: _OutputContext) -> None:
     """Write core inversion artifacts needed before final output dispatch."""
     trace_path = context.paths.get("trace")
@@ -478,19 +466,13 @@ def _finalize_output(context: _OutputContext) -> xr.Dataset | dict | InversionOu
         print(f"Post processing Complete. Time taken = {end_post - start_post:.2f} seconds")
         return outputs
 
-    if context.output_format == "hbmcmc_postprocessing":
+    if context.output_format == "legacy":
         from openghg_inversions.hbmcmc.hbmcmc_output import define_output_filename
 
         from ..postprocessing.legacy_outputs import make_legacy_hbmcmc_output
 
         outputs = make_legacy_hbmcmc_output(
             inv_out=_get_inversion_output(context),
-            mcmc_results=context.mcmc_results,
-            # TODO: Stop threading these explicitly once make_legacy_hbmcmc_output
-            # can consume the needed arrays directly from the modern model/input data path.
-            sigma_freq_index=context.legacy_postprocess_args["sigma_freq_index"],
-            Hx=context.legacy_postprocess_args["Hx"],
-            Hbc=context.legacy_postprocess_args.get("Hbc"),
             country_file=context.country_file,
             use_bc=context.use_bc,
         )
@@ -557,23 +539,7 @@ def _finalize_output(context: _OutputContext) -> xr.Dataset | dict | InversionOu
         print(f"Post processing Complete. Time taken = {end_post - start_post:.2f} seconds")
         return xr.merge([conc_outs, flux_outs.rename(time="flux_time")])
 
-    # Legacy default hbmcmc output path.
-    mcmc_results = context.mcmc_results.copy()
-    del mcmc_results["trace"]
-    del mcmc_results["model"]
-    legacy_postprocess_args = _prepare_legacy_hbmcmc_postprocess_args(context)
-    legacy_postprocess_args.update(mcmc_results)
-    post_process_args_selection, _ = split_function_inputs(
-        legacy_postprocess_args, mcmc.inferpymc_postprocessouts
-    )
-    out = mcmc.inferpymc_postprocessouts(**post_process_args_selection)
-
-    end_post = time.time()
-
-    print(f"Post processing Complete. Time taken = {end_post - start_post:.2f} seconds")
-    print("---- Inversion completed ----")
-
-    return out
+    raise ValueError(f"Unsupported fixedbasisMCMC output_format {context.output_format!r}.")
 
 
 # ------------------------------------------------------------
@@ -647,13 +613,14 @@ def fixedbasisMCMC(
     output_format: Literal[
         "hbmcmc",
         "hbmcmc_postprocessing",
+        "legacy",
         "paris",
         "basic",
         "merged_data",
         "inv_out",
         "mcmc_args",
         "mcmc_results",
-    ] = "hbmcmc",
+    ] = "legacy",
     paris_postprocessing: bool = False,
     paris_postprocessing_kwargs: dict | None = None,
     power: dict | float = 1.99,
@@ -662,8 +629,8 @@ def fixedbasisMCMC(
 ) -> xr.Dataset | dict | InversionOutput:
     """Script to run hierarchical Bayesian MCMC (RHIME) for inference of emissions.
 
-    Uses PyMC to solve the inverse problem. Saves an output from the inversion code
-    using inferpymc_postprocessouts.
+    Uses PyMC to solve the inverse problem. This is now a legacy compatibility
+    entry point; new workflows should call ``run_rhime`` directly.
 
     Args:
         species: Atmospheric trace gas species of interest (e.g. 'co2').
@@ -774,9 +741,9 @@ def fixedbasisMCMC(
         min_error_options: Dictionary of additional arguments to pass the the function used to calculate min. model
             error (as specified by `min_error`).
         output_format: Select what is returned/saved by inversion.
-            - "hbmcmc": (default) return the results of `inferpymc_postprocessouts`, and save result as netCDF
-            - "hbmcmc_postprocessing": return legacy-style output format, computed using functions from the
-              `postprocessing` submodule
+            - "legacy": (default) return old HBMCMC-compatible output formatting, computed from modern
+              `InversionOutput`, and save result as netCDF. Deprecated aliases: "hbmcmc" and
+              "hbmcmc_postprocessing".
             - "merged_data": return `fp_all` dictionary, no further processing and inversion *not* run
             - "inv_out": return modern `InversionOutput` object
             - "basic": return basic output created by new `postprocessing` submodule
@@ -802,8 +769,7 @@ def fixedbasisMCMC(
 
     output_format = cast(
         Literal[
-            "hbmcmc",
-            "hbmcmc_postprocessing",
+            "legacy",
             "paris",
             "basic",
             "merged_data",

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -260,6 +260,12 @@ def _resolve_output_format(
         )
         resolved_output_format = "legacy"
 
+    if is_column and resolved_output_format == "legacy":
+        raise ValueError(
+            "Legacy HBMCMC output formatting is not supported for column observations; "
+            "use output_format='inv_out' or a modern RHIME output format."
+        )
+
     return resolved_output_format
 
 
@@ -362,6 +368,7 @@ def _build_inversion_output_args(
     *,
     prepared: FixedBasisPreparedData,
     legacy_postprocess_args: dict,
+    mcmc_args: dict,
     mcmc_results: dict,
     sites: list[str],
     averaging_period: list[str | None],
@@ -380,6 +387,7 @@ def _build_inversion_output_args(
     Args:
         prepared: Prepared fixedbasis data including retained basis functions.
         legacy_postprocess_args: Legacy postprocessing values computed alongside inversion inputs.
+        mcmc_args: Arguments passed to ``mcmc.inferpymc``.
         mcmc_results: Raw inversion outputs from ``mcmc.inferpymc``.
         sites: Site names used in the inversion.
         averaging_period: Observation averaging periods used in the inversion.
@@ -416,6 +424,7 @@ def _build_inversion_output_args(
             "output_name": outputname,
             "save_trace": save_trace,
             "save_inversion_output": save_inversion_output,
+            "legacy_hbmcmc_attrs": _legacy_hbmcmc_attrs_from_mcmc_args(mcmc_args),
         },
         "provenance": {
             "contract": "modern_fixedbasis_inversion_output",
@@ -423,6 +432,35 @@ def _build_inversion_output_args(
             "legacy_postprocessing_fields": sorted(str(key) for key in legacy_postprocess_args),
         },
     }
+
+
+def _format_legacy_prior_attr(prior: object) -> str | None:
+    """Format a prior dictionary using the historical HBMCMC attribute shape."""
+    if not isinstance(prior, dict):
+        return None
+    return ",".join(f"{key},{value}" for key, value in prior.items())
+
+
+def _legacy_hbmcmc_attrs_from_mcmc_args(mcmc_args: dict) -> dict[str, str]:
+    """Return legacy output attrs that are still needed by old fixedbasis workflows."""
+    attrs = {
+        "Burn in": str(int(mcmc_args["burn"])),
+        "Tuning steps": str(int(mcmc_args["tune"])),
+        "Number of chains": str(int(mcmc_args["nchain"])),
+        "Error for each site": str(mcmc_args["sigma_per_site"]),
+    }
+
+    prior_attrs = {
+        "Emissions Prior": _format_legacy_prior_attr(mcmc_args.get("xprior")),
+        "Model error Prior": _format_legacy_prior_attr(mcmc_args.get("sigprior")),
+    }
+    if mcmc_args.get("use_bc"):
+        prior_attrs["BCs Prior"] = _format_legacy_prior_attr(mcmc_args.get("bcprior"))
+    if mcmc_args.get("add_offset"):
+        prior_attrs["Offset Prior"] = _format_legacy_prior_attr(mcmc_args.get("offsetprior"))
+
+    attrs.update({name: value for name, value in prior_attrs.items() if value is not None})
+    return attrs
 
 
 def _get_inversion_output(context: _OutputContext) -> InversionOutput:
@@ -919,6 +957,7 @@ def fixedbasisMCMC(
     inversion_output_args = _build_inversion_output_args(
         prepared=prepared,
         legacy_postprocess_args=legacy_postprocess_args,
+        mcmc_args=mcmc_args,
         mcmc_results=mcmc_results,
         sites=sites,
         averaging_period=averaging_period,

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -8,11 +8,10 @@ from typing import Any
 
 import numpy as np
 
-# import pytensor before pymc so we can set config values
-import pytensor
+# Configure PyTensor before importing PyMC.
+from openghg_inversions._pymc_config import configure_pytensor
 
-pytensor.config.floatX = "float32"
-pytensor.config.warn_float64 = "warn"
+configure_pytensor()
 
 import pymc as pm  # noqa: E402
 import pandas as pd  # noqa: E402

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -1051,9 +1051,6 @@ def inferpymc_postprocessouts(
     outds.attrs["Date created"] = str(pd.Timestamp("today"))
     outds.attrs["Convergence"] = convergence
     outds.attrs["Repository version"] = code_version()
-    outds.attrs["min_model_error"] = (
-        min_error  # TODO: remove this once PARIS formatting switches over to using min error data var
-    )
 
     # variables with variable length data types shouldn't be compressed
     # e.g. object ("O") or unicode ("U") type

--- a/openghg_inversions/hbmcmc/run_hbmcmc.py
+++ b/openghg_inversions/hbmcmc/run_hbmcmc.py
@@ -211,6 +211,8 @@ def fixedbasis_params_to_rhime(params: dict[str, Any]) -> dict[str, Any]:
     _normalise_legacy_output_format(translated)
     _translate_legacy_options(translated)
     translated["output_filename_convention"] = "legacy"
+    if "save_inversion_output" not in translated and translated["output_format"] != "inv_out":
+        translated["save_inversion_output"] = False
     return normalise_rhime_params(translated)
 
 

--- a/openghg_inversions/hbmcmc/run_hbmcmc.py
+++ b/openghg_inversions/hbmcmc/run_hbmcmc.py
@@ -37,6 +37,7 @@ import warnings
 
 import openghg_inversions.hbmcmc.hbmcmc_output as output
 
+from openghg_inversions._timing import log_timing, timed, timer_seconds, timer_start
 from openghg_inversions.config import config
 from openghg_inversions.config.paths import Paths
 from openghg_inversions.inversion_data import prepare_rhime_inputs
@@ -351,15 +352,20 @@ def main(argv: list[str] | None = None) -> None:
             f"Configuration file cannot be found.\nPlease check path and filename are correct: {config_file}"
         )
 
+    timing_start = timer_start()
     mcmc_type = extract_mcmc_type(config_file)
     print(f"Using MCMC type: {mcmc_type} - routing fixedbasis-style config to run_rhime(...)")
-
     param = hbmcmc_extract_param(config_file, mcmc_type, **command_line_args)
+    log_timing("run_hbmcmc.config_extract", timer_seconds(timing_start))
 
-    rhime_params = fixedbasis_params_to_rhime(param)
-    validate_rhime_params(rhime_params)
+    with timed("run_hbmcmc.fixedbasis_to_rhime_translation"):
+        rhime_params = fixedbasis_params_to_rhime(param)
 
-    output.copy_config_file(str(config_file), param=param, **command_line_args)
+    with timed("run_hbmcmc.validation"):
+        validate_rhime_params(rhime_params)
+
+    with timed("run_hbmcmc.config_copy"):
+        output.copy_config_file(str(config_file), param=param, **command_line_args)
 
     run_rhime(**rhime_params)
 

--- a/openghg_inversions/hbmcmc/run_hbmcmc.py
+++ b/openghg_inversions/hbmcmc/run_hbmcmc.py
@@ -1,4 +1,8 @@
-"""Wrapper script to read in parameters from a configuration file and run underlying MCMC script.
+"""Compatibility script for running old fixedbasis-style configs through RHIME.
+
+This entry point preserves the historical ``run_hbmcmc.py`` command-line
+surface for old INI files, but translates supported fixedbasis-style parameter
+names and calls the modern ``run_rhime`` pathway.
 
 Run as:
     $ python run_hbmcmc.py [start end -c config.ini]
@@ -27,13 +31,33 @@ import sys
 import argparse
 from pathlib import Path
 from shutil import copyfile
-from collections.abc import Callable
+from typing import Any
 
-import openghg_inversions.hbmcmc.hbmcmc as mcmc
 import openghg_inversions.hbmcmc.hbmcmc_output as output
 
 from openghg_inversions.config import config
 from openghg_inversions.config.paths import Paths
+from openghg_inversions.rhime import run_rhime
+from openghg_inversions.rhime.params import normalise_rhime_params
+
+
+_RUN_HBMCMC_RHIME_ALIASES = {
+    "nit": "draws",
+    "nchain": "chains",
+    "verbose": "progressbar",
+    "sampler_kwargs": "sample_kwargs",
+}
+_RUN_HBMCMC_OUTPUT_ALIASES = {
+    "hbmcmc": "legacy",
+    "hbmcmc_postprocessing": "legacy",
+}
+_UNSUPPORTED_TRUE_LEGACY_OPTIONS = {
+    "calculate_min_error": "`calculate_min_error` is not supported by the RHIME compatibility shim; use `min_error`.",
+    "reparameterise_log_normal": (
+        "`reparameterise_log_normal` is not supported by the RHIME compatibility shim; "
+        "set `reparameterise` in the relevant prior dictionary if needed."
+    ),
+}
 
 
 def fixed_basis_expected_param() -> list[str]:
@@ -60,7 +84,7 @@ def fixed_basis_expected_param() -> list[str]:
     return expected_param
 
 
-def extract_mcmc_type(config_file: str, default: str = "fixed_basis") -> str:
+def extract_mcmc_type(config_file: str | Path, default: str = "fixed_basis") -> str:
     """Find value which describes the MCMC function to use.
 
     Checks the input configuation file the "mcmc_type" keyword within
@@ -87,26 +111,79 @@ def extract_mcmc_type(config_file: str, default: str = "fixed_basis") -> str:
     return mcmc_type
 
 
-def define_mcmc_function(mcmc_type: str) -> Callable:
-    """Links mcmc_type name to function.
+def _legacy_option_enabled(value: Any) -> bool:
+    """Return whether a legacy option value should be treated as enabled."""
+    if value is None or value is False:
+        return False
+    if isinstance(value, str):
+        return value.strip().lower() not in {"", "false", "none", "0"}
+    return True
 
-    Args:
-      mcmc_type (str):
-        Keyword for MCMC function to use.
-        Current option "fixed_basis" (openghg_inversions.hbmcmc.fixedbasisMCMC())
 
-    Returns:
-      Function
+def _translate_legacy_aliases(params: dict[str, Any]) -> None:
+    """Translate legacy run_hbmcmc parameter names to RHIME names in-place."""
+    for old, new in _RUN_HBMCMC_RHIME_ALIASES.items():
+        if old not in params:
+            continue
+        if new in params:
+            print(f"Ignoring deprecated run_hbmcmc parameter {old!r} because {new!r} was also supplied.")
+        else:
+            params[new] = params[old]
+        del params[old]
+
+
+def _normalise_legacy_output_format(params: dict[str, Any]) -> None:
+    """Map old HBMCMC output names to the modern compatibility output."""
+    paris_postprocessing = params.pop("paris_postprocessing", False)
+    if _legacy_option_enabled(paris_postprocessing):
+        params["output_format"] = "paris"
+        return
+
+    raw_output_format = params.get("output_format")
+    if raw_output_format is None:
+        params["output_format"] = "legacy"
+        return
+
+    output_format = str(raw_output_format).lower()
+    params["output_format"] = _RUN_HBMCMC_OUTPUT_ALIASES.get(output_format, output_format)
+
+
+def _drop_or_reject_legacy_only_options(params: dict[str, Any]) -> None:
+    """Drop no-op legacy options and reject enabled unsupported options."""
+    for name, message in _UNSUPPORTED_TRUE_LEGACY_OPTIONS.items():
+        if name not in params:
+            continue
+        value = params.pop(name)
+        if _legacy_option_enabled(value):
+            raise ValueError(message)
+
+
+def fixedbasis_params_to_rhime(params: dict[str, Any]) -> dict[str, Any]:
+    """Translate fixedbasis-style script/config parameters into RHIME arguments.
+
+    The compatibility shim deliberately stays at the entrypoint boundary:
+    legacy config spellings are normalised here, then the modern ``run_rhime``
+    API performs its existing validation and spec construction.
     """
-    function_dict = {"fixed_basis": mcmc.fixedbasisMCMC}
+    translated = dict(params)
+    mcmc_type = translated.pop("mcmc_type", "fixed_basis")
+    if mcmc_type != "fixed_basis":
+        raise ValueError(f"Unsupported run_hbmcmc mcmc_type {mcmc_type!r}; expected 'fixed_basis'.")
 
-    return function_dict[mcmc_type]
+    _translate_legacy_aliases(translated)
+    _normalise_legacy_output_format(translated)
+    _drop_or_reject_legacy_only_options(translated)
+    translated.setdefault("output_filename_convention", "legacy")
+    return normalise_rhime_params(translated)
 
 
 def hbmcmc_extract_param(
-    config_file: str, mcmc_type: str | None = "fixed_basis", print_param: bool | None = True, **command_line
+    config_file: str | Path,
+    mcmc_type: str | None = "fixed_basis",
+    print_param: bool | None = True,
+    **command_line,
 ):
-    """Extract parameters from input configuration file and associated MCMC function.
+    """Extract fixedbasis-style parameters from an input configuration file.
 
     Checks the mcmc_type to extract the required parameters.
 
@@ -117,16 +194,16 @@ def hbmcmc_extract_param(
         Keyword for MCMC function to use.
         Default = "fixed_basis" (only option at present)
       print_param:
-        Went set to True, print out extracted parameter names.
+        When set to True, print out extracted parameter names.
         Default = True
       command_line:
         Any additional command line arguments to be added to the param
         dictionary or to superceed values contained within the config file.
 
     Returns:
-      function,collections.OrderedDict:
-        MCMC function to use, dictionary of parameter names and values passed
-        to MCMC function
+      dict:
+        Dictionary of parameter names and values from the fixedbasis-style
+        configuration file plus command-line overrides.
 
     Raises:
         ValueError if expected parameter is missing or has `None` value.
@@ -164,15 +241,13 @@ def hbmcmc_extract_param(
     return param
 
 
-if __name__ == "__main__":
-    openghginv_path = Paths.openghginv
-    config_file = openghginv_path / "hbmcmc" / "hbmcmc_input.ini"
-
+def build_parser(default_config_file: Path) -> argparse.ArgumentParser:
+    """Build the legacy run_hbmcmc argument parser."""
     parser = argparse.ArgumentParser(description="Running Hierarchical Bayesian MCMC script")
     parser.add_argument("start", help="Start date string of the format YYYY-MM-DD", nargs="?")
     parser.add_argument("end", help="End date sting of the format YYYY-MM-DD", nargs="?")
     parser.add_argument(
-        "-c", "--config", help="Name (including path) of configuration file", default=config_file
+        "-c", "--config", help="Name (including path) of configuration file", default=default_config_file
     )
     parser.add_argument(
         "-r",
@@ -189,8 +264,15 @@ if __name__ == "__main__":
         "--output-path",
         help="Path to write ini file and results to.",
     )
+    return parser
 
-    args = parser.parse_args()
+
+def main(argv: list[str] | None = None) -> None:
+    """Run fixedbasis-style configs through the modern RHIME path."""
+    openghginv_path = Paths.openghginv
+    config_file = openghginv_path / "hbmcmc" / "hbmcmc_input.ini"
+
+    args = build_parser(config_file).parse_args(argv)
 
     config_file = Path(args.config)
     command_line_args = {}
@@ -223,11 +305,14 @@ if __name__ == "__main__":
         )
 
     mcmc_type = extract_mcmc_type(config_file)
-    mcmc_function = define_mcmc_function(mcmc_type)
-    print(f"Using MCMC type: {mcmc_type} - function {mcmc_function.__name__}(...)")
+    print(f"Using MCMC type: {mcmc_type} - routing fixedbasis-style config to run_rhime(...)")
 
     param = hbmcmc_extract_param(config_file, mcmc_type, **command_line_args)
 
-    output.copy_config_file(config_file, param=param, **command_line_args)
+    output.copy_config_file(str(config_file), param=param, **command_line_args)
 
-    mcmc_function(**param)
+    run_rhime(**fixedbasis_params_to_rhime(param))
+
+
+if __name__ == "__main__":
+    main()

--- a/openghg_inversions/hbmcmc/run_hbmcmc.py
+++ b/openghg_inversions/hbmcmc/run_hbmcmc.py
@@ -47,10 +47,6 @@ _RUN_HBMCMC_RHIME_ALIASES = {
     "verbose": "progressbar",
     "sampler_kwargs": "sample_kwargs",
 }
-_RUN_HBMCMC_OUTPUT_ALIASES = {
-    "hbmcmc": "legacy",
-    "hbmcmc_postprocessing": "legacy",
-}
 _UNSUPPORTED_TRUE_LEGACY_OPTIONS = {
     "calculate_min_error": "`calculate_min_error` is not supported by the RHIME compatibility shim; use `min_error`.",
     "reparameterise_log_normal": (
@@ -144,8 +140,7 @@ def _normalise_legacy_output_format(params: dict[str, Any]) -> None:
         params["output_format"] = "legacy"
         return
 
-    output_format = str(raw_output_format).lower()
-    params["output_format"] = _RUN_HBMCMC_OUTPUT_ALIASES.get(output_format, output_format)
+    params["output_format"] = str(raw_output_format).lower()
 
 
 def _drop_or_reject_legacy_only_options(params: dict[str, Any]) -> None:
@@ -173,7 +168,7 @@ def fixedbasis_params_to_rhime(params: dict[str, Any]) -> dict[str, Any]:
     _translate_legacy_aliases(translated)
     _normalise_legacy_output_format(translated)
     _drop_or_reject_legacy_only_options(translated)
-    translated.setdefault("output_filename_convention", "legacy")
+    translated["output_filename_convention"] = "legacy"
     return normalise_rhime_params(translated)
 
 
@@ -300,8 +295,7 @@ def main(argv: list[str] | None = None) -> None:
 
     if not config_file.exists():
         raise ValueError(
-            "Configuration file cannot be found.\n"
-            f"Please check path and filename are correct: {config_file}"
+            f"Configuration file cannot be found.\nPlease check path and filename are correct: {config_file}"
         )
 
     mcmc_type = extract_mcmc_type(config_file)
@@ -309,9 +303,11 @@ def main(argv: list[str] | None = None) -> None:
 
     param = hbmcmc_extract_param(config_file, mcmc_type, **command_line_args)
 
+    rhime_params = fixedbasis_params_to_rhime(param)
+
     output.copy_config_file(str(config_file), param=param, **command_line_args)
 
-    run_rhime(**fixedbasis_params_to_rhime(param))
+    run_rhime(**rhime_params)
 
 
 if __name__ == "__main__":

--- a/openghg_inversions/hbmcmc/run_hbmcmc.py
+++ b/openghg_inversions/hbmcmc/run_hbmcmc.py
@@ -291,7 +291,7 @@ def build_parser(default_config_file: Path) -> argparse.ArgumentParser:
     """Build the legacy run_hbmcmc argument parser."""
     parser = argparse.ArgumentParser(description="Running Hierarchical Bayesian MCMC script")
     parser.add_argument("start", help="Start date string of the format YYYY-MM-DD", nargs="?")
-    parser.add_argument("end", help="End date sting of the format YYYY-MM-DD", nargs="?")
+    parser.add_argument("end", help="End date string of the format YYYY-MM-DD", nargs="?")
     parser.add_argument(
         "-c", "--config", help="Name (including path) of configuration file", default=default_config_file
     )

--- a/openghg_inversions/hbmcmc/run_hbmcmc.py
+++ b/openghg_inversions/hbmcmc/run_hbmcmc.py
@@ -32,6 +32,7 @@ import argparse
 from pathlib import Path
 from shutil import copyfile
 from typing import Any
+import warnings
 
 import openghg_inversions.hbmcmc.hbmcmc_output as output
 
@@ -47,13 +48,8 @@ _RUN_HBMCMC_RHIME_ALIASES = {
     "verbose": "progressbar",
     "sampler_kwargs": "sample_kwargs",
 }
-_UNSUPPORTED_TRUE_LEGACY_OPTIONS = {
-    "calculate_min_error": "`calculate_min_error` is not supported by the RHIME compatibility shim; use `min_error`.",
-    "reparameterise_log_normal": (
-        "`reparameterise_log_normal` is not supported by the RHIME compatibility shim; "
-        "set `reparameterise` in the relevant prior dictionary if needed."
-    ),
-}
+_LOGNORMAL_PRIOR_NAMES = ("xprior", "x_prior", "bcprior", "bc_prior")
+_MIN_ERROR_METHODS = {"residual", "percentile"}
 
 
 def fixed_basis_expected_param() -> list[str]:
@@ -143,14 +139,58 @@ def _normalise_legacy_output_format(params: dict[str, Any]) -> None:
     params["output_format"] = str(raw_output_format).lower()
 
 
-def _drop_or_reject_legacy_only_options(params: dict[str, Any]) -> None:
-    """Drop no-op legacy options and reject enabled unsupported options."""
-    for name, message in _UNSUPPORTED_TRUE_LEGACY_OPTIONS.items():
-        if name not in params:
+def _translate_calculate_min_error(params: dict[str, Any]) -> None:
+    """Translate legacy ``calculate_min_error`` to the modern ``min_error`` option."""
+    if "calculate_min_error" not in params:
+        return
+
+    value = params.pop("calculate_min_error")
+    if not _legacy_option_enabled(value):
+        return
+
+    method = str(value).strip().lower()
+    if method not in _MIN_ERROR_METHODS:
+        raise ValueError(
+            "`calculate_min_error` is deprecated and can only be translated when set to "
+            f"one of {sorted(_MIN_ERROR_METHODS)!r}; use `min_error` instead."
+        )
+
+    warnings.warn(
+        "`calculate_min_error` is deprecated. The run_hbmcmc compatibility shim is translating "
+        "it to `min_error`.",
+        FutureWarning,
+        stacklevel=3,
+    )
+    params["min_error"] = method
+
+
+def _translate_reparameterise_log_normal(params: dict[str, Any]) -> None:
+    """Translate legacy lognormal reparameterisation flag into prior dictionaries."""
+    value = params.pop("reparameterise_log_normal", False)
+    if not _legacy_option_enabled(value):
+        return
+
+    warnings.warn(
+        "`reparameterise_log_normal` is deprecated. The run_hbmcmc compatibility shim is setting "
+        "`reparameterise=True` in lognormal emissions and BC prior dictionaries.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+    for name in _LOGNORMAL_PRIOR_NAMES:
+        prior = params.get(name)
+        if not isinstance(prior, dict):
             continue
-        value = params.pop(name)
-        if _legacy_option_enabled(value):
-            raise ValueError(message)
+        if str(prior.get("pdf", "")).lower() != "lognormal":
+            continue
+        prior = prior.copy()
+        prior["reparameterise"] = True
+        params[name] = prior
+
+
+def _translate_legacy_options(params: dict[str, Any]) -> None:
+    """Translate legacy fixedbasis options that have modern RHIME equivalents."""
+    _translate_calculate_min_error(params)
+    _translate_reparameterise_log_normal(params)
 
 
 def fixedbasis_params_to_rhime(params: dict[str, Any]) -> dict[str, Any]:
@@ -167,7 +207,7 @@ def fixedbasis_params_to_rhime(params: dict[str, Any]) -> dict[str, Any]:
 
     _translate_legacy_aliases(translated)
     _normalise_legacy_output_format(translated)
-    _drop_or_reject_legacy_only_options(translated)
+    _translate_legacy_options(translated)
     translated["output_filename_convention"] = "legacy"
     return normalise_rhime_params(translated)
 

--- a/openghg_inversions/hbmcmc/run_hbmcmc.py
+++ b/openghg_inversions/hbmcmc/run_hbmcmc.py
@@ -14,7 +14,7 @@ start - Start of date range to use for MCMC inversion (YYYY-MM-DD)
 end - End of date range to use for MCMC inversion (YYYY-MM-DD) (must be after start)
 -c / --config - configuration file. See config/ folder for templates and examples of this input file.
 
-If start and end are specified these will superceed the values within the configuration file, if present.
+If start and end are specified these will supersede the values within the configuration file, if present.
 If -c option is not specified, this script will look for configuration file within the
 acrg_hbmcmc/ directory called `hbmcmc_input.ini`.
 
@@ -81,7 +81,7 @@ def fixed_basis_expected_param() -> list[str]:
 def extract_mcmc_type(config_file: str | Path, default: str = "fixed_basis") -> str:
     """Find value which describes the MCMC function to use.
 
-    Checks the input configuation file the "mcmc_type" keyword within
+    Checks the input configuration file the "mcmc_type" keyword within
     the "MCMC.TYPE" section. If not present, the default is used.
 
     Args:
@@ -244,7 +244,7 @@ def hbmcmc_extract_param(
         Default = True
       command_line:
         Any additional command line arguments to be added to the param
-        dictionary or to superceed values contained within the config file.
+        dictionary or to supersede values contained within the config file.
 
     Returns:
       dict:
@@ -267,7 +267,7 @@ def hbmcmc_extract_param(
         config_file, expected_param=expected_param, ignore_sections=[mcmc_type_section]
     )
 
-    # Command line values added to param (or superceed inputs from the config
+    # Command line values added to param (or supersede inputs from the config
     # file)
     for key, value in command_line.items():
         if value is not None:

--- a/openghg_inversions/hbmcmc/run_hbmcmc.py
+++ b/openghg_inversions/hbmcmc/run_hbmcmc.py
@@ -29,6 +29,7 @@ This file will need to be edited to add parameters for your MCMC run.
 import json
 import sys
 import argparse
+import inspect
 from pathlib import Path
 from shutil import copyfile
 from typing import Any
@@ -38,8 +39,9 @@ import openghg_inversions.hbmcmc.hbmcmc_output as output
 
 from openghg_inversions.config import config
 from openghg_inversions.config.paths import Paths
+from openghg_inversions.inversion_data import prepare_rhime_inputs
 from openghg_inversions.rhime import run_rhime
-from openghg_inversions.rhime.params import normalise_rhime_params
+from openghg_inversions.rhime.params import make_rhime_runner_setup, normalise_rhime_params
 
 
 _RUN_HBMCMC_RHIME_ALIASES = {
@@ -212,6 +214,15 @@ def fixedbasis_params_to_rhime(params: dict[str, Any]) -> dict[str, Any]:
     return normalise_rhime_params(translated)
 
 
+def validate_rhime_params(params: dict[str, Any]) -> None:
+    """Validate translated single-sector RHIME params before script side effects."""
+    make_rhime_runner_setup(
+        params=params,
+        multisector=False,
+        data_param_names=set(inspect.signature(prepare_rhime_inputs).parameters),
+    )
+
+
 def hbmcmc_extract_param(
     config_file: str | Path,
     mcmc_type: str | None = "fixed_basis",
@@ -344,6 +355,7 @@ def main(argv: list[str] | None = None) -> None:
     param = hbmcmc_extract_param(config_file, mcmc_type, **command_line_args)
 
     rhime_params = fixedbasis_params_to_rhime(param)
+    validate_rhime_params(rhime_params)
 
     output.copy_config_file(str(config_file), param=param, **command_line_args)
 

--- a/openghg_inversions/inversion_data/preparation.py
+++ b/openghg_inversions/inversion_data/preparation.py
@@ -22,6 +22,7 @@ import warnings
 import numpy as np
 import xarray as xr
 
+from openghg_inversions._timing import log_timing, timed, timer_seconds, timer_start
 from openghg_inversions.basis import basis_functions_wrapper, make_basis_functions
 from openghg_inversions.basis._helpers import _legacy_multisource_h_if_needed, bc_sensitivity
 from openghg_inversions.basis.basis_functions import BasisFunctions
@@ -425,6 +426,7 @@ def _rhime_site_data_from_basis_functions(
         if fp_data[site].sizes.get("time", 0) == 0:
             continue
         fp_x_flux = fp_data[site][fp_x_flux_name]
+        timing_start = timer_start()
         sensitivity = basis_functions.sensitivity(fp_x_flux)
         state_dims = [dim for dim in sensitivity.dims if dim not in fp_x_flux.dims]
         if "region" in sensitivity.dims:
@@ -446,14 +448,23 @@ def _rhime_site_data_from_basis_functions(
                 flux_sources=flux_sources,
             )
         fp_data[site]["H"] = sensitivity
+        log_timing(
+            "rhime.prepare_inputs.footprint_sensitivity",
+            timer_seconds(timing_start),
+            site=site,
+            nmeasure=fp_data[site].sizes.get("time"),
+            regions=sensitivity.sizes.get("region"),
+            sources=sensitivity.sizes.get("source"),
+        )
 
     if use_bc:
-        fp_data = bc_sensitivity(
-            fp_data,
-            domain=domain,
-            basis_case=bc_basis_case,
-            bc_basis_directory=bc_basis_directory,
-        )
+        with timed("rhime.prepare_inputs.bc_sensitivity", sites=len(sites)):
+            fp_data = bc_sensitivity(
+                fp_data,
+                domain=domain,
+                basis_case=bc_basis_case,
+                bc_basis_directory=bc_basis_directory,
+            )
 
     return fp_data
 
@@ -678,88 +689,107 @@ def prepare_rhime_inputs(
         Modern RHIME prepared inputs containing canonical ``inv_inputs`` and a
         retained ``BasisFunctions`` object.
     """
-    merged = _prepare_merged_data(
-        species=species,
-        sites=sites,
-        domain=domain,
-        averaging_period=averaging_period,
-        start_date=start_date,
-        end_date=end_date,
-        output_name=output_name,
-        flux_sources=flux_sources,
-        split_by_sectors=split_by_sectors,
-        bc_store=bc_store,
-        obs_store=obs_store,
-        footprint_store=footprint_store,
-        emissions_store=emissions_store,
-        met_model=met_model,
-        fp_model=fp_model,
-        fp_height=fp_height,
-        fp_species=fp_species,
-        inlet=inlet,
-        instrument=instrument,
-        max_level=max_level,
-        calibration_scale=calibration_scale,
-        obs_data_level=obs_data_level,
-        platform=platform,
-        use_tracer=use_tracer,
-        use_bc=use_bc,
-        bc_input=bc_input,
-        averaging_error=averaging_error,
-        reload_merged_data=reload_merged_data,
-        save_merged_data=save_merged_data,
-        merged_data_dir=merged_data_dir,
-        merged_data_name=merged_data_name,
-    )
+    with timed("rhime.prepare_inputs.merged_data", sites=len(sites), split_by_sectors=split_by_sectors):
+        merged = _prepare_merged_data(
+            species=species,
+            sites=sites,
+            domain=domain,
+            averaging_period=averaging_period,
+            start_date=start_date,
+            end_date=end_date,
+            output_name=output_name,
+            flux_sources=flux_sources,
+            split_by_sectors=split_by_sectors,
+            bc_store=bc_store,
+            obs_store=obs_store,
+            footprint_store=footprint_store,
+            emissions_store=emissions_store,
+            met_model=met_model,
+            fp_model=fp_model,
+            fp_height=fp_height,
+            fp_species=fp_species,
+            inlet=inlet,
+            instrument=instrument,
+            max_level=max_level,
+            calibration_scale=calibration_scale,
+            obs_data_level=obs_data_level,
+            platform=platform,
+            use_tracer=use_tracer,
+            use_bc=use_bc,
+            bc_input=bc_input,
+            averaging_error=averaging_error,
+            reload_merged_data=reload_merged_data,
+            save_merged_data=save_merged_data,
+            merged_data_dir=merged_data_dir,
+            merged_data_name=merged_data_name,
+        )
 
-    basis_functions = make_basis_functions(
+    with timed(
+        "rhime.prepare_inputs.basis_build",
         basis_algorithm=basis_algorithm,
         nbasis=nbasis,
         fp_basis_case=fp_basis_case,
-        basis_directory=basis_directory,
-        country_directory=country_directory,
-        fp_all=merged.fp_all,
-        species=species,
-        domain=domain,
-        start_date=start_date,
-        fix_outer_regions=fix_basis_outer_regions,
-        emissions_name=flux_sources,
-        outputname=output_name,
-        output_path=basis_output_path,
-    )
+    ):
+        basis_functions = make_basis_functions(
+            basis_algorithm=basis_algorithm,
+            nbasis=nbasis,
+            fp_basis_case=fp_basis_case,
+            basis_directory=basis_directory,
+            country_directory=country_directory,
+            fp_all=merged.fp_all,
+            species=species,
+            domain=domain,
+            start_date=start_date,
+            fix_outer_regions=fix_basis_outer_regions,
+            emissions_name=flux_sources,
+            outputname=output_name,
+            output_path=basis_output_path,
+        )
     basis_source = basis_functions.basis_artifact_source or "generated"
 
-    fp_data = _rhime_site_data_from_basis_functions(
-        fp_all=merged.fp_all,
-        basis_functions=basis_functions,
-        sites=merged.sites,
-        domain=domain,
-        split_by_sectors=split_by_sectors,
-        flux_sources=flux_sources,
-        use_bc=use_bc,
-        bc_basis_case=bc_basis_case,
-        bc_basis_directory=_bc_basis_directory_arg(bc_basis_directory),
-    )
-    fp_data, prepared_sites, prepared_averaging_period = _apply_filters_and_drop_empty_sites(
-        fp_data=fp_data,
-        sites=merged.sites,
-        averaging_period=merged.averaging_period,
-        filters=filters,
-    )
+    with timed("rhime.prepare_inputs.footprint_sensitivity_total", sites=len(merged.sites)):
+        fp_data = _rhime_site_data_from_basis_functions(
+            fp_all=merged.fp_all,
+            basis_functions=basis_functions,
+            sites=merged.sites,
+            domain=domain,
+            split_by_sectors=split_by_sectors,
+            flux_sources=flux_sources,
+            use_bc=use_bc,
+            bc_basis_case=bc_basis_case,
+            bc_basis_directory=_bc_basis_directory_arg(bc_basis_directory),
+        )
+    with timed("rhime.prepare_inputs.obs_filtering", sites=len(merged.sites), filters=filters is not None):
+        fp_data, prepared_sites, prepared_averaging_period = _apply_filters_and_drop_empty_sites(
+            fp_data=fp_data,
+            sites=merged.sites,
+            averaging_period=merged.averaging_period,
+            filters=filters,
+        )
     _set_domain_attrs(fp_data, prepared_sites, domain)
 
-    inv_inputs = _make_inv_inputs(
-        fp_data=fp_data,
-        sites=prepared_sites,
-        start_date=start_date,
-        bc_freq=bc_freq,
-        sigma_freq=sigma_freq,
-        min_error=min_error,
-        calculate_min_error=None,
-        min_error_options=min_error_options,
-    )
+    with timed("rhime.prepare_inputs.make_inv_inputs", sites=len(prepared_sites)):
+        inv_inputs = _make_inv_inputs(
+            fp_data=fp_data,
+            sites=prepared_sites,
+            start_date=start_date,
+            bc_freq=bc_freq,
+            sigma_freq=sigma_freq,
+            min_error=min_error,
+            calculate_min_error=None,
+            min_error_options=min_error_options,
+        )
     _warn_for_nan_inputs(inv_inputs, use_bc=use_bc)
     site_lats, site_lons = _site_release_coordinates(fp_data, prepared_sites)
+    log_timing(
+        "rhime.prepare_inputs.prepared_dims",
+        0.0,
+        nmeasure=inv_inputs.sizes.get("nmeasure"),
+        sites=len(prepared_sites),
+        regions=inv_inputs.sizes.get("region"),
+        sources=inv_inputs.sizes.get("source"),
+        basis_source=basis_source,
+    )
 
     return RhimePreparedInputs(
         inv_inputs=inv_inputs,

--- a/openghg_inversions/inversion_data/preparation.py
+++ b/openghg_inversions/inversion_data/preparation.py
@@ -69,6 +69,8 @@ class RhimePreparedInputs:
         averaging_period: Averaging periods aligned to retained sites.
         basis_artifact_source: Description of whether the basis was generated
             or loaded from an artifact.
+        site_lats: Release latitudes aligned to ``sites``, when available.
+        site_lons: Release longitudes aligned to ``sites``, when available.
     """
 
     inv_inputs: xr.Dataset
@@ -76,6 +78,8 @@ class RhimePreparedInputs:
     sites: tuple[str, ...]
     averaging_period: tuple[str | None, ...]
     basis_artifact_source: str
+    site_lats: tuple[float, ...] | None = None
+    site_lons: tuple[float, ...] | None = None
 
 
 @dataclass
@@ -94,6 +98,35 @@ def _filter_site_aligned_value(value: object, keep_indices: list[int]) -> object
     if not isinstance(value, Sequence):
         return value
     return [item for index, item in enumerate(value) if index in keep_indices]
+
+
+def _first_scalar_data_value(ds: xr.Dataset, names: tuple[str, ...]) -> float:
+    """Return the first scalar value found in a dataset variable or coordinate."""
+    for name in names:
+        if name not in ds:
+            continue
+        values = np.asarray(ds[name].values).reshape(-1)
+        if values.size:
+            return float(values[0])
+    return np.nan
+
+
+def _site_release_coordinates(
+    fp_data: dict[str, xr.Dataset],
+    sites: Sequence[str],
+) -> tuple[tuple[float, ...], tuple[float, ...]]:
+    """Return release lat/lon values aligned to retained sites."""
+    lats: list[float] = []
+    lons: list[float] = []
+    for site in sites:
+        site_data = fp_data.get(site)
+        if site_data is None:
+            lats.append(np.nan)
+            lons.append(np.nan)
+            continue
+        lats.append(_first_scalar_data_value(site_data, ("release_lat", "sitelats")))
+        lons.append(_first_scalar_data_value(site_data, ("release_lon", "sitelons")))
+    return tuple(lats), tuple(lons)
 
 
 def _drop_sites_missing_from_loaded_data(
@@ -726,6 +759,7 @@ def prepare_rhime_inputs(
         min_error_options=min_error_options,
     )
     _warn_for_nan_inputs(inv_inputs, use_bc=use_bc)
+    site_lats, site_lons = _site_release_coordinates(fp_data, prepared_sites)
 
     return RhimePreparedInputs(
         inv_inputs=inv_inputs,
@@ -733,4 +767,6 @@ def prepare_rhime_inputs(
         basis_artifact_source=basis_source,
         sites=tuple(prepared_sites),
         averaging_period=tuple(prepared_averaging_period),
+        site_lats=site_lats,
+        site_lons=site_lons,
     )

--- a/openghg_inversions/models/__init__.py
+++ b/openghg_inversions/models/__init__.py
@@ -1,5 +1,11 @@
 """Reusable model-building helpers for OpenGHG inversions."""
 
+# ruff: noqa: E402
+
+from openghg_inversions._pymc_config import configure_pytensor
+
+configure_pytensor()
+
 from openghg_inversions.models.components import (
     LinearComponentResult,
     add_inferpymc_likelihood_component,

--- a/openghg_inversions/postprocessing/countries.py
+++ b/openghg_inversions/postprocessing/countries.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import json
 import warnings
 from collections import defaultdict
+from collections.abc import Iterable, Mapping, Sequence
 from pathlib import Path
 from typing import cast, Literal, TypeVar
-from collections.abc import Iterable, Mapping, Sequence
 from typing_extensions import Self
 
 import xarray as xr

--- a/openghg_inversions/postprocessing/legacy_outputs.py
+++ b/openghg_inversions/postprocessing/legacy_outputs.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
 
@@ -383,44 +382,41 @@ def _as_legacy_sensitivity(data: xr.DataArray, description: str) -> np.ndarray:
     return _as_array(data.transpose(parameter_dims[0], "nmeasure"))
 
 
-def _posterior_first_chain_var(
-    inv_out: InversionOutput, names: tuple[str, ...], description: str
-) -> xr.DataArray:
-    """Return a posterior variable from the first chain with draw first."""
+def _posterior_first_chain(inv_out: InversionOutput) -> xr.Dataset:
+    """Return posterior samples for the first chain, matching the old adapter."""
     posterior = getattr(inv_out.trace, "posterior", None)
     if posterior is None:
         raise ValueError("Legacy HBMCMC output formatting requires posterior trace samples.")
+    if "chain" in posterior.dims:
+        return posterior.isel(chain=0, drop=True)
+    return posterior
 
+
+def _posterior_var(posterior: xr.Dataset, names: tuple[str, ...], description: str) -> xr.DataArray:
+    """Return a posterior variable by first available name."""
     for name in names:
         if name in posterior:
-            trace = posterior[name]
-            if "chain" in trace.dims:
-                trace = trace.isel(chain=0, drop=True)
-            if "draw" in trace.dims:
-                trace = trace.transpose("draw", ...)
-            return trace
+            return posterior[name]
 
     raise ValueError(f"Legacy HBMCMC output formatting requires posterior samples for {description}.")
 
 
-def _legacy_xtrace(inv_out: InversionOutput) -> np.ndarray:
-    """Return first-chain flux-scale samples with legacy ``(steps, nparam)`` shape."""
-    trace = _posterior_first_chain_var(
-        inv_out, (inv_out.variable_name("flux_scale"), "x"), "emissions scaling"
-    )
+def _legacy_trace_matrix(trace: xr.DataArray, description: str) -> np.ndarray:
+    """Return first-chain trace samples with legacy ``(steps, nparam)`` shape."""
+    if "draw" in trace.dims:
+        trace = trace.transpose("draw", ...)
     values = _as_array(trace)
     if values.ndim == 1:
         return values[:, np.newaxis]
     if values.ndim != 2:
-        raise ValueError(f"Emissions scaling trace must be one- or two-dimensional; got {trace.dims!r}.")
+        raise ValueError(f"{description} trace must be one- or two-dimensional; got {trace.dims!r}.")
     return values
 
 
-def _legacy_sigtrace(inv_out: InversionOutput) -> np.ndarray:
+def _legacy_sigma_trace(trace: xr.DataArray) -> np.ndarray:
     """Return first-chain sigma samples with legacy ``(steps, nsigma_site, nsigma_time)`` shape."""
-    trace = _posterior_first_chain_var(
-        inv_out, ("sigma", inv_out.variable_name("model_error")), "model-error sigma"
-    )
+    if "draw" in trace.dims:
+        trace = trace.transpose("draw", ...)
     values = _as_array(trace)
     if values.ndim == 1:
         return values[:, np.newaxis, np.newaxis]
@@ -428,19 +424,6 @@ def _legacy_sigtrace(inv_out: InversionOutput) -> np.ndarray:
         return values[:, np.newaxis, :]
     if values.ndim != 3:
         raise ValueError(f"Sigma trace must have at most three legacy dimensions; got {trace.dims!r}.")
-    return values
-
-
-def _legacy_bctrace(inv_out: InversionOutput) -> np.ndarray:
-    """Return first-chain boundary-condition samples with legacy ``(steps, nBC)`` shape."""
-    trace = _posterior_first_chain_var(inv_out, ("bc",), "boundary-condition scaling")
-    values = _as_array(trace)
-    if values.ndim == 1:
-        return values[:, np.newaxis]
-    if values.ndim != 2:
-        raise ValueError(
-            f"Boundary-condition scaling trace must be one- or two-dimensional; got {trace.dims!r}."
-        )
     return values
 
 
@@ -468,20 +451,29 @@ def _legacy_convergence(inv_out: InversionOutput) -> str:
     return "Failed" if max_rhat > 1.05 else "Passed"
 
 
-@dataclass(frozen=True)
-class _LegacyCoreArrays:
-    """Core arrays needed by the legacy NetCDF product."""
+def _legacy_inferpymc_fields(inv_out: InversionOutput, *, use_bc: bool) -> dict[str, np.ndarray]:
+    """Derive the old inferpymc result fields needed by the legacy formatter."""
+    posterior = _posterior_first_chain(inv_out)
+    xouts = _legacy_trace_matrix(
+        _posterior_var(posterior, (inv_out.variable_name("flux_scale"), "x"), "emissions scaling"),
+        "Emissions scaling",
+    )
+    sigouts = _legacy_sigma_trace(
+        _posterior_var(posterior, ("sigma", inv_out.variable_name("model_error")), "model-error sigma")
+    )
+    fields = {"xouts": xouts, "sigouts": sigouts}
 
-    Hx: np.ndarray
-    Hbc: np.ndarray | None
-    sigma_freq_index: np.ndarray
-    xtrace: np.ndarray
-    sigtrace: np.ndarray
-    bctrace: np.ndarray | None
+    if use_bc:
+        fields["bcouts"] = _legacy_trace_matrix(
+            _posterior_var(posterior, ("bc",), "boundary-condition scaling"),
+            "Boundary-condition scaling",
+        )
+
+    return fields
 
 
-def _legacy_core_arrays(inv_out: InversionOutput, *, use_bc: bool) -> _LegacyCoreArrays:
-    """Derive legacy-format core arrays from model constants and posterior samples."""
+def _legacy_postprocess_fields(inv_out: InversionOutput, *, use_bc: bool) -> dict[str, np.ndarray]:
+    """Derive old postprocess/inferpymc field names from modern inversion output."""
     Hx = _as_legacy_sensitivity(
         _model_or_input_var(
             inv_out,
@@ -514,14 +506,14 @@ def _legacy_core_arrays(inv_out: InversionOutput, *, use_bc: bool) -> _LegacyCor
         sigma_freq_index.transpose("nmeasure") if "nmeasure" in sigma_freq_index.dims else sigma_freq_index
     ).astype(int, copy=False)
 
-    return _LegacyCoreArrays(
-        Hx=Hx,
-        Hbc=Hbc,
-        sigma_freq_index=sigma_freq,
-        xtrace=_legacy_xtrace(inv_out),
-        sigtrace=_legacy_sigtrace(inv_out),
-        bctrace=_legacy_bctrace(inv_out) if use_bc else None,
-    )
+    fields = {
+        "Hx": Hx,
+        "sigma_freq_index": sigma_freq,
+        **_legacy_inferpymc_fields(inv_out, use_bc=use_bc),
+    }
+    if Hbc is not None:
+        fields["Hbc"] = Hbc
+    return fields
 
 
 def _format_legacy_attr_prior(prior: object) -> str | None:
@@ -595,7 +587,13 @@ def make_legacy_hbmcmc_output(
 
     """
     domain = _require_legacy_domain(inv_out)
-    core = _legacy_core_arrays(inv_out, use_bc=use_bc)
+    legacy_fields = _legacy_postprocess_fields(inv_out, use_bc=use_bc)
+    Hx = legacy_fields["Hx"]
+    Hbc = legacy_fields.get("Hbc")
+    xouts = legacy_fields["xouts"]
+    sigouts = legacy_fields["sigouts"]
+    bcouts = legacy_fields.get("bcouts")
+    sigma_freq_index = legacy_fields["sigma_freq_index"]
     times = _legacy_measurement_times(inv_out)
     site_indicators, site_names = _legacy_site_fields(inv_out)
 
@@ -643,9 +641,9 @@ def make_legacy_hbmcmc_output(
         times,
     )
 
-    yapriori = core.Hx.sum(axis=0)
-    if use_bc and core.Hbc is not None and core.bctrace is not None:
-        yapriori = yapriori + core.Hbc.sum(axis=0)
+    yapriori = Hx.sum(axis=0)
+    if use_bc and Hbc is not None and bcouts is not None:
+        yapriori = yapriori + Hbc.sum(axis=0)
 
     obs = _obs_input(inv_out, "y_obs", "Yobs")
     zero_obs = xr.zeros_like(obs)
@@ -668,10 +666,10 @@ def make_legacy_hbmcmc_output(
         "Yoffmode": conc.get("offset_posterior_mode", zero_obs),
         "Yoff68": conc.get("offset_posterior_hdi_68", zero_hdi),
         "Yoff95": conc.get("offset_posterior_hdi_95", zero_hdi),
-        "xtrace": (("steps", "nparam"), core.xtrace),
-        "sigtrace": (("steps", "nsigma_site", "nsigma_time"), core.sigtrace),
+        "xtrace": (("steps", "nparam"), xouts),
+        "sigtrace": (("steps", "nsigma_site", "nsigma_time"), sigouts),
         "siteindicator": site_indicators,
-        "sigmafreqindex": ("nmeasure", core.sigma_freq_index),
+        "sigmafreqindex": ("nmeasure", sigma_freq_index),
         "sitenames": site_names,
         "fluxapriori": apriori_flux,
         "fluxmode": flux["flux_posterior_mode"],
@@ -686,20 +684,20 @@ def make_legacy_hbmcmc_output(
         "country95": country["country_posterior_hdi_95"],
         "countryapriori": country["country_prior_mean"],
         "countrydefinition": (("lat", "lon"), country_idx),
-        "xsensitivity": (("nmeasure", "nparam"), core.Hx.T),
+        "xsensitivity": (("nmeasure", "nparam"), Hx.T),
     }
 
-    if use_bc and core.Hbc is not None:
+    if use_bc and Hbc is not None and bcouts is not None:
         data_vars.update(
             {
-                "YaprioriBC": ("nmeasure", core.Hbc.sum(axis=0)),
+                "YaprioriBC": ("nmeasure", Hbc.sum(axis=0)),
                 "YmodmeanBC": conc["mu_bc_posterior_mean"],
                 "YmodmedianBC": conc["mu_bc_posterior_median"],
                 "YmodmodeBC": conc["mu_bc_posterior_mode"],
                 "Ymod95BC": conc["mu_bc_posterior_hdi_95"],
                 "Ymod68BC": conc["mu_bc_posterior_hdi_68"],
-                "bctrace": (("steps", "nBC"), core.bctrace),
-                "bcsensitivity": (("nmeasure", "nBC"), core.Hbc.T),
+                "bctrace": (("steps", "nBC"), bcouts),
+                "bcsensitivity": (("nmeasure", "nBC"), Hbc.T),
             }
         )
 
@@ -708,19 +706,19 @@ def make_legacy_hbmcmc_output(
             data_vars[name] = _flatten_nmeasure_for_legacy(value)
 
     coords: dict[str, Any] = {
-        "stepnum": ("steps", np.arange(core.xtrace.shape[0])),
-        "paramnum": ("nparam", np.arange(core.Hx.shape[0])),
-        "measurenum": ("nmeasure", np.arange(core.Hx.shape[1])),
-        "nsigma_site": ("nsigma_site", np.arange(core.sigtrace.shape[1])),
-        "nsigma_time": ("nsigma_time", np.arange(core.sigtrace.shape[2])),
+        "stepnum": ("steps", np.arange(xouts.shape[0])),
+        "paramnum": ("nparam", np.arange(Hx.shape[0])),
+        "measurenum": ("nmeasure", np.arange(Hx.shape[1])),
+        "nsigma_site": ("nsigma_site", np.arange(sigouts.shape[1])),
+        "nsigma_time": ("nsigma_time", np.arange(sigouts.shape[2])),
         "countrynames": country["countrynames"],
     }
     if "nUI" in conc.dims or "nUI" in country.dims:
         n_ui = conc.sizes.get("nUI", country.sizes.get("nUI"))
         if n_ui is not None:
             coords["UInum"] = ("nUI", np.arange(n_ui))
-    if use_bc and core.Hbc is not None:
-        coords["numBC"] = ("nBC", np.arange(core.Hbc.shape[0]))
+    if use_bc and Hbc is not None:
+        coords["numBC"] = ("nBC", np.arange(Hbc.shape[0]))
 
     out = xr.Dataset(data_vars, coords=coords)
 

--- a/openghg_inversions/postprocessing/legacy_outputs.py
+++ b/openghg_inversions/postprocessing/legacy_outputs.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Hashable
 from pathlib import Path
 from typing import Any, cast
 
@@ -189,6 +190,16 @@ def _set_legacy_var_attrs(ds: xr.Dataset, obs_units: str, country_units: str, us
     for dv in ds.data_vars:
         if "longname" not in ds[dv].attrs:
             ds[dv].attrs["longname"] = str(dv).replace("_", " ")
+
+
+def _cast_legacy_float_data_vars(ds: xr.Dataset) -> xr.Dataset:
+    """Cast floating legacy data variables to float32 at the product boundary."""
+    updates: dict[Hashable, xr.DataArray] = {}
+    for name in ds.data_vars:
+        if name in ds and np.issubdtype(ds[name].dtype, np.floating):
+            updates[name] = ds[name].astype("float32")
+
+    return ds.assign(updates) if updates else ds
 
 
 def _rename_hdi_for_legacy(ds: xr.Dataset) -> xr.Dataset:
@@ -799,7 +810,7 @@ def make_legacy_hbmcmc_output(
     if use_bc and Hbc is not None:
         coords["numBC"] = ("nBC", np.arange(Hbc.shape[0]))
 
-    out = xr.Dataset(data_vars, coords=coords)
+    out = _cast_legacy_float_data_vars(xr.Dataset(data_vars, coords=coords))
 
     obs_units = observation_inputs_for_outputs(inv_out)["y_obs"].attrs.get("units", "")
     if obs_units.endswith("mol/mol"):

--- a/openghg_inversions/postprocessing/legacy_outputs.py
+++ b/openghg_inversions/postprocessing/legacy_outputs.py
@@ -92,6 +92,7 @@ def _set_legacy_var_attrs(ds: xr.Dataset, obs_units: str, country_units: str, us
         "Yerror": f"{obs_units} mol/mol",
         "Yerror_repeatability": f"{obs_units} mol/mol",
         "Yerror_variability": f"{obs_units} mol/mol",
+        "min_model_error": f"{obs_units} mol/mol",
         "Yapriori": f"{obs_units} mol/mol",
         "Ymodmean": f"{obs_units} mol/mol",
         "Ymodmedian": f"{obs_units} mol/mol",
@@ -134,6 +135,8 @@ def _set_legacy_var_attrs(ds: xr.Dataset, obs_units: str, country_units: str, us
         "siteindicator": "index of site of measurement corresponding to sitenames",
         "sigmafreqindex": "period over which the model error is estimated",
         "sitenames": "site names",
+        "sitelons": "site longitudes corresponding to site names",
+        "sitelats": "site latitudes corresponding to site names",
         "fluxapriori": "mean a priori flux over period",
         "fluxmode": "mode posterior flux over period",
         "scalingmean": "mean scaling factor field over period",
@@ -341,6 +344,57 @@ def _obs_input(inv_out: InversionOutput, name: str, legacy_name: str) -> xr.Data
     return _flatten_nmeasure_for_legacy(observation_inputs_for_outputs(inv_out)[name]).rename(legacy_name)
 
 
+def _legacy_min_model_error(inv_out: InversionOutput) -> xr.DataArray:
+    """Return minimum model error in the legacy flat observation shape."""
+    try:
+        min_error = _model_or_input_var(
+            inv_out,
+            model_name=inv_out.variable_name("minimum_error"),
+            input_name="min_error",
+            description="minimum model error",
+        )
+    except ValueError:
+        min_error = xr.zeros_like(_obs_input(inv_out, "y_obs", "Yobs"))
+
+    if "nmeasure" not in min_error.dims:
+        obs = _obs_input(inv_out, "y_obs", "Yobs")
+        values = _as_array(min_error)
+        if values.size != 1:
+            raise ValueError(
+                f"Legacy HBMCMC minimum model error must be scalar or have nmeasure; got {min_error.dims!r}."
+            )
+        min_error = xr.full_like(obs, float(values.reshape(-1)[0]))
+
+    return _flatten_nmeasure_for_legacy(min_error).rename("min_model_error")
+
+
+def _site_metadata_values(inv_out: InversionOutput, names: tuple[str, ...], nsite: int) -> np.ndarray:
+    """Return site-aligned metadata values, or NaNs when unavailable."""
+    for metadata in (inv_out.run_metadata, inv_out.output_metadata):
+        for name in names:
+            values = metadata.get(name)
+            if values is None:
+                continue
+            array = np.asarray(values, dtype=float)
+            if array.size != nsite:
+                raise ValueError(
+                    f"Legacy HBMCMC site metadata {name!r} has {array.size} values for {nsite} sites."
+                )
+            return array
+    return np.full(nsite, np.nan, dtype=float)
+
+
+def _legacy_site_locations(inv_out: InversionOutput, nsite: int) -> tuple[xr.DataArray, xr.DataArray]:
+    """Return site longitudes and latitudes in the historical variables."""
+    lons = _site_metadata_values(inv_out, ("sitelons", "site_lons", "site_longitudes"), nsite)
+    lats = _site_metadata_values(inv_out, ("sitelats", "site_lats", "site_latitudes"), nsite)
+    coords = {"nsite": np.arange(nsite)}
+    return (
+        xr.DataArray(lons, dims=("nsite",), coords=coords, name="sitelons"),
+        xr.DataArray(lats, dims=("nsite",), coords=coords, name="sitelats"),
+    )
+
+
 def _as_array(data: Any) -> np.ndarray:
     """Convert xarray or array-like values to a NumPy array without relying on ``.values``."""
     return np.asarray(data.values if isinstance(data, xr.DataArray) else data)
@@ -529,6 +583,15 @@ def _legacy_postprocess_fields(inv_out: InversionOutput, *, use_bc: bool) -> dic
     return fields
 
 
+def _legacy_flat_basis(inv_out: InversionOutput) -> xr.DataArray:
+    """Return the legacy zero-based basis-function map."""
+    basis = flat_basis_for_output(inv_out)
+    values = _as_array(basis)
+    if values.size and np.nanmin(values) >= 1:
+        values = values - 1
+    return xr.DataArray(values, dims=basis.dims, coords=basis.coords, attrs=basis.attrs, name="basisfunctions")
+
+
 def _format_legacy_attr_prior(prior: object) -> str | None:
     """Format prior metadata using the historical comma-separated attr shape."""
     if not isinstance(prior, dict):
@@ -609,6 +672,7 @@ def make_legacy_hbmcmc_output(
     sigma_freq_index = legacy_fields["sigma_freq_index"]
     times = _legacy_measurement_times(inv_out)
     site_indicators, site_names = _legacy_site_fields(inv_out)
+    site_lons, site_lats = _legacy_site_locations(inv_out, site_names.sizes["nsite"])
 
     conc = make_concentration_outputs(
         inv_out,
@@ -666,6 +730,7 @@ def make_legacy_hbmcmc_output(
         "Yerror": _obs_input(inv_out, "y_obs_error", "Yerror"),
         "Yerror_repeatability": _obs_input(inv_out, "y_obs_repeatability", "Yerror_repeatability"),
         "Yerror_variability": _obs_input(inv_out, "y_obs_variability", "Yerror_variability"),
+        "min_model_error": _legacy_min_model_error(inv_out),
         "Ytime": times,
         "Yapriori": ("nmeasure", yapriori),
         "Ymodmean": conc["y_posterior_predictive_mean"],
@@ -683,11 +748,13 @@ def make_legacy_hbmcmc_output(
         "siteindicator": site_indicators,
         "sigmafreqindex": ("nmeasure", sigma_freq_index),
         "sitenames": site_names,
+        "sitelons": site_lons,
+        "sitelats": site_lats,
         "fluxapriori": apriori_flux,
         "fluxmode": flux["flux_posterior_mode"],
         "scalingmean": flux["scaling_posterior_mean"],
         "scalingmode": flux["scaling_posterior_mode"],
-        "basisfunctions": flat_basis_for_output(inv_out),
+        "basisfunctions": _legacy_flat_basis(inv_out),
         "countrymean": country["country_posterior_mean"],
         "countrymedian": country["country_posterior_median"],
         "countrymode": country["country_posterior_mode"],

--- a/openghg_inversions/postprocessing/legacy_outputs.py
+++ b/openghg_inversions/postprocessing/legacy_outputs.py
@@ -11,6 +11,7 @@ import pandas as pd
 import xarray as xr
 
 from openghg_inversions import utils
+from openghg_inversions._country_file import load_country_dataset
 from openghg_inversions.postprocessing.inversion_output import InversionOutput
 from openghg_inversions.postprocessing.make_outputs import (
     flat_basis_for_output,
@@ -345,6 +346,18 @@ def _as_array(data: Any) -> np.ndarray:
     return np.asarray(data.values if isinstance(data, xr.DataArray) else data)
 
 
+def _legacy_country_index(domain: str, country_file: str | Path | None = None) -> np.ndarray:
+    """Return the raw country index grid used by legacy-format outputs."""
+    country_dataset = load_country_dataset(
+        utils.get_country_file_path(country_file=country_file, domain=domain)
+    )
+    if "country" in country_dataset:
+        return _as_array(country_dataset["country"])
+    if "region" in country_dataset:
+        return _as_array(country_dataset["region"])
+    raise ValueError("Variables 'country' or 'region' not found in country file.")
+
+
 def _model_or_input_var(
     inv_out: InversionOutput,
     *,
@@ -632,8 +645,7 @@ def make_legacy_hbmcmc_output(
     )
     country = _rename_hdi_for_legacy(_rename_country_for_legacy(country))
 
-    country_obj = utils.get_country(domain, country_file=country_file)
-    country_idx = country_obj.country
+    country_idx = _legacy_country_index(domain, country_file=country_file)
     apriori_flux = _compute_apriori_flux(
         inv_out.flux,
         str(inv_out.start_time.date()),

--- a/openghg_inversions/postprocessing/legacy_outputs.py
+++ b/openghg_inversions/postprocessing/legacy_outputs.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
+import arviz as az
 import numpy as np
 import pandas as pd
 import xarray as xr
@@ -357,25 +358,165 @@ def _as_array(data: Any) -> np.ndarray:
     return np.asarray(data.values if isinstance(data, xr.DataArray) else data)
 
 
+def _first_available_data_var(
+    inv_out: InversionOutput, names: tuple[str, ...], description: str
+) -> xr.DataArray:
+    """Return the first matching model-data or inversion-input variable."""
+    datasets: list[xr.Dataset] = []
+    try:
+        datasets.append(inv_out.model_data())
+    except ValueError:
+        pass
+
+    datasets.append(inv_out.inv_inputs)
+
+    for dataset in datasets:
+        for name in names:
+            if name in dataset:
+                return dataset[name]
+
+    raise ValueError(
+        f"Legacy HBMCMC output formatting requires {description} in InferenceData model data "
+        "or InversionOutput.inv_inputs."
+    )
+
+
+def _legacy_sensitivity_matrix(data: xr.DataArray, description: str) -> np.ndarray:
+    """Return a sensitivity matrix with legacy ``(parameter, nmeasure)`` shape."""
+    if "nmeasure" not in data.dims:
+        if data.ndim != 2:
+            raise ValueError(f"{description} must be two-dimensional; got dims {data.dims!r}.")
+        return _as_array(data)
+
+    parameter_dims = [dim for dim in data.dims if dim != "nmeasure"]
+    if len(parameter_dims) != 1:
+        raise ValueError(f"{description} must have one parameter dimension and nmeasure; got {data.dims!r}.")
+
+    return _as_array(data.transpose(parameter_dims[0], "nmeasure"))
+
+
+def _legacy_hx(inv_out: InversionOutput) -> np.ndarray:
+    """Return emissions sensitivity from model data, falling back to inversion inputs."""
+    data = _first_available_data_var(
+        inv_out,
+        (inv_out.variable_name("emissions_sensitivity"), "H", "Hx"),
+        "emissions sensitivity",
+    )
+    return _legacy_sensitivity_matrix(data, "Emissions sensitivity")
+
+
+def _legacy_hbc(inv_out: InversionOutput) -> np.ndarray:
+    """Return boundary-condition sensitivity from model data, falling back to inversion inputs."""
+    data = _first_available_data_var(
+        inv_out,
+        (inv_out.variable_name("baseline_sensitivity"), "H_bc", "Hbc"),
+        "boundary-condition sensitivity",
+    )
+    return _legacy_sensitivity_matrix(data, "Boundary-condition sensitivity")
+
+
+def _legacy_sigma_freq_index(inv_out: InversionOutput) -> np.ndarray:
+    """Return the observation-aligned sigma frequency index."""
+    data = _first_available_data_var(inv_out, ("sigma_freq_index",), "sigma frequency index")
+    return _as_array(data.transpose("nmeasure") if "nmeasure" in data.dims else data).astype(int, copy=False)
+
+
+def _posterior_first_chain_var(
+    inv_out: InversionOutput, names: tuple[str, ...], description: str
+) -> xr.DataArray:
+    """Return a posterior variable from the first chain with draw first."""
+    posterior = getattr(inv_out.trace, "posterior", None)
+    if posterior is None:
+        raise ValueError("Legacy HBMCMC output formatting requires posterior trace samples.")
+
+    for name in names:
+        if name in posterior:
+            trace = posterior[name]
+            if "chain" in trace.dims:
+                trace = trace.isel(chain=0, drop=True)
+            if "draw" in trace.dims:
+                trace = trace.transpose("draw", ...)
+            return trace
+
+    raise ValueError(f"Legacy HBMCMC output formatting requires posterior samples for {description}.")
+
+
+def _legacy_xtrace(inv_out: InversionOutput) -> np.ndarray:
+    """Return first-chain flux-scale samples with legacy ``(steps, nparam)`` shape."""
+    trace = _posterior_first_chain_var(
+        inv_out, (inv_out.variable_name("flux_scale"), "x"), "emissions scaling"
+    )
+    values = _as_array(trace)
+    if values.ndim == 1:
+        return values[:, np.newaxis]
+    if values.ndim != 2:
+        raise ValueError(f"Emissions scaling trace must be one- or two-dimensional; got {trace.dims!r}.")
+    return values
+
+
+def _legacy_sigtrace(inv_out: InversionOutput) -> np.ndarray:
+    """Return first-chain sigma samples with legacy ``(steps, nsigma_site, nsigma_time)`` shape."""
+    trace = _posterior_first_chain_var(
+        inv_out, ("sigma", inv_out.variable_name("model_error")), "model-error sigma"
+    )
+    values = _as_array(trace)
+    if values.ndim == 1:
+        return values[:, np.newaxis, np.newaxis]
+    if values.ndim == 2:
+        return values[:, np.newaxis, :]
+    if values.ndim != 3:
+        raise ValueError(f"Sigma trace must have at most three legacy dimensions; got {trace.dims!r}.")
+    return values
+
+
+def _legacy_bctrace(inv_out: InversionOutput) -> np.ndarray:
+    """Return first-chain boundary-condition samples with legacy ``(steps, nBC)`` shape."""
+    trace = _posterior_first_chain_var(inv_out, ("bc",), "boundary-condition scaling")
+    values = _as_array(trace)
+    if values.ndim == 1:
+        return values[:, np.newaxis]
+    if values.ndim != 2:
+        raise ValueError(
+            f"Boundary-condition scaling trace must be one- or two-dimensional; got {trace.dims!r}."
+        )
+    return values
+
+
+def _legacy_convergence(inv_out: InversionOutput) -> str:
+    """Return legacy convergence status from ArviZ R-hat when enough chains exist."""
+    posterior = getattr(inv_out.trace, "posterior", None)
+    if posterior is None or posterior.sizes.get("chain", 0) < 2 or posterior.sizes.get("draw", 0) < 2:
+        return "Unavailable"
+
+    x_name = inv_out.variable_name("flux_scale")
+    if x_name not in posterior and "x" in posterior:
+        x_name = "x"
+    if x_name not in posterior:
+        return "Unavailable"
+
+    try:
+        rhat_dataset = cast(xr.Dataset, az.rhat(inv_out.trace, var_names=[x_name]))
+        rhat = rhat_dataset[x_name]
+        max_rhat = float(rhat.max(skipna=True).item())
+    except (AttributeError, KeyError, TypeError, ValueError):
+        return "Unavailable"
+
+    if not np.isfinite(max_rhat):
+        return "Unavailable"
+    return "Failed" if max_rhat > 1.05 else "Passed"
+
+
 def make_legacy_hbmcmc_output(
     inv_out: InversionOutput,
-    mcmc_results: dict,
-    sigma_freq_index: np.ndarray | xr.DataArray,
-    Hx: np.ndarray | xr.DataArray,
-    Hbc: np.ndarray | xr.DataArray | None = None,
     country_file: str | Path | None = None,
     use_bc: bool = False,
 ) -> xr.Dataset:
-    """Create a legacy-format hbmcmc output dataset from compatibility inputs.
+    """Create a legacy-format hbmcmc output dataset from modern inversion output.
 
     TODO: needs to handle offsets
 
     Args:
         inv_out: Inversion outputs container.
-        mcmc_results: Compatibility sampling outputs returned by ``inferpymc``.
-        sigma_freq_index: Sigma frequency index per measurement.
-        Hx: Emissions sensitivity matrix with shape ``(nparam, nmeasure)``.
-        Hbc: Boundary-condition sensitivity matrix with shape ``(nBC, nmeasure)``.
         country_file: Optional path to country definition file.
         use_bc: Whether BC variables should be included.
 
@@ -384,10 +525,13 @@ def make_legacy_hbmcmc_output(
         ``inferpymc_postprocessouts``.
 
     """
-    Hx_arr = _as_array(Hx)
-    Hbc_arr = _as_array(Hbc) if Hbc is not None else None
-    sigma_freq = _as_array(sigma_freq_index)
     domain = _require_legacy_domain(inv_out)
+    Hx_arr = _legacy_hx(inv_out)
+    Hbc_arr = _legacy_hbc(inv_out) if use_bc else None
+    sigma_freq = _legacy_sigma_freq_index(inv_out)
+    xouts_arr = _legacy_xtrace(inv_out)
+    sigouts_arr = _legacy_sigtrace(inv_out)
+    bcouts_arr = _legacy_bctrace(inv_out) if use_bc else None
     times = _legacy_measurement_times(inv_out)
     site_indicators, site_names = _legacy_site_fields(inv_out)
 
@@ -464,8 +608,8 @@ def make_legacy_hbmcmc_output(
         "Yoffmode": conc.get("offset_posterior_mode", zero_obs),
         "Yoff68": conc.get("offset_posterior_hdi_68", zero_hdi),
         "Yoff95": conc.get("offset_posterior_hdi_95", zero_hdi),
-        "xtrace": (("steps", "nparam"), _as_array(mcmc_results["xouts"])),
-        "sigtrace": (("steps", "nsigma_site", "nsigma_time"), _as_array(mcmc_results["sigouts"])),
+        "xtrace": (("steps", "nparam"), xouts_arr),
+        "sigtrace": (("steps", "nsigma_site", "nsigma_time"), sigouts_arr),
         "siteindicator": site_indicators,
         "sigmafreqindex": ("nmeasure", sigma_freq),
         "sitenames": site_names,
@@ -494,7 +638,7 @@ def make_legacy_hbmcmc_output(
                 "YmodmodeBC": conc["mu_bc_posterior_mode"],
                 "Ymod95BC": conc["mu_bc_posterior_hdi_95"],
                 "Ymod68BC": conc["mu_bc_posterior_hdi_68"],
-                "bctrace": (("steps", "nBC"), _as_array(mcmc_results["bcouts"])),
+                "bctrace": (("steps", "nBC"), bcouts_arr),
                 "bcsensitivity": (("nmeasure", "nBC"), Hbc_arr.T),
             }
         )
@@ -503,8 +647,6 @@ def make_legacy_hbmcmc_output(
         if isinstance(value, xr.DataArray):
             data_vars[name] = _flatten_nmeasure_for_legacy(value)
 
-    xouts_arr = _as_array(mcmc_results["xouts"])
-    sigouts_arr = _as_array(mcmc_results["sigouts"])
     coords: dict[str, Any] = {
         "stepnum": ("steps", np.arange(xouts_arr.shape[0])),
         "paramnum": ("nparam", np.arange(Hx_arr.shape[0])),
@@ -535,7 +677,6 @@ def make_legacy_hbmcmc_output(
 
     out.attrs["Start date"] = str(inv_out.start_time.date())
     out.attrs["End date"] = str(inv_out.end_time.date())
-    if "convergence" in mcmc_results:
-        out.attrs["Convergence"] = mcmc_results["convergence"]
+    out.attrs["Convergence"] = _legacy_convergence(inv_out)
 
     return out

--- a/openghg_inversions/postprocessing/legacy_outputs.py
+++ b/openghg_inversions/postprocessing/legacy_outputs.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
 
@@ -340,48 +341,35 @@ def _obs_input(inv_out: InversionOutput, name: str, legacy_name: str) -> xr.Data
     return _flatten_nmeasure_for_legacy(observation_inputs_for_outputs(inv_out)[name]).rename(legacy_name)
 
 
-def _flux_scale_trace(inv_out: InversionOutput) -> xr.Dataset:
-    """Return flux-scale traces using legacy-compatible ``x`` names."""
-    trace = inv_out.trace_dataset(var_roles="flux_scale")
-    flux_scale_name = inv_out.variable_name("flux_scale")
-    return trace.rename(
-        {
-            data_var: str(data_var).replace(f"{flux_scale_name}_", "x_", 1)
-            for data_var in trace.data_vars
-            if str(data_var).startswith(f"{flux_scale_name}_")
-        }
-    )
-
-
 def _as_array(data: Any) -> np.ndarray:
     """Convert xarray or array-like values to a NumPy array without relying on ``.values``."""
     return np.asarray(data.values if isinstance(data, xr.DataArray) else data)
 
 
-def _first_available_data_var(
-    inv_out: InversionOutput, names: tuple[str, ...], description: str
+def _model_or_input_var(
+    inv_out: InversionOutput,
+    *,
+    model_name: str,
+    input_name: str,
+    description: str,
 ) -> xr.DataArray:
-    """Return the first matching model-data or inversion-input variable."""
-    datasets: list[xr.Dataset] = []
+    """Return a variable from model constant data, falling back to inversion inputs."""
     try:
-        datasets.append(inv_out.model_data())
+        model_data = inv_out.model_data()
     except ValueError:
-        pass
+        model_data = xr.Dataset()
 
-    datasets.append(inv_out.inv_inputs)
-
-    for dataset in datasets:
-        for name in names:
-            if name in dataset:
-                return dataset[name]
-
+    if model_name in model_data:
+        return model_data[model_name]
+    if input_name in inv_out.inv_inputs:
+        return inv_out.inv_inputs[input_name]
     raise ValueError(
-        f"Legacy HBMCMC output formatting requires {description} in InferenceData model data "
-        "or InversionOutput.inv_inputs."
+        f"Legacy HBMCMC output formatting requires {description} as model data {model_name!r} "
+        f"or InversionOutput.inv_inputs variable {input_name!r}."
     )
 
 
-def _legacy_sensitivity_matrix(data: xr.DataArray, description: str) -> np.ndarray:
+def _as_legacy_sensitivity(data: xr.DataArray, description: str) -> np.ndarray:
     """Return a sensitivity matrix with legacy ``(parameter, nmeasure)`` shape."""
     if "nmeasure" not in data.dims:
         if data.ndim != 2:
@@ -393,32 +381,6 @@ def _legacy_sensitivity_matrix(data: xr.DataArray, description: str) -> np.ndarr
         raise ValueError(f"{description} must have one parameter dimension and nmeasure; got {data.dims!r}.")
 
     return _as_array(data.transpose(parameter_dims[0], "nmeasure"))
-
-
-def _legacy_hx(inv_out: InversionOutput) -> np.ndarray:
-    """Return emissions sensitivity from model data, falling back to inversion inputs."""
-    data = _first_available_data_var(
-        inv_out,
-        (inv_out.variable_name("emissions_sensitivity"), "H", "Hx"),
-        "emissions sensitivity",
-    )
-    return _legacy_sensitivity_matrix(data, "Emissions sensitivity")
-
-
-def _legacy_hbc(inv_out: InversionOutput) -> np.ndarray:
-    """Return boundary-condition sensitivity from model data, falling back to inversion inputs."""
-    data = _first_available_data_var(
-        inv_out,
-        (inv_out.variable_name("baseline_sensitivity"), "H_bc", "Hbc"),
-        "boundary-condition sensitivity",
-    )
-    return _legacy_sensitivity_matrix(data, "Boundary-condition sensitivity")
-
-
-def _legacy_sigma_freq_index(inv_out: InversionOutput) -> np.ndarray:
-    """Return the observation-aligned sigma frequency index."""
-    data = _first_available_data_var(inv_out, ("sigma_freq_index",), "sigma frequency index")
-    return _as_array(data.transpose("nmeasure") if "nmeasure" in data.dims else data).astype(int, copy=False)
 
 
 def _posterior_first_chain_var(
@@ -506,6 +468,113 @@ def _legacy_convergence(inv_out: InversionOutput) -> str:
     return "Failed" if max_rhat > 1.05 else "Passed"
 
 
+@dataclass(frozen=True)
+class _LegacyCoreArrays:
+    """Core arrays needed by the legacy NetCDF product."""
+
+    Hx: np.ndarray
+    Hbc: np.ndarray | None
+    sigma_freq_index: np.ndarray
+    xtrace: np.ndarray
+    sigtrace: np.ndarray
+    bctrace: np.ndarray | None
+
+
+def _legacy_core_arrays(inv_out: InversionOutput, *, use_bc: bool) -> _LegacyCoreArrays:
+    """Derive legacy-format core arrays from model constants and posterior samples."""
+    Hx = _as_legacy_sensitivity(
+        _model_or_input_var(
+            inv_out,
+            model_name=inv_out.variable_name("emissions_sensitivity"),
+            input_name="H",
+            description="emissions sensitivity",
+        ),
+        "Emissions sensitivity",
+    )
+    Hbc = (
+        _as_legacy_sensitivity(
+            _model_or_input_var(
+                inv_out,
+                model_name=inv_out.variable_name("baseline_sensitivity"),
+                input_name="H_bc",
+                description="boundary-condition sensitivity",
+            ),
+            "Boundary-condition sensitivity",
+        )
+        if use_bc
+        else None
+    )
+    sigma_freq_index = _model_or_input_var(
+        inv_out,
+        model_name="sigma_freq_index",
+        input_name="sigma_freq_index",
+        description="sigma frequency index",
+    )
+    sigma_freq = _as_array(
+        sigma_freq_index.transpose("nmeasure") if "nmeasure" in sigma_freq_index.dims else sigma_freq_index
+    ).astype(int, copy=False)
+
+    return _LegacyCoreArrays(
+        Hx=Hx,
+        Hbc=Hbc,
+        sigma_freq_index=sigma_freq,
+        xtrace=_legacy_xtrace(inv_out),
+        sigtrace=_legacy_sigtrace(inv_out),
+        bctrace=_legacy_bctrace(inv_out) if use_bc else None,
+    )
+
+
+def _format_legacy_attr_prior(prior: object) -> str | None:
+    """Format prior metadata using the historical comma-separated attr shape."""
+    if not isinstance(prior, dict):
+        return None
+    return ",".join(f"{key},{value}" for key, value in prior.items())
+
+
+def _legacy_single_sector_x_prior(model_metadata: dict[str, Any]) -> object | None:
+    """Return the single-sector emissions prior stored by modern RHIME metadata."""
+    sectors = model_metadata.get("sectors")
+    if isinstance(sectors, (list, tuple)) and sectors:
+        sector = sectors[0]
+        if isinstance(sector, dict):
+            return sector.get("x_prior")
+    return None
+
+
+def _legacy_hbmcmc_attrs(inv_out: InversionOutput) -> dict[str, str]:
+    """Return legacy dataset attrs from explicit compatibility metadata or modern metadata."""
+    attrs: dict[str, str] = {}
+    explicit_attrs = inv_out.output_metadata.get("legacy_hbmcmc_attrs")
+    if isinstance(explicit_attrs, dict):
+        attrs.update({str(key): str(value) for key, value in explicit_attrs.items()})
+
+    sampler = inv_out.output_metadata.get("sampler")
+    if isinstance(sampler, dict):
+        if "burn" in sampler:
+            attrs.setdefault("Burn in", str(int(sampler["burn"])))
+        if "tune" in sampler:
+            attrs.setdefault("Tuning steps", str(int(sampler["tune"])))
+        if "chains" in sampler:
+            attrs.setdefault("Number of chains", str(int(sampler["chains"])))
+
+    posterior = getattr(inv_out.trace, "posterior", None)
+    if posterior is not None and "chain" in posterior.sizes:
+        attrs.setdefault("Number of chains", str(int(posterior.sizes["chain"])))
+
+    model_metadata = inv_out.model_metadata
+    attrs.setdefault("Error for each site", str(model_metadata.get("sigma_per_site", "Unavailable")))
+
+    prior_attrs = {
+        "Emissions Prior": _format_legacy_attr_prior(_legacy_single_sector_x_prior(model_metadata)),
+        "Model error Prior": _format_legacy_attr_prior(model_metadata.get("sigma_prior")),
+        "BCs Prior": _format_legacy_attr_prior(model_metadata.get("bc_prior")),
+        "Offset Prior": _format_legacy_attr_prior(model_metadata.get("offset_prior")),
+    }
+    attrs.update({name: value for name, value in prior_attrs.items() if name not in attrs and value})
+
+    return attrs
+
+
 def make_legacy_hbmcmc_output(
     inv_out: InversionOutput,
     country_file: str | Path | None = None,
@@ -526,12 +595,7 @@ def make_legacy_hbmcmc_output(
 
     """
     domain = _require_legacy_domain(inv_out)
-    Hx_arr = _legacy_hx(inv_out)
-    Hbc_arr = _legacy_hbc(inv_out) if use_bc else None
-    sigma_freq = _legacy_sigma_freq_index(inv_out)
-    xouts_arr = _legacy_xtrace(inv_out)
-    sigouts_arr = _legacy_sigtrace(inv_out)
-    bcouts_arr = _legacy_bctrace(inv_out) if use_bc else None
+    core = _legacy_core_arrays(inv_out, use_bc=use_bc)
     times = _legacy_measurement_times(inv_out)
     site_indicators, site_names = _legacy_site_fields(inv_out)
 
@@ -544,14 +608,10 @@ def make_legacy_hbmcmc_output(
             "mode_kde__chunk_size": 1,
         },
     )
-    x_trace = _flux_scale_trace(inv_out)
-    state_dim = inv_out.basis_functions.operator.meta.state_dim
-    flux_chunk_dim = state_dim if state_dim in x_trace.dims else "nx" if "nx" in x_trace.dims else "region"
     flux = make_flux_outputs(
         inv_out,
         stats=["mean", "mode_kde"],
         stats_args={
-            "mode_kde__chunk_dim": flux_chunk_dim,
             "mode_kde__chunk_size": 1,
         },
     )
@@ -583,9 +643,9 @@ def make_legacy_hbmcmc_output(
         times,
     )
 
-    yapriori = Hx_arr.sum(axis=0)
-    if use_bc and Hbc_arr is not None:
-        yapriori = yapriori + Hbc_arr.sum(axis=0)
+    yapriori = core.Hx.sum(axis=0)
+    if use_bc and core.Hbc is not None and core.bctrace is not None:
+        yapriori = yapriori + core.Hbc.sum(axis=0)
 
     obs = _obs_input(inv_out, "y_obs", "Yobs")
     zero_obs = xr.zeros_like(obs)
@@ -608,10 +668,10 @@ def make_legacy_hbmcmc_output(
         "Yoffmode": conc.get("offset_posterior_mode", zero_obs),
         "Yoff68": conc.get("offset_posterior_hdi_68", zero_hdi),
         "Yoff95": conc.get("offset_posterior_hdi_95", zero_hdi),
-        "xtrace": (("steps", "nparam"), xouts_arr),
-        "sigtrace": (("steps", "nsigma_site", "nsigma_time"), sigouts_arr),
+        "xtrace": (("steps", "nparam"), core.xtrace),
+        "sigtrace": (("steps", "nsigma_site", "nsigma_time"), core.sigtrace),
         "siteindicator": site_indicators,
-        "sigmafreqindex": ("nmeasure", sigma_freq),
+        "sigmafreqindex": ("nmeasure", core.sigma_freq_index),
         "sitenames": site_names,
         "fluxapriori": apriori_flux,
         "fluxmode": flux["flux_posterior_mode"],
@@ -626,20 +686,20 @@ def make_legacy_hbmcmc_output(
         "country95": country["country_posterior_hdi_95"],
         "countryapriori": country["country_prior_mean"],
         "countrydefinition": (("lat", "lon"), country_idx),
-        "xsensitivity": (("nmeasure", "nparam"), Hx_arr.T),
+        "xsensitivity": (("nmeasure", "nparam"), core.Hx.T),
     }
 
-    if use_bc and Hbc_arr is not None:
+    if use_bc and core.Hbc is not None:
         data_vars.update(
             {
-                "YaprioriBC": ("nmeasure", Hbc_arr.sum(axis=0)),
+                "YaprioriBC": ("nmeasure", core.Hbc.sum(axis=0)),
                 "YmodmeanBC": conc["mu_bc_posterior_mean"],
                 "YmodmedianBC": conc["mu_bc_posterior_median"],
                 "YmodmodeBC": conc["mu_bc_posterior_mode"],
                 "Ymod95BC": conc["mu_bc_posterior_hdi_95"],
                 "Ymod68BC": conc["mu_bc_posterior_hdi_68"],
-                "bctrace": (("steps", "nBC"), bcouts_arr),
-                "bcsensitivity": (("nmeasure", "nBC"), Hbc_arr.T),
+                "bctrace": (("steps", "nBC"), core.bctrace),
+                "bcsensitivity": (("nmeasure", "nBC"), core.Hbc.T),
             }
         )
 
@@ -648,19 +708,19 @@ def make_legacy_hbmcmc_output(
             data_vars[name] = _flatten_nmeasure_for_legacy(value)
 
     coords: dict[str, Any] = {
-        "stepnum": ("steps", np.arange(xouts_arr.shape[0])),
-        "paramnum": ("nparam", np.arange(Hx_arr.shape[0])),
-        "measurenum": ("nmeasure", np.arange(Hx_arr.shape[1])),
-        "nsigma_site": ("nsigma_site", np.arange(sigouts_arr.shape[1])),
-        "nsigma_time": ("nsigma_time", np.arange(sigouts_arr.shape[2])),
+        "stepnum": ("steps", np.arange(core.xtrace.shape[0])),
+        "paramnum": ("nparam", np.arange(core.Hx.shape[0])),
+        "measurenum": ("nmeasure", np.arange(core.Hx.shape[1])),
+        "nsigma_site": ("nsigma_site", np.arange(core.sigtrace.shape[1])),
+        "nsigma_time": ("nsigma_time", np.arange(core.sigtrace.shape[2])),
         "countrynames": country["countrynames"],
     }
     if "nUI" in conc.dims or "nUI" in country.dims:
         n_ui = conc.sizes.get("nUI", country.sizes.get("nUI"))
         if n_ui is not None:
             coords["UInum"] = ("nUI", np.arange(n_ui))
-    if use_bc and Hbc_arr is not None:
-        coords["numBC"] = ("nBC", np.arange(Hbc_arr.shape[0]))
+    if use_bc and core.Hbc is not None:
+        coords["numBC"] = ("nBC", np.arange(core.Hbc.shape[0]))
 
     out = xr.Dataset(data_vars, coords=coords)
 
@@ -678,5 +738,6 @@ def make_legacy_hbmcmc_output(
     out.attrs["Start date"] = str(inv_out.start_time.date())
     out.attrs["End date"] = str(inv_out.end_time.date())
     out.attrs["Convergence"] = _legacy_convergence(inv_out)
+    out.attrs.update(_legacy_hbmcmc_attrs(inv_out))
 
     return out

--- a/openghg_inversions/postprocessing/make_paris_outputs.py
+++ b/openghg_inversions/postprocessing/make_paris_outputs.py
@@ -1,8 +1,10 @@
 from pathlib import Path
 import getpass
 import re
+from collections.abc import Hashable
 from typing import Any, Literal
 
+import numpy as np
 import pandas as pd
 import xarray as xr
 
@@ -130,6 +132,16 @@ def add_variable_attrs(
     return ds
 
 
+def _cast_float_data_vars_to_float32(ds: xr.Dataset) -> xr.Dataset:
+    """Cast floating PARIS data variables to float32 at the product boundary."""
+    updates: dict[Hashable, xr.DataArray] = {}
+    for name in ds.data_vars:
+        if np.issubdtype(ds[name].dtype, np.floating):
+            updates[name] = ds[name].astype("float32")
+
+    return ds.assign(updates) if updates else ds
+
+
 def convert_time_to_unix_epoch(x: xr.Dataset, units: str = "1s") -> xr.Dataset:
     """Convert `time` coordinate of xarray Dataset or DataArray to number of "units" since 1 Jan 1970 (the "UNIX epoch")."""
     time_converted = (pd.DatetimeIndex(x.time) - pd.Timestamp("1970-01-01")) / pd.Timedelta(units)
@@ -232,7 +244,7 @@ def paris_concentration_outputs(
 
     result.attrs = make_global_attrs("conc")
 
-    return result
+    return _cast_float_data_vars_to_float32(result)
 
 
 def _flux_frequency_to_offset(flux_frequency: str) -> pd.DateOffset | pd.Timedelta:
@@ -399,7 +411,7 @@ def paris_flux_output(
 
     result.attrs = make_global_attrs("flux")
 
-    return result.as_numpy()
+    return _cast_float_data_vars_to_float32(result).as_numpy()
 
 
 def infer_flux_frequency(flux: xr.DataArray) -> str:

--- a/openghg_inversions/postprocessing/stats.py
+++ b/openghg_inversions/postprocessing/stats.py
@@ -101,27 +101,40 @@ def mode_kde(
     """
 
     def mode_of_row(row):
-        if np.all(np.isnan(row)):
+        row = row[np.isfinite(row)]
+        if row.size == 0:
             return np.nan
 
-        if np.nanmax(row) > np.nanmin(row):
-            xvals = np.linspace(np.nanmin(row), np.nanmax(row), 200)
+        if row.size == 1:
+            return float(row[0])
+
+        if np.max(row) > np.min(row):
+            xvals = np.linspace(np.min(row), np.max(row), 200)
             kde = scipy.stats.gaussian_kde(row).evaluate(xvals)
             return xvals[kde.argmax()]
 
-        return np.nanmean(row)
+        return float(np.mean(row))
 
     def func(arr):
+        if arr.shape[-1] == 0:
+            return np.full(arr.shape[:-1], np.nan, dtype=float)
         return np.apply_along_axis(func1d=mode_of_row, axis=-1, arr=arr)
 
     if chunk_dim is not None:
         return xr.apply_ufunc(
             func,
-            ds.dropna(dim=sample_dim).chunk({chunk_dim: chunk_size}),
+            ds.chunk({chunk_dim: chunk_size}),
             input_core_dims=[[sample_dim]],
             dask="parallelized",
+            output_dtypes=[float],
         )
-    return xr.apply_ufunc(func, ds, input_core_dims=[[sample_dim]], dask="parallelized")
+    return xr.apply_ufunc(
+        func,
+        ds,
+        input_core_dims=[[sample_dim]],
+        dask="parallelized",
+        output_dtypes=[float],
+    )
 
 
 @register_stat

--- a/openghg_inversions/rhime/outputs.py
+++ b/openghg_inversions/rhime/outputs.py
@@ -55,6 +55,36 @@ def _define_output_filename(
     return Path(output_path) / f"{output_name}_{species}_{domain}_{start_date}{ext}"
 
 
+def _define_legacy_output_filename(
+    output_path: str | Path,
+    species: str,
+    domain: str,
+    output_name: str,
+    start_date: str,
+    *,
+    ext: str = ".nc",
+) -> Path:
+    """Create the old fixedbasis/HBMCMC output filename for compatibility."""
+    return Path(output_path) / f"{species.upper()}_{domain}_{output_name}_{start_date}{ext}"
+
+
+def _define_derived_output_filename(
+    output_spec: RhimeOutputSpec,
+    *,
+    species: str,
+    domain: str,
+    output_name: str,
+    start_date: str,
+    ext: str = ".nc",
+) -> Path:
+    """Create a derived-output filename using the requested convention."""
+    if output_spec.output_path is None:
+        raise ValueError("An output path is required when saving RHIME outputs.")
+    if output_spec.output_filename_convention == "legacy":
+        return _define_legacy_output_filename(output_spec.output_path, species, domain, output_name, start_date, ext=ext)
+    return _define_output_filename(output_spec.output_path, species, domain, output_name, start_date, ext=ext)
+
+
 def _save_inferencedata(idata: az.InferenceData, path: str | Path) -> None:
     """Save InferenceData, preferring the h5netcdf backend with fallbacks."""
     if isinstance(idata, az.InferenceData):
@@ -204,20 +234,20 @@ def make_standard_output_bundle(
 
         if output_spec.output_path is not None:
             Path(output_spec.output_path).mkdir(parents=True, exist_ok=True)
-            conc_file = _define_output_filename(
-                output_spec.output_path,
-                model_spec.species,
-                model_spec.domain,
-                output_spec.output_name + "_conc",
-                run_spec.start_date,
+            conc_file = _define_derived_output_filename(
+                output_spec,
+                species=model_spec.species,
+                domain=model_spec.domain,
+                output_name=output_spec.output_name + "_conc",
+                start_date=run_spec.start_date,
                 ext=".nc",
             )
-            flux_file = _define_output_filename(
-                output_spec.output_path,
-                model_spec.species,
-                model_spec.domain,
-                output_spec.output_name + "_flux",
-                run_spec.start_date,
+            flux_file = _define_derived_output_filename(
+                output_spec,
+                species=model_spec.species,
+                domain=model_spec.domain,
+                output_name=output_spec.output_name + "_flux",
+                start_date=run_spec.start_date,
                 ext=".nc",
             )
             conc_outs.to_netcdf(
@@ -228,6 +258,29 @@ def make_standard_output_bundle(
             )
             output_metadata["paris_concentration_path"] = str(conc_file)
             output_metadata["paris_flux_path"] = str(flux_file)
+    elif output_spec.output_format == "legacy":
+        from openghg_inversions.postprocessing.legacy_outputs import make_legacy_hbmcmc_output
+
+        output_metadata["postprocessing_input_contract"] = "modern_inversion_output"
+        legacy_out = make_legacy_hbmcmc_output(
+            inv_out,
+            country_file=country_file,
+            use_bc=model_spec.use_bc,
+        )
+        outputs["legacy"] = legacy_out
+
+        if output_spec.output_path is not None:
+            Path(output_spec.output_path).mkdir(parents=True, exist_ok=True)
+            legacy_file = _define_derived_output_filename(
+                output_spec,
+                species=model_spec.species,
+                domain=model_spec.domain,
+                output_name=output_spec.output_name,
+                start_date=run_spec.start_date,
+                ext=".nc",
+            )
+            legacy_out.to_netcdf(legacy_file, mode="w", encoding=ncdf_encoding(legacy_out))
+            output_metadata["legacy_output_path"] = str(legacy_file)
 
     return RhimeOutputBundle(inv_out=inv_out, outputs=outputs, output_metadata=output_metadata)
 

--- a/openghg_inversions/rhime/outputs.py
+++ b/openghg_inversions/rhime/outputs.py
@@ -9,6 +9,7 @@ from typing import Any, cast
 import arviz as az
 import xarray as xr
 
+from openghg_inversions._timing import timed
 from openghg_inversions.array_ops import sparse_xr_dot
 from openghg_inversions.inversion_data import RhimePreparedInputs
 from openghg_inversions.models import RhimeModelSpec
@@ -198,14 +199,15 @@ def make_standard_output_bundle(
 
     outputs: dict[str, Any] = {}
     output_metadata: dict[str, Any] = {}
-    inv_out = _make_inversion_output(
-        prepared=prepared,
-        idata=idata,
-        run_spec=run_spec,
-        model_spec=model_spec,
-        output_spec=output_spec,
-        sampler=sampler,
-    )
+    with timed("rhime.output.inversion_output_create", output_format=output_spec.output_format):
+        inv_out = _make_inversion_output(
+            prepared=prepared,
+            idata=idata,
+            run_spec=run_spec,
+            model_spec=model_spec,
+            output_spec=output_spec,
+            sampler=sampler,
+        )
     outputs["inversion_output"] = inv_out
     output_metadata["inversion_output_contract"] = "modern"
 
@@ -216,7 +218,8 @@ def make_standard_output_bundle(
     )
     if trace_path is not None:
         trace_path.parent.mkdir(parents=True, exist_ok=True)
-        _save_inferencedata(idata, trace_path)
+        with timed("rhime.output.trace_save", path=trace_path):
+            _save_inferencedata(idata, trace_path)
         output_metadata["trace_path"] = str(trace_path)
 
     inv_out_path = _resolve_output_path(
@@ -226,27 +229,30 @@ def make_standard_output_bundle(
     )
     if inv_out_path is not None:
         inv_out_path.parent.mkdir(parents=True, exist_ok=True)
-        inv_out.save(inv_out_path)
+        with timed("rhime.output.inversion_output_save", path=inv_out_path):
+            inv_out.save(inv_out_path)
         output_metadata["inversion_output_path"] = str(inv_out_path)
 
     if output_spec.output_format == "basic":
         from openghg_inversions.postprocessing.make_outputs import basic_output
 
         output_metadata["postprocessing_input_contract"] = "modern_inversion_output"
-        outputs["basic"] = basic_output(inv_out, country_file=country_file)
+        with timed("rhime.output.basic_postprocess"):
+            outputs["basic"] = basic_output(inv_out, country_file=country_file)
     elif output_spec.output_format == "paris":
         from openghg_inversions.postprocessing.make_paris_outputs import make_paris_outputs
 
         output_metadata["postprocessing_input_contract"] = "modern_inversion_output"
         obs_avg_period = prepared.averaging_period[0] or "0h"
         kwargs = output_spec.paris_postprocessing_kwargs or {}
-        flux_outs, conc_outs = make_paris_outputs(
-            inv_out,
-            country_file=country_file,
-            domain=model_spec.domain,
-            obs_avg_period=obs_avg_period,
-            **kwargs,
-        )
+        with timed("rhime.output.paris_postprocess"):
+            flux_outs, conc_outs = make_paris_outputs(
+                inv_out,
+                country_file=country_file,
+                domain=model_spec.domain,
+                obs_avg_period=obs_avg_period,
+                **kwargs,
+            )
         outputs["paris_flux"] = flux_outs
         outputs["paris_concentration"] = conc_outs
 
@@ -268,23 +274,26 @@ def make_standard_output_bundle(
                 start_date=run_spec.start_date,
                 ext=".nc",
             )
-            conc_outs.to_netcdf(
-                conc_file, unlimited_dims=["time"], mode="w", encoding=ncdf_encoding(conc_outs)
-            )
-            flux_outs.to_netcdf(
-                flux_file, unlimited_dims=["time"], mode="w", encoding=ncdf_encoding(flux_outs)
-            )
+            with timed("rhime.output.paris_concentration_netcdf_write", path=conc_file):
+                conc_outs.to_netcdf(
+                    conc_file, unlimited_dims=["time"], mode="w", encoding=ncdf_encoding(conc_outs)
+                )
+            with timed("rhime.output.paris_flux_netcdf_write", path=flux_file):
+                flux_outs.to_netcdf(
+                    flux_file, unlimited_dims=["time"], mode="w", encoding=ncdf_encoding(flux_outs)
+                )
             output_metadata["paris_concentration_path"] = str(conc_file)
             output_metadata["paris_flux_path"] = str(flux_file)
     elif output_spec.output_format == "legacy":
         from openghg_inversions.postprocessing.legacy_outputs import make_legacy_hbmcmc_output
 
         output_metadata["postprocessing_input_contract"] = "modern_inversion_output"
-        legacy_out = make_legacy_hbmcmc_output(
-            inv_out,
-            country_file=country_file,
-            use_bc=model_spec.use_bc,
-        )
+        with timed("rhime.output.legacy_postprocess"):
+            legacy_out = make_legacy_hbmcmc_output(
+                inv_out,
+                country_file=country_file,
+                use_bc=model_spec.use_bc,
+            )
         outputs["legacy"] = legacy_out
 
         if output_spec.output_path is not None:
@@ -297,7 +306,8 @@ def make_standard_output_bundle(
                 start_date=run_spec.start_date,
                 ext=".nc",
             )
-            legacy_out.to_netcdf(legacy_file, mode="w", encoding=ncdf_encoding(legacy_out))
+            with timed("rhime.output.legacy_netcdf_write", path=legacy_file):
+                legacy_out.to_netcdf(legacy_file, mode="w", encoding=ncdf_encoding(legacy_out))
             output_metadata["legacy_output_path"] = str(legacy_file)
 
     return RhimeOutputBundle(inv_out=inv_out, outputs=outputs, output_metadata=output_metadata)
@@ -352,21 +362,23 @@ def make_multisector_output_bundle(
 ) -> RhimeOutputBundle:
     """Create and optionally save transitional multi-sector RHIME outputs."""
     inv_out = None
-    diagnostics = _make_multisector_flux_diagnostics(
-        idata=idata,
-        prepared=prepared,
-        model_spec=model_spec,
-    )
+    with timed("rhime.output.multisector_diagnostics"):
+        diagnostics = _make_multisector_flux_diagnostics(
+            idata=idata,
+            prepared=prepared,
+            model_spec=model_spec,
+        )
     outputs: dict[str, Any] = {"sector_flux_diagnostics": diagnostics}
     output_metadata: dict[str, Any] = {}
     if output_spec.output_format != "none":
-        inv_out = _make_inversion_output(
-            prepared=prepared,
-            idata=idata,
-            run_spec=run_spec,
-            model_spec=model_spec,
-            output_spec=output_spec,
-        )
+        with timed("rhime.output.inversion_output_create", output_format=output_spec.output_format):
+            inv_out = _make_inversion_output(
+                prepared=prepared,
+                idata=idata,
+                run_spec=run_spec,
+                model_spec=model_spec,
+                output_spec=output_spec,
+            )
         outputs["inversion_output"] = inv_out
         output_metadata["inversion_output_contract"] = "modern"
 
@@ -377,7 +389,8 @@ def make_multisector_output_bundle(
         )
         if inv_out_path is not None:
             inv_out_path.parent.mkdir(parents=True, exist_ok=True)
-            inv_out.save(inv_out_path)
+            with timed("rhime.output.inversion_output_save", path=inv_out_path):
+                inv_out.save(inv_out_path)
             output_metadata["inversion_output_path"] = str(inv_out_path)
 
     if output_spec.output_format == "paris":
@@ -391,7 +404,8 @@ def make_multisector_output_bundle(
             Path(output_spec.output_path)
             / f"{output_spec.output_name}{run_spec.start_date}_sector_flux_diagnostics.nc"
         )
-        diagnostics.to_netcdf(diagnostics_path, mode="w", encoding=ncdf_encoding(diagnostics))
+        with timed("rhime.output.multisector_diagnostics_netcdf_write", path=diagnostics_path):
+            diagnostics.to_netcdf(diagnostics_path, mode="w", encoding=ncdf_encoding(diagnostics))
         output_metadata["sector_flux_diagnostics_path"] = str(diagnostics_path)
 
     return RhimeOutputBundle(inv_out=inv_out, outputs=outputs, output_metadata=output_metadata)

--- a/openghg_inversions/rhime/outputs.py
+++ b/openghg_inversions/rhime/outputs.py
@@ -16,7 +16,8 @@ from openghg_inversions.postprocessing.inversion_output import (
     InversionOutput,
     _reset_serialisation_multiindexes,
 )
-from openghg_inversions.rhime.specs import RhimeOutputSpec, RhimeRunSpec
+from openghg_inversions.rhime.sampling import RhimeSampler
+from openghg_inversions.rhime.specs import OutputFilenameConvention, RhimeOutputSpec, RhimeRunSpec
 from openghg_inversions.utils import ncdf_encoding
 
 
@@ -49,23 +50,15 @@ def _define_output_filename(
     output_name: str,
     start_date: str,
     *,
+    filename_convention: OutputFilenameConvention = "rhime",
     ext: str = ".nc",
 ) -> Path:
-    """Create the RHIME output filename used for derived NetCDF products."""
-    return Path(output_path) / f"{output_name}_{species}_{domain}_{start_date}{ext}"
-
-
-def _define_legacy_output_filename(
-    output_path: str | Path,
-    species: str,
-    domain: str,
-    output_name: str,
-    start_date: str,
-    *,
-    ext: str = ".nc",
-) -> Path:
-    """Create the old fixedbasis/HBMCMC output filename for compatibility."""
-    return Path(output_path) / f"{species.upper()}_{domain}_{output_name}_{start_date}{ext}"
+    """Create a derived NetCDF filename using the selected convention."""
+    if filename_convention == "legacy":
+        filename = f"{species.upper()}_{domain}_{output_name}_{start_date}{ext}"
+    else:
+        filename = f"{output_name}_{species}_{domain}_{start_date}{ext}"
+    return Path(output_path) / filename
 
 
 def _define_derived_output_filename(
@@ -80,9 +73,15 @@ def _define_derived_output_filename(
     """Create a derived-output filename using the requested convention."""
     if output_spec.output_path is None:
         raise ValueError("An output path is required when saving RHIME outputs.")
-    if output_spec.output_filename_convention == "legacy":
-        return _define_legacy_output_filename(output_spec.output_path, species, domain, output_name, start_date, ext=ext)
-    return _define_output_filename(output_spec.output_path, species, domain, output_name, start_date, ext=ext)
+    return _define_output_filename(
+        output_spec.output_path,
+        species,
+        domain,
+        output_name,
+        start_date,
+        filename_convention=output_spec.output_filename_convention,
+        ext=ext,
+    )
 
 
 def _save_inferencedata(idata: az.InferenceData, path: str | Path) -> None:
@@ -137,6 +136,7 @@ def _make_inversion_output(
     run_spec: RhimeRunSpec,
     model_spec: RhimeModelSpec,
     output_spec: RhimeOutputSpec,
+    sampler: RhimeSampler | None = None,
 ) -> InversionOutput:
     """Create the modern RHIME InversionOutput without fixedbasis legacy adapters."""
     return InversionOutput(
@@ -158,12 +158,26 @@ def _make_inversion_output(
             "output_name": output_spec.output_name,
             "save_trace": output_spec.save_trace,
             "save_inversion_output": output_spec.save_inversion_output,
+            "sampler": _sampler_metadata(sampler),
         },
         provenance={
             "contract": "modern_rhime_inversion_output",
             "compatibility_issue": "401",
         },
     )
+
+
+def _sampler_metadata(sampler: RhimeSampler | None) -> dict[str, int | str] | None:
+    """Return serialisable sampler metadata for compatibility output attrs."""
+    if sampler is None:
+        return None
+    return {
+        "draws": sampler.draws,
+        "burn": sampler.burn,
+        "tune": sampler.tune,
+        "chains": sampler.chains,
+        "nuts_sampler": sampler.nuts_sampler,
+    }
 
 
 def make_standard_output_bundle(
@@ -174,6 +188,7 @@ def make_standard_output_bundle(
     idata: az.InferenceData,
     prepared: RhimePreparedInputs,
     country_file: str | None,
+    sampler: RhimeSampler | None = None,
 ) -> RhimeOutputBundle:
     """Create and optionally save standard RHIME outputs."""
     if output_spec.output_format == "none":
@@ -187,6 +202,7 @@ def make_standard_output_bundle(
         run_spec=run_spec,
         model_spec=model_spec,
         output_spec=output_spec,
+        sampler=sampler,
     )
     outputs["inversion_output"] = inv_out
     output_metadata["inversion_output_contract"] = "modern"

--- a/openghg_inversions/rhime/outputs.py
+++ b/openghg_inversions/rhime/outputs.py
@@ -150,6 +150,8 @@ def _make_inversion_output(
             "averaging_period": list(run_spec.averaging_period),
             "split_by_sectors": run_spec.split_by_sectors,
             "basis_artifact_source": prepared.basis_artifact_source,
+            "site_lats": list(prepared.site_lats) if prepared.site_lats is not None else None,
+            "site_lons": list(prepared.site_lons) if prepared.site_lons is not None else None,
         },
         model_metadata=asdict(model_spec),
         output_metadata={

--- a/openghg_inversions/rhime/params.py
+++ b/openghg_inversions/rhime/params.py
@@ -29,6 +29,10 @@ _ALIASES = {
     "offsetprior": "offset_prior",
     "emissions_name": "flux_sources",
 }
+_OUTPUT_FORMAT_ALIASES = {
+    "hbmcmc": "legacy",
+    "hbmcmc_postprocessing": "legacy",
+}
 
 _INT_OPTIONS = ("draws", "burn", "tune", "chains")
 _MAPPING_OPTIONS = (
@@ -126,6 +130,7 @@ def params_from_config(
 def normalise_rhime_params(params: Mapping[str, Any]) -> dict[str, Any]:
     """Normalize aliases, coerce simple scalars, and validate structured values."""
     normalized = normalise_param_aliases(params)
+    normalise_output_format_alias(normalized)
     coerce_simple_param_types(normalized)
     validate_rhime_param_types(normalized)
     return normalized
@@ -163,6 +168,23 @@ def normalise_param_aliases(params: Mapping[str, Any]) -> dict[str, Any]:
         raise ValueError("`mcmc_type` is not supported by RHIME runners; use `nuts_sampler` if needed.")
 
     return normalized
+
+
+def normalise_output_format_alias(params: dict[str, Any]) -> None:
+    """Normalize deprecated HBMCMC output format names in-place."""
+    output_format = params.get("output_format")
+    if output_format is None:
+        return
+    output_format = str(output_format).lower()
+    alias = _OUTPUT_FORMAT_ALIASES.get(output_format)
+    if alias is not None:
+        warnings.warn(
+            f"RHIME output_format {output_format!r} is deprecated; use {alias!r} instead.",
+            UserWarning,
+            stacklevel=3,
+        )
+        output_format = alias
+    params["output_format"] = output_format
 
 
 def coerce_simple_param_types(params: dict[str, Any]) -> None:
@@ -312,6 +334,7 @@ def validate_supported_params(params: Mapping[str, Any], *, data_params: set[str
         "save_trace",
         "save_inversion_output",
         "paris_postprocessing_kwargs",
+        "output_filename_convention",
         "offset_args",
         "country_file",
         "add_offset",
@@ -478,6 +501,7 @@ def make_rhime_runner_setup(
         paris_postprocessing_kwargs=normalise_optional_mapping(
             remaining.pop("paris_postprocessing_kwargs", None)
         ),
+        output_filename_convention=remaining.pop("output_filename_convention", "rhime"),
         multisector=multisector,
     )
     model_spec = _make_model_spec(

--- a/openghg_inversions/rhime/params.py
+++ b/openghg_inversions/rhime/params.py
@@ -491,12 +491,14 @@ def make_rhime_runner_setup(
             remaining.pop("posterior_predictive_kwargs", None)
         ),
     )
+    output_format = remaining.pop("output_format", "inv_out")
+    save_inversion_output = remaining.pop("save_inversion_output", output_format == "inv_out")
     output_spec = make_output_spec(
-        output_format=remaining.pop("output_format", "inv_out"),
+        output_format=output_format,
         output_path=output_path,
         output_name=output_name,
         save_trace=remaining.pop("save_trace", False),
-        save_inversion_output=remaining.pop("save_inversion_output", True),
+        save_inversion_output=save_inversion_output,
         country_file=remaining.get("country_file"),
         paris_postprocessing_kwargs=normalise_optional_mapping(
             remaining.pop("paris_postprocessing_kwargs", None)

--- a/openghg_inversions/rhime/runner.py
+++ b/openghg_inversions/rhime/runner.py
@@ -181,6 +181,7 @@ def _run_common(
             idata=idata,
             prepared=prepared,
             country_file=run_spec.output.country_file,
+            sampler=setup.sampler,
         )
     _apply_output_bundle(result, output_bundle)
 

--- a/openghg_inversions/rhime/runner.py
+++ b/openghg_inversions/rhime/runner.py
@@ -30,12 +30,12 @@ from dataclasses import dataclass, field, replace
 import inspect
 from pathlib import Path
 from typing import Any
-import time
 
 import arviz as az
 import pymc as pm
 import xarray as xr
 
+from openghg_inversions._timing import log_timing, timer_seconds, timer_start
 from openghg_inversions.basis.basis_functions import BasisFunctions
 from openghg_inversions.rhime.outputs import (
     RhimeOutputBundle,
@@ -142,17 +142,43 @@ def _run_common(
     params: dict[str, Any],
 ) -> RhimeResult:
     """Run the shared RHIME pipeline after public wrapper/config normalization."""
+    timing_start = timer_start()
     setup = _make_rhime_runner_setup(params=params, multisector=multisector)
+    log_timing("rhime.runner_setup", timer_seconds(timing_start), multisector=multisector)
+
+    timing_start = timer_start()
     prepared = prepare_rhime_inputs(**setup.data_args)
+    log_timing(
+        "rhime.prepare_inputs",
+        timer_seconds(timing_start),
+        multisector=multisector,
+        nmeasure=prepared.inv_inputs.sizes.get("nmeasure"),
+        sites=len(prepared.sites),
+        regions=prepared.inv_inputs.sizes.get("region"),
+        sources=prepared.inv_inputs.sizes.get("source"),
+        basis_source=prepared.basis_artifact_source,
+    )
     run_spec = _run_spec_with_prepared_inputs(setup.run_spec, prepared)
 
-    start_build = time.time()
+    build_and_sample_start = timer_start()
+    timing_start = timer_start()
     if multisector:
         model = build_rhime_multisector_model_from_spec(prepared.inv_inputs, run_spec.model)
     else:
         model = build_rhime_model_from_spec(prepared.inv_inputs, run_spec.model)
+    log_timing("rhime.model_build", timer_seconds(timing_start), multisector=multisector)
 
+    timing_start = timer_start()
     idata = setup.sampler.sample(model)
+    log_timing(
+        "rhime.sampler_total",
+        timer_seconds(timing_start),
+        draws=setup.sampler.draws,
+        burn=setup.sampler.burn,
+        tune=setup.sampler.tune,
+        chains=setup.sampler.chains,
+        nuts_sampler=setup.sampler.nuts_sampler,
+    )
     result = RhimeResult(
         run_spec=run_spec,
         model_spec=run_spec.model,
@@ -162,9 +188,10 @@ def _run_common(
         sampler=setup.sampler,
         model=model,
         basis_functions=prepared.basis_functions,
-        output_metadata={"build_and_sample_seconds": time.time() - start_build},
+        output_metadata={"build_and_sample_seconds": timer_seconds(build_and_sample_start)},
     )
 
+    timing_start = timer_start()
     if multisector:
         output_bundle = make_multisector_output_bundle(
             output_spec=run_spec.output,
@@ -183,6 +210,12 @@ def _run_common(
             country_file=run_spec.output.country_file,
             sampler=setup.sampler,
         )
+    log_timing(
+        "rhime.output_bundle_total",
+        timer_seconds(timing_start),
+        multisector=multisector,
+        output_format=run_spec.output.output_format,
+    )
     _apply_output_bundle(result, output_bundle)
 
     return result

--- a/openghg_inversions/rhime/sampling.py
+++ b/openghg_inversions/rhime/sampling.py
@@ -6,12 +6,72 @@ from collections.abc import Sequence
 from typing import Any, Literal, cast
 
 import arviz as az
+import numpy as np
 import pymc as pm
+import xarray as xr
 
 from openghg_inversions._timing import log_timing, timer_seconds, timer_start
 from openghg_inversions.models.coords import get_coord_registry, restore_inferencedata_coords
 
 NutsSampler = Literal["pymc", "nutpie", "numpyro", "blackjax"]
+
+
+def _finite_values(data: xr.DataArray) -> np.ndarray:
+    """Return finite numeric values from a sample-stats variable."""
+    values = np.asarray(data.values)
+    if values.dtype == bool:
+        return values.astype(float).reshape(-1)
+    values = values.astype(float, copy=False).reshape(-1)
+    return values[np.isfinite(values)]
+
+
+def _sample_stat_mean(sample_stats: xr.Dataset, name: str) -> float | None:
+    """Return a finite mean for a sample-stats variable, if available."""
+    if name not in sample_stats:
+        return None
+    values = _finite_values(sample_stats[name])
+    if values.size == 0:
+        return None
+    return float(values.mean())
+
+
+def _sample_stat_max(sample_stats: xr.Dataset, name: str) -> float | None:
+    """Return a finite maximum for a sample-stats variable, if available."""
+    if name not in sample_stats:
+        return None
+    values = _finite_values(sample_stats[name])
+    if values.size == 0:
+        return None
+    return float(values.max())
+
+
+def _sample_stat_sum(sample_stats: xr.Dataset, name: str) -> int | None:
+    """Return an integer sum for a sample-stats variable, if available."""
+    if name not in sample_stats:
+        return None
+    values = _finite_values(sample_stats[name])
+    if values.size == 0:
+        return None
+    return int(values.sum())
+
+
+def _log_sample_stats(trace: az.InferenceData, *, label: str) -> None:
+    """Log compact sampler diagnostics from an ``InferenceData`` object."""
+    sample_stats = getattr(trace, "sample_stats", None)
+    if not isinstance(sample_stats, xr.Dataset):
+        return
+
+    fields: dict[str, float | int | None] = {
+        "n_steps_mean": _sample_stat_mean(sample_stats, "n_steps"),
+        "n_steps_max": _sample_stat_max(sample_stats, "n_steps"),
+        "tree_depth_mean": _sample_stat_mean(sample_stats, "tree_depth"),
+        "tree_depth_max": _sample_stat_max(sample_stats, "tree_depth"),
+        "step_size_mean": _sample_stat_mean(sample_stats, "step_size"),
+        "acceptance_rate_mean": _sample_stat_mean(sample_stats, "acceptance_rate"),
+        "divergences": _sample_stat_sum(sample_stats, "diverging"),
+    }
+    if any(value is not None for value in fields.values()):
+        log_timing(label, 0.0, **fields)
 
 
 class RhimeSampler:
@@ -143,6 +203,7 @@ class RhimeSampler:
             chains=self.chains,
             nuts_sampler=self.nuts_sampler,
         )
+        _log_sample_stats(raw_trace, label="rhime.sampler.sample_stats")
 
         timing_start = timer_start()
         trace = cast(az.InferenceData, raw_trace.isel(draw=slice(self.burn, None)))

--- a/openghg_inversions/rhime/sampling.py
+++ b/openghg_inversions/rhime/sampling.py
@@ -8,6 +8,7 @@ from typing import Any, Literal, cast
 import arviz as az
 import pymc as pm
 
+from openghg_inversions._timing import log_timing, timer_seconds, timer_start
 from openghg_inversions.models.coords import get_coord_registry, restore_inferencedata_coords
 
 NutsSampler = Literal["pymc", "nutpie", "numpyro", "blackjax"]
@@ -120,6 +121,7 @@ class RhimeSampler:
         sample_kwargs.setdefault("progressbar", self.progressbar)
         sample_kwargs.setdefault("cores", self.chains)
 
+        timing_start = timer_start()
         with model:
             raw_trace = cast(
                 az.InferenceData,
@@ -133,12 +135,29 @@ class RhimeSampler:
                     **sample_kwargs,
                 ),
             )
+        log_timing(
+            "rhime.sampler.pm_sample",
+            timer_seconds(timing_start),
+            draws=self.draws,
+            tune=self.tune,
+            chains=self.chains,
+            nuts_sampler=self.nuts_sampler,
+        )
 
+        timing_start = timer_start()
         trace = cast(az.InferenceData, raw_trace.isel(draw=slice(self.burn, None)))
+        log_timing("rhime.sampler.burn_slicing", timer_seconds(timing_start), burn=self.burn)
+
         trace = self._extend_predictive(trace, model=model)
+        timing_start = timer_start()
         registry = get_coord_registry(model)
         if registry is not None:
             trace = restore_inferencedata_coords(trace, registry)
+        log_timing(
+            "rhime.sampler.coord_restore",
+            timer_seconds(timing_start),
+            restored=registry is not None,
+        )
         return trace
 
     def _extend_predictive(self, trace: az.InferenceData, *, model: pm.Model) -> az.InferenceData:
@@ -149,8 +168,14 @@ class RhimeSampler:
                 if self.sample_prior_predictive is True
                 else int(self.sample_prior_predictive)
             )
+            timing_start = timer_start()
             with model:
                 trace.extend(pm.sample_prior_predictive(prior_draws, model))
+            log_timing(
+                "rhime.sampler.prior_predictive",
+                timer_seconds(timing_start),
+                draws=prior_draws,
+            )
 
         if self.sample_posterior_predictive:
             posterior_var_names = (
@@ -160,7 +185,13 @@ class RhimeSampler:
             posterior_predictive_kwargs.setdefault("model", model)
             if posterior_var_names is not None:
                 posterior_predictive_kwargs.setdefault("var_names", posterior_var_names)
+            timing_start = timer_start()
             with model:
                 trace.extend(pm.sample_posterior_predictive(trace, **posterior_predictive_kwargs))
+            log_timing(
+                "rhime.sampler.posterior_predictive",
+                timer_seconds(timing_start),
+                var_names=posterior_var_names,
+            )
 
         return trace

--- a/openghg_inversions/rhime/specs.py
+++ b/openghg_inversions/rhime/specs.py
@@ -32,8 +32,9 @@ class RhimeOutputSpec:
         output_name: Base output name.
         save_trace: Trace save setting. If true, save to ``output_path`` using
             the default trace file name; if a path, save there.
-        save_inversion_output: Inversion-output save setting. Defaults to true
-            for CLI-friendly behaviour.
+        save_inversion_output: Inversion-output save setting. Runner parameter
+            normalization defaults this to true for ``output_format="inv_out"``
+            and false for derived product formats.
         country_file: Optional country mask file used by derived outputs.
         paris_postprocessing_kwargs: Extra keyword arguments for PARIS output
             creation.

--- a/openghg_inversions/rhime/specs.py
+++ b/openghg_inversions/rhime/specs.py
@@ -14,7 +14,8 @@ from typing import Any, Literal, cast
 
 from openghg_inversions.models.rhime import RhimeModelSpec
 
-OutputFormat = Literal["none", "inv_out", "basic", "paris"]
+OutputFormat = Literal["none", "inv_out", "basic", "paris", "legacy"]
+OutputFilenameConvention = Literal["rhime", "legacy"]
 
 
 @dataclass(frozen=True)
@@ -24,7 +25,9 @@ class RhimeOutputSpec:
     Args:
         output_format: Output mode. ``"inv_out"`` saves/returns the modern
             inversion output, ``"basic"`` and ``"paris"`` additionally create
-            derived outputs, and ``"none"`` skips output products.
+            derived outputs, ``"legacy"`` creates the old HBMCMC-compatible
+            NetCDF product from modern RHIME output, and ``"none"`` skips
+            output products.
         output_path: Directory for saved outputs.
         output_name: Base output name.
         save_trace: Trace save setting. If true, save to ``output_path`` using
@@ -34,6 +37,10 @@ class RhimeOutputSpec:
         country_file: Optional country mask file used by derived outputs.
         paris_postprocessing_kwargs: Extra keyword arguments for PARIS output
             creation.
+        output_filename_convention: Filename convention for derived products.
+            Direct RHIME runs use ``"rhime"``. The ``run_hbmcmc.py``
+            compatibility shim uses ``"legacy"`` for old SLURM/config
+            workflows.
     """
 
     output_format: OutputFormat = "inv_out"
@@ -43,6 +50,7 @@ class RhimeOutputSpec:
     save_inversion_output: str | Path | bool = True
     country_file: str | None = None
     paris_postprocessing_kwargs: dict[str, Any] | None = None
+    output_filename_convention: OutputFilenameConvention = "rhime"
 
 
 @dataclass(frozen=True)
@@ -72,7 +80,7 @@ class RhimeRunSpec:
 
 def validate_output_format(output_format: str) -> None:
     """Raise if a RHIME output format is not supported by the modern runners."""
-    valid_formats = {"none", "inv_out", "basic", "paris"}
+    valid_formats = {"none", "inv_out", "basic", "paris", "legacy"}
     if output_format not in valid_formats:
         raise ValueError(
             f"Unsupported RHIME output_format {output_format!r}; expected one of {sorted(valid_formats)!r}."
@@ -88,6 +96,8 @@ def validate_output_path_settings(
     multisector: bool,
 ) -> None:
     """Raise if output settings imply a default save path but none is supplied."""
+    if multisector and output_format == "legacy":
+        raise ValueError("RHIME output_format 'legacy' supports only single-sector runs.")
     if output_format == "none":
         return
     if output_path is not None:
@@ -96,6 +106,16 @@ def validate_output_path_settings(
         raise ValueError("`output_path` is required when `save_trace=True`.")
     if save_inversion_output is True:
         raise ValueError("`output_path` is required when saving the RHIME InversionOutput.")
+
+
+def validate_output_filename_convention(output_filename_convention: str) -> None:
+    """Raise if an output filename convention is not supported."""
+    valid_conventions = {"rhime", "legacy"}
+    if output_filename_convention not in valid_conventions:
+        raise ValueError(
+            "Unsupported RHIME output_filename_convention "
+            f"{output_filename_convention!r}; expected one of {sorted(valid_conventions)!r}."
+        )
 
 
 def make_output_spec(
@@ -107,10 +127,12 @@ def make_output_spec(
     save_inversion_output: str | Path | bool,
     country_file: str | None,
     paris_postprocessing_kwargs: dict[str, Any] | None,
+    output_filename_convention: str,
     multisector: bool,
 ) -> RhimeOutputSpec:
     """Create validated output settings from normalized RHIME parameters."""
     validate_output_format(output_format)
+    validate_output_filename_convention(output_filename_convention)
     validate_output_path_settings(
         output_format=output_format,
         output_path=output_path,
@@ -126,4 +148,5 @@ def make_output_spec(
         save_inversion_output=save_inversion_output,
         country_file=country_file,
         paris_postprocessing_kwargs=paris_postprocessing_kwargs,
+        output_filename_convention=cast(OutputFilenameConvention, output_filename_convention),
     )

--- a/openghg_inversions/rhime/specs.py
+++ b/openghg_inversions/rhime/specs.py
@@ -131,6 +131,8 @@ def make_output_spec(
     multisector: bool,
 ) -> RhimeOutputSpec:
     """Create validated output settings from normalized RHIME parameters."""
+    output_format = output_format.lower()
+    output_filename_convention = output_filename_convention.lower()
     validate_output_format(output_format)
     validate_output_filename_convention(output_filename_convention)
     validate_output_path_settings(

--- a/tests/postprocessing/test_countries.py
+++ b/tests/postprocessing/test_countries.py
@@ -1,9 +1,20 @@
+import h5py
+import numpy as np
 import pytest
 import xarray as xr
 
 import openghg_inversions._country_file as country_file_loader
 from openghg_inversions.postprocessing.countries import Countries, CountryRegions, paris_regions_dict
 from openghg_inversions.postprocessing._country_codes import CountryInfoList
+
+
+def _write_minimal_country_file(path):
+    with h5py.File(path, "w") as h5:
+        h5.create_dataset("lat", data=np.array([1.0, 2.0], dtype="float32"))
+        h5.create_dataset("lon", data=np.array([3.0, 4.0], dtype="float32"))
+        h5.create_dataset("country", data=np.array([[0.0, 1.0], [1.0, 0.0]]))
+        h5.create_dataset("name", data=np.array([b"OCEAN", b"FRANCE"]))
+        h5.create_dataset("country_code", data=np.array([b"OCEAN", b"FRA"]))
 
 
 def test_countries_from_file_falls_back_to_h5netcdf(monkeypatch, europe_country_file):
@@ -33,6 +44,27 @@ def test_countries_from_file_falls_back_to_h5netcdf(monkeypatch, europe_country_
 
     assert open_calls == ["default", "h5netcdf"]
     assert len(countries.country_selections) == len(dataset.name)
+
+
+def test_countries_from_file_falls_back_when_xarray_engines_fail(monkeypatch, tmp_path):
+    """Check country files can be read directly when xarray/HDF5 scale decoding fails."""
+    country_file = tmp_path / "country_TEST.nc"
+    _write_minimal_country_file(country_file)
+
+    def fail_open_dataset(*args, **kwargs):
+        raise RuntimeError("Unspecified error in H5DSget_num_scales")
+
+    monkeypatch.setattr(country_file_loader.xr, "open_dataset", fail_open_dataset)
+
+    with pytest.warns(RuntimeWarning, match="direct HDF5 reader 'h5py'"):
+        dataset = country_file_loader.load_country_dataset(country_file)
+
+    assert dataset.attrs[country_file_loader.COUNTRY_FILE_SELECTED_ENGINE_ATTR] == "h5py"
+
+    countries = Countries(dataset)
+
+    assert list(countries.country_labels) == ["OCEAN", "FRANCE"]
+    assert dict(countries.matrix.sizes) == {"lat": 2, "lon": 2, "country": 2}
 
 
 def test_country_regions_missing_check():
@@ -93,7 +125,6 @@ def test_countries_matrix_with_regions(country_code, country_ds, europe_country_
     )
 
     assert len(countries.country_selections) == len(country_ds.name) + len(paris_regions_dict["europe"])
-
 
 @pytest.mark.parametrize("country_code", ["alpha2", "alpha3", None])
 def test_countries_matrix_with_regions_EASTASIA(country_code, country_ds_eastasia, eastasia_country_file):

--- a/tests/postprocessing/test_legacy_outputs.py
+++ b/tests/postprocessing/test_legacy_outputs.py
@@ -285,6 +285,9 @@ def test_make_legacy_hbmcmc_output_derives_model_data_inputs(
     np.testing.assert_allclose(output["sitelats"].values, np.array([52.5]))
     np.testing.assert_allclose(output["sitelons"].values, np.array([1.25]))
     np.testing.assert_array_equal(output["basisfunctions"].values, np.array([[0]]))
+    for name in output.data_vars:
+        if np.issubdtype(output[name].dtype, np.floating):
+            assert output[name].dtype == np.dtype("float32")
     assert np.isfinite(output["Ymod68"].values).sum() == output["Ymod68"].size
     assert np.isfinite(output["Ymod95"].values).sum() == output["Ymod95"].size
     assert np.isfinite(output["country68"].values).sum() == output["country68"].size
@@ -307,4 +310,7 @@ def test_make_legacy_hbmcmc_output_falls_back_to_inv_inputs_for_sensitivities(
     np.testing.assert_allclose(output["bcsensitivity"].values, np.array([[1.0], [2.0]]))
     np.testing.assert_array_equal(output["sigmafreqindex"].values, np.array([7, 8]))
     np.testing.assert_allclose(output["bctrace"].values, np.full((3, 1), 0.5))
+    assert output["bcsensitivity"].dtype == np.dtype("float32")
+    assert output["bctrace"].dtype == np.dtype("float32")
+    assert output["YaprioriBC"].dtype == np.dtype("float32")
     assert "YaprioriBC" in output

--- a/tests/postprocessing/test_legacy_outputs.py
+++ b/tests/postprocessing/test_legacy_outputs.py
@@ -240,6 +240,14 @@ def test_make_legacy_hbmcmc_output_derives_model_data_inputs(
 ) -> None:
     """Legacy HBMCMC output no longer requires inferpymc result or side-channel arrays."""
     inv_out = _legacy_inv_out(model_data=True)
+    inv_out.output_metadata["legacy_hbmcmc_attrs"] = {
+        "Burn in": "1",
+        "Tuning steps": "2",
+        "Number of chains": "1",
+        "Error for each site": "True",
+        "Emissions Prior": "pdf,normal,mu,1.0,sigma,0.2",
+        "Model error Prior": "pdf,uniform,lower,0.1,upper,10.0",
+    }
 
     output = legacy_outputs.make_legacy_hbmcmc_output(inv_out)
 
@@ -248,6 +256,7 @@ def test_make_legacy_hbmcmc_output_derives_model_data_inputs(
     np.testing.assert_allclose(output["xtrace"].values, np.ones((3, 1)))
     np.testing.assert_allclose(output["sigtrace"].values, np.ones((3, 1, 2)))
     assert output.attrs["Convergence"] == "Unavailable"
+    assert output.attrs["Emissions Prior"] == "pdf,normal,mu,1.0,sigma,0.2"
 
 
 def test_make_legacy_hbmcmc_output_falls_back_to_inv_inputs_for_sensitivities(

--- a/tests/postprocessing/test_legacy_outputs.py
+++ b/tests/postprocessing/test_legacy_outputs.py
@@ -1,12 +1,15 @@
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
 
 import arviz as az
+import h5py
 import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
 
+from openghg_inversions import _country_file as country_file_mod
 from openghg_inversions import utils
 from openghg_inversions.postprocessing import legacy_outputs
 from openghg_inversions.postprocessing.inversion_output import InversionOutput
@@ -57,6 +60,15 @@ def _basis_functions_stub() -> SimpleNamespace:
         flux=flux,
         operator=SimpleNamespace(meta=SimpleNamespace(state_dim="region")),
     )
+
+
+def _write_minimal_country_file(path: str | Path) -> None:
+    """Write a minimal country file for fallback loader tests."""
+    with h5py.File(path, "w") as h5:
+        h5.create_dataset("lat", data=np.array([52.0], dtype="float32"))
+        h5.create_dataset("lon", data=np.array([1.0], dtype="float32"))
+        h5.create_dataset("country", data=np.array([[1.0]]))
+        h5.create_dataset("name", data=np.array([b"UNITED KINGDOM"]))
 
 
 def _legacy_inv_out(*, model_data: bool, include_bc: bool = False, chains: int = 1) -> InversionOutput:
@@ -170,9 +182,7 @@ def stub_legacy_product_builders(monkeypatch: pytest.MonkeyPatch) -> None:
         ),
     )
     monkeypatch.setattr(
-        legacy_outputs.utils,
-        "get_country",
-        lambda domain, country_file=None: SimpleNamespace(country=np.array([[1]])),
+        legacy_outputs, "_legacy_country_index", lambda domain, country_file=None: np.array([[1]])
     )
 
 
@@ -209,6 +219,21 @@ def test_map_times_to_available_period_positions_handles_gappy_flux_months():
     )
 
     np.testing.assert_array_equal(positions, np.array([0, 0, 1, 2]))
+
+
+def test_legacy_country_index_falls_back_when_h5netcdf_open_fails(monkeypatch, tmp_path):
+    """Legacy country index loading uses the same direct HDF5 fallback as modern country outputs."""
+    country_file = tmp_path / "country_TEST.nc"
+    _write_minimal_country_file(country_file)
+
+    def fail_open_dataset(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("Unspecified error in H5DSget_num_scales")
+
+    monkeypatch.setattr(country_file_mod.xr, "open_dataset", fail_open_dataset)
+
+    country_index = legacy_outputs._legacy_country_index("TEST", country_file=country_file)
+
+    np.testing.assert_array_equal(country_index, np.array([[1.0]]))
 
 
 def test_compute_apriori_flux_handles_multi_year_flux_time():

--- a/tests/postprocessing/test_legacy_outputs.py
+++ b/tests/postprocessing/test_legacy_outputs.py
@@ -112,6 +112,8 @@ def _legacy_inv_out(*, model_data: bool, include_bc: bool = False, chains: int =
             "start_date": "2019-01-01",
             "end_date": "2019-01-02",
             "sites": ["TAC"],
+            "site_lats": [52.5],
+            "site_lons": [1.25],
             "split_by_sectors": False,
         },
         model_metadata={"species": "ch4", "domain": "EUROPE"},
@@ -278,6 +280,14 @@ def test_make_legacy_hbmcmc_output_derives_model_data_inputs(
 
     np.testing.assert_allclose(output["xsensitivity"].values, np.array([[0.25], [0.75]]))
     np.testing.assert_array_equal(output["sigmafreqindex"].values, np.array([0, 1]))
+    np.testing.assert_allclose(output["min_model_error"].values, np.zeros(2))
+    np.testing.assert_allclose(output["sitelats"].values, np.array([52.5]))
+    np.testing.assert_allclose(output["sitelons"].values, np.array([1.25]))
+    np.testing.assert_array_equal(output["basisfunctions"].values, np.array([[0]]))
+    assert np.isfinite(output["Ymod68"].values).sum() == output["Ymod68"].size
+    assert np.isfinite(output["Ymod95"].values).sum() == output["Ymod95"].size
+    assert np.isfinite(output["country68"].values).sum() == output["country68"].size
+    assert np.isfinite(output["country95"].values).sum() == output["country95"].size
     np.testing.assert_allclose(output["xtrace"].values, np.ones((3, 1)))
     np.testing.assert_allclose(output["sigtrace"].values, np.ones((3, 1, 2)))
     assert output.attrs["Convergence"] == "Unavailable"

--- a/tests/postprocessing/test_legacy_outputs.py
+++ b/tests/postprocessing/test_legacy_outputs.py
@@ -281,6 +281,7 @@ def test_make_legacy_hbmcmc_output_derives_model_data_inputs(
     np.testing.assert_allclose(output["xsensitivity"].values, np.array([[0.25], [0.75]]))
     np.testing.assert_array_equal(output["sigmafreqindex"].values, np.array([0, 1]))
     np.testing.assert_allclose(output["min_model_error"].values, np.zeros(2))
+    assert "min_model_error" not in output.attrs
     np.testing.assert_allclose(output["sitelats"].values, np.array([52.5]))
     np.testing.assert_allclose(output["sitelons"].values, np.array([1.25]))
     np.testing.assert_array_equal(output["basisfunctions"].values, np.array([[0]]))

--- a/tests/postprocessing/test_legacy_outputs.py
+++ b/tests/postprocessing/test_legacy_outputs.py
@@ -1,9 +1,179 @@
+from types import SimpleNamespace
+from typing import Any, cast
+
+import arviz as az
 import numpy as np
 import pandas as pd
+import pytest
 import xarray as xr
 
 from openghg_inversions import utils
+from openghg_inversions.postprocessing import legacy_outputs
+from openghg_inversions.postprocessing.inversion_output import InversionOutput
 from openghg_inversions.postprocessing.legacy_outputs import _compute_apriori_flux
+
+
+def _minimal_legacy_inv_inputs(*, include_bc: bool = False) -> xr.Dataset:
+    """Build observation and fallback sensitivity inputs for legacy output tests."""
+    data_vars = {
+        "H": (("region", "nmeasure"), np.array([[9.0, 9.0]])),
+        "mf": (
+            ("nmeasure",),
+            np.array([1900.0, 1901.0]),
+            {"units": "1e-09 mol/mol", "long_name": "observed_mole_fraction"},
+        ),
+        "mf_error": (("nmeasure",), np.array([2.0, 2.1]), {"units": "1e-09 mol/mol"}),
+        "mf_repeatability": (("nmeasure",), np.array([1.0, 1.1]), {"units": "1e-09 mol/mol"}),
+        "mf_variability": (("nmeasure",), np.array([1.5, 1.6]), {"units": "1e-09 mol/mol"}),
+        "site_indicator": (("nmeasure",), np.array([0, 0])),
+        "sigma_freq_index": (("nmeasure",), np.array([7, 8])),
+        "min_error": (("nmeasure",), np.zeros(2)),
+    }
+    coords = {
+        "region": np.array([0]),
+        "nmeasure": np.arange(2),
+        "site": ("nmeasure", np.array(["TAC", "TAC"])),
+        "time": (
+            "nmeasure",
+            np.array(["2019-01-01T00:00:00", "2019-01-01T01:00:00"], dtype="datetime64[ns]"),
+        ),
+    }
+    if include_bc:
+        data_vars["H_bc"] = (("bc_region", "nmeasure"), np.array([[1.0, 2.0]]))
+        coords["bc_region"] = np.array([0])
+
+    return xr.Dataset(data_vars=data_vars, coords=coords).set_index(nmeasure=["site", "time"])
+
+
+def _basis_functions_stub() -> SimpleNamespace:
+    """Return the minimal basis-functions interface consumed by the legacy adapter."""
+    flux = xr.DataArray(
+        np.array([[1.0]]),
+        dims=("lat", "lon"),
+        coords={"lat": [52.0], "lon": [1.0]},
+        name="flux",
+    )
+    return SimpleNamespace(
+        flux=flux,
+        operator=SimpleNamespace(meta=SimpleNamespace(state_dim="region")),
+    )
+
+
+def _legacy_inv_out(*, model_data: bool, include_bc: bool = False, chains: int = 1) -> InversionOutput:
+    """Build a minimal InversionOutput for legacy adapter tests."""
+    draw_count = 3
+    posterior_vars = {
+        "x": (("chain", "draw", "region"), np.ones((chains, draw_count, 1))),
+        "sigma": (
+            ("chain", "draw", "nsigma_site", "nsigma_time"),
+            np.ones((chains, draw_count, 1, 2)),
+        ),
+    }
+    coords: dict[str, object] = {
+        "chain": np.arange(chains),
+        "draw": np.arange(draw_count),
+        "region": np.array([0]),
+        "nsigma_site": np.array([0]),
+        "nsigma_time": np.array([0, 1]),
+    }
+    if include_bc:
+        posterior_vars["bc"] = (("chain", "draw", "bc_region"), np.full((chains, draw_count, 1), 0.5))
+        coords["bc_region"] = np.array([0])
+
+    groups: dict[str, xr.Dataset] = {"posterior": xr.Dataset(posterior_vars, coords=coords)}
+    if model_data:
+        constant_vars = {
+            "hx": (("nmeasure", "region"), np.array([[0.25], [0.75]])),
+            "sigma_freq_index": (("nmeasure",), np.array([0, 1])),
+        }
+        constant_coords: dict[str, object] = {"nmeasure": np.arange(2), "region": np.array([0])}
+        if include_bc:
+            constant_vars["hbc"] = (("nmeasure", "bc_region"), np.array([[0.5], [1.5]]))
+            constant_coords["bc_region"] = np.array([0])
+        groups["constant_data"] = xr.Dataset(constant_vars, coords=constant_coords)
+
+    return InversionOutput(
+        trace=cast(Any, az.InferenceData)(**groups),
+        inv_inputs=_minimal_legacy_inv_inputs(include_bc=include_bc),
+        basis_functions=cast(Any, _basis_functions_stub()),
+        run_metadata={
+            "start_date": "2019-01-01",
+            "end_date": "2019-01-02",
+            "sites": ["TAC"],
+            "split_by_sectors": False,
+        },
+        model_metadata={"species": "ch4", "domain": "EUROPE"},
+    )
+
+
+@pytest.fixture
+def stub_legacy_product_builders(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub heavy postprocessing builders so adapter tests focus on input derivation."""
+    nmeasure = np.arange(2)
+    hdi = np.array(["lower", "upper"])
+    lat = np.array([52.0])
+    lon = np.array([1.0])
+    country = np.array(["United Kingdom"])
+
+    def fake_concentration_outputs(inv_out: InversionOutput, **kwargs: object) -> xr.Dataset:
+        data_vars = {
+            "y_posterior_predictive_mean": (("nmeasure",), np.array([1.0, 2.0])),
+            "y_posterior_predictive_median": (("nmeasure",), np.array([1.0, 2.0])),
+            "y_posterior_predictive_mode": (("nmeasure",), np.array([1.0, 2.0])),
+            "y_posterior_predictive_hdi_68": (("nmeasure", "hdi"), np.ones((2, 2))),
+            "y_posterior_predictive_hdi_95": (("nmeasure", "hdi"), np.ones((2, 2))),
+        }
+        if "bc" in cast(Any, inv_out.trace).posterior:
+            data_vars.update(
+                {
+                    "mu_bc_posterior_mean": (("nmeasure",), np.array([0.5, 1.5])),
+                    "mu_bc_posterior_median": (("nmeasure",), np.array([0.5, 1.5])),
+                    "mu_bc_posterior_mode": (("nmeasure",), np.array([0.5, 1.5])),
+                    "mu_bc_posterior_hdi_68": (("nmeasure", "hdi"), np.ones((2, 2))),
+                    "mu_bc_posterior_hdi_95": (("nmeasure", "hdi"), np.ones((2, 2))),
+                }
+            )
+        return xr.Dataset(data_vars, coords={"nmeasure": nmeasure, "hdi": hdi})
+
+    def fake_flux_outputs(inv_out: InversionOutput, **kwargs: object) -> xr.Dataset:
+        return xr.Dataset(
+            {
+                "flux_posterior_mode": (("lat", "lon"), np.array([[1.0]])),
+                "scaling_posterior_mean": (("lat", "lon"), np.array([[1.0]])),
+                "scaling_posterior_mode": (("lat", "lon"), np.array([[1.0]])),
+            },
+            coords={"lat": lat, "lon": lon},
+        )
+
+    def fake_country_outputs(inv_out: InversionOutput, **kwargs: object) -> xr.Dataset:
+        return xr.Dataset(
+            {
+                "country_posterior_mean": (("country",), np.array([1.0])),
+                "country_posterior_median": (("country",), np.array([1.0])),
+                "country_posterior_mode": (("country",), np.array([1.0])),
+                "country_posterior_stdev": (("country",), np.array([0.1])),
+                "country_posterior_hdi_68": (("country", "hdi"), np.ones((1, 2))),
+                "country_posterior_hdi_95": (("country", "hdi"), np.ones((1, 2))),
+                "country_prior_mean": (("country",), np.array([1.0])),
+            },
+            coords={"country": country, "hdi": hdi},
+        )
+
+    monkeypatch.setattr(legacy_outputs, "make_concentration_outputs", fake_concentration_outputs)
+    monkeypatch.setattr(legacy_outputs, "make_flux_outputs", fake_flux_outputs)
+    monkeypatch.setattr(legacy_outputs, "make_country_outputs", fake_country_outputs)
+    monkeypatch.setattr(
+        legacy_outputs,
+        "flat_basis_for_output",
+        lambda inv_out: xr.DataArray(
+            np.array([[1]]), dims=("lat", "lon"), coords={"lat": lat, "lon": lon}, name="basis"
+        ),
+    )
+    monkeypatch.setattr(
+        legacy_outputs.utils,
+        "get_country",
+        lambda domain, country_file=None: SimpleNamespace(country=np.array([[1]])),
+    )
 
 
 def test_compute_apriori_flux_handles_missing_month():
@@ -34,7 +204,9 @@ def test_map_times_to_available_period_positions_handles_gappy_flux_months():
     times = pd.to_datetime(["2019-01-15", "2019-01-20", "2019-03-10", "2019-04-20"])
     flux_times = pd.to_datetime(["2019-01-01", "2019-03-01", "2019-04-01"])
 
-    positions = utils._map_times_to_available_period_positions(times, flux_times, "monthly")
+    positions = utils._map_times_to_available_period_positions(
+        times.to_numpy(), flux_times.to_numpy(), "monthly"
+    )
 
     np.testing.assert_array_equal(positions, np.array([0, 0, 1, 2]))
 
@@ -61,3 +233,33 @@ def test_compute_apriori_flux_handles_multi_year_flux_time():
         apriori_flux,
         xr.DataArray([[1.75]], dims=["lat", "lon"], coords={"lat": [0.0], "lon": [0.0]}),
     )
+
+
+def test_make_legacy_hbmcmc_output_derives_model_data_inputs(
+    stub_legacy_product_builders: None,
+) -> None:
+    """Legacy HBMCMC output no longer requires inferpymc result or side-channel arrays."""
+    inv_out = _legacy_inv_out(model_data=True)
+
+    output = legacy_outputs.make_legacy_hbmcmc_output(inv_out)
+
+    np.testing.assert_allclose(output["xsensitivity"].values, np.array([[0.25], [0.75]]))
+    np.testing.assert_array_equal(output["sigmafreqindex"].values, np.array([0, 1]))
+    np.testing.assert_allclose(output["xtrace"].values, np.ones((3, 1)))
+    np.testing.assert_allclose(output["sigtrace"].values, np.ones((3, 1, 2)))
+    assert output.attrs["Convergence"] == "Unavailable"
+
+
+def test_make_legacy_hbmcmc_output_falls_back_to_inv_inputs_for_sensitivities(
+    stub_legacy_product_builders: None,
+) -> None:
+    """Legacy HBMCMC output derives sensitivities from inv_inputs when model data is absent."""
+    inv_out = _legacy_inv_out(model_data=False, include_bc=True)
+
+    output = legacy_outputs.make_legacy_hbmcmc_output(inv_out, use_bc=True)
+
+    np.testing.assert_allclose(output["xsensitivity"].values, np.array([[9.0], [9.0]]))
+    np.testing.assert_allclose(output["bcsensitivity"].values, np.array([[1.0], [2.0]]))
+    np.testing.assert_array_equal(output["sigmafreqindex"].values, np.array([7, 8]))
+    np.testing.assert_allclose(output["bctrace"].values, np.full((3, 1), 0.5))
+    assert "YaprioriBC" in output

--- a/tests/postprocessing/test_stats.py
+++ b/tests/postprocessing/test_stats.py
@@ -1,0 +1,36 @@
+"""Tests for postprocessing statistics helpers."""
+
+from __future__ import annotations
+
+import numpy as np
+import xarray as xr
+
+from openghg_inversions.postprocessing.stats import mode_kde
+
+
+def test_mode_kde_handles_nan_rows_with_dask_chunks() -> None:
+    """KDE mode should filter NaNs per row instead of dropping all draws globally."""
+    data = np.array(
+        [
+            [np.nan, 1.0, 1.0],
+            [np.nan, 2.0, np.nan],
+            [np.nan, 3.0, 2.0],
+        ]
+    )
+    ds = xr.Dataset({"y": (("draw", "nmeasure"), data)})
+
+    result = mode_kde(ds, chunk_dim="nmeasure", chunk_size=1).compute()
+
+    assert result["y_mode"].dims == ("nmeasure",)
+    assert np.isnan(result["y_mode"].values[0])
+    assert np.isfinite(result["y_mode"].values[1])
+    assert np.isfinite(result["y_mode"].values[2])
+
+
+def test_mode_kde_handles_single_finite_value() -> None:
+    """Rows with one finite value should return that value without calling scipy KDE."""
+    ds = xr.Dataset({"y": (("draw", "nmeasure"), np.array([[np.nan], [4.2], [np.nan]]))})
+
+    result = mode_kde(ds, chunk_dim="nmeasure", chunk_size=1).compute()
+
+    np.testing.assert_allclose(result["y_mode"].values, [4.2])

--- a/tests/test_basis_operators.py
+++ b/tests/test_basis_operators.py
@@ -63,6 +63,21 @@ def test_bucket_basis_operator_roundtrip_preserves_default_state_dim():
     assert "state" in op2.basis_matrix.dims
 
 
+def test_bucket_basis_operator_accepts_zero_based_flat_basis():
+    """Legacy HBMCMC output basis labels can still reconstruct a dummy basis."""
+    basis = xr.DataArray(
+        np.array([[0, 1, 2]], dtype=int),
+        dims=("lat", "lon"),
+        coords={"lat": [0.0], "lon": [0.0, 1.0, 2.0]},
+        name="basis_flat",
+    )
+
+    op = BucketBasisOperator(basis, state_dim="state")
+
+    assert list(op.basis_matrix.state.values) == [0, 1, 2]
+    assert op.basis_matrix.sizes["state"] == 3
+
+
 # --------------------------------------------------------------------------------------
 # Test interpolation for MultiSourceBucketBasisOperator
 # --------------------------------------------------------------------------------------

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -742,6 +742,12 @@ def test_resolve_output_format_canonicalizes_paris_compatibility():
     assert resolved == "paris"
 
 
+def test_resolve_output_format_rejects_column_legacy_output():
+    """Legacy HBMCMC formatting remains unsupported for column observations."""
+    with pytest.raises(ValueError, match="column observations"):
+        _resolve_output_format("hbmcmc", paris_postprocessing=False, is_column=True)
+
+
 def test_paris_postprocessing_compatibility_matches_paris_output_format(mcmc_args):
     """Compatibility PARIS output matches the explicit canonical format."""
     explicit_args = mcmc_args.copy()

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -11,6 +11,7 @@ import openghg_inversions.hbmcmc.hbmcmc as hbmcmc_module
 from openghg_inversions.basis.basis_functions import BASIS_ARTIFACT_SOURCE_ATTR, BasisFunctions
 from openghg_inversions.hbmcmc.hbmcmc import _resolve_output_format, fixedbasisMCMC
 from openghg_inversions.hbmcmc.hbmcmc_output import define_output_filename
+from openghg_inversions.postprocessing import legacy_outputs
 from openghg_inversions.postprocessing.inversion_output import InversionOutput
 from openghg_inversions.postprocessing.make_outputs import (
     basic_output,
@@ -249,10 +250,11 @@ def test_fixedbasisMCMC_merged_data_returns_prepared_fp_all(monkeypatch, tmp_pat
     assert captured_kwargs["reload_merged_data"] is False
 
 
-def test_fixedbasisMCMC_hbmcmc_output_uses_legacy_postprocess_path(monkeypatch, tmp_path):
-    """The default hbmcmc output path still consumes legacy postprocessing args."""
+def test_fixedbasisMCMC_hbmcmc_output_uses_modern_legacy_formatter(monkeypatch, tmp_path):
+    """Deprecated hbmcmc output aliases route through the modern legacy formatter."""
     prepared = _minimal_fixedbasis_prepared_data()
     captured_inferpymc_args = {}
+    captured_formatter_args = {}
 
     def fake_prepare_fixedbasis_inversion_data(**kwargs):
         return prepared
@@ -260,13 +262,23 @@ def test_fixedbasisMCMC_hbmcmc_output_uses_legacy_postprocess_path(monkeypatch, 
     def fake_inferpymc(**kwargs):
         captured_inferpymc_args.update(kwargs)
         return {
-            "trace": object(),
+            "trace": az.from_dict(
+                posterior={"x": np.ones((1, 2, 1)), "sigma": np.ones((1, 2, 1, 1))},
+                coords={"nx": [0], "nsigma_site": [0], "nsigma_time": [0]},
+                dims={"x": ["nx"], "sigma": ["nsigma_site", "nsigma_time"]},
+            ),
             "model": object(),
             "xouts": np.array([[1.0], [1.1]], dtype="float64"),
         }
 
-    def fake_inferpymc_postprocessouts(xouts):
-        return xr.Dataset({"xtrace_mean": (("nx",), xouts.mean(axis=0))})
+    def fail_inferpymc_postprocessouts(**kwargs):
+        raise AssertionError("output_format='legacy' must not call inferpymc_postprocessouts")
+
+    def fake_make_legacy_hbmcmc_output(inv_out, country_file=None, use_bc=False):
+        captured_formatter_args["inv_out"] = inv_out
+        captured_formatter_args["country_file"] = country_file
+        captured_formatter_args["use_bc"] = use_bc
+        return xr.Dataset({"xtrace_mean": (("nx",), np.array([1.05]))})
 
     monkeypatch.setattr(
         hbmcmc_module,
@@ -274,7 +286,8 @@ def test_fixedbasisMCMC_hbmcmc_output_uses_legacy_postprocess_path(monkeypatch, 
         fake_prepare_fixedbasis_inversion_data,
     )
     monkeypatch.setattr(hbmcmc_module.mcmc, "inferpymc", fake_inferpymc)
-    monkeypatch.setattr(hbmcmc_module.mcmc, "inferpymc_postprocessouts", fake_inferpymc_postprocessouts)
+    monkeypatch.setattr(hbmcmc_module.mcmc, "inferpymc_postprocessouts", fail_inferpymc_postprocessouts)
+    monkeypatch.setattr(legacy_outputs, "make_legacy_hbmcmc_output", fake_make_legacy_hbmcmc_output)
 
     result = fixedbasisMCMC(
         species="ch4",
@@ -290,6 +303,9 @@ def test_fixedbasisMCMC_hbmcmc_output_uses_legacy_postprocess_path(monkeypatch, 
     )
 
     assert captured_inferpymc_args["inv_inputs"] is prepared.inv_inputs
+    assert isinstance(captured_formatter_args["inv_out"], InversionOutput)
+    assert captured_formatter_args["country_file"] is None
+    assert captured_formatter_args["use_bc"] is False
     assert isinstance(result, xr.Dataset)
     assert result["xtrace_mean"].dims == ("nx",)
     assert result["xtrace_mean"].values.tolist() == [1.05]

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -795,6 +795,8 @@ def test_hbmcmc_postprocessing_preserves_expected_vars_attrs_and_coords(mcmc_arg
     assert outputs["Yobs"].dims == ("nmeasure",)
     assert outputs["Ymod68"].dims == ("nmeasure", "nUI")
     assert outputs["country68"].dims == ("countrynames", "nUI")
+    for interval_name in ("Ymod68", "Ymod95", "country68", "country95"):
+        assert np.isfinite(outputs[interval_name].values).sum() == outputs[interval_name].size
     assert "UInum" in outputs.coords
     assert "countrynames" in outputs.coords
 

--- a/tests/test_pymc_config.py
+++ b/tests/test_pymc_config.py
@@ -1,0 +1,30 @@
+"""Tests for process-wide PyTensor defaults used by PyMC model paths."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_rhime_import_configures_pytensor_float32_before_pymc() -> None:
+    """Importing RHIME applies the same float32 PyTensor default as legacy fixedbasis."""
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import pytensor; "
+                "print('before=' + pytensor.config.floatX); "
+                "import openghg_inversions.rhime; "
+                "print('after=' + pytensor.config.floatX); "
+                "print('warn=' + pytensor.config.warn_float64)"
+            ),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    values = dict(line.split("=", 1) for line in completed.stdout.strip().splitlines())
+    assert values["after"] == "float32"
+    assert values["warn"] == "warn"

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -844,6 +844,15 @@ def test_rhime_sampler_runs_pymc_sampling_and_predictive_steps(
 
     class FakeInferenceData:
         posterior = FakePosterior()
+        sample_stats = xr.Dataset(
+            {
+                "n_steps": (("chain", "draw"), np.array([[1, 2, 3], [4, 5, 6]])),
+                "tree_depth": (("chain", "draw"), np.array([[2, 2, 3], [3, 4, 4]])),
+                "step_size": (("chain", "draw"), np.array([[0.1, 0.1, 0.2], [0.2, 0.2, 0.2]])),
+                "acceptance_rate": (("chain", "draw"), np.array([[0.8, 0.9, 1.0], [0.7, 0.8, 0.9]])),
+                "diverging": (("chain", "draw"), np.array([[False, True, False], [False, False, True]])),
+            }
+        )
 
         def __init__(self) -> None:
             self.isel_kwargs: dict[str, Any] | None = None
@@ -858,6 +867,7 @@ def test_rhime_sampler_runs_pymc_sampling_and_predictive_steps(
 
     fake_idata = FakeInferenceData()
     seen: dict[str, Any] = {}
+    timings: list[tuple[str, dict[str, Any]]] = []
 
     def fake_sample(**kwargs: Any) -> Any:
         seen["sample_kwargs"] = kwargs
@@ -871,7 +881,11 @@ def test_rhime_sampler_runs_pymc_sampling_and_predictive_steps(
         seen["posterior_predictive"] = {"trace": trace, **kwargs}
         return "posterior"
 
+    def fake_log_timing(label: str, seconds: float, **fields: Any) -> None:
+        timings.append((label, fields))
+
     monkeypatch.setattr("openghg_inversions.rhime.sampling.pm.sample", fake_sample)
+    monkeypatch.setattr(rhime_sampling, "log_timing", fake_log_timing)
     monkeypatch.setattr(
         "openghg_inversions.rhime.sampling.pm.sample_prior_predictive",
         fake_prior_predictive,
@@ -913,6 +927,14 @@ def test_rhime_sampler_runs_pymc_sampling_and_predictive_steps(
         "random_seed": 42,
     }
     assert fake_idata.extensions == ["prior", "posterior"]
+    sample_stats_fields = dict(timings)["rhime.sampler.sample_stats"]
+    assert sample_stats_fields["n_steps_mean"] == 3.5
+    assert sample_stats_fields["n_steps_max"] == 6.0
+    assert sample_stats_fields["tree_depth_mean"] == 3.0
+    assert sample_stats_fields["tree_depth_max"] == 4.0
+    assert sample_stats_fields["step_size_mean"] == pytest.approx(1.0 / 6.0)
+    assert sample_stats_fields["acceptance_rate_mean"] == pytest.approx(0.85)
+    assert sample_stats_fields["divergences"] == 2
 
 
 def test_rhime_sampler_restores_registered_coords_after_predictive_steps(

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -714,6 +714,23 @@ def test_legacy_sampling_names_are_not_rhime_config_aliases() -> None:
         )
 
 
+@pytest.mark.parametrize(
+    ("legacy_output_format", "expected_output_format"),
+    [
+        ("hbmcmc", "legacy"),
+        ("hbmcmc_postprocessing", "legacy"),
+        ("legacy", "legacy"),
+    ],
+)
+def test_rhime_normalises_legacy_output_format_aliases(
+    legacy_output_format: str, expected_output_format: str
+) -> None:
+    """Old HBMCMC output names now select the modern legacy formatter."""
+    params = rhime_params.normalise_rhime_params({"output_format": legacy_output_format})
+
+    assert params["output_format"] == expected_output_format
+
+
 def test_build_rhime_model_from_spec_forwards_single_sector_prior(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1825,7 +1842,7 @@ def test_run_rhime_rejects_unsupported_output_format(tmp_path: Path) -> None:
         "flux_sources": ["total-ukghg-edgar7"],
         "output_path": str(tmp_path),
         "output_name": "test",
-        "output_format": "legacy",
+        "output_format": "definitely-not-supported",
     }
 
     with pytest.raises(ValueError, match="Unsupported RHIME output_format"):
@@ -1842,7 +1859,7 @@ def test_run_rhime_can_validate_output_format_without_output_path() -> None:
         "end_date": "2019-01-02",
         "flux_sources": ["total-ukghg-edgar7"],
         "output_name": "test",
-        "output_format": "legacy",
+        "output_format": "definitely-not-supported",
     }
 
     with pytest.raises(ValueError, match="Unsupported RHIME output_format"):
@@ -1908,6 +1925,17 @@ def test_output_path_validation_rejects_default_standard_save_without_path() -> 
         )
 
 
+def test_output_path_validation_rejects_multisector_legacy_output() -> None:
+    with pytest.raises(ValueError, match="single-sector"):
+        rhime_specs.validate_output_path_settings(
+            output_format="legacy",
+            output_path="outputs",
+            save_trace=False,
+            save_inversion_output=False,
+            multisector=True,
+        )
+
+
 def test_make_output_spec_validates_trace_save_path() -> None:
     with pytest.raises(ValueError, match="save_trace"):
         rhime_specs.make_output_spec(
@@ -1918,6 +1946,7 @@ def test_make_output_spec_validates_trace_save_path() -> None:
             save_inversion_output=False,
             country_file=None,
             paris_postprocessing_kwargs=None,
+            output_filename_convention="rhime",
             multisector=False,
         )
 
@@ -2509,6 +2538,74 @@ def test_standard_paris_output_uses_modern_postprocessing_without_legacy_adapter
     assert bundle.output_metadata["postprocessing_input_contract"] == "modern_inversion_output"
     assert "paris_flux" in bundle.outputs
     assert "paris_concentration" in bundle.outputs
+
+
+def test_standard_legacy_output_uses_modern_inversion_output(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """RHIME legacy output is formatted from modern InversionOutput."""
+    model_spec, output_spec, run_spec = _minimal_output_specs(output_format="legacy")
+    output_spec = RhimeOutputSpec(
+        output_format="legacy",
+        output_path=str(tmp_path),
+        output_name="legacy_test",
+        save_inversion_output=False,
+        output_filename_convention="legacy",
+    )
+    run_spec = RhimeRunSpec(
+        run_spec.start_date,
+        run_spec.end_date,
+        run_spec.sites,
+        run_spec.averaging_period,
+        model_spec,
+        output_spec,
+    )
+    prepared = RhimePreparedInputs(
+        inv_inputs=_minimal_output_inv_inputs(),
+        basis_functions=_fake_basis_functions(),
+        sites=("TAC",),
+        averaging_period=("1h",),
+        basis_artifact_source="generated",
+    )
+    captured: dict[str, Any] = {}
+
+    def fail_inferpymc_postprocessouts(**kwargs: Any) -> None:
+        raise AssertionError("run_rhime legacy output must not call inferpymc_postprocessouts")
+
+    def fake_make_legacy_hbmcmc_output(
+        inv_out: InversionOutput,
+        country_file: str | None = None,
+        use_bc: bool = False,
+    ) -> xr.Dataset:
+        captured["inv_out"] = inv_out
+        captured["country_file"] = country_file
+        captured["use_bc"] = use_bc
+        return xr.Dataset({"legacy": ((), 1)})
+
+    monkeypatch.setattr(legacy_mcmc, "inferpymc_postprocessouts", fail_inferpymc_postprocessouts)
+    monkeypatch.setattr(
+        "openghg_inversions.postprocessing.legacy_outputs.make_legacy_hbmcmc_output",
+        fake_make_legacy_hbmcmc_output,
+    )
+
+    bundle = rhime_outputs.make_standard_output_bundle(
+        output_spec=output_spec,
+        run_spec=run_spec,
+        model_spec=model_spec,
+        idata=_minimal_output_idata(),
+        prepared=prepared,
+        country_file="countries.json",
+    )
+
+    assert isinstance(bundle.inv_out, InversionOutput)
+    assert captured["inv_out"] is bundle.inv_out
+    assert captured["country_file"] == "countries.json"
+    assert captured["use_bc"] is True
+    assert bundle.output_metadata["postprocessing_input_contract"] == "modern_inversion_output"
+    assert "legacy" in bundle.outputs
+    expected_path = tmp_path / "CH4_EUROPE_legacy_test_2019-01-01.nc"
+    assert expected_path.exists()
+    assert bundle.output_metadata["legacy_output_path"] == str(expected_path)
 
 
 def test_save_inferencedata_prefers_h5netcdf(tmp_path: Path) -> None:

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -2359,6 +2359,12 @@ def test_modern_paris_flux_outputs_use_retained_basis_operator(
     assert "flux_total_posterior" in flux_outputs
     assert "country_flux_total_posterior" in flux_outputs
     assert "flux_total_posterior_inversion_grid" in flux_outputs
+    for name in (
+        "flux_total_posterior",
+        "country_flux_total_posterior",
+        "flux_total_posterior_inversion_grid",
+    ):
+        assert flux_outputs[name].dtype == np.dtype("float32")
     assert operator.interpolate_calls
     assert operator.basis_matrix_accesses
 
@@ -2510,6 +2516,10 @@ def test_paris_output_processes_modern_output(europe_country_file: Path) -> None
     assert "Yapost" in conc_outputs
     assert "flux_total_posterior" in flux_outputs
     assert "country_flux_total_posterior" in flux_outputs
+    for name in ("uYtotal", "YapostBC", "Yapost", "YaprioriBC", "Yapriori"):
+        assert conc_outputs[name].dtype == np.dtype("float32")
+    for name in ("flux_total_posterior", "country_flux_total_posterior"):
+        assert flux_outputs[name].dtype == np.dtype("float32")
 
 
 def test_standard_basic_output_uses_modern_postprocessing_without_legacy_adapter(monkeypatch) -> None:

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -1951,6 +1951,43 @@ def test_make_output_spec_validates_trace_save_path() -> None:
         )
 
 
+def test_make_output_spec_normalizes_filename_convention_case() -> None:
+    spec = rhime_specs.make_output_spec(
+        output_format="Legacy",
+        output_path="outputs",
+        output_name="test",
+        save_trace=False,
+        save_inversion_output=False,
+        country_file=None,
+        paris_postprocessing_kwargs=None,
+        output_filename_convention="Legacy",
+        multisector=False,
+    )
+
+    assert spec.output_format == "legacy"
+    assert spec.output_filename_convention == "legacy"
+
+
+def test_derived_output_filename_can_use_legacy_convention(tmp_path: Path) -> None:
+    spec = RhimeOutputSpec(
+        output_format="legacy",
+        output_path=str(tmp_path),
+        output_name="legacy_test",
+        save_inversion_output=False,
+        output_filename_convention="legacy",
+    )
+
+    filename = rhime_outputs._define_derived_output_filename(
+        spec,
+        species="ch4",
+        domain="EUROPE",
+        output_name=spec.output_name,
+        start_date="2019-01-01",
+    )
+
+    assert filename == tmp_path / "CH4_EUROPE_legacy_test_2019-01-01.nc"
+
+
 def test_make_standard_output_bundle_returns_outputs_without_mutating_result() -> None:
     model_spec, output_spec, run_spec = _minimal_output_specs()
     prepared = RhimePreparedInputs(
@@ -2550,7 +2587,6 @@ def test_standard_legacy_output_uses_modern_inversion_output(
         output_path=str(tmp_path),
         output_name="legacy_test",
         save_inversion_output=False,
-        output_filename_convention="legacy",
     )
     run_spec = RhimeRunSpec(
         run_spec.start_date,
@@ -2603,7 +2639,7 @@ def test_standard_legacy_output_uses_modern_inversion_output(
     assert captured["use_bc"] is True
     assert bundle.output_metadata["postprocessing_input_contract"] == "modern_inversion_output"
     assert "legacy" in bundle.outputs
-    expected_path = tmp_path / "CH4_EUROPE_legacy_test_2019-01-01.nc"
+    expected_path = tmp_path / "legacy_test_ch4_EUROPE_2019-01-01.nc"
     assert expected_path.exists()
     assert bundle.output_metadata["legacy_output_path"] == str(expected_path)
 

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -1925,6 +1925,35 @@ def test_output_path_validation_rejects_default_standard_save_without_path() -> 
         )
 
 
+def test_runner_setup_defaults_inv_out_save_only_for_inv_out_format(tmp_path: Path) -> None:
+    """Derived RHIME products should not save large inv_out sidecars unless requested."""
+    base_params = {
+        "species": "ch4",
+        "sites": ["TAC"],
+        "averaging_period": ["1h"],
+        "domain": "EUROPE",
+        "start_date": "2019-01-01",
+        "end_date": "2019-01-02",
+        "flux_sources": ["total-ukghg-edgar7"],
+        "output_name": "test",
+    }
+    data_params = set(inspect.signature(prepare_rhime_inputs).parameters)
+
+    inv_out_setup = rhime_params.make_rhime_runner_setup(
+        params={**base_params, "output_format": "inv_out", "output_path": str(tmp_path)},
+        multisector=False,
+        data_param_names=data_params,
+    )
+    paris_setup = rhime_params.make_rhime_runner_setup(
+        params={**base_params, "output_format": "paris"},
+        multisector=False,
+        data_param_names=data_params,
+    )
+
+    assert inv_out_setup.run_spec.output.save_inversion_output is True
+    assert paris_setup.run_spec.output.save_inversion_output is False
+
+
 def test_output_path_validation_rejects_multisector_legacy_output() -> None:
     with pytest.raises(ValueError, match="single-sector"):
         rhime_specs.validate_output_path_settings(

--- a/tests/test_run_hbmcmc_shim.py
+++ b/tests/test_run_hbmcmc_shim.py
@@ -108,6 +108,18 @@ def test_fixedbasis_params_to_rhime_preserves_paris_compatibility_flag(tmp_path:
     assert "paris_postprocessing" not in translated
 
 
+def test_fixedbasis_params_to_rhime_forces_legacy_filename_convention(tmp_path: Path) -> None:
+    """run_hbmcmc keeps historical filenames even if a RHIME override is supplied."""
+    config_file = tmp_path / "hbmcmc.ini"
+    _fixedbasis_config(config_file)
+    params = run_hbmcmc.hbmcmc_extract_param(str(config_file), print_param=False)
+    params["output_filename_convention"] = "rhime"
+
+    translated = run_hbmcmc.fixedbasis_params_to_rhime(params)
+
+    assert translated["output_filename_convention"] == "legacy"
+
+
 def test_run_hbmcmc_main_routes_to_run_rhime(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     config_file = tmp_path / "hbmcmc.ini"
     output_path = tmp_path / "outputs"
@@ -148,3 +160,26 @@ def test_run_hbmcmc_main_routes_to_run_rhime(monkeypatch: pytest.MonkeyPatch, tm
     assert seen["run_rhime_kwargs"]["chains"] == 2
     assert seen["run_rhime_kwargs"]["output_format"] == "legacy"
     assert seen["run_rhime_kwargs"]["output_filename_convention"] == "legacy"
+
+
+def test_run_hbmcmc_main_validates_before_copying_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Unsupported legacy options fail before output directories or config copies are created."""
+    config_file = tmp_path / "hbmcmc.ini"
+    _fixedbasis_config(config_file)
+
+    def fail_copy_config_file(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("Config copy should happen only after shim validation.")
+
+    monkeypatch.setattr(run_hbmcmc.output, "copy_config_file", fail_copy_config_file)
+
+    with pytest.raises(ValueError, match="calculate_min_error"):
+        run_hbmcmc.main(
+            [
+                "-c",
+                str(config_file),
+                "--kwargs",
+                '{"calculate_min_error": true}',
+            ]
+        )

--- a/tests/test_run_hbmcmc_shim.py
+++ b/tests/test_run_hbmcmc_shim.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import openghg_inversions.hbmcmc.run_hbmcmc as run_hbmcmc
+
+
+def _fixedbasis_config(path: Path) -> None:
+    path.write_text(
+        """
+[INPUT.MEASUREMENTS]
+species = "ch4"
+sites = ["TAC"]
+averaging_period = ["1h"]
+start_date = "2019-01-01"
+end_date = "2019-01-02"
+
+[INPUT.PRIORS]
+domain = "EUROPE"
+emissions_name = ["total-ukghg-edgar7"]
+
+[MCMC.TYPE]
+mcmc_type = "fixed_basis"
+
+[MCMC.PDF]
+xprior = {"pdf": "normal", "mu": 1.0, "sigma": 1.0}
+bcprior = {"pdf": "normal", "mu": 1.0, "sigma": 1.0}
+sigprior = {"pdf": "uniform", "lower": 0.1, "upper": 10.0}
+
+[MCMC.ITERATIONS]
+nit = 7
+burn = 1
+tune = 2
+
+[MCMC.NCHAIN]
+nchain = 3
+
+[MCMC.OPTIONS]
+verbose = True
+sampler_kwargs = {"target_accept": 0.9}
+reparameterise_log_normal = False
+
+[MCMC.OUTPUT]
+outputpath = "out"
+outputname = "legacy_run"
+output_format = "hbmcmc"
+""",
+        encoding="utf-8",
+    )
+
+
+def test_fixedbasis_params_to_rhime_translates_legacy_names(tmp_path: Path) -> None:
+    config_file = tmp_path / "hbmcmc.ini"
+    _fixedbasis_config(config_file)
+    params = run_hbmcmc.hbmcmc_extract_param(str(config_file), print_param=False)
+
+    translated = run_hbmcmc.fixedbasis_params_to_rhime(params)
+
+    assert translated["output_path"] == "out"
+    assert translated["output_name"] == "legacy_run"
+    assert translated["flux_sources"] == ["total-ukghg-edgar7"]
+    assert translated["draws"] == 7
+    assert translated["burn"] == 1
+    assert translated["tune"] == 2
+    assert translated["chains"] == 3
+    assert translated["progressbar"] is True
+    assert translated["sample_kwargs"] == {"target_accept": 0.9}
+    assert translated["output_format"] == "legacy"
+    assert translated["output_filename_convention"] == "legacy"
+    assert "mcmc_type" not in translated
+    assert "nit" not in translated
+    assert "nchain" not in translated
+
+
+def test_fixedbasis_params_to_rhime_rejects_enabled_legacy_options(tmp_path: Path) -> None:
+    config_file = tmp_path / "hbmcmc.ini"
+    _fixedbasis_config(config_file)
+    params = run_hbmcmc.hbmcmc_extract_param(str(config_file), print_param=False)
+    params["reparameterise_log_normal"] = True
+
+    with pytest.raises(ValueError, match="reparameterise_log_normal"):
+        run_hbmcmc.fixedbasis_params_to_rhime(params)
+
+
+def test_fixedbasis_params_to_rhime_rejects_non_fixed_basis_mcmc_type(tmp_path: Path) -> None:
+    config_file = tmp_path / "hbmcmc.ini"
+    _fixedbasis_config(config_file)
+    params = run_hbmcmc.hbmcmc_extract_param(str(config_file), print_param=False)
+    params["mcmc_type"] = "tdmcmc"
+
+    with pytest.raises(ValueError, match="fixed_basis"):
+        run_hbmcmc.fixedbasis_params_to_rhime(params)
+
+
+def test_fixedbasis_params_to_rhime_preserves_paris_compatibility_flag(tmp_path: Path) -> None:
+    config_file = tmp_path / "hbmcmc.ini"
+    _fixedbasis_config(config_file)
+    params = run_hbmcmc.hbmcmc_extract_param(str(config_file), print_param=False)
+    params.pop("output_format")
+    params["paris_postprocessing"] = True
+
+    translated = run_hbmcmc.fixedbasis_params_to_rhime(params)
+
+    assert translated["output_format"] == "paris"
+    assert "paris_postprocessing" not in translated
+
+
+def test_run_hbmcmc_main_routes_to_run_rhime(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    config_file = tmp_path / "hbmcmc.ini"
+    output_path = tmp_path / "outputs"
+    _fixedbasis_config(config_file)
+    seen: dict[str, Any] = {}
+
+    def fake_copy_config_file(config_file_arg: str, param: dict[str, Any], **command_line: Any) -> None:
+        seen["copy_config_file"] = config_file_arg
+        seen["copy_param"] = param
+        seen["copy_command_line"] = command_line
+
+    def fake_run_rhime(**kwargs: Any) -> None:
+        seen["run_rhime_kwargs"] = kwargs
+
+    monkeypatch.setattr(run_hbmcmc.output, "copy_config_file", fake_copy_config_file)
+    monkeypatch.setattr(run_hbmcmc, "run_rhime", fake_run_rhime)
+
+    run_hbmcmc.main(
+        [
+            "2020-01-01",
+            "2020-02-01",
+            "-c",
+            str(config_file),
+            "--output-path",
+            str(output_path),
+            "--kwargs",
+            '{"nchain": 2}',
+        ]
+    )
+
+    assert seen["copy_config_file"] == str(config_file)
+    assert seen["copy_command_line"]["start_date"] == "2020-01-01"
+    assert seen["copy_command_line"]["end_date"] == "2020-02-01"
+    assert seen["copy_command_line"]["outputpath"] == str(output_path)
+    assert seen["run_rhime_kwargs"]["start_date"] == "2020-01-01"
+    assert seen["run_rhime_kwargs"]["end_date"] == "2020-02-01"
+    assert seen["run_rhime_kwargs"]["output_path"] == str(output_path)
+    assert seen["run_rhime_kwargs"]["chains"] == 2
+    assert seen["run_rhime_kwargs"]["output_format"] == "legacy"
+    assert seen["run_rhime_kwargs"]["output_filename_convention"] == "legacy"

--- a/tests/test_run_hbmcmc_shim.py
+++ b/tests/test_run_hbmcmc_shim.py
@@ -202,3 +202,26 @@ def test_run_hbmcmc_main_validates_before_copying_config(
                 '{"calculate_min_error": true}',
             ]
         )
+
+
+def test_run_hbmcmc_main_validates_rhime_params_before_copying_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Unsupported RHIME params fail before output directories or config copies are created."""
+    config_file = tmp_path / "hbmcmc.ini"
+    _fixedbasis_config(config_file)
+
+    def fail_copy_config_file(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("Config copy should happen only after RHIME validation.")
+
+    monkeypatch.setattr(run_hbmcmc.output, "copy_config_file", fail_copy_config_file)
+
+    with pytest.raises(ValueError, match="Unsupported RHIME parameter"):
+        run_hbmcmc.main(
+            [
+                "-c",
+                str(config_file),
+                "--kwargs",
+                '{"unknown_rhime_option": true}',
+            ]
+        )

--- a/tests/test_run_hbmcmc_shim.py
+++ b/tests/test_run_hbmcmc_shim.py
@@ -70,6 +70,7 @@ def test_fixedbasis_params_to_rhime_translates_legacy_names(tmp_path: Path) -> N
     assert translated["sample_kwargs"] == {"target_accept": 0.9}
     assert translated["output_format"] == "legacy"
     assert translated["output_filename_convention"] == "legacy"
+    assert translated["save_inversion_output"] is False
     assert "mcmc_type" not in translated
     assert "nit" not in translated
     assert "nchain" not in translated
@@ -137,6 +138,18 @@ def test_fixedbasis_params_to_rhime_forces_legacy_filename_convention(tmp_path: 
     translated = run_hbmcmc.fixedbasis_params_to_rhime(params)
 
     assert translated["output_filename_convention"] == "legacy"
+
+
+def test_fixedbasis_params_to_rhime_preserves_explicit_inversion_output_save(tmp_path: Path) -> None:
+    """run_hbmcmc only suppresses inv_out sidecars when the old config did not request them."""
+    config_file = tmp_path / "hbmcmc.ini"
+    _fixedbasis_config(config_file)
+    params = run_hbmcmc.hbmcmc_extract_param(str(config_file), print_param=False)
+    params["save_inversion_output"] = "explicit_inv_out.nc"
+
+    translated = run_hbmcmc.fixedbasis_params_to_rhime(params)
+
+    assert translated["save_inversion_output"] == "explicit_inv_out.nc"
 
 
 def test_run_hbmcmc_main_routes_to_run_rhime(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/test_run_hbmcmc_shim.py
+++ b/tests/test_run_hbmcmc_shim.py
@@ -75,14 +75,33 @@ def test_fixedbasis_params_to_rhime_translates_legacy_names(tmp_path: Path) -> N
     assert "nchain" not in translated
 
 
-def test_fixedbasis_params_to_rhime_rejects_enabled_legacy_options(tmp_path: Path) -> None:
+def test_fixedbasis_params_to_rhime_translates_reparameterise_log_normal(tmp_path: Path) -> None:
     config_file = tmp_path / "hbmcmc.ini"
     _fixedbasis_config(config_file)
     params = run_hbmcmc.hbmcmc_extract_param(str(config_file), print_param=False)
     params["reparameterise_log_normal"] = True
+    params["xprior"] = {"pdf": "lognormal", "mean": 1.0, "stdev": 2.0}
+    params["bcprior"] = {"pdf": "lognormal", "mean": 1.0, "stdev": 1.0}
 
-    with pytest.raises(ValueError, match="reparameterise_log_normal"):
-        run_hbmcmc.fixedbasis_params_to_rhime(params)
+    with pytest.warns(DeprecationWarning, match="reparameterise_log_normal"):
+        translated = run_hbmcmc.fixedbasis_params_to_rhime(params)
+
+    assert translated["x_prior"]["reparameterise"] is True
+    assert translated["bc_prior"]["reparameterise"] is True
+    assert "reparameterise_log_normal" not in translated
+
+
+def test_fixedbasis_params_to_rhime_translates_calculate_min_error(tmp_path: Path) -> None:
+    config_file = tmp_path / "hbmcmc.ini"
+    _fixedbasis_config(config_file)
+    params = run_hbmcmc.hbmcmc_extract_param(str(config_file), print_param=False)
+    params["calculate_min_error"] = "percentile"
+
+    with pytest.warns(FutureWarning, match="calculate_min_error"):
+        translated = run_hbmcmc.fixedbasis_params_to_rhime(params)
+
+    assert translated["min_error"] == "percentile"
+    assert "calculate_min_error" not in translated
 
 
 def test_fixedbasis_params_to_rhime_rejects_non_fixed_basis_mcmc_type(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Refs #416.

This implements the first fixedbasis cleanup slice after PR #439:

- Adds `output_format="legacy"` as the modern single-sector RHIME compatibility product.
- Routes deprecated `hbmcmc` and `hbmcmc_postprocessing` output names to `legacy`.
- Changes `fixedbasisMCMC` default output to `legacy` and removes normal output dispatch to `inferpymc_postprocessouts`.
- Refactors `make_legacy_hbmcmc_output(...)` to consume modern `InversionOutput` directly, deriving the old `Hx`, `Hbc`, `sigma_freq_index`, first-chain `xouts` / `sigouts` / `bcouts`, old legacy attrs, and convergence internally from modern model data and trace fields.
- Adds a `run_hbmcmc.py` compatibility shim that reads fixedbasis-style configs, translates old option names to RHIME arguments, validates before copying configs, preserves legacy filename conventions, and calls `run_rhime(...)`.
- Translates deprecated legacy options with modern equivalents in the shim: `calculate_min_error="residual"|"percentile"` to `min_error`, and `reparameterise_log_normal=True` into `reparameterise=True` for lognormal emissions/BC priors.
- Updates docs, templates, cleanup plan, and changelog to describe `run_hbmcmc.py` as the active legacy-config compatibility route, direct `fixedbasisMCMC(...)` as temporary dead-end legacy Python code, and new work as RHIME-first.

## Remaining #416 Work

This does not close #416. Remaining removal steps include:

- Run representative SLURM/fixedbasis-style jobs through `run_hbmcmc.py` before merging this compatibility switch.
- Remove or quarantine direct `fixedbasisMCMC` once enough fixedbasis-style script parity is covered through `run_hbmcmc.py` -> `run_rhime`.
- Remove direct `inferpymc` sampling compatibility after the fixedbasis Python entry point is retired.
- Delete `inferpymc_postprocessouts` once old-format output parity is covered by the modern legacy formatter.
- Replace legacy flat `**kwargs` / INI passthrough with explicit argument routing/namespaces instead of restoring arbitrary `inferpymc` passthrough.
- Write broader user docs after the compatibility/refactor surface is simpler; the cleanup plan now records the required orientation and module-responsibility map.

## Validation

- `uv run pytest tests/test_run_hbmcmc_shim.py tests/postprocessing/test_legacy_outputs.py tests/test_rhime.py tests/test_postprocessing.py -q`
- `uv run ruff check openghg_inversions/hbmcmc/run_hbmcmc.py openghg_inversions/postprocessing/legacy_outputs.py tests/test_run_hbmcmc_shim.py`
- `uv run ruff format --check openghg_inversions/hbmcmc/run_hbmcmc.py openghg_inversions/postprocessing/legacy_outputs.py tests/test_run_hbmcmc_shim.py`
- `uv run pyright openghg_inversions/hbmcmc/run_hbmcmc.py openghg_inversions/postprocessing/legacy_outputs.py tests/test_run_hbmcmc_shim.py`
- `uv run sphinx-build -b html docs docs/_build/html`
- `git diff --check`

Notes:

- Strict `uv run sphinx-build -W -b html docs docs/_build/html` still exits nonzero on existing warnings, including missing `_static` and autodoc import failures due to `openghg.analyse._utils`. The non-`-W` docs build succeeds with those warnings.