### PR TITLE
Fix xdist test store population

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
-from collections import Counter, namedtuple
+import json
+from collections import namedtuple
 from contextlib import contextmanager
 import getpass
 import os
@@ -12,7 +13,6 @@ from types import MappingProxyType
 from unittest.mock import patch
 
 import pytest
-from openghg.retrieve import search
 from openghg.standardise import (
     standardise_surface,
     standardise_bc,
@@ -20,11 +20,13 @@ from openghg.standardise import (
     standardise_footprint,
     standardise_column,
 )
-from openghg.types import ObjectStoreError
 import xarray as xr
 import zarr
 
 _raw_data_path = Path(".").resolve() / "tests/data/"
+_TEST_STORE_DIR_NAME = "openghg_inversions_testing_store"
+_TEST_STORE_READY_MARKER_NAME = "openghg_inversions_testing_store.ready.json"
+_TEST_STORE_LOCK_NAME = "openghg_inversions_testing_store.lock"
 
 
 @pytest.fixture(scope="session")
@@ -112,7 +114,7 @@ def southamerica_country_file(raw_data_path):
 
 @pytest.fixture(scope="session")
 def session_config_mocker(user_data_path) -> Iterator[dict]:
-    inversions_test_store_path = user_data_path / "openghg_inversions_testing_store"
+    inversions_test_store_path = user_data_path / _TEST_STORE_DIR_NAME
 
     mock_config = {
         "object_store": {
@@ -246,19 +248,50 @@ flux_satellite_datapath = (
 test_data_list.append(TestData(standardise_flux, flux_satellite_metadata, flux_satellite_datapath, "flux"))
 
 
-def _openghg_test_store_needs_data() -> bool:
-    """Return True when the shared OpenGHG test store needs population."""
-    try:
-        results = search(store="inversions_tests")
-    except ObjectStoreError:
-        return True
+def _test_store_path(user_data_path: Path) -> Path:
+    """Return the shared OpenGHG object-store path used by tests."""
+    return user_data_path / _TEST_STORE_DIR_NAME
 
-    try:
-        found_dtypes = results.results["data_type"].to_list()
-    except KeyError:
-        return True
 
-    return Counter([x.data_type for x in test_data_list]) != Counter(found_dtypes)
+def _test_store_ready_marker_path(user_data_path: Path) -> Path:
+    """Return the marker path used to identify a populated shared test store."""
+    return user_data_path / _TEST_STORE_READY_MARKER_NAME
+
+
+def _test_store_signature() -> str:
+    """Return a stable signature for the source data used to populate the store."""
+    entries = []
+    for test_data in test_data_list:
+        file_stat = test_data.path.stat()
+        entries.append(
+            {
+                "data_type": test_data.data_type,
+                "standardise_function": test_data.func.__name__,
+                "metadata": test_data.metadata,
+                "path": str(test_data.path),
+                "size": file_stat.st_size,
+                "mtime_ns": file_stat.st_mtime_ns,
+            }
+        )
+
+    return json.dumps(entries, indent=2, sort_keys=True)
+
+
+def _test_store_is_marked_ready(user_data_path: Path) -> bool:
+    """Return True when the ready marker matches the current fixture manifest."""
+    if not _test_store_path(user_data_path).exists():
+        return False
+
+    marker_path = _test_store_ready_marker_path(user_data_path)
+    try:
+        return marker_path.read_text() == _test_store_signature()
+    except OSError:
+        return False
+
+
+def _mark_test_store_ready(user_data_path: Path) -> None:
+    """Write the ready marker after the shared test store has been populated."""
+    _test_store_ready_marker_path(user_data_path).write_text(_test_store_signature())
 
 
 @contextmanager
@@ -285,28 +318,36 @@ def _file_lock(lock_path: Path, timeout: float = 120.0) -> Iterator[None]:
 def openghg_test_store(session_config_mocker, user_data_path) -> None:
     """Add data to test object.
 
-    Check first if there is enough data. A more specific
-    check for the data necessary for testing is carried out
-    in "test_conftest.py".
+    The shared test store is expensive to populate, so first-time setup is
+    guarded by a cross-worker lock and an explicit ready marker. A more specific
+    check for the data necessary for testing is carried out in
+    "test_conftest.py".
 
     This fixture depends on `session_config_mocker` to make sure
     that `session_config_mocker` runs first.
     """
-    if _openghg_test_store_needs_data():
-        with _file_lock(user_data_path / "openghg_inversions_testing_store.lock"):
-            if not _openghg_test_store_needs_data():
-                return
+    if _test_store_is_marked_ready(user_data_path):
+        return
 
-            session_config_mocker["object_store"]["inversions_tests"]["permissions"] = "rw"
-            try:
-                for test_data in test_data_list:
-                    standardise_fn = test_data.func
-                    file_path = test_data.path
-                    metadata = dict(test_data.metadata)
-                    metadata["store"] = "inversions_tests"
-                    standardise_fn(filepath=file_path, **metadata)
-            finally:
-                session_config_mocker["object_store"]["inversions_tests"]["permissions"] = "r"
+    with _file_lock(user_data_path / _TEST_STORE_LOCK_NAME):
+        if _test_store_is_marked_ready(user_data_path):
+            return
+
+        shutil.rmtree(_test_store_path(user_data_path), ignore_errors=True)
+        _test_store_ready_marker_path(user_data_path).unlink(missing_ok=True)
+
+        session_config_mocker["object_store"]["inversions_tests"]["permissions"] = "rw"
+        try:
+            for test_data in test_data_list:
+                standardise_fn = test_data.func
+                file_path = test_data.path
+                metadata = dict(test_data.metadata)
+                metadata["store"] = "inversions_tests"
+                standardise_fn(filepath=file_path, **metadata)
+        finally:
+            session_config_mocker["object_store"]["inversions_tests"]["permissions"] = "r"
+
+        _mark_test_store_ready(user_data_path)
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -1,8 +1,54 @@
+import sys
+
 import pytest
 
 from openghg.retrieve import search
 
 pytestmark = pytest.mark.usefixtures("openghg_test_store")
+
+
+def _test_fixture_module():
+    """Return pytest's loaded test fixture module."""
+    for module in sys.modules.values():
+        if getattr(module, "_TEST_STORE_DIR_NAME", None) == "openghg_inversions_testing_store":
+            return module
+    raise AssertionError("Could not find loaded tests/conftest.py module")
+
+
+def test_openghg_test_store_rebuilds_unmarked_store(monkeypatch, tmp_path):
+    """The shared test store uses an explicit marker instead of OpenGHG search."""
+    test_fixtures = _test_fixture_module()
+    source_path = tmp_path / "source.nc"
+    source_path.write_text("fake data")
+    store_path = test_fixtures._test_store_path(tmp_path)
+    store_path.mkdir()
+    stale_file = store_path / "stale"
+    stale_file.write_text("left over from partial setup")
+    standardise_calls = []
+
+    def standardise_fake(filepath, **metadata):
+        standardise_calls.append((filepath, metadata))
+        store_path.mkdir(exist_ok=True)
+
+    fake_data = test_fixtures.TestData(
+        standardise_fake,
+        {"species": "ch4"},
+        source_path,
+        "surface",
+    )
+    mock_config = {"object_store": {"inversions_tests": {"permissions": "r"}}}
+    monkeypatch.setattr(test_fixtures, "test_data_list", [fake_data])
+
+    test_fixtures.openghg_test_store.__wrapped__(mock_config, tmp_path)
+
+    assert standardise_calls == [(source_path, {"species": "ch4", "store": "inversions_tests"})]
+    assert not stale_file.exists()
+    assert mock_config["object_store"]["inversions_tests"]["permissions"] == "r"
+    assert test_fixtures._test_store_is_marked_ready(tmp_path)
+
+    test_fixtures.openghg_test_store.__wrapped__(mock_config, tmp_path)
+
+    assert len(standardise_calls) == 1
 
 
 def test_default_session_fixture():


### PR DESCRIPTION
* **Summary of changes**

- Replace the OpenGHG-search-based shared test-store completion check with an explicit ready marker tied to the fixture data manifest.
- Rebuild stale or partially populated unmarked stores under the existing cross-worker file lock, then switch the store back to read-only after population.
- Add a focused regression test that verifies an unmarked stale store is rebuilt once and subsequent fixture calls skip population via the marker.

* **Please check if the PR fulfills these requirements**

- Closes #xxxx: no linked issue; fixes the xdist/shared-store CI failure seen on PR #462.
- [x] Tests added and passing
- Documentation and tutorials updated/added: not applicable for a test fixture fix.
- Added an entry to the `CHANGELOG.md` file: not applicable for a CI/test-fixture fix.
- Added any new requirements to `requirements.txt`: not applicable; no requirement changes.

Validation:

- `uv run ruff check tests/conftest.py tests/test_conftest.py`
- `HOME=/tmp MPLCONFIGDIR=/tmp uv run pytest tests/test_conftest.py -n 2 --dist=loadscope -q`
- `HOME=/tmp MPLCONFIGDIR=/tmp tox -e py310-openghgPrev -- tests/test_conftest.py tests/test_get_data.py -q`
- `HOME=/tmp MPLCONFIGDIR=/tmp tox -e py310-openghgDev -- tests/test_conftest.py tests/test_get_data.py -q`
- `HOME=/tmp MPLCONFIGDIR=/tmp tox -e lint`
- `uv run ruff format --check tests/conftest.py tests/test_conftest.py`
- `git diff --check`