### PR TITLE
Document region-constrained basis usage

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -71,8 +71,9 @@ NOTE: flux and boundary conditions data usually has a specific *domain*, but it 
     -   default location is `openghg_inversions/countries`
 -   basis functions
     -   &ldquo;basis function&rdquo; usually means a netCDF file with latitude and longitude coordinates, with integer values. So all of the coordinates with value 1 are in region 1, and so on.
-    -   basis functions for fluxes are created on the fly by a &ldquo;quadtree basis&rdquo; algorithm. You can also read in pre-defined basis functions. Default location: `openghg_inversions/basis_functions`
-    -   basis functions for the boundary conditions have a similar format. Defaul location `openghg_inversions/bc_basis_functions`
+    -   basis functions for fluxes can be created on the fly with the `quadtree` or `weighted` algorithms. You can also read in pre-defined basis functions. Default location: `openghg_inversions/basis_functions`
+    -   region-constrained basis generation is available through the Python basis API when the caller supplies an already loaded `region_classes` `DataArray`. This is intended for land/sea, country, or other region-class masks, and keeps labels from crossing those classes. The current `.ini`/`run_hbmcmc.py` route does not yet load `region_classes` from a file, so use a saved basis file or the Python wrapper for this case.
+    -   basis functions for the boundary conditions have a similar format. Default location `openghg_inversions/bc_basis_functions`
 
 Summary
 
@@ -249,6 +250,9 @@ met_model = 'UKV'  ; or None if not specified, check the metadata for your footp
 ; - if specified, looks for file format {fp_basis_case}_{domain}_*.nc
 ; - if None, creates basis function using quadtree algorithm and associated parameters
 ;   - nbasis - Number of basis functions to use for quadtree derived basis function (rounded to %4)
+; Region-constrained basis functions are available through the Python basis API
+; when a caller supplies region_classes. This .ini route does not currently load
+; region_classes from file.
 
 bc_basis_case  = "NESW"
 bc_basis_directory = "/group/chemistry/acrg/LPDM/bc_basis_functions/"  ; LPDM/bc_basis_functions is default

--- a/docs/plans/mask_constrained_basis.md
+++ b/docs/plans/mask_constrained_basis.md
@@ -33,6 +33,80 @@ part of #340.
   allocation plus automatic allocation proportional to class total weight, with a
   minimum for non-empty mapped classes.
 
+## Concrete Region And Partition Options
+
+Do not change accepted `run_hbmcmc.py` inputs until #448 has landed. Once that
+interface is available, the same region/partition options should be exposed
+through `run-rhime`, `run-rhime-multisector`, and their Python equivalents. The
+pre-#448 work should stay in pure helpers and lower-level Python APIs so it can
+be tested without committing to config syntax.
+
+### Region Sources
+
+- Existing land/sea files. This is the smallest usable option because the
+  legacy weighted algorithm already uses files such as
+  `country-land-sea_{domain}.nc` and `country-EUROPE-UKMO-landsea-2023.nc`.
+  Add a coordinate-preserving loader that returns a `region_classes`
+  `DataArray`, rather than reusing the current NumPy-only
+  `_weighted.load_landsea_indices`. This gives a direct lower-level replacement
+  for "weighted, but constrained by land/sea" and should be easy to test with
+  the existing synthetic #318 fixture plus one package land/sea file.
+- Country or region masks from `country_file`. The workflows preserved in
+  `~/Documents/ipython_histories/ipython_hist_26.py` and
+  `ipython_hist_27.py` used country masks, PARIS country groupings, and
+  country-fraction matrices. A concrete helper could load a named variable from
+  a country file, optionally group country labels into larger named regions, and
+  return `region_classes`. This is useful, but needs careful handling of ocean,
+  unmatched country codes, fractional cells, and whether grouping follows
+  postprocessing country-region definitions.
+- User-specified inner rectangle. Add a helper that converts latitude/longitude
+  bounds, two corner points, or grid-index bounds into a binary
+  `region_classes` field. This would be useful for inner/outer experiments and
+  realistic tests before full country-region configuration is available.
+  Decide whether the outer cells are a second class, left unmapped, or routed to
+  a separate fixed-outer-region path.
+- Fixed InTEM outer-region files. Keep `fixed_outer_regions_basis` for backwards
+  compatibility because the InTEM regions are familiar to users. A new, clearer
+  interface can still expose the same files as a region source, but should
+  preserve the known outer-region behaviour while allowing the inner region to
+  use any split strategy.
+- Direct user-supplied mask file and variable. For Python APIs this already
+  exists as a `DataArray`. For CLI/config routes after #448, the minimal general
+  form is likely a file path plus variable name plus optional unmapped values.
+  This overlaps with land/sea and country files, so keep the implementation
+  common.
+
+### Partition And Grouping Options
+
+- Keep greedy axis-parallel splitting as the current default because it is the
+  cleaned-up prototype path and does not depend on the poorly designed legacy
+  weighted recursion.
+- Keep the existing recursive weighted splitter as an explicit compatibility
+  strategy only.
+- Add small partition-step adapters for quadtree-style splits and prototype
+  inertial splits when there is a clear test case. The current `PartitionStep`
+  boundary can already accept steps that return more than two child partitions.
+- Treat simulated annealing, precomputed multiscale weights, and observation-
+  weighted definitions as future optimizer/weight-builder work. They are useful
+  sources from `~/Documents/basis_functions`, but they should not block the
+  first usable region-source options.
+- Start tracking partition/group metadata alongside labels. Inner/outer regions,
+  land/sea, country groups, and future layered masks should be represented as
+  basis groups or coordinates so priors and posterior summaries can be applied
+  by group. This likely needs a non-`xarray` internal representation before
+  conversion to a `BasisFunctions` artifact.
+
+### Test Strategy
+
+- Before #448: test pure loaders and helper functions with small fixtures, plus
+  lower-level Python calls into `region_constrained_basis_function`.
+- After #448: add real-world integration tests through `run_hbmcmc.py`,
+  `run-rhime`, and `run-rhime-multisector`, using the same option schema where
+  possible.
+- For regression fixtures, prefer tiny deterministic arrays first. Larger frozen
+  basis fixtures can be added later behind a pytest mark once the interface is
+  stable.
+
 ## Status
 
 - 2026-06-01: Prototype examples pushed without PR.

--- a/docs/plans/mask_constrained_basis.md
+++ b/docs/plans/mask_constrained_basis.md
@@ -9,12 +9,13 @@ part of #340.
 
 - `codex/basis-prototype-examples`: pushed as a reference branch only. No PR opened.
 - `codex/318-landsea-regression`: targeted regression test for current weighted
-  land/sea behavior. Intended to prove whether the existing algorithm crosses
-  land/sea classes before changing production code.
-- `codex/449-mask-constrained-core`: planned follow-up branch for a pure
-  mask/region-constrained helper and split-strategy protocol.
-- `codex/325-region-mask-basis`: planned follow-up branch for country/region-mask
-  callers built on the #449 helper.
+  land/sea behavior. Merged through PR #462.
+- `codex/449-mask-constrained-core`: pure mask/region-constrained helper and
+  split-strategy protocol. Merged through PR #462.
+- `codex/325-region-mask-basis`: country/region-mask caller adapter built on the
+  #449 helper. Merged through PR #462.
+- `codex/449-docs-docstrings`: follow-up branch for merged-status tracking,
+  user-facing region-configuration notes, and focused basis docstring cleanup.
 
 ## Design Notes
 
@@ -110,3 +111,11 @@ part of #340.
   priority-queue wrapper that pops the highest-weight partition first and can
   accept split steps that return more than two child partitions without
   overshooting the requested target count.
+- 2026-06-02: PR #462 merged the stacked #318/#449/#325 implementation into
+  `devel`. The direct weighted land/sea regression did not expose a boundary
+  crossing bug, so production weighted behavior was left unchanged; the separate
+  coordinate-safety risk remains tracked as future interface cleanup.
+- 2026-06-02: Started `codex/449-docs-docstrings` to document the merged
+  `region_constrained` path. Current note: the pure Python basis API accepts an
+  already loaded `region_classes` `DataArray`, but `.ini`/`run_hbmcmc.py` users
+  do not yet have a file-loading/config hook for these masks.

--- a/docs/usage/getting_started.rst
+++ b/docs/usage/getting_started.rst
@@ -299,7 +299,7 @@ The following file, ``my_hbmcmc_inputs.ini`` can be used to run an
    met_model = 'UKV'  ; or None if not specified, check the metadata for your footprint
 
    [INPUT.BASIS_CASE]
-   ; Input values to extract the basis cases to use within the inversion for boundary conditions nd emissions
+   ; Input values to extract the basis cases to use within the inversion for boundary conditions and emissions
    ; basis_algorithm (str): Choice of basis function algorithm to use. One of "quadtree" or "weighted".
    ; The Python basis API also supports "region_constrained" when the caller supplies a region_classes DataArray;
    ; this .ini route does not currently load region_classes from file.

--- a/docs/usage/getting_started.rst
+++ b/docs/usage/getting_started.rst
@@ -79,11 +79,19 @@ Data not stored in OpenGHG
   - “basis function” usually means a netCDF file with latitude and
     longitude coordinates, with integer values. So all of the
     coordinates with value 1 are in region 1, and so on.
-  - basis functions for fluxes are created on the fly by a “quadtree
-    basis” algorithm. You can also read in pre-defined basis functions.
-    Default location: ``openghg_inversions/basis_functions``
+  - basis functions for fluxes can be created on the fly with the
+    ``quadtree`` or ``weighted`` algorithms. You can also read in
+    pre-defined basis functions. Default location:
+    ``openghg_inversions/basis_functions``
+  - region-constrained basis generation is available through the Python
+    basis API when the caller supplies an already loaded ``region_classes``
+    ``DataArray``. This is intended for land/sea, country, or other
+    region-class masks, and keeps labels from crossing those classes. The
+    current ``.ini``/``run_hbmcmc.py`` route does not yet load
+    ``region_classes`` from a file, so use a saved basis file or the Python
+    wrapper for this case.
   - basis functions for the boundary conditions have a similar format.
-    Defaul location ``openghg_inversions/bc_basis_functions``
+    Default location ``openghg_inversions/bc_basis_functions``
 
 Summary
 
@@ -292,7 +300,9 @@ The following file, ``my_hbmcmc_inputs.ini`` can be used to run an
 
    [INPUT.BASIS_CASE]
    ; Input values to extract the basis cases to use within the inversion for boundary conditions nd emissions
-   ; basis_algorithm (str): Choice of basis function algorithm to use. One of "quadtree" or "weighted"
+   ; basis_algorithm (str): Choice of basis function algorithm to use. One of "quadtree" or "weighted".
+   ; The Python basis API also supports "region_constrained" when the caller supplies a region_classes DataArray;
+   ; this .ini route does not currently load region_classes from file.
    ; bc_basis_case (str): Boundary conditions basis, defaults to "NESW" (looks for file format {bc_basis_case}_{domain}_*.nc)
    ; bc_basis_directory (str/None): Directory for bc_basis functions. If None provided, creates new folder in openghg_inversions expecting to find bc_basis_function files there.
    ; fp_basis_case (str/None): Emissions bases:

--- a/openghg_inversions/basis/_functions.py
+++ b/openghg_inversions/basis/_functions.py
@@ -136,20 +136,19 @@ def basis_boundary_conditions(domain: str, basis_case: str, bc_basis_directory: 
 def _flux_fp_from_fp_all(
     fp_all: dict, emissions_name: list[str] | None = None
 ) -> tuple[xr.DataArray, list[xr.DataArray]]:
-    """Get flux and list of footprints from `fp_all` dictionary and optional list of emissions names.
+    """Extract a flux field and site footprints from a legacy ``fp_all`` mapping.
 
     Args:
-      fp_all (dict):
-        Output from footprints_data_merge() function. Dictionary of datasets.
-      emissions_name (list):
-        List of "source" key words as used for retrieving specific emissions
-        from the object store.
+        fp_all: Dictionary returned by the merged-data preparation path. Flux
+            data are expected under the ``".flux"`` key, while measurement-site
+            footprint datasets are stored under the remaining site keys.
+        emissions_name: Optional list of OpenGHG flux source names. When
+            supplied, the first source is selected from ``fp_all[".flux"]``.
+            When omitted, the first available flux entry is used.
 
     Returns:
-      flux (xarray.DataArray):
-        Array containing the flux data.
-      footprints (list):
-        List of xarray DataArray containing the footprints of each sites.
+        Tuple containing the selected flux ``DataArray`` and the list of
+        footprint ``DataArray`` objects for all sites.
     """
     if emissions_name is not None:
         flux = fp_all[".flux"][emissions_name[0]].data.flux
@@ -172,19 +171,17 @@ def _mean_fp_times_mean_flux(
 ) -> xr.DataArray:
     """Multiply mean flux by mean of footprints, optionally restricted to a Boolean mask.
 
-    Args :
-      flux (xarray.DataArray):
-        Array containing the flux data.
-      footprints (list):
-        List of xarray DataArray containing the footprints of each sites.
-      abs_flux (bool):
-        If True this will take the absolute value of the flux in the multiplication.
-      mask (xarray.DataArray):
-        Boolean mask on lat/lon coordinates, indicates the spatial area kept during
-        the multiplication.
+    Args:
+        flux: Flux field with a ``time`` dimension and spatial grid dimensions.
+        footprints: Footprint fields for each site. Their time coordinates are
+            outer-aligned before summing so every measurement contributes once.
+        abs_flux: If true, use the absolute value of ``flux`` before averaging.
+        mask: Optional Boolean spatial mask. When supplied, weights outside the
+            mask are dropped from the returned field.
 
-    Return:
-      xarray DataArray containing temporal mean flux multiplied by temporal mean of footprints
+    Returns:
+        Spatial weight field equal to temporal mean flux multiplied by the
+        measurement-weighted temporal mean footprint.
     """
     if abs_flux is True:
         print("Using absolute value of flux array.")
@@ -222,43 +219,34 @@ def quadtree_basis_function(
     seed: int | None = None,
     mask: xr.DataArray | None = None,
 ) -> xr.DataArray:
-    """Creates a basis function with nbasis grid cells using a quadtree algorithm.
+    """Create a basis field with the quadtree algorithm.
 
     The domain is split with smaller grid cells for regions which contribute
-    more to the a priori (above basline) mole fraction. This is based on the
+    more to the a priori above-baseline mole fraction. This is based on the
     average footprint over the inversion period and the a priori emissions field.
 
     The number of basis functions is optimised using dual annealing. Probably
-    not the best or fastest method as there should only be one minima, but doesn't
-    require the Jacobian or Hessian for optimisation.
+    not the best or fastest method as there should only be one minimum, but it
+    does not require the Jacobian or Hessian for optimisation.
 
     Args:
-      fp_all (dict):
-        fp_all dictionary of datasets as produced from get_data functions
-      start_date (str):
-        Start date of period of inversion
-      domain (str):
-        Domain across which to calculate basis functions.
-      emissions_name (list):
-        List of keyword "source" args used for retrieving emissions files
-        from the Object store
-        Default None
-      nbasis (int):
-        Desired number of basis function regions
-        Default 100
-      abs_flux (bool):
-        When set to True uses absolute values of a flux array
-        Default False
-      seed (int):
-        Optional seed to pass to scipy.optimize.dual_annealing. Used for testing.
-        Default None
-      mask (xarray.DataArray):
-        Boolean mask on lat/lon coordinates. Used to find basis on sub-region
-        Default None
+        fp_all: Legacy merged-data dictionary produced by the data preparation
+            path.
+        start_date: Start date of the inversion period.
+        domain: Domain across which to calculate basis functions.
+        emissions_name: Optional list of OpenGHG flux source names used to
+            select emissions from ``fp_all``.
+        nbasis: Desired number of basis regions.
+        country_directory: Accepted for a consistent basis-algorithm interface;
+            the quadtree algorithm does not use it.
+        abs_flux: If true, use absolute flux values when constructing weights.
+        seed: Optional seed passed to ``scipy.optimize.dual_annealing``.
+        mask: Optional Boolean spatial mask for fitting basis functions over a
+            sub-region.
 
     Returns:
-      quad_basis (xarray.DataArray):
-        Array with lat/lon dimensions and basis regions encoded by integers.
+        Basis field with ``lat``/``lon`` dimensions, a singleton ``time``
+        dimension, and integer region labels.
     """
     flux, footprints = _flux_fp_from_fp_all(fp_all, emissions_name)
     fps = _mean_fp_times_mean_flux(flux, footprints, abs_flux=abs_flux, mask=mask).as_numpy()
@@ -287,38 +275,30 @@ def bucket_basis_function(
     abs_flux: bool = False,
     mask: xr.DataArray | None = None,
 ) -> xr.DataArray:
-    """Basis functions calculated using a weighted region approach
-    where each basis function / scaling region contains approximately
-    the same value.
+    """Create a basis field with the legacy weighted bucket algorithm.
+
+    This algorithm recursively splits weighted rectangles so each scaling region
+    contains approximately the same total weight. The implementation also uses
+    land/sea masks from ``country_directory`` through the lower-level weighted
+    algorithm.
 
     Args:
-      fp_all (dict):
-        fp_all dictionary of datasets as produced from get_data functions
-      start_date (str):
-        Start date of period of inversion
-      domain (str):
-        domain for the basis functions to be calculated over
-      emissions_name (list):
-        List of keyword "source" args used for retrieving emissions files
-        from the Object store
-        Default None
-      nbasis (int):
-        Desired number of basis function regions
-        Default 100
-      country_directory (str):
-        Directory containing land-sea files. If None, will use default files.
-      abs_flux (bool):
-        When set to True uses absolute values of a flux array
-        Default False
-      mask (xarray.DataArray):
-        Boolean mask on lat/lon coordinates. Used to find basis on sub-region
-        Default None
-      country_directory (str):
-        Directory containing land-sea files. If None, will use default files.
+        fp_all: Legacy merged-data dictionary produced by the data preparation
+            path.
+        start_date: Start date of the inversion period.
+        domain: Domain across which to calculate basis functions.
+        emissions_name: Optional list of OpenGHG flux source names used to
+            select emissions from ``fp_all``.
+        nbasis: Desired number of basis regions.
+        country_directory: Optional directory containing land/sea files. When
+            omitted, default package files are used.
+        abs_flux: If true, use absolute flux values when constructing weights.
+        mask: Optional Boolean spatial mask for fitting basis functions over a
+            sub-region.
 
     Returns:
-      bucket_basis (xarray.DataArray):
-        Array with lat/lon dimensions and basis regions encoded by integers.
+        Basis field with ``lat``/``lon`` dimensions, a singleton ``time``
+        dimension, and integer region labels.
     """
     flux, footprints = _flux_fp_from_fp_all(fp_all, emissions_name)
     fps = _mean_fp_times_mean_flux(flux, footprints, abs_flux=abs_flux, mask=mask).as_numpy()
@@ -357,7 +337,41 @@ def region_constrained_basis_function(
 
     This adapter keeps file loading outside the constrained algorithm: callers
     provide ``region_classes`` directly, for example from a country file,
-    land/sea file, or a user-defined region-class field.
+    land/sea file, or a user-defined region-class field. It links the pure
+    ``region_constrained_basis`` helper to the current ``fp_all``-based wrapper
+    interface by constructing the usual footprint-times-flux weight field first.
+
+    Args:
+        fp_all: Legacy merged-data dictionary produced by the data preparation
+            path.
+        start_date: Start date of the inversion period.
+        domain: Domain across which to calculate basis functions.
+        emissions_name: Optional list of OpenGHG flux source names used to
+            select emissions from ``fp_all``.
+        nbasis: Total number of basis regions, or class-local allocation
+            accepted by ``region_constrained_basis``.
+        country_directory: Accepted for a consistent basis-algorithm interface;
+            file loading for ``region_classes`` must happen before calling this
+            adapter.
+        abs_flux: If true, use absolute flux values when constructing weights.
+        mask: Optional Boolean spatial mask for fitting basis functions over a
+            sub-region.
+        region_classes: Two-dimensional class field on the same spatial grid as
+            the generated weights. Positive basis labels are generated
+            independently within each non-null class value.
+        allocation: Automatic allocation mode used when ``nbasis`` is an
+            integer. ``"weight"`` allocates regions by total class weight;
+            ``"area"`` allocates by mapped cell count.
+        min_regions_per_class: Minimum automatic allocation for each non-empty
+            mapped class.
+
+    Returns:
+        Basis field with ``lat``/``lon`` dimensions, a singleton ``time``
+        dimension, and globally unique integer labels that do not cross
+        ``region_classes`` values.
+
+    Raises:
+        ValueError: If ``region_classes`` is not supplied.
     """
     if region_classes is None:
         raise ValueError("region_classes must be supplied for the region_constrained basis algorithm.")
@@ -435,44 +449,37 @@ def fixed_outer_regions_basis(
     region_allocation: AllocationMode = "weight",
     min_regions_per_class: int = 1,
 ) -> xr.DataArray:
-    """Fix outer region of basis functions to InTEM regions, and fit the inner regions using `basis_algorithm`.
+    """Use fixed InTEM outer regions and fit inner regions with an algorithm.
+
+    The InTEM outer-region file defines known outer labels. The largest region
+    value is treated as the inner inversion region; this inner mask is passed to
+    ``basis_algorithm`` and then inserted back into the fixed outer map.
 
     Args:
-      fp_all (dict):
-        fp_all dictionary object as produced from get_data functions
-      start_date (str):
-        Start date of period of inference
-      basis_algorithm (str):
-        Name of the basis algorithm used. Options are "quadtree", "weighted",
-        "region_constrained"
-      domain (str):
-        domain for the basis functions to be calculated over
-      emissions_name (list):
-        List of keyword "source" args used for retrieving emissions files
-        from the Object store.
-      nbasis (int):
-        Desired number of basis function regions
-        Default 100
-      country_directory (str):
-        Directory containing land-sea files and InTEM outer region files.
-        If None, will use default files.
-      abs_flux:
-        When set to True uses absolute values of a flux array
-        Default False
-      region_classes:
-        Region or country class field used with ``basis_algorithm="region_constrained"``.
-        File loading should happen before calling this helper.
-        Default None
-      region_allocation:
-        Allocation mode for ``region_constrained``. One of ``"weight"`` or ``"area"``.
-        Default "weight"
-      min_regions_per_class:
-        Minimum automatic allocation for each non-empty mapped class.
-        Default 1
+        fp_all: Legacy merged-data dictionary produced by the data preparation
+            path.
+        start_date: Start date of the inversion period.
+        basis_algorithm: Algorithm used to fit the inner region. Supported
+            values are ``"quadtree"``, ``"weighted"``, and
+            ``"region_constrained"``.
+        domain: Domain across which to calculate basis functions.
+        emissions_name: Optional list of OpenGHG flux source names used to
+            select emissions from ``fp_all``.
+        nbasis: Desired number of inner-region basis labels.
+        country_directory: Optional directory containing land/sea files and the
+            InTEM outer-region file. When omitted, default package files are
+            used.
+        abs_flux: If true, use absolute flux values when constructing weights.
+        region_classes: Region or country class field used only with
+            ``basis_algorithm="region_constrained"``. File loading should
+            happen before calling this helper.
+        region_allocation: Allocation mode for ``region_constrained``. One of
+            ``"weight"`` or ``"area"``.
+        min_regions_per_class: Minimum automatic allocation for each non-empty
+            mapped class when using ``region_constrained``.
 
     Returns:
-        basis (xarray.DataArray) :
-          Array with lat/lon dimensions and basis regions encoded by integers.
+        Basis field with fixed outer labels and generated inner labels.
     """
     if country_directory is None:
         logger.info(f"Loading default InTEM outer region file for domain {domain}.")

--- a/openghg_inversions/basis/_wrapper.py
+++ b/openghg_inversions/basis/_wrapper.py
@@ -1,4 +1,4 @@
-"""Functions to calling basis function algorithms and applying basis functions to data."""
+"""Wrappers for creating basis functions and applying them to sensitivities."""
 
 from collections.abc import Mapping
 from pathlib import Path
@@ -43,6 +43,50 @@ def make_basis_functions(
 
     This helper owns basis artifact generation/loading without applying the
     legacy fixedbasis ``fp_data`` side channels.
+
+    Args:
+        fp_all: Legacy merged-data dictionary containing flux and footprint data.
+        species: Atmospheric trace gas species used when saving generated basis
+            artifacts.
+        domain: Inversion domain used for generated basis metadata and basis
+            artifact lookup.
+        start_date: Start date of the inversion period.
+        emissions_name: Optional list of OpenGHG flux source names used to
+            select emissions from ``fp_all``.
+        nbasis: Desired number of generated basis regions.
+        basis_algorithm: Algorithm used when generating a basis field on the
+            fly. Supported values are ``"quadtree"``, ``"weighted"``, and
+            ``"region_constrained"``.
+        fix_outer_regions: If true, use fixed InTEM outer regions and generate
+            basis labels only for the inner region.
+        fp_basis_case: Optional saved emissions basis case. When supplied, a
+            saved artifact is loaded instead of generating a basis.
+        basis_directory: Optional root directory for saved emissions basis
+            artifacts.
+        country_directory: Optional directory containing auxiliary land/sea and
+            InTEM outer-region files used by generated basis algorithms.
+        outputname: Optional output-name component used when saving generated
+            basis artifacts.
+        output_path: Optional directory where generated basis artifacts should
+            be saved.
+        basis_output_format: Format for saved generated basis artifacts.
+            ``"legacy"`` writes the historical flat netCDF file, while
+            ``"datatree"`` writes the retained ``BasisFunctions`` artifact.
+        region_classes: Two-dimensional class field used only with
+            ``basis_algorithm="region_constrained"``. Loading this field from a
+            file is the caller's responsibility.
+        region_allocation: Automatic class-allocation mode for
+            ``region_constrained``. One of ``"weight"`` or ``"area"``.
+        min_regions_per_class: Minimum automatic allocation for each non-empty
+            mapped class when using ``region_constrained``.
+
+    Returns:
+        Retained emissions basis object ready for sensitivity projection.
+
+    Raises:
+        ValueError: If neither a saved basis case nor an algorithm is supplied,
+            or if an unsupported output format or basis algorithm is requested.
+        TypeError: If a generated algorithm returns an unsupported basis object.
     """
     saving_generated_basis = output_path is not None and basis_algorithm is not None and fp_basis_case is None
     if saving_generated_basis and basis_output_format not in _VALID_BASIS_OUTPUT_FORMATS:
@@ -189,85 +233,61 @@ def basis_functions_wrapper(
     region_allocation: Literal["weight", "area"] = "weight",
     min_regions_per_class: int = 1,
 ):
-    """Wrapper function for selecting basis function
-    algorithm.
+    """Create basis sensitivities for a legacy fixed-basis inversion.
 
     Args:
-      fp_all (dict):
-        Dictionary object produced from get_data functions
-      species (str):
-        Atmospheric trace gas species of interest
-      domain (str):
-        Model domain
-      start_date (str):
-        Start date of period of inference
-      emissions_name (str/list):
-        Emissions dataset key words for retrieving from object store
-      nbasis (int):
-        Number of basis function regions to calculated in domain
-      use_bc (bool):
-        Option to include/exclude boundary conditions in inversion
-      basis_algorithm (str, optional):
-        One of "quadtree" (for using Quadtree algorithm) or
-        "weighted" (for using an algorihtm that splits region
-        by input data). Land-sea separation is not imposed in the
-        quadtree basis functions, but is imposed by default in "weighted"
-        "region_constrained" uses a caller-supplied ``region_classes``
-        field to prevent labels crossing those classes.
-        Default None
-      fixed_outer_region (bool):
-        When set to True uses InTEM regions to derive basis functions for inner region
-        Default False
-      fp_basis_case (str):
-        Name of basis function to use for emissions.
-        Default None
-      bc_basis_case (str, optional):
-        Name of basis case type for boundary conditions (NOTE, I don't
-        think that currently you can do anything apart from scaling NSEW
-        boundary conditions if you want to scale these monthly.)
-        Default None
-      basis_directory (str, optional):
-        Directory containing the basis function if not default.
-        Default None
-      bc_basis_directory (str, optional):
-        Directory containing the boundary condition basis functions
-        (e.g. files starting with "NESW")
-        Default None
-      region_classes (xarray.DataArray, optional):
-        Region or country class field used with ``basis_algorithm="region_constrained"``.
-        File loading should happen before calling this wrapper.
-        Default None
-      region_allocation (str, optional):
-        Allocation mode for ``region_constrained``. One of ``"weight"`` or ``"area"``.
-        Default "weight"
-      min_regions_per_class (int, optional):
-        Minimum automatic allocation for each non-empty mapped class.
-        Default 1
-      outputname (str, optional):
-        File output name
-        Default None
-      output_path (str, optional):
-        Passed to `outputdir` argument of `quadtree_basis_function`. Used for testing.
-        Default None
-      return_basis_objects (bool, optional):
-        If True, return a tuple ``(fp_data, basis_objects)`` where
-        ``basis_objects["emissions"]`` is a ``BasisFunctions`` object constructed
-        from the basis used in this wrapper.
-        Default False
-      basis_output_format (str, optional):
-        Format to use when saving basis output with ``output_path``:
-        - ``"legacy"``: save legacy flat basis netCDF (default)
-        - ``"datatree"``: save BasisFunctions DataTree netCDF
-        Default "legacy"
+        fp_all: Legacy merged-data dictionary containing flux and footprint data.
+        species: Atmospheric trace gas species used when saving generated basis
+            artifacts.
+        domain: Inversion domain.
+        start_date: Start date of the inversion period.
+        emissions_name: Optional list of OpenGHG flux source names used to
+            select emissions from ``fp_all``.
+        nbasis: Desired number of generated basis regions.
+        use_bc: If true, include boundary-condition sensitivities.
+        basis_algorithm: Algorithm used when generating a basis field on the
+            fly. ``"quadtree"`` does not impose land/sea separation,
+            ``"weighted"`` uses the legacy weighted land/sea split, and
+            ``"region_constrained"`` requires caller-supplied
+            ``region_classes`` to prevent labels crossing those classes.
+        fix_outer_regions: If true, use fixed InTEM outer regions and generate
+            basis labels only for the inner region.
+        fp_basis_case: Optional saved emissions basis case. When supplied, a
+            saved artifact is loaded instead of generating a basis.
+        bc_basis_case: Boundary-condition basis case to load when ``use_bc`` is
+            true.
+        basis_directory: Optional root directory for saved emissions basis
+            artifacts.
+        bc_basis_directory: Optional root directory for saved boundary-condition
+            basis artifacts.
+        country_directory: Optional directory containing auxiliary land/sea and
+            InTEM outer-region files used by generated basis algorithms.
+        outputname: Optional output-name component used when saving generated
+            basis artifacts.
+        output_path: Optional directory where generated basis artifacts should
+            be saved.
+        return_basis_objects: If true, return the legacy ``fp_data`` dictionary
+            plus retained basis objects.
+        basis_output_format: Format for saved generated basis artifacts.
+            ``"legacy"`` writes the historical flat netCDF file, while
+            ``"datatree"`` writes the retained ``BasisFunctions`` artifact.
+        region_classes: Two-dimensional class field used only with
+            ``basis_algorithm="region_constrained"``. Loading this field from a
+            file is the caller's responsibility.
+        region_allocation: Automatic class-allocation mode for
+            ``region_constrained``. One of ``"weight"`` or ``"area"``.
+        min_regions_per_class: Minimum automatic allocation for each non-empty
+            mapped class when using ``region_constrained``.
 
     Returns:
-      fp_data (dict) or tuple[dict, dict[str, BasisFunctions]]:
-        By default, returns a dictionary object similar to fp_all but with information
-        on basis functions and sensitivities.
+        By default, returns a dictionary similar to ``fp_all`` but with basis
+        function and sensitivity data added. If ``return_basis_objects=True``,
+        returns ``(fp_data, basis_objects)`` where ``basis_objects["emissions"]``
+        is the retained emissions ``BasisFunctions`` object.
 
-        If ``return_basis_objects=True``, returns ``(fp_data, basis_objects)`` where
-        ``basis_objects`` contains an ``"emissions"`` key with a ``BasisFunctions``
-        object that wraps the basis operator and representative flux.
+    Raises:
+        ValueError: If boundary conditions are requested without
+            ``bc_basis_case``.
     """
     if use_bc is True and bc_basis_case is None:
         raise ValueError("If `use_bc` is True, you must specify `bc_basis_case`.")

--- a/openghg_inversions/basis/algorithms/_constrained.py
+++ b/openghg_inversions/basis/algorithms/_constrained.py
@@ -44,7 +44,18 @@ class SplitStrategy(Protocol):
         class_mask: np.ndarray,
         target_regions: int,
     ) -> np.ndarray:
-        """Return positive local labels for cells in ``class_mask``."""
+        """Split one class into local basis labels.
+
+        Args:
+            weights: Non-negative weight field for the full grid.
+            class_mask: Boolean mask selecting the cells in the class being
+                split.
+            target_regions: Requested number of local labels for this class.
+
+        Returns:
+            Integer label array with positive labels inside ``class_mask`` and
+            zero outside it.
+        """
         ...
 
 
@@ -52,7 +63,17 @@ class PartitionStep(Protocol):
     """Strategy protocol for splitting one partition into child partitions."""
 
     def __call__(self, nodes: GridPartition, weights: np.ndarray) -> list[GridPartition]:
-        """Return child partitions for ``nodes``."""
+        """Split one grid-node partition.
+
+        Args:
+            nodes: Grid nodes in the partition being split.
+            weights: Non-negative weight field aligned to the source grid.
+
+        Returns:
+            Child grid-node partitions. Returning one child leaves the
+            partition effectively unsplit; returning multiple children lets the
+            greedy orchestrator decide how many can fit in the target count.
+        """
         ...
 
 
@@ -69,7 +90,16 @@ class AxisParallelSplitStep:
     clean_splits: bool = False
 
     def __call__(self, nodes: GridPartition, weights: np.ndarray) -> list[GridPartition]:
-        """Return child partitions from an axis-parallel split."""
+        """Return child partitions from one axis-parallel split.
+
+        Args:
+            nodes: Grid nodes in the partition being split.
+            weights: Non-negative weight field aligned to the source grid.
+
+        Returns:
+            Two child partitions when the split succeeds, or the original
+            partition when the input cannot be split without an empty side.
+        """
         left, right = _axis_parallel_split_nodes(
             nodes,
             weights,
@@ -100,7 +130,18 @@ class GreedyAxisParallelSplitStrategy:
         class_mask: np.ndarray,
         target_regions: int,
     ) -> np.ndarray:
-        """Return class-local labels using greedy axis-parallel bisection."""
+        """Return class-local labels using greedy repeated splitting.
+
+        Args:
+            weights: Non-negative weight field for the full grid.
+            class_mask: Boolean mask selecting the cells in the class being
+                split.
+            target_regions: Requested number of local labels for this class.
+
+        Returns:
+            Integer label array with positive class-local labels inside
+            ``class_mask`` and zero outside it.
+        """
         if target_regions < 1:
             raise ValueError("target_regions must be at least 1.")
         if not class_mask.any():
@@ -142,7 +183,18 @@ class AxisAlignedWeightedSplitStrategy:
         class_mask: np.ndarray,
         target_regions: int,
     ) -> np.ndarray:
-        """Return class-local labels using recursive weighted bucket splits."""
+        """Return class-local labels using recursive weighted bucket splits.
+
+        Args:
+            weights: Non-negative weight field for the full grid.
+            class_mask: Boolean mask selecting the cells in the class being
+                split.
+            target_regions: Requested number of local labels for this class.
+
+        Returns:
+            Integer label array with positive class-local labels inside
+            ``class_mask`` and zero outside it.
+        """
         if target_regions < 1:
             raise ValueError("target_regions must be at least 1.")
         if not class_mask.any():

--- a/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_satellite_template.ini
+++ b/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_satellite_template.ini
@@ -89,7 +89,7 @@ bc_input = "cams"
 ; this .ini route does not currently load region_classes from file.
 ; bc_basis_case (str): Boundary conditions basis, defaults to "NESW" (looks for file format {bc_basis_case}_{domain}_*.nc)
 ; bc_basis_directory (str/None): Directory for bc_basis functions. If None provided, creates new folder in openghg_inversions
-;                                expecting to find bc_basis_funciton files there. 
+;                                expecting to find bc_basis_function files there.
 ; fp_basis_case (str/None): Emissions bases:
 ; - if specified, looks for file format {fp_basis_case}_{domain}_*.nc
 ; - if None, creates basis function using algorithm specified and associated parameters

--- a/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_satellite_template.ini
+++ b/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_satellite_template.ini
@@ -84,7 +84,9 @@ bc_input = "cams"
 
 [INPUT.BASIS_CASE]
 ; Input values to extract the basis cases to use within the inversion for boundary conditions and emissions
-; basis_algorithm (str): Choice of basis function algorithm to use. One of "quadtree" or "weighted"
+; basis_algorithm (str): Choice of basis function algorithm to use. One of "quadtree" or "weighted".
+; The Python basis API also supports "region_constrained" when the caller supplies a region_classes DataArray;
+; this .ini route does not currently load region_classes from file.
 ; bc_basis_case (str): Boundary conditions basis, defaults to "NESW" (looks for file format {bc_basis_case}_{domain}_*.nc)
 ; bc_basis_directory (str/None): Directory for bc_basis functions. If None provided, creates new folder in openghg_inversions
 ;                                expecting to find bc_basis_funciton files there. 

--- a/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template.ini
+++ b/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template.ini
@@ -82,7 +82,7 @@ bc_input = None
 ; this .ini route does not currently load region_classes from file.
 ; bc_basis_case (str): Boundary conditions basis, defaults to "NESW" (looks for file format {bc_basis_case}_{domain}_*.nc)
 ; bc_basis_directory (str/None): Directory for bc_basis functions. If None provided, creates new folder in openghg_inversions
-;                                expecting to find bc_basis_funciton files there.
+;                                expecting to find bc_basis_function files there.
 ; fp_basis_case (str/None): Emissions bases:
 ; - if specified, looks for file format {fp_basis_case}_{domain}_*.nc
 ; - if None, creates basis function using algorithm specified and associated parameters

--- a/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template.ini
+++ b/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template.ini
@@ -77,7 +77,9 @@ bc_input = None
 
 [INPUT.BASIS_CASE]
 ; Input values to extract the basis cases to use within the inversion for boundary conditions and emissions
-; basis_algorithm (str): Choice of basis function algorithm to use. One of "quadtree" or "weighted"
+; basis_algorithm (str): Choice of basis function algorithm to use. One of "quadtree" or "weighted".
+; The Python basis API also supports "region_constrained" when the caller supplies a region_classes DataArray;
+; this .ini route does not currently load region_classes from file.
 ; bc_basis_case (str): Boundary conditions basis, defaults to "NESW" (looks for file format {bc_basis_case}_{domain}_*.nc)
 ; bc_basis_directory (str/None): Directory for bc_basis functions. If None provided, creates new folder in openghg_inversions
 ;                                expecting to find bc_basis_funciton files there.

--- a/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template_example.ini
+++ b/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template_example.ini
@@ -84,7 +84,7 @@ bc_input = "camsv19"
 ; this .ini route does not currently load region_classes from file.
 ; bc_basis_case (str): Boundary conditions basis, defaults to "NESW" (looks for file format {bc_basis_case}_{domain}_*.nc)
 ; bc_basis_directory (str/None): Directory for bc_basis functions. If None provided, creates new folder in openghg_inversions
-;                                expecting to find bc_basis_funciton files there.
+;                                expecting to find bc_basis_function files there.
 ; fp_basis_case (str/None): Emissions bases:
 ; - if specified, looks for file format {fp_basis_case}_{domain}_*.nc
 ; - if None, creates basis function using algorithm specified and associated parameters

--- a/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template_example.ini
+++ b/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template_example.ini
@@ -79,7 +79,9 @@ bc_input = "camsv19"
 
 [INPUT.BASIS_CASE]
 ; Input values to extract the basis cases to use within the inversion for boundary conditions and emissions
-; basis_algorithm (str): Choice of basis function algorithm to use. One of "quadtree" or "weighted"
+; basis_algorithm (str): Choice of basis function algorithm to use. One of "quadtree" or "weighted".
+; The Python basis API also supports "region_constrained" when the caller supplies a region_classes DataArray;
+; this .ini route does not currently load region_classes from file.
 ; bc_basis_case (str): Boundary conditions basis, defaults to "NESW" (looks for file format {bc_basis_case}_{domain}_*.nc)
 ; bc_basis_directory (str/None): Directory for bc_basis functions. If None provided, creates new folder in openghg_inversions
 ;                                expecting to find bc_basis_funciton files there.

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -703,9 +703,13 @@ def fixedbasisMCMC(
         country_file: Path to the country definition file.
         bc_input: Variable for calling BC data from 'bc_store' - equivalent of
             'emissions_name' for fluxes.
-        basis_algorithm: Select basis function algorithm for creating basis function file
-            for emissions on the fly. Options include "quadtree" or "weighted".
-            Defaults to "weighted" which distinguishes between land-sea regions.
+        basis_algorithm: Select basis function algorithm for creating basis
+            function file for emissions on the fly. Current fixedbasis and
+            ``run_hbmcmc.py`` configs support ``"quadtree"`` or
+            ``"weighted"``; ``"weighted"`` distinguishes between land-sea
+            regions. The lower-level Python basis API also supports
+            ``"region_constrained"`` when a caller supplies an already loaded
+            ``region_classes`` field.
         nbasis: Number of basis functions that you want if using quadtree derived
             basis function. This will optimise to closest value that fits with
             quadtree splitting algorithm, i.e. nbasis % 4 = 1.


### PR DESCRIPTION
* **Summary of changes**

- Documents that `region_constrained` currently requires Python callers to supply an already loaded `region_classes` `DataArray`.
- Updates `.ini`/`run_hbmcmc.py` user-facing wording so region-constrained basis generation is not presented as a config-file mask-loading path yet.
- Cleans focused basis docstrings around the constrained adapter, wrapper boundary, and split strategy protocols.
- Updates `docs/plans/mask_constrained_basis.md` with the PR #462 merge status and concrete future options for region sources, partition steps, grouping, and tests.

Refs #449.

* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [x] Tests added and passing
- [x] Documentation and tutorials updated/added
- [ ] Added an entry to the `CHANGELOG.md` file
- [ ] Added any new requirements to `requirements.txt`

Validation:

- `uv run ruff check openghg_inversions/basis/_functions.py openghg_inversions/basis/_wrapper.py openghg_inversions/basis/algorithms/_constrained.py openghg_inversions/hbmcmc/hbmcmc.py`
- `uv run ruff format --check openghg_inversions/basis/_functions.py openghg_inversions/basis/_wrapper.py openghg_inversions/basis/algorithms/_constrained.py openghg_inversions/hbmcmc/hbmcmc.py`
- `uv run pyright openghg_inversions/basis/_functions.py openghg_inversions/basis/_wrapper.py openghg_inversions/basis/algorithms/_constrained.py openghg_inversions/hbmcmc/hbmcmc.py`
- `uv run pytest tests/test_constrained_basis_algorithm.py tests/test_basis_functions.py -k "region_constrained or legacy_basis_function_names or landsea"`
- `uv run sphinx-build -b html docs docs/_build/html` succeeded with existing autodoc warnings around `openghg.analyse._utils`.

The second commit only updates the planning document, so I did not rerun the Python checks after that commit.