### PR TITLE
Add mask-constrained basis generation

### DIFF
--- a/docs/plans/mask_constrained_basis.md
+++ b/docs/plans/mask_constrained_basis.md
@@ -23,9 +23,11 @@ part of #340.
 - Partition each mapped class independently, then offset labels globally so
   region labels never collide across classes.
 - Preserve unmapped cells consistently with label `0`.
-- Start with the current axis-parallel weighted split strategy. Do not implement
-  inertial partitions yet, but keep the strategy boundary explicit so an inertial
-  split, quadtree-style split, or other partitioning step can be substituted.
+- Start with a prototype-inspired greedy axis-parallel repeated-bisection split
+  strategy rather than the current recursive weighted bucket splitter. Do not
+  implement inertial partitions yet, but keep the strategy boundary explicit so
+  an inertial split, quadtree-style split, recursive weighted split, or other
+  partitioning step can be substituted.
 - Document `nbasis` allocation. Initial target: support explicit per-class
   allocation plus automatic allocation proportional to class total weight, with a
   minimum for non-empty mapped classes.
@@ -54,11 +56,20 @@ part of #340.
   `min_regions_per_class`, raises when the requested `nbasis` is below the class
   minimum or above mapped-cell capacity, and falls back from weight to area when
   all class weights are zero.
-- 2026-06-01: Added `SplitStrategy` plus
-  `AxisAlignedWeightedSplitStrategy`. This keeps the current axis-parallel
-  weighted split as the default while leaving a direct substitution point for
-  future inertial or quadtree-style strategies. No inertial split implemented.
+- 2026-06-01: Added `SplitStrategy` plus the initial
+  `AxisAlignedWeightedSplitStrategy`. This kept the current axis-parallel
+  weighted split available while leaving a direct substitution point for future
+  inertial or quadtree-style strategies. No inertial split implemented.
 - 2026-06-01: Subagent review fixes for #449 core: all-zero class weights now
   split using an area surrogate, explicit allocations are checked against
   mapped-cell capacity, and `SplitStrategy` is exported for typed custom
   strategies.
+- 2026-06-02: User review noted the existing recursive weighted algorithm is a
+  poor default for the constrained helper. Prototype research found the clean
+  non-recursive replacement in
+  `~/Documents/inversions/src/inversions/basis_algorithms.py`: greedy repeated
+  bisection that repeatedly splits the highest-weight current part, with
+  axis-parallel and inertial split functions. The #449 core now uses a
+  cleaned-up `GreedyAxisParallelSplitStrategy` as the constrained default and
+  keeps `AxisAlignedWeightedSplitStrategy` as an explicit compatibility
+  strategy.

--- a/docs/plans/mask_constrained_basis.md
+++ b/docs/plans/mask_constrained_basis.md
@@ -58,3 +58,7 @@ part of #340.
   `AxisAlignedWeightedSplitStrategy`. This keeps the current axis-parallel
   weighted split as the default while leaving a direct substitution point for
   future inertial or quadtree-style strategies. No inertial split implemented.
+- 2026-06-01: Subagent review fixes for #449 core: all-zero class weights now
+  split using an area surrogate, explicit allocations are checked against
+  mapped-cell capacity, and `SplitStrategy` is exported for typed custom
+  strategies.

--- a/docs/plans/mask_constrained_basis.md
+++ b/docs/plans/mask_constrained_basis.md
@@ -73,3 +73,40 @@ part of #340.
   cleaned-up `GreedyAxisParallelSplitStrategy` as the constrained default and
   keeps `AxisAlignedWeightedSplitStrategy` as an explicit compatibility
   strategy.
+- 2026-06-01: Added #325 caller-facing adapter
+  `region_constrained_basis_function` and
+  `basis_algorithm="region_constrained"`.
+  It uses the #449 core helper with a caller-supplied `region_classes`
+  `DataArray`; country/region file loading remains outside the algorithm. The
+  wrapper now passes through `region_classes`, `region_allocation`, and
+  `min_regions_per_class` only for this algorithm.
+- 2026-06-01: Subagent review completed on the stacked #325 branch. Fixes made:
+  `region_constrained` now works through `fixed_outer_regions_basis` when
+  `region_classes` is supplied; all-zero class weights use an area surrogate for
+  splitting; explicit allocation is checked against mapped-cell capacity; and
+  `SplitStrategy` is exported. The apparent positional API issue for
+  the legacy compressed names `quadtreebasisfunction`/`bucketbasisfunction` was
+  present on `origin/devel`, but new wrapper options were moved to the end of
+  `basis_functions_wrapper` to avoid changing its existing positional order.
+- 2026-06-02: Research in `~/Documents/basis_functions` found bucket-threshold
+  optimizers, simulated annealing experiments, and numba notebook fragments.
+  These are useful future research inputs but are not clean drop-in
+  `SplitStrategy` candidates yet.
+- 2026-06-02: Histories `~/Documents/ipython_histories/ipython_hist_26.py` and
+  `ipython_hist_27.py` preserve country/region partition workflows: land/sea
+  and PARIS country partitions, country-fraction matrix labeling, and
+  `outer_region_definition_EUROPE.nc` with inner region `region == 6`. Follow-up
+  #325 work should keep file loading outside the pure helper and add tiny
+  land/sea, country, and outer-region fixtures that assert labels do not cross
+  classes.
+- 2026-06-02: Added PEP-style public function names
+  `quadtree_basis_function`, `bucket_basis_function`, and
+  `region_constrained_basis_function`. The old compressed names
+  `quadtreebasisfunction` and `bucketbasisfunction` remain as deprecated aliases
+  with warnings for compatibility; the draft-only compressed
+  `regionconstrainedbasisfunction` alias was removed before PR.
+- 2026-06-02: Extracted a `PartitionStep` protocol and `AxisParallelSplitStep`
+  from the greedy constrained strategy. Greedy orchestration now uses a small
+  priority-queue wrapper that pops the highest-weight partition first and can
+  accept split steps that return more than two child partitions without
+  overshooting the requested target count.

--- a/docs/plans/mask_constrained_basis.md
+++ b/docs/plans/mask_constrained_basis.md
@@ -43,3 +43,18 @@ part of #340.
   while `_weighted.bucket_split_landsea_basis` still slices the full land/sea
   file from index zero. The #449 helper should preserve coordinates and align
   masks before converting to arrays.
+- 2026-06-01: Added #449 core helper in
+  `openghg_inversions.basis.algorithms._constrained`.
+  `region_constrained_basis(weights, region_classes, nbasis, ...)` aligns 2D
+  `xarray.DataArray` inputs exactly, treats non-null class values as mapped,
+  preserves unmapped cells as output label `0`, partitions each class
+  independently, and offsets labels globally.
+- 2026-06-01: Added `allocate_nbasis_by_class` with explicit allocation mapping
+  support and automatic `weight`/`area` allocation. Automatic allocation enforces
+  `min_regions_per_class`, raises when the requested `nbasis` is below the class
+  minimum or above mapped-cell capacity, and falls back from weight to area when
+  all class weights are zero.
+- 2026-06-01: Added `SplitStrategy` plus
+  `AxisAlignedWeightedSplitStrategy`. This keeps the current axis-parallel
+  weighted split as the default while leaving a direct substitution point for
+  future inertial or quadtree-style strategies. No inertial split implemented.

--- a/docs/plans/mask_constrained_basis.md
+++ b/docs/plans/mask_constrained_basis.md
@@ -1,0 +1,45 @@
+# Mask-Constrained Basis Work Plan
+
+## Scope
+
+This tracks the branch sequence for issues #318, #449, #325, and the split-strategy
+part of #340.
+
+## Branches
+
+- `codex/basis-prototype-examples`: pushed as a reference branch only. No PR opened.
+- `codex/318-landsea-regression`: targeted regression test for current weighted
+  land/sea behavior. Intended to prove whether the existing algorithm crosses
+  land/sea classes before changing production code.
+- `codex/449-mask-constrained-core`: planned follow-up branch for a pure
+  mask/region-constrained helper and split-strategy protocol.
+- `codex/325-region-mask-basis`: planned follow-up branch for country/region-mask
+  callers built on the #449 helper.
+
+## Design Notes
+
+- Keep file loading outside the core constrained helper. The core should accept
+  a 2D weight field and a 2D mask/region-class `xarray.DataArray`.
+- Partition each mapped class independently, then offset labels globally so
+  region labels never collide across classes.
+- Preserve unmapped cells consistently with label `0`.
+- Start with the current axis-parallel weighted split strategy. Do not implement
+  inertial partitions yet, but keep the strategy boundary explicit so an inertial
+  split, quadtree-style split, or other partitioning step can be substituted.
+- Document `nbasis` allocation. Initial target: support explicit per-class
+  allocation plus automatic allocation proportional to class total weight, with a
+  minimum for non-empty mapped classes.
+
+## Status
+
+- 2026-06-01: Prototype examples pushed without PR.
+- 2026-06-01: Started #318 regression branch from `origin/devel`.
+- 2026-06-01: Added a synthetic #318 regression test for
+  `bucket_split_landsea_basis`. Current direct weighted land/sea labels do not
+  cross land/sea classes, so this branch does not need a production fix.
+- 2026-06-01: Mapper review found a separate coordinate-safety risk: when
+  `fixed_outer_regions_basis` calls weighted with a cropped mask,
+  `_mean_fp_times_mean_flux(..., drop=True)` can shift the weight-field origin
+  while `_weighted.bucket_split_landsea_basis` still slices the full land/sea
+  file from index zero. The #449 helper should preserve coordinates and align
+  masks before converting to arrays.

--- a/openghg_inversions/basis/__init__.py
+++ b/openghg_inversions/basis/__init__.py
@@ -1,6 +1,11 @@
 """Functions for creating basis functions and applying them to sensitivity matrices."""
 
-from ._functions import bucketbasisfunction, quadtreebasisfunction, fixed_outer_regions_basis
+from ._functions import (
+    bucketbasisfunction,
+    fixed_outer_regions_basis,
+    quadtreebasisfunction,
+    regionconstrainedbasisfunction,
+)
 from ._wrapper import (
     basis_functions_wrapper,
     load_basis_functions,
@@ -11,6 +16,7 @@ __all__ = [
     "bucketbasisfunction",
     "quadtreebasisfunction",
     "fixed_outer_regions_basis",
+    "regionconstrainedbasisfunction",
     "basis_functions_wrapper",
     "load_basis_functions",
     "make_basis_functions",

--- a/openghg_inversions/basis/__init__.py
+++ b/openghg_inversions/basis/__init__.py
@@ -7,7 +7,6 @@ from ._functions import (
     quadtree_basis_function,
     quadtreebasisfunction,
     region_constrained_basis_function,
-    regionconstrainedbasisfunction,
 )
 from ._wrapper import (
     basis_functions_wrapper,
@@ -22,7 +21,6 @@ __all__ = [
     "quadtreebasisfunction",
     "fixed_outer_regions_basis",
     "region_constrained_basis_function",
-    "regionconstrainedbasisfunction",
     "basis_functions_wrapper",
     "load_basis_functions",
     "make_basis_functions",

--- a/openghg_inversions/basis/__init__.py
+++ b/openghg_inversions/basis/__init__.py
@@ -1,9 +1,12 @@
 """Functions for creating basis functions and applying them to sensitivity matrices."""
 
 from ._functions import (
+    bucket_basis_function,
     bucketbasisfunction,
     fixed_outer_regions_basis,
+    quadtree_basis_function,
     quadtreebasisfunction,
+    region_constrained_basis_function,
     regionconstrainedbasisfunction,
 )
 from ._wrapper import (
@@ -13,9 +16,12 @@ from ._wrapper import (
 )
 
 __all__ = [
+    "bucket_basis_function",
     "bucketbasisfunction",
+    "quadtree_basis_function",
     "quadtreebasisfunction",
     "fixed_outer_regions_basis",
+    "region_constrained_basis_function",
     "regionconstrainedbasisfunction",
     "basis_functions_wrapper",
     "load_basis_functions",

--- a/openghg_inversions/basis/_functions.py
+++ b/openghg_inversions/basis/_functions.py
@@ -66,7 +66,7 @@ def basis(domain: str, basis_case: str, basis_directory: str | None = None) -> x
 
     if len(files) == 0:
         raise FileNotFoundError(
-            f"Can't find basis function files for domain '{domain}'and basis_case '{basis_case}' "
+            f"Can't find basis function files for domain '{domain}' and basis_case '{basis_case}' "
         )
 
     basis_ds = read_netcdfs(files)
@@ -125,7 +125,7 @@ def basis_boundary_conditions(domain: str, basis_case: str, bc_basis_directory: 
 
     if len(files) == 0:
         raise FileNotFoundError(
-            f"Can't find BC basis function files for domain '{domain}'and bc_basis_case '{basis_case}' "
+            f"Can't find BC basis function files for domain '{domain}' and bc_basis_case '{basis_case}' "
         )
 
     basis_ds = read_netcdfs(files)
@@ -407,16 +407,6 @@ def bucketbasisfunction(*args, **kwargs) -> xr.DataArray:
         stacklevel=2,
     )
     return bucket_basis_function(*args, **kwargs)
-
-
-def regionconstrainedbasisfunction(*args, **kwargs) -> xr.DataArray:
-    """Deprecated alias for :func:`region_constrained_basis_function`."""
-    warnings.warn(
-        "`regionconstrainedbasisfunction` is deprecated; use `region_constrained_basis_function` instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return region_constrained_basis_function(*args, **kwargs)
 
 
 # dict to retrieve basis function and description by algorithm name

--- a/openghg_inversions/basis/_functions.py
+++ b/openghg_inversions/basis/_functions.py
@@ -1,6 +1,7 @@
 """Functions to create basis datasets from fluxes and footprints."""
 
 import os
+import warnings
 
 import getpass
 from collections import namedtuple
@@ -210,7 +211,7 @@ def _mean_fp_times_mean_flux(
     return mean_fp * mean_flux
 
 
-def quadtreebasisfunction(
+def quadtree_basis_function(
     fp_all: dict,
     start_date: str,
     domain: str,
@@ -276,7 +277,7 @@ def quadtreebasisfunction(
     return quad_basis
 
 
-def bucketbasisfunction(
+def bucket_basis_function(
     fp_all: dict,
     start_date: str,
     domain: str,
@@ -339,7 +340,7 @@ def bucketbasisfunction(
     return bucket_basis
 
 
-def regionconstrainedbasisfunction(
+def region_constrained_basis_function(
     fp_all: dict,
     start_date: str,
     domain: str,
@@ -388,14 +389,44 @@ def regionconstrainedbasisfunction(
     return constrained_basis
 
 
+def quadtreebasisfunction(*args, **kwargs) -> xr.DataArray:
+    """Deprecated alias for :func:`quadtree_basis_function`."""
+    warnings.warn(
+        "`quadtreebasisfunction` is deprecated; use `quadtree_basis_function` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return quadtree_basis_function(*args, **kwargs)
+
+
+def bucketbasisfunction(*args, **kwargs) -> xr.DataArray:
+    """Deprecated alias for :func:`bucket_basis_function`."""
+    warnings.warn(
+        "`bucketbasisfunction` is deprecated; use `bucket_basis_function` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return bucket_basis_function(*args, **kwargs)
+
+
+def regionconstrainedbasisfunction(*args, **kwargs) -> xr.DataArray:
+    """Deprecated alias for :func:`region_constrained_basis_function`."""
+    warnings.warn(
+        "`regionconstrainedbasisfunction` is deprecated; use `region_constrained_basis_function` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return region_constrained_basis_function(*args, **kwargs)
+
+
 # dict to retrieve basis function and description by algorithm name
 BasisFunction = namedtuple("BasisFunction", ["description", "algorithm"])
 basis_functions = {
-    "quadtree": BasisFunction("quadtree algorithm", quadtreebasisfunction),
-    "weighted": BasisFunction("weighted by data algorithm", bucketbasisfunction),
+    "quadtree": BasisFunction("quadtree algorithm", quadtree_basis_function),
+    "weighted": BasisFunction("weighted by data algorithm", bucket_basis_function),
     "region_constrained": BasisFunction(
         "region-constrained weighted by data algorithm",
-        regionconstrainedbasisfunction,
+        region_constrained_basis_function,
     ),
 }
 

--- a/openghg_inversions/basis/_functions.py
+++ b/openghg_inversions/basis/_functions.py
@@ -12,6 +12,7 @@ import pandas as pd
 import xarray as xr
 import logging
 
+from .algorithms import AllocationMode, region_constrained_basis
 from .algorithms import quadtree_algorithm, weighted_algorithm
 
 from openghg_inversions.config.paths import Paths
@@ -54,7 +55,7 @@ def basis(domain: str, basis_case: str, basis_directory: str | None = None) -> x
         if not basis_path.exists():
             basis_path.mkdir()
             raise ValueError(
-                f"Default basis directory {basis_path} was empty. " "Add basis files or specify `basis_path`."
+                f"Default basis directory {basis_path} was empty. Add basis files or specify `basis_path`."
             )
     else:
         basis_path = Path(basis_directory)
@@ -64,7 +65,7 @@ def basis(domain: str, basis_case: str, basis_directory: str | None = None) -> x
 
     if len(files) == 0:
         raise FileNotFoundError(
-            f"Can't find basis function files for domain '{domain}'" f"and basis_case '{basis_case}' "
+            f"Can't find basis function files for domain '{domain}'and basis_case '{basis_case}' "
         )
 
     basis_ds = read_netcdfs(files)
@@ -123,7 +124,7 @@ def basis_boundary_conditions(domain: str, basis_case: str, bc_basis_directory: 
 
     if len(files) == 0:
         raise FileNotFoundError(
-            f"Can't find BC basis function files for domain '{domain}'" f"and bc_basis_case '{basis_case}' "
+            f"Can't find BC basis function files for domain '{domain}'and bc_basis_case '{basis_case}' "
         )
 
     basis_ds = read_netcdfs(files)
@@ -212,7 +213,7 @@ def _mean_fp_times_mean_flux(
 def quadtreebasisfunction(
     fp_all: dict,
     start_date: str,
-    domain : str,
+    domain: str,
     emissions_name: list[str] | None = None,
     nbasis: int = 100,
     country_directory: str | None = None,
@@ -236,7 +237,7 @@ def quadtreebasisfunction(
       start_date (str):
         Start date of period of inversion
       domain (str):
-        Domain across which to calculate basis functions. 
+        Domain across which to calculate basis functions.
       emissions_name (list):
         List of keyword "source" args used for retrieving emissions files
         from the Object store
@@ -278,12 +279,12 @@ def quadtreebasisfunction(
 def bucketbasisfunction(
     fp_all: dict,
     start_date: str,
-    domain : str,
+    domain: str,
     emissions_name: list[str] | None = None,
     nbasis: int = 100,
     country_directory: str | None = None,
     abs_flux: bool = False,
-    mask: xr.DataArray | None = None
+    mask: xr.DataArray | None = None,
 ) -> xr.DataArray:
     """Basis functions calculated using a weighted region approach
     where each basis function / scaling region contains approximately
@@ -323,7 +324,9 @@ def bucketbasisfunction(
     fps = fps / fps.max()
 
     # use xr.apply_ufunc to keep xarray coords
-    func = partial(weighted_algorithm, nregion=nbasis, bucket=1, domain=domain, country_directory=country_directory)
+    func = partial(
+        weighted_algorithm, nregion=nbasis, bucket=1, domain=domain, country_directory=country_directory
+    )
     bucket_basis = xr.apply_ufunc(func, fps)
 
     bucket_basis = bucket_basis.expand_dims({"time": [pd.to_datetime(start_date)]}, axis=-1)
@@ -336,11 +339,64 @@ def bucketbasisfunction(
     return bucket_basis
 
 
+def regionconstrainedbasisfunction(
+    fp_all: dict,
+    start_date: str,
+    domain: str,
+    emissions_name: list[str] | None = None,
+    nbasis: int = 100,
+    country_directory: str | None = None,
+    abs_flux: bool = False,
+    mask: xr.DataArray | None = None,
+    region_classes: xr.DataArray | None = None,
+    allocation: AllocationMode = "weight",
+    min_regions_per_class: int = 1,
+) -> xr.DataArray:
+    """Create weighted basis regions constrained by caller-supplied classes.
+
+    This adapter keeps file loading outside the constrained algorithm: callers
+    provide ``region_classes`` directly, for example from a country file,
+    land/sea file, or a user-defined region-class field.
+    """
+    if region_classes is None:
+        raise ValueError("region_classes must be supplied for the region_constrained basis algorithm.")
+
+    flux, footprints = _flux_fp_from_fp_all(fp_all, emissions_name)
+    weights = _mean_fp_times_mean_flux(flux, footprints, abs_flux=abs_flux, mask=mask).as_numpy()
+    max_weight = float(weights.max())
+    if max_weight > 0:
+        weights = weights / max_weight
+
+    region_classes = region_classes.transpose(*weights.dims)
+    region_classes = region_classes.sel({dim: weights.coords[dim] for dim in weights.dims})
+
+    constrained_basis = region_constrained_basis(
+        weights,
+        region_classes,
+        nbasis,
+        allocation=allocation,
+        min_regions_per_class=min_regions_per_class,
+    )
+
+    constrained_basis = constrained_basis.expand_dims({"time": [pd.to_datetime(start_date)]}, axis=-1)
+    constrained_basis = constrained_basis.rename("basis")
+
+    constrained_basis.attrs["creator"] = getpass.getuser()
+    constrained_basis.attrs["date created"] = str(pd.Timestamp.today())
+    constrained_basis.attrs["domain"] = domain
+
+    return constrained_basis
+
+
 # dict to retrieve basis function and description by algorithm name
 BasisFunction = namedtuple("BasisFunction", ["description", "algorithm"])
 basis_functions = {
     "quadtree": BasisFunction("quadtree algorithm", quadtreebasisfunction),
     "weighted": BasisFunction("weighted by data algorithm", bucketbasisfunction),
+    "region_constrained": BasisFunction(
+        "region-constrained weighted by data algorithm",
+        regionconstrainedbasisfunction,
+    ),
 }
 
 
@@ -353,6 +409,10 @@ def fixed_outer_regions_basis(
     nbasis: int = 100,
     country_directory: str | None = None,
     abs_flux: bool = False,
+    *,
+    region_classes: xr.DataArray | None = None,
+    region_allocation: AllocationMode = "weight",
+    min_regions_per_class: int = 1,
 ) -> xr.DataArray:
     """Fix outer region of basis functions to InTEM regions, and fit the inner regions using `basis_algorithm`.
 
@@ -362,7 +422,8 @@ def fixed_outer_regions_basis(
       start_date (str):
         Start date of period of inference
       basis_algorithm (str):
-        Name of the basis algorithm used. Options are "quadtree", "weighted"
+        Name of the basis algorithm used. Options are "quadtree", "weighted",
+        "region_constrained"
       domain (str):
         domain for the basis functions to be calculated over
       emissions_name (list):
@@ -377,6 +438,16 @@ def fixed_outer_regions_basis(
       abs_flux:
         When set to True uses absolute values of a flux array
         Default False
+      region_classes:
+        Region or country class field used with ``basis_algorithm="region_constrained"``.
+        File loading should happen before calling this helper.
+        Default None
+      region_allocation:
+        Allocation mode for ``region_constrained``. One of ``"weight"`` or ``"area"``.
+        Default "weight"
+      min_regions_per_class:
+        Minimum automatic allocation for each non-empty mapped class.
+        Default 1
 
     Returns:
         basis (xarray.DataArray) :
@@ -399,15 +470,31 @@ def fixed_outer_regions_basis(
     mask = intem_regions == inner_index
 
     basis_function = basis_functions[basis_algorithm].algorithm
-    inner_region = basis_function(fp_all, start_date, domain, emissions_name, nbasis, country_directory=country_directory, abs_flux=abs_flux, mask=mask)
+    algorithm_kwargs = {"country_directory": country_directory, "abs_flux": abs_flux, "mask": mask}
+    if basis_algorithm == "region_constrained":
+        algorithm_kwargs.update(
+            {
+                "region_classes": region_classes,
+                "allocation": region_allocation,
+                "min_regions_per_class": min_regions_per_class,
+            }
+        )
+    inner_region = basis_function(
+        fp_all,
+        start_date,
+        domain,
+        emissions_name,
+        nbasis,
+        **algorithm_kwargs,
+    )
 
-    basis = intem_regions.rename("basis") 
+    basis = intem_regions.rename("basis")
 
     loc_dict = {
         "lat": slice(inner_region.lat.min(), inner_region.lat.max() + 0.1),
         "lon": slice(inner_region.lon.min(), inner_region.lon.max() + 0.1),
     }
-    basis.loc[loc_dict] = (inner_region + inner_index-1).squeeze().values
+    basis.loc[loc_dict] = (inner_region + inner_index - 1).squeeze().values
 
     basis += 1  # intem_region_definitions.nc regions start at 0, not 1
 

--- a/openghg_inversions/basis/_wrapper.py
+++ b/openghg_inversions/basis/_wrapper.py
@@ -3,7 +3,7 @@
 from collections.abc import Mapping
 from pathlib import Path
 from time import time
-from typing import Literal, cast
+from typing import Any, Literal, cast
 
 import xarray as xr
 
@@ -35,6 +35,9 @@ def make_basis_functions(
     outputname: str | None = None,
     output_path: str | None = None,
     basis_output_format: Literal["legacy", "datatree"] = "legacy",
+    region_classes: xr.DataArray | None = None,
+    region_allocation: Literal["weight", "area"] = "weight",
+    min_regions_per_class: int = 1,
 ) -> BasisFunctions:
     """Create or load retained emissions basis functions.
 
@@ -70,11 +73,21 @@ def make_basis_functions(
         print("Using fixed outer regions for basis functions.")
         try:
             basis_data_array = fixed_outer_regions_basis(
-                fp_all, start_date, basis_algorithm, domain, emissions_name, nbasis, country_directory
+                fp_all,
+                start_date,
+                basis_algorithm,
+                domain,
+                emissions_name,
+                nbasis,
+                country_directory,
+                region_classes=region_classes,
+                region_allocation=region_allocation,
+                min_regions_per_class=min_regions_per_class,
             )
         except KeyError as e:
             raise ValueError(
-                "Basis algorithm not recognised. Please use either 'quadtree' or 'weighted', or input a basis function file"
+                "Basis algorithm not recognised. Please use 'quadtree', 'weighted', "
+                "'region_constrained', or input a basis function file"
             ) from e
         print(f"Using InTEM regions with {basis_algorithm} to derive basis functions for inner region.")
         print("Using generated in-memory basis artifact.")
@@ -89,11 +102,26 @@ def make_basis_functions(
             basis_function = basis_functions[basis_algorithm]
         except KeyError as e:
             raise ValueError(
-                "Basis algorithm not recognised. Please use either 'quadtree' or 'weighted', or input a basis function file"
+                "Basis algorithm not recognised. Please use 'quadtree', 'weighted', "
+                "'region_constrained', or input a basis function file"
             ) from e
         print(f"Using {basis_function.description} to derive basis functions.")
+        algorithm_kwargs: dict[str, Any] = {"country_directory": country_directory}
+        if basis_algorithm == "region_constrained":
+            algorithm_kwargs.update(
+                {
+                    "region_classes": region_classes,
+                    "allocation": region_allocation,
+                    "min_regions_per_class": min_regions_per_class,
+                }
+            )
         basis_candidate = basis_function.algorithm(
-            fp_all, start_date, domain, emissions_name, nbasis, country_directory=country_directory
+            fp_all,
+            start_date,
+            domain,
+            emissions_name,
+            nbasis,
+            **algorithm_kwargs,
         )
         if not isinstance(basis_candidate, (xr.DataArray, Mapping)):
             raise TypeError(
@@ -111,6 +139,8 @@ def make_basis_functions(
     print(f"Computing basis took {time() - basis_start}s.")
 
     if saving_generated_basis:
+        assert basis_algorithm is not None
+        assert output_path is not None
         if not isinstance(basis_data_array, xr.DataArray):
             raise TypeError("Saving generated basis output currently requires a single flat basis DataArray.")
         if basis_output_format == "legacy":
@@ -155,6 +185,9 @@ def basis_functions_wrapper(
     output_path: str | None = None,
     return_basis_objects: bool = False,
     basis_output_format: Literal["legacy", "datatree"] = "legacy",
+    region_classes: xr.DataArray | None = None,
+    region_allocation: Literal["weight", "area"] = "weight",
+    min_regions_per_class: int = 1,
 ):
     """Wrapper function for selecting basis function
     algorithm.
@@ -179,6 +212,8 @@ def basis_functions_wrapper(
         "weighted" (for using an algorihtm that splits region
         by input data). Land-sea separation is not imposed in the
         quadtree basis functions, but is imposed by default in "weighted"
+        "region_constrained" uses a caller-supplied ``region_classes``
+        field to prevent labels crossing those classes.
         Default None
       fixed_outer_region (bool):
         When set to True uses InTEM regions to derive basis functions for inner region
@@ -198,6 +233,16 @@ def basis_functions_wrapper(
         Directory containing the boundary condition basis functions
         (e.g. files starting with "NESW")
         Default None
+      region_classes (xarray.DataArray, optional):
+        Region or country class field used with ``basis_algorithm="region_constrained"``.
+        File loading should happen before calling this wrapper.
+        Default None
+      region_allocation (str, optional):
+        Allocation mode for ``region_constrained``. One of ``"weight"`` or ``"area"``.
+        Default "weight"
+      min_regions_per_class (int, optional):
+        Minimum automatic allocation for each non-empty mapped class.
+        Default 1
       outputname (str, optional):
         File output name
         Default None
@@ -239,6 +284,9 @@ def basis_functions_wrapper(
         fp_basis_case=fp_basis_case,
         basis_directory=basis_directory,
         country_directory=country_directory,
+        region_classes=region_classes,
+        region_allocation=region_allocation,
+        min_regions_per_class=min_regions_per_class,
         outputname=outputname,
         output_path=output_path,
         basis_output_format=basis_output_format,
@@ -374,7 +422,7 @@ def _save_basis(
       basis (xarray.DataArray):
         basis dataset to save
       basis_algorithm (str):
-        name of basis algorithm (e.g. "quadtree" or "weighted")
+        name of basis algorithm (e.g. "quadtree", "weighted", or "region_constrained")
       output_dir (str):
         root directory to save basis functions
       domain (str):

--- a/openghg_inversions/basis/_wrapper.py
+++ b/openghg_inversions/basis/_wrapper.py
@@ -247,7 +247,7 @@ def basis_functions_wrapper(
         File output name
         Default None
       output_path (str, optional):
-        Passed to `outputdir` argument of `quadtreebasisfunction`. Used for testing.
+        Passed to `outputdir` argument of `quadtree_basis_function`. Used for testing.
         Default None
       return_basis_objects (bool, optional):
         If True, return a tuple ``(fp_data, basis_objects)`` where

--- a/openghg_inversions/basis/algorithms/__init__.py
+++ b/openghg_inversions/basis/algorithms/__init__.py
@@ -1,7 +1,9 @@
 """Algorithms for computing basis functions."""
 
 from ._constrained import (
+    AllocationMode,
     AxisAlignedWeightedSplitStrategy,
+    SplitStrategy,
     allocate_nbasis_by_class,
     region_constrained_basis,
 )
@@ -9,7 +11,9 @@ from ._quadtree import get_quadtree_basis as quadtree_algorithm
 from ._weighted import nregion_landsea_basis as weighted_algorithm
 
 __all__ = [
+    "AllocationMode",
     "AxisAlignedWeightedSplitStrategy",
+    "SplitStrategy",
     "allocate_nbasis_by_class",
     "quadtree_algorithm",
     "region_constrained_basis",

--- a/openghg_inversions/basis/algorithms/__init__.py
+++ b/openghg_inversions/basis/algorithms/__init__.py
@@ -2,8 +2,10 @@
 
 from ._constrained import (
     AllocationMode,
+    AxisParallelSplitStep,
     AxisAlignedWeightedSplitStrategy,
     GreedyAxisParallelSplitStrategy,
+    PartitionStep,
     SplitStrategy,
     allocate_nbasis_by_class,
     region_constrained_basis,
@@ -13,9 +15,11 @@ from ._weighted import nregion_landsea_basis as weighted_algorithm
 
 __all__ = [
     "AllocationMode",
+    "AxisParallelSplitStep",
     "AxisAlignedWeightedSplitStrategy",
     "GreedyAxisParallelSplitStrategy",
     "SplitStrategy",
+    "PartitionStep",
     "allocate_nbasis_by_class",
     "quadtree_algorithm",
     "region_constrained_basis",

--- a/openghg_inversions/basis/algorithms/__init__.py
+++ b/openghg_inversions/basis/algorithms/__init__.py
@@ -1,5 +1,17 @@
 """Algorithms for computing basis functions."""
+
+from ._constrained import (
+    AxisAlignedWeightedSplitStrategy,
+    allocate_nbasis_by_class,
+    region_constrained_basis,
+)
 from ._quadtree import get_quadtree_basis as quadtree_algorithm
 from ._weighted import nregion_landsea_basis as weighted_algorithm
 
-__all__ = ["quadtree_algorithm", "weighted_algorithm"]
+__all__ = [
+    "AxisAlignedWeightedSplitStrategy",
+    "allocate_nbasis_by_class",
+    "quadtree_algorithm",
+    "region_constrained_basis",
+    "weighted_algorithm",
+]

--- a/openghg_inversions/basis/algorithms/__init__.py
+++ b/openghg_inversions/basis/algorithms/__init__.py
@@ -3,6 +3,7 @@
 from ._constrained import (
     AllocationMode,
     AxisAlignedWeightedSplitStrategy,
+    GreedyAxisParallelSplitStrategy,
     SplitStrategy,
     allocate_nbasis_by_class,
     region_constrained_basis,
@@ -13,6 +14,7 @@ from ._weighted import nregion_landsea_basis as weighted_algorithm
 __all__ = [
     "AllocationMode",
     "AxisAlignedWeightedSplitStrategy",
+    "GreedyAxisParallelSplitStrategy",
     "SplitStrategy",
     "allocate_nbasis_by_class",
     "quadtree_algorithm",

--- a/openghg_inversions/basis/algorithms/_constrained.py
+++ b/openghg_inversions/basis/algorithms/_constrained.py
@@ -16,7 +16,8 @@ label-offset behavior.
 from __future__ import annotations
 
 from collections.abc import Hashable, Iterable, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from queue import PriorityQueue
 from typing import Literal, Protocol, TypeAlias, cast
 
 import numpy as np
@@ -47,6 +48,39 @@ class SplitStrategy(Protocol):
         ...
 
 
+class PartitionStep(Protocol):
+    """Strategy protocol for splitting one partition into child partitions."""
+
+    def __call__(self, nodes: GridPartition, weights: np.ndarray) -> list[GridPartition]:
+        """Return child partitions for ``nodes``."""
+        ...
+
+
+@dataclass(frozen=True)
+class AxisParallelSplitStep:
+    """Split one partition along an axis-parallel line.
+
+    This is a cleaned-up version of the prototype's axis-parallel split step.
+    Greedy orchestration is handled separately by
+    :class:`GreedyAxisParallelSplitStrategy`.
+    """
+
+    balanced: bool = True
+    clean_splits: bool = False
+
+    def __call__(self, nodes: GridPartition, weights: np.ndarray) -> list[GridPartition]:
+        """Return child partitions from an axis-parallel split."""
+        left, right = _axis_parallel_split_nodes(
+            nodes,
+            weights,
+            balanced=self.balanced,
+            clean_splits=self.clean_splits,
+        )
+        if not left or not right:
+            return [nodes]
+        return [left, right]
+
+
 @dataclass(frozen=True)
 class GreedyAxisParallelSplitStrategy:
     """Class-local greedy repeated-bisection strategy.
@@ -58,6 +92,7 @@ class GreedyAxisParallelSplitStrategy:
 
     balanced: bool = True
     clean_splits: bool = False
+    split_step: PartitionStep | None = None
 
     def __call__(
         self,
@@ -76,12 +111,15 @@ class GreedyAxisParallelSplitStrategy:
             class_weights = class_mask.astype(np.float64)
 
         nodes = _node_list_from_mask(class_mask)
-        partition = _greedy_axis_parallel_partitioning(
+        split_step = self.split_step or AxisParallelSplitStep(
+            balanced=self.balanced,
+            clean_splits=self.clean_splits,
+        )
+        partition = _greedy_partitioning(
             [nodes],
             target_regions,
             class_weights,
-            balanced=self.balanced,
-            clean_splits=self.clean_splits,
+            split_step=split_step,
         )
         return _labels_from_node_partition(partition, weights.shape)
 
@@ -517,58 +555,103 @@ def _labels_from_node_partition(partition: list[GridPartition], shape: tuple[int
     return labels
 
 
-def _greedy_axis_parallel_partitioning(
+@dataclass(order=True)
+class _PrioritizedPartition:
+    """Priority queue item for selecting the next partition to split."""
+
+    priority: tuple[float, int, int]
+    nodes: GridPartition = field(compare=False)
+
+
+class _PartitionPriorityQueue:
+    """Priority queue that pops the highest-weight partition first."""
+
+    def __init__(self, weights: np.ndarray) -> None:
+        """Create a partition priority queue ranked by weight and size.
+
+        Args:
+            weights: Non-negative weight field used to rank partitions.
+        """
+        self._queue: PriorityQueue[_PrioritizedPartition] = PriorityQueue()
+        self._weights = weights
+        self._counter = 0
+
+    def __bool__(self) -> bool:
+        """Return true when the queue contains at least one partition."""
+        return not self._queue.empty()
+
+    def push(self, nodes: GridPartition) -> None:
+        """Insert a partition into the priority queue."""
+        if not nodes:
+            return
+        priority = (-_node_weight(nodes, self._weights), -len(nodes), self._counter)
+        self._counter += 1
+        self._queue.put_nowait(_PrioritizedPartition(priority, nodes))
+
+    def pop(self) -> GridPartition:
+        """Remove and return the highest-priority partition."""
+        return self._queue.get_nowait().nodes
+
+
+def _greedy_partitioning(
     init_partition: list[GridPartition],
     target_regions: int,
     weights: np.ndarray,
     *,
-    balanced: bool,
-    clean_splits: bool,
+    split_step: PartitionStep,
 ) -> list[GridPartition]:
-    """Split the highest-weight active partition until a target count is reached.
+    """Apply a partition step greedily until a target count is reached.
 
     Args:
         init_partition: Initial list of partitions to refine. For class-local
             splitting this normally contains one node list for the class.
         target_regions: Desired number of output partitions.
-        weights: Non-negative weight field used for part ranking, weighted axis
-            choice, and balanced split points.
-        balanced: If true, split each selected part near half its total weight.
-            If false, split near half its cell count.
-        clean_splits: If true, avoid splitting nodes with the same selected-axis
-            coordinate across both sides. This can produce degenerate splits.
+        weights: Non-negative weight field used for part ranking and passed to
+            ``split_step``.
+        split_step: Callable that splits one selected partition into child
+            partitions. Returning fewer than two non-empty children marks the
+            selected partition as done.
 
     Returns:
         List of output partitions. The result may contain fewer than
         ``target_regions`` entries when no active partition can be split further.
     """
-    active = [nodes for nodes in init_partition if nodes]
+    active = _PartitionPriorityQueue(weights)
     done: list[GridPartition] = []
+    current_regions = 0
 
-    while len(done) + len(active) < target_regions and active:
-        split_index = max(
-            range(len(active)),
-            key=lambda index: (_node_weight(active[index], weights), len(active[index])),
-        )
-        nodes = active.pop(split_index)
-        left, right = _axis_parallel_split_nodes(
-            nodes,
-            weights,
-            balanced=balanced,
-            clean_splits=clean_splits,
-        )
+    for nodes in init_partition:
+        if not nodes:
+            continue
+        current_regions += 1
+        if len(nodes) > 1:
+            active.push(nodes)
+        else:
+            done.append(nodes)
 
-        if not left or not right:
+    while current_regions < target_regions and active:
+        nodes = active.pop()
+        child_partitions = [child for child in split_step(nodes, weights) if child]
+
+        if len(child_partitions) < 2:
+            done.append(nodes)
+            continue
+        if current_regions - 1 + len(child_partitions) > target_regions:
             done.append(nodes)
             continue
 
-        for subnodes in (left, right):
+        current_regions -= 1
+        for subnodes in child_partitions:
+            current_regions += 1
             if len(subnodes) > 1:
-                active.append(subnodes)
+                active.push(subnodes)
             else:
                 done.append(subnodes)
 
-    return done + active
+    while active:
+        done.append(active.pop())
+
+    return done
 
 
 def _axis_parallel_split_nodes(
@@ -720,9 +803,11 @@ def _labels_dataarray(labels: np.ndarray, weights: xr.DataArray) -> xr.DataArray
 
 __all__ = [
     "AllocationMode",
+    "AxisParallelSplitStep",
     "AxisAlignedWeightedSplitStrategy",
     "GreedyAxisParallelSplitStrategy",
     "NbasisAllocation",
+    "PartitionStep",
     "SplitStrategy",
     "allocate_nbasis_by_class",
     "region_constrained_basis",

--- a/openghg_inversions/basis/algorithms/_constrained.py
+++ b/openghg_inversions/basis/algorithms/_constrained.py
@@ -1,0 +1,384 @@
+"""Mask- and region-constrained basis generation helpers.
+
+The helpers in this module are intentionally pure: callers pass an already
+computed 2D weight field and an already loaded 2D class mask. File loading,
+footprint/flux reduction, and domain-specific country lookup stay at the caller
+boundary.
+
+The first implementation uses the existing axis-aligned weighted split shape:
+each class is split independently with rectangular bucket splits, then labels
+are offset globally. The class orchestration accepts a split strategy protocol so
+an inertial partition, quadtree step, or other tile generator can be substituted
+without changing mask alignment or label-offset behavior.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Hashable, Iterable, Mapping
+from dataclasses import dataclass
+from typing import Literal, Protocol, cast
+
+import numpy as np
+import numpy.typing as npt
+import pandas as pd
+import xarray as xr
+
+from ._weighted import bucket_value_split
+
+AllocationMode = Literal["weight", "area"]
+NbasisAllocation = int | Mapping[Hashable, int]
+
+
+class SplitStrategy(Protocol):
+    """Strategy protocol for class-local basis splitting."""
+
+    def __call__(
+        self,
+        weights: np.ndarray,
+        class_mask: np.ndarray,
+        target_regions: int,
+    ) -> np.ndarray:
+        """Return positive local labels for cells in ``class_mask``."""
+        ...
+
+
+@dataclass(frozen=True)
+class AxisAlignedWeightedSplitStrategy:
+    """Class-local axis-aligned weighted split strategy.
+
+    This is the mask-aware core of the existing weighted basis shape: recursively
+    split rectangles along the longer axis until each rectangle is below a
+    threshold. The threshold is searched to approximate ``target_regions``.
+    """
+
+    max_iter: int = 32
+
+    def __call__(
+        self,
+        weights: np.ndarray,
+        class_mask: np.ndarray,
+        target_regions: int,
+    ) -> np.ndarray:
+        """Return class-local labels using weighted rectangular bucket splits."""
+        if target_regions < 1:
+            raise ValueError("target_regions must be at least 1.")
+        if not class_mask.any():
+            return np.zeros(weights.shape, dtype=np.int64)
+
+        class_weights = np.where(class_mask, weights, 0.0)
+        total_weight = float(class_weights.sum())
+        if total_weight == 0.0:
+            return _labels_for_bucket(class_weights, class_mask, bucket=0.0)
+
+        low = 0.0
+        high = total_weight
+        best = _labels_for_bucket(class_weights, class_mask, bucket=high)
+        best_error = abs(_count_positive_labels(best) - target_regions)
+
+        for _ in range(self.max_iter):
+            bucket = (low + high) / 2.0
+            labels = _labels_for_bucket(class_weights, class_mask, bucket=bucket)
+            nregions = _count_positive_labels(labels)
+            error = abs(nregions - target_regions)
+            if error < best_error:
+                best = labels
+                best_error = error
+                if error == 0:
+                    break
+
+            if nregions > target_regions:
+                low = bucket
+            else:
+                high = bucket
+
+        return best
+
+
+def region_constrained_basis(
+    weights: xr.DataArray,
+    region_classes: xr.DataArray,
+    nbasis: NbasisAllocation,
+    *,
+    allocation: AllocationMode = "weight",
+    min_regions_per_class: int = 1,
+    split_strategy: SplitStrategy | None = None,
+    unmapped_values: Iterable[Hashable] = (),
+) -> xr.DataArray:
+    """Generate basis labels independently inside each mask/region class.
+
+    Args:
+        weights: Two-dimensional non-negative weight field.
+        region_classes: Two-dimensional class field on the same grid as
+            ``weights``. Each non-null value is treated as a mapped class unless
+            listed in ``unmapped_values``.
+        nbasis: Either a total number of basis regions to allocate across
+            classes, or an explicit mapping from class value to class-local
+            region target.
+        allocation: Automatic allocation mode used when ``nbasis`` is an
+            integer. ``"weight"`` allocates proportional to class total weight,
+            falling back to area if all class weights are zero. ``"area"``
+            allocates proportional to mapped cell count.
+        min_regions_per_class: Minimum automatic allocation for each non-empty
+            mapped class. If the requested total is smaller than this minimum
+            requires, a ``ValueError`` is raised.
+        split_strategy: Class-local splitting strategy. Defaults to
+            :class:`AxisAlignedWeightedSplitStrategy`.
+        unmapped_values: Additional class values to leave as output label ``0``.
+
+    Returns:
+        ``xarray.DataArray`` with the same dimensions and coordinates as
+        ``weights``. Mapped cells receive globally unique positive integer
+        labels; unmapped cells receive ``0``.
+
+    Notes:
+        Labels are guaranteed not to cross class boundaries because each class is
+        split independently and relabelled with a global offset. The default
+        rectangular strategy can assign one label to disconnected pieces of the
+        same class if the class mask itself is disconnected; contiguity is not
+        guaranteed by this helper.
+    """
+    weights, region_classes = _align_2d_inputs(weights, region_classes)
+    weight_values = _validate_weights(weights)
+    class_values = region_classes.to_numpy()
+    mapped_classes = _mapped_classes(class_values, unmapped_values)
+    strategy = split_strategy or AxisAlignedWeightedSplitStrategy()
+
+    labels = np.zeros(weight_values.shape, dtype=np.int64)
+    if not mapped_classes:
+        return _labels_dataarray(labels, weights)
+
+    targets = allocate_nbasis_by_class(
+        weights,
+        region_classes,
+        nbasis,
+        allocation=allocation,
+        min_regions_per_class=min_regions_per_class,
+        unmapped_values=unmapped_values,
+    )
+
+    next_label = 1
+    for class_value in mapped_classes:
+        target_regions = targets[class_value]
+        class_mask = class_values == class_value
+        local_labels = strategy(weight_values, class_mask, target_regions)
+        for local_label in _positive_labels(local_labels):
+            labels[(local_labels == local_label) & class_mask] = next_label
+            next_label += 1
+
+    return _labels_dataarray(labels, weights)
+
+
+def allocate_nbasis_by_class(
+    weights: xr.DataArray,
+    region_classes: xr.DataArray,
+    nbasis: NbasisAllocation,
+    *,
+    allocation: AllocationMode = "weight",
+    min_regions_per_class: int = 1,
+    unmapped_values: Iterable[Hashable] = (),
+) -> dict[Hashable, int]:
+    """Allocate class-local region targets for constrained basis generation."""
+    if min_regions_per_class < 0:
+        raise ValueError("min_regions_per_class must be non-negative.")
+    weights, region_classes = _align_2d_inputs(weights, region_classes)
+    weight_values = _validate_weights(weights)
+    class_values = region_classes.to_numpy()
+    mapped_classes = _mapped_classes(class_values, unmapped_values)
+
+    if isinstance(nbasis, Mapping):
+        return _explicit_allocation(mapped_classes, nbasis)
+
+    if nbasis < 0:
+        raise ValueError("nbasis must be non-negative.")
+    if not mapped_classes:
+        if nbasis != 0:
+            raise ValueError("Cannot allocate basis regions without mapped classes.")
+        return {}
+
+    capacities = {
+        class_value: int(np.count_nonzero(class_values == class_value)) for class_value in mapped_classes
+    }
+    minima = {
+        class_value: min(min_regions_per_class, capacity) for class_value, capacity in capacities.items()
+    }
+
+    min_total = sum(minima.values())
+    max_total = sum(capacities.values())
+    if nbasis < min_total:
+        raise ValueError(
+            f"nbasis={nbasis} is smaller than the minimum {min_total} required "
+            f"for {len(mapped_classes)} mapped classes."
+        )
+    if nbasis > max_total:
+        raise ValueError(f"nbasis={nbasis} exceeds the {max_total} mapped cells available for splitting.")
+
+    scores = _allocation_scores(weight_values, class_values, mapped_classes, allocation)
+    return _distribute_regions(mapped_classes, scores, minima, capacities, nbasis)
+
+
+def _align_2d_inputs(
+    weights: xr.DataArray,
+    region_classes: xr.DataArray,
+) -> tuple[xr.DataArray, xr.DataArray]:
+    if weights.ndim != 2:
+        raise ValueError("weights must be two-dimensional.")
+    if region_classes.ndim != 2:
+        raise ValueError("region_classes must be two-dimensional.")
+    if set(weights.dims) != set(region_classes.dims):
+        raise ValueError("weights and region_classes must use the same dimensions.")
+
+    region_classes = region_classes.transpose(*weights.dims)
+    weights, region_classes = xr.align(weights, region_classes, join="exact")
+    return weights, region_classes
+
+
+def _validate_weights(weights: xr.DataArray) -> np.ndarray:
+    values = np.asarray(weights.to_numpy(), dtype=np.float64)
+    if not np.isfinite(values).all():
+        raise ValueError("weights must be finite.")
+    if (values < 0.0).any():
+        raise ValueError("weights must be non-negative.")
+    return values
+
+
+def _mapped_classes(
+    class_values: npt.NDArray[np.object_] | np.ndarray,
+    unmapped_values: Iterable[Hashable],
+) -> list[Hashable]:
+    unmapped = set(unmapped_values)
+    classes: list[Hashable] = []
+    for value in pd.unique(class_values.ravel()):
+        if pd.isna(value) or value in unmapped:
+            continue
+        classes.append(cast(Hashable, value))
+    return classes
+
+
+def _explicit_allocation(
+    mapped_classes: list[Hashable],
+    nbasis: Mapping[Hashable, int],
+) -> dict[Hashable, int]:
+    missing = [class_value for class_value in mapped_classes if class_value not in nbasis]
+    if missing:
+        raise ValueError(f"Explicit nbasis allocation is missing classes: {missing!r}.")
+
+    allocations = {class_value: int(nbasis[class_value]) for class_value in mapped_classes}
+    invalid = {class_value: target for class_value, target in allocations.items() if target < 1}
+    if invalid:
+        raise ValueError(f"Class allocations must be positive for mapped classes: {invalid!r}.")
+    return allocations
+
+
+def _allocation_scores(
+    weights: np.ndarray,
+    class_values: np.ndarray,
+    mapped_classes: list[Hashable],
+    allocation: AllocationMode,
+) -> dict[Hashable, float]:
+    if allocation == "area":
+        return {
+            class_value: float(np.count_nonzero(class_values == class_value))
+            for class_value in mapped_classes
+        }
+    if allocation != "weight":
+        raise ValueError("allocation must be 'weight' or 'area'.")
+
+    scores = {
+        class_value: float(weights[class_values == class_value].sum()) for class_value in mapped_classes
+    }
+    if sum(scores.values()) == 0.0:
+        return _allocation_scores(weights, class_values, mapped_classes, "area")
+    return scores
+
+
+def _distribute_regions(
+    mapped_classes: list[Hashable],
+    scores: Mapping[Hashable, float],
+    minima: Mapping[Hashable, int],
+    capacities: Mapping[Hashable, int],
+    nbasis: int,
+) -> dict[Hashable, int]:
+    allocations = dict(minima)
+    remaining = nbasis - sum(allocations.values())
+
+    while remaining > 0:
+        candidates = [
+            class_value
+            for class_value in mapped_classes
+            if allocations[class_value] < capacities[class_value]
+        ]
+        if not candidates:
+            break
+
+        score_total = sum(scores[class_value] for class_value in candidates)
+        if score_total == 0.0:
+            score_total = float(len(candidates))
+            candidate_scores = {class_value: 1.0 for class_value in candidates}
+        else:
+            candidate_scores = {class_value: scores[class_value] for class_value in candidates}
+
+        quotas = {
+            class_value: remaining * candidate_scores[class_value] / score_total for class_value in candidates
+        }
+        extras = {
+            class_value: min(
+                int(np.floor(quota)),
+                capacities[class_value] - allocations[class_value],
+            )
+            for class_value, quota in quotas.items()
+        }
+
+        added = sum(extras.values())
+        if added == 0:
+            class_value = max(
+                candidates,
+                key=lambda value: (
+                    quotas[value],
+                    capacities[value] - allocations[value],
+                    str(value),
+                ),
+            )
+            extras[class_value] = 1
+            added = 1
+
+        for class_value, extra in extras.items():
+            allocations[class_value] += extra
+        remaining -= added
+
+    return allocations
+
+
+def _labels_for_bucket(weights: np.ndarray, class_mask: np.ndarray, bucket: float) -> np.ndarray:
+    labels = np.zeros(weights.shape, dtype=np.int64)
+    label = 1
+    for ymin, ymax, xmin, xmax in bucket_value_split(weights, bucket):
+        region_mask = class_mask[ymin:ymax, xmin:xmax]
+        if not region_mask.any():
+            continue
+        label_slice = labels[ymin:ymax, xmin:xmax]
+        label_slice[region_mask] = label
+        label += 1
+    return labels
+
+
+def _count_positive_labels(labels: np.ndarray) -> int:
+    return len(_positive_labels(labels))
+
+
+def _positive_labels(labels: np.ndarray) -> np.ndarray:
+    unique = np.unique(labels)
+    return unique[unique > 0]
+
+
+def _labels_dataarray(labels: np.ndarray, weights: xr.DataArray) -> xr.DataArray:
+    return xr.DataArray(labels, dims=weights.dims, coords=weights.coords, name="basis")
+
+
+__all__ = [
+    "AllocationMode",
+    "AxisAlignedWeightedSplitStrategy",
+    "NbasisAllocation",
+    "SplitStrategy",
+    "allocate_nbasis_by_class",
+    "region_constrained_basis",
+]

--- a/openghg_inversions/basis/algorithms/_constrained.py
+++ b/openghg_inversions/basis/algorithms/_constrained.py
@@ -5,18 +5,19 @@ computed 2D weight field and an already loaded 2D class mask. File loading,
 footprint/flux reduction, and domain-specific country lookup stay at the caller
 boundary.
 
-The first implementation uses the existing axis-aligned weighted split shape:
-each class is split independently with rectangular bucket splits, then labels
-are offset globally. The class orchestration accepts a split strategy protocol so
-an inertial partition, quadtree step, or other tile generator can be substituted
-without changing mask alignment or label-offset behavior.
+The default implementation uses the prototype-inspired greedy axis-parallel
+split shape: each class is split independently with repeated bisection, then
+labels are offset globally. The class orchestration accepts a split strategy
+protocol so an inertial partition, quadtree step, recursive weighted split, or
+other tile generator can be substituted without changing mask alignment or
+label-offset behavior.
 """
 
 from __future__ import annotations
 
 from collections.abc import Hashable, Iterable, Mapping
 from dataclasses import dataclass
-from typing import Literal, Protocol, cast
+from typing import Literal, Protocol, TypeAlias, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -25,8 +26,12 @@ import xarray as xr
 
 from ._weighted import bucket_value_split
 
-AllocationMode = Literal["weight", "area"]
-NbasisAllocation = int | Mapping[Hashable, int]
+# Allocation modes control how an integer ``nbasis`` is distributed across
+# region classes before class-local splitting is applied.
+AllocationMode: TypeAlias = Literal["weight", "area"]
+NbasisAllocation: TypeAlias = int | Mapping[Hashable, int]
+GridNode: TypeAlias = tuple[int, int]
+GridPartition: TypeAlias = list[GridNode]
 
 
 class SplitStrategy(Protocol):
@@ -43,12 +48,52 @@ class SplitStrategy(Protocol):
 
 
 @dataclass(frozen=True)
-class AxisAlignedWeightedSplitStrategy:
-    """Class-local axis-aligned weighted split strategy.
+class GreedyAxisParallelSplitStrategy:
+    """Class-local greedy repeated-bisection strategy.
 
-    This is the mask-aware core of the existing weighted basis shape: recursively
-    split rectangles along the longer axis until each rectangle is below a
-    threshold. The threshold is searched to approximate ``target_regions``.
+    This is a cleaned-up version of the prototype's axis-parallel partitioning
+    algorithm. It repeatedly splits the highest-weight current part until the
+    requested class-local region count is reached or no splittable parts remain.
+    """
+
+    balanced: bool = True
+    clean_splits: bool = False
+
+    def __call__(
+        self,
+        weights: np.ndarray,
+        class_mask: np.ndarray,
+        target_regions: int,
+    ) -> np.ndarray:
+        """Return class-local labels using greedy axis-parallel bisection."""
+        if target_regions < 1:
+            raise ValueError("target_regions must be at least 1.")
+        if not class_mask.any():
+            return np.zeros(weights.shape, dtype=np.int64)
+
+        class_weights = np.where(class_mask, weights, 0.0)
+        if float(class_weights.sum()) == 0.0:
+            class_weights = class_mask.astype(np.float64)
+
+        nodes = _node_list_from_mask(class_mask)
+        partition = _greedy_axis_parallel_partitioning(
+            [nodes],
+            target_regions,
+            class_weights,
+            balanced=self.balanced,
+            clean_splits=self.clean_splits,
+        )
+        return _labels_from_node_partition(partition, weights.shape)
+
+
+@dataclass(frozen=True)
+class AxisAlignedWeightedSplitStrategy:
+    """Compatibility strategy based on the existing recursive weighted basis.
+
+    This keeps the current weighted basis shape available for comparison:
+    recursively split rectangles along the longer axis until each rectangle is
+    below a searched threshold. New constrained code defaults to
+    :class:`GreedyAxisParallelSplitStrategy` instead.
     """
 
     max_iter: int = 32
@@ -59,7 +104,7 @@ class AxisAlignedWeightedSplitStrategy:
         class_mask: np.ndarray,
         target_regions: int,
     ) -> np.ndarray:
-        """Return class-local labels using weighted rectangular bucket splits."""
+        """Return class-local labels using recursive weighted bucket splits."""
         if target_regions < 1:
             raise ValueError("target_regions must be at least 1.")
         if not class_mask.any():
@@ -123,7 +168,7 @@ def region_constrained_basis(
             mapped class. If the requested total is smaller than this minimum
             requires, a ``ValueError`` is raised.
         split_strategy: Class-local splitting strategy. Defaults to
-            :class:`AxisAlignedWeightedSplitStrategy`.
+            :class:`GreedyAxisParallelSplitStrategy`.
         unmapped_values: Additional class values to leave as output label ``0``.
 
     Returns:
@@ -134,7 +179,7 @@ def region_constrained_basis(
     Notes:
         Labels are guaranteed not to cross class boundaries because each class is
         split independently and relabelled with a global offset. The default
-        rectangular strategy can assign one label to disconnected pieces of the
+        strategy can assign one label to disconnected pieces of the
         same class if the class mask itself is disconnected; contiguity is not
         guaranteed by this helper.
     """
@@ -142,7 +187,7 @@ def region_constrained_basis(
     weight_values = _validate_weights(weights)
     class_values = region_classes.to_numpy()
     mapped_classes = _mapped_classes(class_values, unmapped_values)
-    strategy = split_strategy or AxisAlignedWeightedSplitStrategy()
+    strategy = split_strategy or GreedyAxisParallelSplitStrategy()
 
     labels = np.zeros(weight_values.shape, dtype=np.int64)
     if not mapped_classes:
@@ -178,7 +223,27 @@ def allocate_nbasis_by_class(
     min_regions_per_class: int = 1,
     unmapped_values: Iterable[Hashable] = (),
 ) -> dict[Hashable, int]:
-    """Allocate class-local region targets for constrained basis generation."""
+    """Allocate class-local region targets for constrained basis generation.
+
+    Args:
+        weights: Two-dimensional non-negative weight field.
+        region_classes: Two-dimensional class field aligned to ``weights``.
+        nbasis: Total number of regions to distribute, or an explicit mapping
+            from class value to class-local region target.
+        allocation: Automatic allocation mode. ``"weight"`` uses class total
+            weight, falling back to area if all mapped weights are zero.
+            ``"area"`` uses mapped cell count.
+        min_regions_per_class: Minimum automatic allocation for each non-empty
+            mapped class.
+        unmapped_values: Additional class values to leave unallocated.
+
+    Returns:
+        Mapping from mapped class value to target number of local regions.
+
+    Raises:
+        ValueError: If inputs cannot be aligned, weights are invalid, or the
+            requested allocation is impossible.
+    """
     if min_regions_per_class < 0:
         raise ValueError("min_regions_per_class must be non-negative.")
     weights, region_classes = _align_2d_inputs(weights, region_classes)
@@ -223,6 +288,22 @@ def _align_2d_inputs(
     weights: xr.DataArray,
     region_classes: xr.DataArray,
 ) -> tuple[xr.DataArray, xr.DataArray]:
+    """Validate, transpose, and exactly align the 2D weight and class fields.
+
+    Args:
+        weights: Two-dimensional weight field whose dimension order defines the
+            output dimension order.
+        region_classes: Two-dimensional class field using the same dimension
+            names and coordinates as ``weights``.
+
+    Returns:
+        ``weights`` and ``region_classes`` with identical coordinates and
+        ``region_classes`` transposed to match ``weights``.
+
+    Raises:
+        ValueError: If either input is not 2D or the dimension names differ.
+        xarray.AlignmentError: If coordinates do not match exactly.
+    """
     if weights.ndim != 2:
         raise ValueError("weights must be two-dimensional.")
     if region_classes.ndim != 2:
@@ -236,6 +317,7 @@ def _align_2d_inputs(
 
 
 def _validate_weights(weights: xr.DataArray) -> np.ndarray:
+    """Return finite non-negative weights as a float NumPy array."""
     values = np.asarray(weights.to_numpy(), dtype=np.float64)
     if not np.isfinite(values).all():
         raise ValueError("weights must be finite.")
@@ -248,6 +330,17 @@ def _mapped_classes(
     class_values: npt.NDArray[np.object_] | np.ndarray,
     unmapped_values: Iterable[Hashable],
 ) -> list[Hashable]:
+    """Return unique class values that should receive basis labels.
+
+    Args:
+        class_values: Raw class array from the aligned ``region_classes`` input.
+        unmapped_values: Additional class values that should remain output label
+            ``0``.
+
+    Returns:
+        Unique class values in first-seen order, excluding nulls and explicitly
+        unmapped values.
+    """
     unmapped = set(unmapped_values)
     classes: list[Hashable] = []
     for value in pd.unique(class_values.ravel()):
@@ -262,6 +355,22 @@ def _explicit_allocation(
     nbasis: Mapping[Hashable, int],
     capacities: Mapping[Hashable, int],
 ) -> dict[Hashable, int]:
+    """Validate and normalize a caller-supplied per-class allocation.
+
+    Args:
+        mapped_classes: Mapped class values that need allocations.
+        nbasis: Caller-supplied mapping from class value to region target.
+        capacities: Maximum possible labels per class, currently the number of
+            mapped cells for that class.
+
+    Returns:
+        Integer allocation for each mapped class, preserving ``mapped_classes``
+        order.
+
+    Raises:
+        ValueError: If an allocation is missing, non-positive, or greater than
+            class capacity.
+    """
     missing = [class_value for class_value in mapped_classes if class_value not in nbasis]
     if missing:
         raise ValueError(f"Explicit nbasis allocation is missing classes: {missing!r}.")
@@ -284,6 +393,21 @@ def _allocation_scores(
     mapped_classes: list[Hashable],
     allocation: AllocationMode,
 ) -> dict[Hashable, float]:
+    """Compute proportional allocation scores for each mapped class.
+
+    Args:
+        weights: Non-negative weight values aligned to ``class_values``.
+        class_values: Raw class values aligned to ``weights``.
+        mapped_classes: Class values eligible for allocation.
+        allocation: ``"weight"`` to score by total class weight, or ``"area"``
+            to score by mapped cell count.
+
+    Returns:
+        Non-negative score for each mapped class.
+
+    Raises:
+        ValueError: If ``allocation`` is not supported.
+    """
     if allocation == "area":
         return {
             class_value: float(np.count_nonzero(class_values == class_value))
@@ -307,6 +431,19 @@ def _distribute_regions(
     capacities: Mapping[Hashable, int],
     nbasis: int,
 ) -> dict[Hashable, int]:
+    """Distribute remaining regions by score while respecting minima and capacity.
+
+    Args:
+        mapped_classes: Class values in deterministic allocation order.
+        scores: Proportional allocation scores per class.
+        minima: Initial allocation per class.
+        capacities: Maximum allocation per class.
+        nbasis: Total number of regions requested across all mapped classes.
+
+    Returns:
+        Allocation whose values sum to ``nbasis`` unless capacities are already
+        exhausted by validated inputs.
+    """
     allocations = dict(minima)
     remaining = nbasis - sum(allocations.values())
 
@@ -357,7 +494,202 @@ def _distribute_regions(
     return allocations
 
 
+def _node_list_from_mask(class_mask: np.ndarray) -> GridPartition:
+    """Return grid-index nodes selected by a Boolean class mask."""
+    return list(zip(*np.where(class_mask)))
+
+
+def _labels_from_node_partition(partition: list[GridPartition], shape: tuple[int, ...]) -> np.ndarray:
+    """Convert node partitions to a dense integer label array.
+
+    Args:
+        partition: Sequence of node lists. Each node list becomes one positive
+            label in output order.
+        shape: Shape of the output label array.
+
+    Returns:
+        Integer label array with label ``0`` outside all partition nodes.
+    """
+    labels = np.zeros(shape, dtype=np.int64)
+    for label, nodes in enumerate(partition, start=1):
+        rows, cols = _node_indices(nodes)
+        labels[rows, cols] = label
+    return labels
+
+
+def _greedy_axis_parallel_partitioning(
+    init_partition: list[GridPartition],
+    target_regions: int,
+    weights: np.ndarray,
+    *,
+    balanced: bool,
+    clean_splits: bool,
+) -> list[GridPartition]:
+    """Split the highest-weight active partition until a target count is reached.
+
+    Args:
+        init_partition: Initial list of partitions to refine. For class-local
+            splitting this normally contains one node list for the class.
+        target_regions: Desired number of output partitions.
+        weights: Non-negative weight field used for part ranking, weighted axis
+            choice, and balanced split points.
+        balanced: If true, split each selected part near half its total weight.
+            If false, split near half its cell count.
+        clean_splits: If true, avoid splitting nodes with the same selected-axis
+            coordinate across both sides. This can produce degenerate splits.
+
+    Returns:
+        List of output partitions. The result may contain fewer than
+        ``target_regions`` entries when no active partition can be split further.
+    """
+    active = [nodes for nodes in init_partition if nodes]
+    done: list[GridPartition] = []
+
+    while len(done) + len(active) < target_regions and active:
+        split_index = max(
+            range(len(active)),
+            key=lambda index: (_node_weight(active[index], weights), len(active[index])),
+        )
+        nodes = active.pop(split_index)
+        left, right = _axis_parallel_split_nodes(
+            nodes,
+            weights,
+            balanced=balanced,
+            clean_splits=clean_splits,
+        )
+
+        if not left or not right:
+            done.append(nodes)
+            continue
+
+        for subnodes in (left, right):
+            if len(subnodes) > 1:
+                active.append(subnodes)
+            else:
+                done.append(subnodes)
+
+    return done + active
+
+
+def _axis_parallel_split_nodes(
+    nodes: GridPartition,
+    weights: np.ndarray,
+    *,
+    balanced: bool,
+    clean_splits: bool,
+) -> tuple[GridPartition, GridPartition]:
+    """Split nodes along an axis-parallel line.
+
+    Args:
+        nodes: Grid-index nodes in the part being split.
+        weights: Non-negative weight field aligned to the source grid.
+        balanced: If true, choose the weighted long axis and split near half
+            total node weight. If false, choose the geometric long axis and
+            split by cell count.
+        clean_splits: If true, keep equal selected-axis coordinates together,
+            even when that makes the split degenerate.
+
+    Returns:
+        Two node lists. Either side may be empty for degenerate input or a
+        degenerate clean split.
+    """
+    if len(nodes) < 2:
+        return nodes, []
+
+    axis = _long_axis_weighted(nodes, weights) if balanced else _long_axis(nodes)
+    ordered = sorted(nodes, key=lambda node: (node[axis], node[1 - axis]))
+
+    if balanced:
+        rows, cols = _node_indices(ordered)
+        split_index = _idx_of_half_cumsum(weights[rows, cols])
+    else:
+        split_index = len(ordered) // 2
+
+    split_index = min(max(split_index, 1), len(ordered) - 1)
+    if clean_splits:
+        threshold = ordered[split_index - 1][axis]
+        left = [node for node in ordered if node[axis] <= threshold]
+        right = [node for node in ordered if node[axis] > threshold]
+        return left, right
+
+    return ordered[:split_index], ordered[split_index:]
+
+
+def _idx_of_half_cumsum(weights: npt.ArrayLike) -> int:
+    """Return the split index whose prefix/suffix weight sums are closest."""
+    weight_values = np.asarray(weights, dtype=np.float64).ravel()
+    if len(weight_values) < 2:
+        return len(weight_values)
+
+    sum1 = 0.0
+    sum2 = float(weight_values.sum())
+    idx = 0
+    while idx < len(weight_values) and sum1 < sum2:
+        sum1 += float(weight_values[idx])
+        sum2 -= float(weight_values[idx])
+        idx += 1
+
+    if idx > 0:
+        old_sum1 = sum1 - float(weight_values[idx - 1])
+        old_sum2 = sum2 + float(weight_values[idx - 1])
+        if (sum1 - sum2) > (old_sum2 - old_sum1):
+            idx -= 1
+
+    return min(max(idx, 1), len(weight_values) - 1)
+
+
+def _long_axis(nodes: GridPartition) -> int:
+    """Return the grid axis with the largest geometric spread."""
+    if not nodes:
+        return 0
+    coords = np.asarray(nodes)
+    return int(np.argmax(coords.max(axis=0) - coords.min(axis=0)))
+
+
+def _long_axis_weighted(nodes: GridPartition, weights: np.ndarray) -> int:
+    """Return the grid axis with the largest weighted absolute spread."""
+    if not nodes:
+        return 0
+    rows, cols = _node_indices(nodes)
+    node_weights = weights[rows, cols].astype(np.float64)
+    total_weight = float(node_weights.sum())
+    if total_weight == 0.0:
+        return _long_axis(nodes)
+
+    coords = np.asarray(nodes, dtype=np.float64)
+    weight_column = node_weights.reshape(-1, 1)
+    centroid = (coords * weight_column).sum(axis=0) / total_weight
+    spread = (weight_column * np.abs(coords - centroid)).sum(axis=0) / total_weight
+    return int(np.argmax(spread))
+
+
+def _node_weight(nodes: GridPartition, weights: np.ndarray) -> float:
+    """Return the total weight assigned to nodes."""
+    rows, cols = _node_indices(nodes)
+    return float(weights[rows, cols].sum())
+
+
+def _node_indices(nodes: GridPartition) -> tuple[list[int], list[int]]:
+    """Split grid-index nodes into row and column index lists."""
+    if not nodes:
+        return [], []
+    rows, cols = zip(*nodes)
+    return list(rows), list(cols)
+
+
 def _labels_for_bucket(weights: np.ndarray, class_mask: np.ndarray, bucket: float) -> np.ndarray:
+    """Apply the rectangular weighted splitter and mask labels to one class.
+
+    Args:
+        weights: Class-local weight field, with cells outside the class normally
+            set to zero.
+        class_mask: Boolean mask selecting cells in the current class.
+        bucket: Maximum rectangular bucket weight passed to
+            :func:`bucket_value_split`.
+
+    Returns:
+        Integer label array with positive labels only inside ``class_mask``.
+    """
     labels = np.zeros(weights.shape, dtype=np.int64)
     label = 1
     for ymin, ymax, xmin, xmax in bucket_value_split(weights, bucket):
@@ -371,21 +703,25 @@ def _labels_for_bucket(weights: np.ndarray, class_mask: np.ndarray, bucket: floa
 
 
 def _count_positive_labels(labels: np.ndarray) -> int:
+    """Return the number of positive labels in an integer label array."""
     return len(_positive_labels(labels))
 
 
 def _positive_labels(labels: np.ndarray) -> np.ndarray:
+    """Return sorted unique positive labels from an integer label array."""
     unique = np.unique(labels)
     return unique[unique > 0]
 
 
 def _labels_dataarray(labels: np.ndarray, weights: xr.DataArray) -> xr.DataArray:
+    """Wrap a label array in a ``basis`` DataArray using weight coordinates."""
     return xr.DataArray(labels, dims=weights.dims, coords=weights.coords, name="basis")
 
 
 __all__ = [
     "AllocationMode",
     "AxisAlignedWeightedSplitStrategy",
+    "GreedyAxisParallelSplitStrategy",
     "NbasisAllocation",
     "SplitStrategy",
     "allocate_nbasis_by_class",

--- a/openghg_inversions/basis/algorithms/_constrained.py
+++ b/openghg_inversions/basis/algorithms/_constrained.py
@@ -68,7 +68,8 @@ class AxisAlignedWeightedSplitStrategy:
         class_weights = np.where(class_mask, weights, 0.0)
         total_weight = float(class_weights.sum())
         if total_weight == 0.0:
-            return _labels_for_bucket(class_weights, class_mask, bucket=0.0)
+            class_weights = class_mask.astype(np.float64)
+            total_weight = float(class_weights.sum())
 
         low = 0.0
         high = total_weight
@@ -185,19 +186,21 @@ def allocate_nbasis_by_class(
     class_values = region_classes.to_numpy()
     mapped_classes = _mapped_classes(class_values, unmapped_values)
 
-    if isinstance(nbasis, Mapping):
-        return _explicit_allocation(mapped_classes, nbasis)
-
-    if nbasis < 0:
-        raise ValueError("nbasis must be non-negative.")
     if not mapped_classes:
-        if nbasis != 0:
+        if not isinstance(nbasis, Mapping) and nbasis != 0:
             raise ValueError("Cannot allocate basis regions without mapped classes.")
         return {}
 
     capacities = {
         class_value: int(np.count_nonzero(class_values == class_value)) for class_value in mapped_classes
     }
+
+    if isinstance(nbasis, Mapping):
+        return _explicit_allocation(mapped_classes, nbasis, capacities)
+
+    if nbasis < 0:
+        raise ValueError("nbasis must be non-negative.")
+
     minima = {
         class_value: min(min_regions_per_class, capacity) for class_value, capacity in capacities.items()
     }
@@ -257,6 +260,7 @@ def _mapped_classes(
 def _explicit_allocation(
     mapped_classes: list[Hashable],
     nbasis: Mapping[Hashable, int],
+    capacities: Mapping[Hashable, int],
 ) -> dict[Hashable, int]:
     missing = [class_value for class_value in mapped_classes if class_value not in nbasis]
     if missing:
@@ -266,6 +270,11 @@ def _explicit_allocation(
     invalid = {class_value: target for class_value, target in allocations.items() if target < 1}
     if invalid:
         raise ValueError(f"Class allocations must be positive for mapped classes: {invalid!r}.")
+    over_allocated = {
+        class_value: target for class_value, target in allocations.items() if target > capacities[class_value]
+    }
+    if over_allocated:
+        raise ValueError(f"Class allocations exceed mapped cell counts: {over_allocated!r}.")
     return allocations
 
 

--- a/tests/test_basis_functions.py
+++ b/tests/test_basis_functions.py
@@ -4,6 +4,7 @@ import pytest
 import xarray as xr
 from types import SimpleNamespace
 
+import openghg_inversions.basis._functions as basis_module
 from openghg_inversions.basis._functions import (
     basis,
     basis_functions,
@@ -12,10 +13,10 @@ from openghg_inversions.basis._functions import (
 )
 from openghg_inversions.basis import (
     basis_functions_wrapper,
-    bucketbasisfunction,
-    quadtreebasisfunction,
+    bucket_basis_function,
+    quadtree_basis_function,
     fixed_outer_regions_basis,
-    regionconstrainedbasisfunction,
+    region_constrained_basis_function,
 )
 from openghg_inversions.basis._wrapper import (
     _save_basis,
@@ -87,7 +88,7 @@ def test_quadtree_basis_function(tac_ch4_data_args, raw_data_path):
     """
     fp_all, *_ = data_processing_surface_notracer(**tac_ch4_data_args)
     emissions_name = next(iter(fp_all[".flux"].keys()))
-    basis_func = quadtreebasisfunction(
+    basis_func = quadtree_basis_function(
         emissions_name=[emissions_name], fp_all=fp_all, start_date="2019-01-01", seed=42, domain="EUROPE"
     )
 
@@ -109,7 +110,7 @@ def test_bucket_basis_function(tac_ch4_data_args, raw_data_path):
     """
     fp_all, *_ = data_processing_surface_notracer(**tac_ch4_data_args)
     emissions_name = next(iter(fp_all[".flux"].keys()))
-    basis_func = bucketbasisfunction(
+    basis_func = bucket_basis_function(
         emissions_name=[emissions_name],
         fp_all=fp_all,
         start_date="2019-01-01",
@@ -155,6 +156,7 @@ def test_fixed_outer_region_basis_function(tac_ch4_data_args, raw_data_path):
 
 
 def _tiny_region_constrained_fp_all() -> tuple[dict, xr.DataArray]:
+    """Build a tiny fp_all fixture and aligned region classes."""
     time = pd.date_range("2020-01-01", periods=2)
     lat = np.arange(4.0)
     lon = np.arange(4.0)
@@ -183,6 +185,7 @@ def _tiny_region_constrained_fp_all() -> tuple[dict, xr.DataArray]:
 
 
 def _assert_basis_labels_do_not_cross_classes(labels: xr.DataArray, classes: xr.DataArray) -> None:
+    """Assert each positive basis label maps to exactly one class value."""
     labels, classes = xr.align(labels, classes, join="exact")
     for label in np.unique(labels.values):
         if label == 0:
@@ -195,7 +198,7 @@ def test_region_constrained_basis_function_uses_supplied_region_classes():
     """Region-constrained basis generation uses caller-supplied class fields."""
     fp_all, region_classes = _tiny_region_constrained_fp_all()
 
-    basis_func = regionconstrainedbasisfunction(
+    basis_func = region_constrained_basis_function(
         fp_all=fp_all,
         start_date="2020-01-01",
         domain="TEST",
@@ -207,6 +210,25 @@ def test_region_constrained_basis_function_uses_supplied_region_classes():
     labels = basis_func.squeeze("time", drop=True)
     assert set(np.unique(labels.values)) == {1, 2, 3, 4}
     _assert_basis_labels_do_not_cross_classes(labels, region_classes)
+
+
+@pytest.mark.parametrize(
+    ("legacy_name", "canonical_name"),
+    [
+        ("bucketbasisfunction", "bucket_basis_function"),
+        ("quadtreebasisfunction", "quadtree_basis_function"),
+        ("regionconstrainedbasisfunction", "region_constrained_basis_function"),
+    ],
+)
+def test_legacy_basis_function_names_warn(monkeypatch, legacy_name, canonical_name):
+    """Legacy compressed basis function names warn and delegate to canonical names."""
+    sentinel = object()
+    monkeypatch.setattr(basis_module, canonical_name, lambda *args, **kwargs: sentinel)
+
+    with pytest.warns(DeprecationWarning, match=f"{legacy_name}.*deprecated"):
+        result = getattr(basis_module, legacy_name)("arg", option=True)
+
+    assert result is sentinel
 
 
 def test_make_basis_functions_accepts_region_constrained_algorithm():

--- a/tests/test_basis_functions.py
+++ b/tests/test_basis_functions.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
+from types import SimpleNamespace
 
 from openghg_inversions.basis._functions import (
     basis,
@@ -14,11 +15,13 @@ from openghg_inversions.basis import (
     bucketbasisfunction,
     quadtreebasisfunction,
     fixed_outer_regions_basis,
+    regionconstrainedbasisfunction,
 )
 from openghg_inversions.basis._wrapper import (
     _save_basis,
     _save_basis_datatree,
     load_basis_functions,
+    make_basis_functions,
 )
 from openghg_inversions.basis.basis_functions import (
     BASIS_ARTIFACT_SOURCE_ATTR,
@@ -149,6 +152,109 @@ def test_fixed_outer_region_basis_function(tac_ch4_data_args, raw_data_path):
     # TODO: create new "fixed" basis function file, since we've switched basis functions from
     # dataset to data array
     xr.testing.assert_allclose(basis_func, basis_func_reloaded.basis)
+
+
+def _tiny_region_constrained_fp_all() -> tuple[dict, xr.DataArray]:
+    time = pd.date_range("2020-01-01", periods=2)
+    lat = np.arange(4.0)
+    lon = np.arange(4.0)
+    coords = {"time": time, "lat": lat, "lon": lon}
+    flux = xr.DataArray(np.ones((2, 4, 4)), dims=("time", "lat", "lon"), coords=coords, name="flux")
+    fp = xr.DataArray(np.ones((2, 4, 4)), dims=("time", "lat", "lon"), coords=coords, name="fp")
+    region_classes = xr.DataArray(
+        np.array(
+            [
+                ["west", "west", "east", "east"],
+                ["west", "west", "east", "east"],
+                ["west", "west", "east", "east"],
+                ["west", "west", "east", "east"],
+            ],
+            dtype=object,
+        ),
+        dims=("lat", "lon"),
+        coords={"lat": lat, "lon": lon},
+        name="region_class",
+    )
+    fp_all = {
+        "SITE": xr.Dataset({"fp": fp}),
+        ".flux": {"total": SimpleNamespace(data=xr.Dataset({"flux": flux}))},
+    }
+    return fp_all, region_classes
+
+
+def _assert_basis_labels_do_not_cross_classes(labels: xr.DataArray, classes: xr.DataArray) -> None:
+    labels, classes = xr.align(labels, classes, join="exact")
+    for label in np.unique(labels.values):
+        if label == 0:
+            continue
+        class_values = set(classes.values[labels.values == label])
+        assert len(class_values) == 1
+
+
+def test_region_constrained_basis_function_uses_supplied_region_classes():
+    """Region-constrained basis generation uses caller-supplied class fields."""
+    fp_all, region_classes = _tiny_region_constrained_fp_all()
+
+    basis_func = regionconstrainedbasisfunction(
+        fp_all=fp_all,
+        start_date="2020-01-01",
+        domain="TEST",
+        emissions_name=["total"],
+        nbasis=4,
+        region_classes=region_classes,
+    )
+
+    labels = basis_func.squeeze("time", drop=True)
+    assert set(np.unique(labels.values)) == {1, 2, 3, 4}
+    _assert_basis_labels_do_not_cross_classes(labels, region_classes)
+
+
+def test_make_basis_functions_accepts_region_constrained_algorithm():
+    """make_basis_functions can build a retained basis from caller-supplied classes."""
+    fp_all, region_classes = _tiny_region_constrained_fp_all()
+
+    basis_object = make_basis_functions(
+        fp_all=fp_all,
+        species="ch4",
+        domain="TEST",
+        start_date="2020-01-01",
+        emissions_name=["total"],
+        nbasis=4,
+        basis_algorithm="region_constrained",
+        region_classes=region_classes,
+    )
+
+    labels = basis_object.flat_basis()
+    _assert_basis_labels_do_not_cross_classes(labels, region_classes)
+
+
+def test_fixed_outer_regions_can_use_region_constrained_algorithm(tmp_path):
+    """Fixed outer regions can pass class fields through to the inner basis algorithm."""
+    fp_all, region_classes = _tiny_region_constrained_fp_all()
+    outer_regions = xr.Dataset(
+        {
+            "region": (
+                ("lat", "lon"),
+                np.ones(region_classes.shape, dtype=int),
+            )
+        },
+        coords=region_classes.coords,
+    )
+    outer_regions.to_netcdf(tmp_path / "outer_region_definition_TEST.nc")
+
+    basis_func = fixed_outer_regions_basis(
+        fp_all=fp_all,
+        start_date="2020-01-01",
+        basis_algorithm="region_constrained",
+        domain="TEST",
+        emissions_name=["total"],
+        nbasis=4,
+        country_directory=str(tmp_path),
+        region_classes=region_classes,
+    )
+
+    labels = basis_func.squeeze("time", drop=True)
+    _assert_basis_labels_do_not_cross_classes(labels, region_classes)
 
 
 def test_fp_sensitivity_one_flux():

--- a/tests/test_basis_functions.py
+++ b/tests/test_basis_functions.py
@@ -4,6 +4,7 @@ import pytest
 import xarray as xr
 from types import SimpleNamespace
 
+import openghg_inversions.basis as basis_package
 import openghg_inversions.basis._functions as basis_module
 from openghg_inversions.basis._functions import (
     basis,
@@ -217,7 +218,6 @@ def test_region_constrained_basis_function_uses_supplied_region_classes():
     [
         ("bucketbasisfunction", "bucket_basis_function"),
         ("quadtreebasisfunction", "quadtree_basis_function"),
-        ("regionconstrainedbasisfunction", "region_constrained_basis_function"),
     ],
 )
 def test_legacy_basis_function_names_warn(monkeypatch, legacy_name, canonical_name):
@@ -229,6 +229,16 @@ def test_legacy_basis_function_names_warn(monkeypatch, legacy_name, canonical_na
         result = getattr(basis_module, legacy_name)("arg", option=True)
 
     assert result is sentinel
+    with pytest.warns(DeprecationWarning, match=f"{legacy_name}.*deprecated"):
+        package_result = getattr(basis_package, legacy_name)("arg", option=True)
+
+    assert package_result is sentinel
+
+
+def test_region_constrained_compressed_name_is_not_exported():
+    """The new region-constrained function only uses the canonical name."""
+    assert not hasattr(basis_module, "regionconstrainedbasisfunction")
+    assert not hasattr(basis_package, "regionconstrainedbasisfunction")
 
 
 def test_make_basis_functions_accepts_region_constrained_algorithm():

--- a/tests/test_constrained_basis_algorithm.py
+++ b/tests/test_constrained_basis_algorithm.py
@@ -1,0 +1,126 @@
+import numpy as np
+import xarray as xr
+
+from openghg_inversions.basis.algorithms import (
+    allocate_nbasis_by_class,
+    region_constrained_basis,
+)
+
+
+def _class_values_for_labels(labels: xr.DataArray, classes: xr.DataArray) -> dict[int, set]:
+    result = {}
+    for label in np.unique(labels.values):
+        if label == 0:
+            continue
+        class_values = classes.values[labels.values == label]
+        result[int(label)] = {value for value in class_values if value == value}
+    return result
+
+
+def test_region_constrained_basis_labels_do_not_cross_classes():
+    """Generated labels are globally unique and stay inside one class."""
+    weights = xr.DataArray(
+        np.array(
+            [
+                [8.0, 7.0, 1.0, 1.0],
+                [6.0, 5.0, 1.0, 1.0],
+                [1.0, 1.0, 6.0, 7.0],
+                [np.nan, np.nan, 8.0, 9.0],
+            ]
+        ),
+        dims=("lat", "lon"),
+        coords={"lat": [10.0, 20.0, 30.0, 40.0], "lon": [1.0, 2.0, 3.0, 4.0]},
+    ).fillna(0.0)
+    classes = xr.DataArray(
+        np.array(
+            [
+                ["land", "land", "sea", "sea"],
+                ["land", "land", "sea", "sea"],
+                ["land", "land", "sea", "sea"],
+                [np.nan, np.nan, "sea", "sea"],
+            ],
+            dtype=object,
+        ),
+        dims=weights.dims,
+        coords=weights.coords,
+    )
+
+    labels = region_constrained_basis(weights, classes, nbasis=4)
+
+    assert labels.name == "basis"
+    assert labels.dims == weights.dims
+    assert labels.sel(lat=40.0, lon=1.0) == 0
+    assert labels.sel(lat=40.0, lon=2.0) == 0
+    assert set(np.unique(labels.values)) == {0, 1, 2, 3, 4}
+    assert all(len(class_values) == 1 for class_values in _class_values_for_labels(labels, classes).values())
+
+
+def test_allocate_nbasis_by_class_weighted_with_minimum():
+    """Automatic allocation keeps a minimum and favours higher-weight classes."""
+    weights = xr.DataArray(
+        np.array([[10.0, 10.0, 1.0, 1.0], [10.0, 10.0, 1.0, 1.0]]),
+        dims=("lat", "lon"),
+    )
+    classes = xr.DataArray(
+        np.array([["high", "high", "low", "low"], ["high", "high", "low", "low"]]),
+        dims=weights.dims,
+    )
+
+    allocation = allocate_nbasis_by_class(weights, classes, nbasis=5)
+
+    assert allocation["high"] > allocation["low"]
+    assert allocation["low"] >= 1
+    assert sum(allocation.values()) == 5
+
+
+def test_region_constrained_basis_uses_explicit_allocation():
+    """Explicit per-class allocation controls class-local region targets."""
+    weights = xr.DataArray(np.ones((4, 4)), dims=("lat", "lon"))
+    classes = xr.DataArray(
+        np.array(
+            [
+                [1, 1, 2, 2],
+                [1, 1, 2, 2],
+                [1, 1, 2, 2],
+                [1, 1, 2, 2],
+            ]
+        ),
+        dims=weights.dims,
+    )
+
+    labels = region_constrained_basis(weights, classes, nbasis={1: 2, 2: 1})
+
+    class_1_labels = set(np.unique(labels.where(classes == 1, 0))) - {0}
+    class_2_labels = set(np.unique(labels.where(classes == 2, 0))) - {0}
+    assert len(class_1_labels) == 2
+    assert len(class_2_labels) == 1
+
+
+def test_region_constrained_basis_accepts_custom_split_strategy():
+    """The strategy boundary allows future inertial or quadtree-style splitters."""
+    weights = xr.DataArray(np.ones((2, 4)), dims=("lat", "lon"))
+    classes = xr.DataArray(
+        np.array([["left", "left", "right", "right"], ["left", "left", "right", "right"]]),
+        dims=weights.dims,
+    )
+
+    class OneRegionPerClass:
+        def __call__(
+            self,
+            weights: np.ndarray,
+            class_mask: np.ndarray,
+            target_regions: int,
+        ) -> np.ndarray:
+            labels = np.zeros(weights.shape, dtype=np.int64)
+            labels[class_mask] = 1
+            return labels
+
+    labels = region_constrained_basis(
+        weights,
+        classes,
+        nbasis=4,
+        split_strategy=OneRegionPerClass(),
+    )
+
+    assert set(np.unique(labels.values)) == {1, 2}
+    assert all(len(class_values) == 1 for class_values in _class_values_for_labels(labels, classes).values())

--- a/tests/test_constrained_basis_algorithm.py
+++ b/tests/test_constrained_basis_algorithm.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 import xarray as xr
 
 from openghg_inversions.basis.algorithms import (
@@ -94,6 +95,29 @@ def test_region_constrained_basis_uses_explicit_allocation():
     class_2_labels = set(np.unique(labels.where(classes == 2, 0))) - {0}
     assert len(class_1_labels) == 2
     assert len(class_2_labels) == 1
+
+
+def test_region_constrained_basis_splits_zero_weight_classes_by_area():
+    """All-zero weights should fall back to area allocation and splitting."""
+    weights = xr.DataArray(np.zeros((2, 4)), dims=("lat", "lon"))
+    classes = xr.DataArray(
+        np.array([["left", "left", "right", "right"], ["left", "left", "right", "right"]]),
+        dims=weights.dims,
+    )
+
+    labels = region_constrained_basis(weights, classes, nbasis=4)
+
+    assert set(np.unique(labels.values)) == {1, 2, 3, 4}
+    assert all(len(class_values) == 1 for class_values in _class_values_for_labels(labels, classes).values())
+
+
+def test_region_constrained_basis_rejects_explicit_over_allocation():
+    """Explicit class allocations cannot request more labels than mapped cells."""
+    weights = xr.DataArray(np.ones((2, 2)), dims=("lat", "lon"))
+    classes = xr.DataArray(np.array([["a", "a"], ["a", "a"]]), dims=weights.dims)
+
+    with pytest.raises(ValueError, match="exceed mapped cell counts"):
+        region_constrained_basis(weights, classes, nbasis={"a": 5})
 
 
 def test_region_constrained_basis_accepts_custom_split_strategy():

--- a/tests/test_constrained_basis_algorithm.py
+++ b/tests/test_constrained_basis_algorithm.py
@@ -130,6 +130,52 @@ def test_greedy_axis_parallel_strategy_hits_target_region_count():
     assert set(np.unique(labels)) == {1, 2, 3, 4, 5}
 
 
+def test_greedy_strategy_accepts_partition_step_returning_multiple_regions():
+    """Greedy splitting accepts partition steps that return more than two children."""
+    weights = np.ones((2, 3))
+    class_mask = np.ones(weights.shape, dtype=bool)
+
+    class SplitByColumn:
+        """Custom partition step that groups nodes by column."""
+
+        def __call__(self, nodes: list[tuple[int, int]], weights: np.ndarray) -> list[list[tuple[int, int]]]:
+            partitions = [[], [], []]
+            for row, col in nodes:
+                partitions[col].append((row, col))
+            return partitions
+
+    labels = GreedyAxisParallelSplitStrategy(split_step=SplitByColumn())(
+        weights,
+        class_mask,
+        target_regions=3,
+    )
+
+    assert set(np.unique(labels)) == {1, 2, 3}
+
+
+def test_greedy_strategy_does_not_overshoot_target_with_multi_region_step():
+    """Multi-region partition steps are skipped when they would exceed target."""
+    weights = np.ones((2, 3))
+    class_mask = np.ones(weights.shape, dtype=bool)
+
+    class SplitByColumn:
+        """Custom partition step that groups nodes by column."""
+
+        def __call__(self, nodes: list[tuple[int, int]], weights: np.ndarray) -> list[list[tuple[int, int]]]:
+            partitions = [[], [], []]
+            for row, col in nodes:
+                partitions[col].append((row, col))
+            return partitions
+
+    labels = GreedyAxisParallelSplitStrategy(split_step=SplitByColumn())(
+        weights,
+        class_mask,
+        target_regions=2,
+    )
+
+    assert set(np.unique(labels)) == {1}
+
+
 def test_region_constrained_basis_rejects_explicit_over_allocation():
     """Explicit class allocations cannot request more labels than mapped cells."""
     weights = xr.DataArray(np.ones((2, 2)), dims=("lat", "lon"))

--- a/tests/test_constrained_basis_algorithm.py
+++ b/tests/test_constrained_basis_algorithm.py
@@ -3,12 +3,14 @@ import pytest
 import xarray as xr
 
 from openghg_inversions.basis.algorithms import (
+    GreedyAxisParallelSplitStrategy,
     allocate_nbasis_by_class,
     region_constrained_basis,
 )
 
 
 def _class_values_for_labels(labels: xr.DataArray, classes: xr.DataArray) -> dict[int, set]:
+    """Collect class values covered by each positive basis label."""
     result = {}
     for label in np.unique(labels.values):
         if label == 0:
@@ -111,6 +113,23 @@ def test_region_constrained_basis_splits_zero_weight_classes_by_area():
     assert all(len(class_values) == 1 for class_values in _class_values_for_labels(labels, classes).values())
 
 
+def test_greedy_axis_parallel_strategy_hits_target_region_count():
+    """Greedy axis-parallel splitting reaches the requested count when cells permit."""
+    weights = np.array(
+        [
+            [8.0, 7.0, 1.0, 1.0],
+            [6.0, 5.0, 1.0, 1.0],
+            [1.0, 1.0, 6.0, 7.0],
+            [1.0, 1.0, 8.0, 9.0],
+        ]
+    )
+    class_mask = np.ones(weights.shape, dtype=bool)
+
+    labels = GreedyAxisParallelSplitStrategy()(weights, class_mask, target_regions=5)
+
+    assert set(np.unique(labels)) == {1, 2, 3, 4, 5}
+
+
 def test_region_constrained_basis_rejects_explicit_over_allocation():
     """Explicit class allocations cannot request more labels than mapped cells."""
     weights = xr.DataArray(np.ones((2, 2)), dims=("lat", "lon"))
@@ -129,6 +148,8 @@ def test_region_constrained_basis_accepts_custom_split_strategy():
     )
 
     class OneRegionPerClass:
+        """Custom test splitter that ignores requested region count."""
+
         def __call__(
             self,
             weights: np.ndarray,

--- a/tests/test_weighted_basis_algorithm.py
+++ b/tests/test_weighted_basis_algorithm.py
@@ -1,0 +1,45 @@
+import numpy as np
+import xarray as xr
+
+from openghg_inversions.basis.algorithms._weighted import bucket_split_landsea_basis
+
+
+def _assert_labels_do_not_cross_classes(labels: np.ndarray, classes: np.ndarray) -> None:
+    for label in np.unique(labels):
+        if label == 0:
+            continue
+        label_classes = np.unique(classes[labels == label])
+        assert len(label_classes) == 1, f"label {label} crosses classes {label_classes}"
+
+
+def test_weighted_landsea_basis_labels_do_not_cross_landsea_classes(tmp_path):
+    """Regression test for #318: weighted land/sea labels stay class-local."""
+    landsea = np.array(
+        [
+            [0, 0, 1, 1],
+            [0, 1, 1, 1],
+            [0, 0, 0, 1],
+            [0, 0, 1, 1],
+        ]
+    )
+    xr.Dataset({"country": (("lat", "lon"), landsea)}).to_netcdf(tmp_path / "country-land-sea_TEST.nc")
+
+    grid = np.array(
+        [
+            [8.0, 7.0, 5.0, 5.0],
+            [6.0, 4.0, 4.0, 3.0],
+            [3.0, 3.0, 3.0, 6.0],
+            [1.0, 1.0, 7.0, 8.0],
+        ]
+    )
+
+    labels = bucket_split_landsea_basis(
+        grid,
+        bucket=12.0,
+        domain="TEST",
+        country_directory=str(tmp_path),
+    )
+
+    assert labels.shape == grid.shape
+    assert labels.min() > 0
+    _assert_labels_do_not_cross_classes(labels, landsea)


### PR DESCRIPTION
* **Summary of changes**

Refs #318, #325, #449.

This opens the final branch in the mask-constrained basis stack:

- Adds a regression guard for current weighted land/sea behavior.
- Adds a pure mask/region-constrained basis helper that accepts 2D weights plus a class mask, partitions each class independently, preserves unmapped cells as label `0`, and offsets labels globally.
- Adds allocation helpers for explicit and automatic per-class `nbasis` allocation.
- Uses a prototype-derived greedy axis-parallel split strategy by default, with priority-queue orchestration and a `PartitionStep` protocol so future axis-parallel, inertial, quadtree, or optimizer-backed split steps can be substituted.
- Adds the caller-facing `region_constrained_basis_function` adapter and `basis_algorithm="region_constrained"` wrapper plumbing.
- Keeps legacy `bucketbasisfunction` and `quadtreebasisfunction` names as deprecated aliases while using underscore-separated names going forward.

PR #448 check before opening:

- PR #448 changed RHIME/HBMCMC output, docs, changelog, and postprocessing paths.
- This branch changed basis code/tests plus `docs/plans/mask_constrained_basis.md`.
- There was no changed-file overlap.
- `git merge-tree --write-tree origin/pr-448 codex/325-region-mask-basis` completed without conflicts.
- Standalone merge-tree checks for PR #448 onto `devel` and this branch onto `devel` also completed without conflicts.

Notes:

- The direct #318 regression did not show current direct weighted land/sea labels crossing land/sea classes, so that branch adds a guard rather than a production fix.
- A separate coordinate-safety risk was identified for cropped fixed-outer-region inputs, and the #449 helper addresses that by keeping xarray alignment at the helper boundary.

* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx (Replace xxxx with the Github issue number): refs #318, #325, and #449, but does not close the full tracking work.
- [x] Tests added and passing
  - `uv run ruff check openghg_inversions/basis/algorithms/_constrained.py openghg_inversions/basis/algorithms/__init__.py openghg_inversions/basis/_functions.py openghg_inversions/basis/__init__.py tests/test_constrained_basis_algorithm.py tests/test_basis_functions.py tests/test_weighted_basis_algorithm.py`
  - `uv run ruff format --check openghg_inversions/basis/algorithms/_constrained.py openghg_inversions/basis/algorithms/__init__.py openghg_inversions/basis/_functions.py openghg_inversions/basis/__init__.py tests/test_constrained_basis_algorithm.py tests/test_basis_functions.py tests/test_weighted_basis_algorithm.py`
  - `uv run pyright openghg_inversions/basis/algorithms/_constrained.py openghg_inversions/basis/_functions.py openghg_inversions/basis/__init__.py openghg_inversions/basis/algorithms/__init__.py`
  - `uv run pytest tests/test_constrained_basis_algorithm.py tests/test_weighted_basis_algorithm.py tests/test_basis_functions.py -k "region_constrained or legacy_basis_function_names or compressed_name or landsea"`
  - `uv run pytest tests/test_conftest.py -n 2 --dist=loadscope`
- [x] Documentation and tutorials updated/added: updated `docs/plans/mask_constrained_basis.md`; no user tutorial changes in this draft stack.
- [ ] Added an entry to the `CHANGELOG.md` file: no changelog entry added for this draft basis stack.
- [x] Added any new requirements to `requirements.txt`: no new requirements needed.