### PR TITLE
[codex] Add country-file HDF5 smoke checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,21 @@ pixi run -e dev typecheck
 pixi run -e dev tox
 ```
 
+To run the optional real country-file HDF5 smoke check on a machine that
+can access the ACRG country files, set the country directory and run the
+Pixi task:
+
+```bash
+OPENGHG_COUNTRY_FILE_SMOKE_DIR=/group/chem/acrg/LPDM/countries pixi run -e dev country-file-smoke
+```
+
+The smoke check opens `country_EUROPE_EEZ_PARIS_gapfilled.nc` and
+`country_EUROPE.nc` with xarray's default backend, `h5netcdf`, and
+`netcdf4`, then exercises `openghg_inversions._country_file.load_country_dataset`.
+It prints the `xarray`, `h5netcdf`, `h5py`, and `netCDF4` versions and the
+per-engine result. Without `OPENGHG_COUNTRY_FILE_SMOKE_DIR`, the real-file
+tests are skipped so uv/pip CI does not need access to cluster data.
+
 To test against a local OpenGHG checkout without replacing the Pixi-managed
 HDF5/NetCDF dependencies, install only the local package code:
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -136,7 +136,7 @@ This is assuming you can ssh into blue pebble, and are able to modify files and 
     -   `module load ...` will load a module
 -   Typically you will use the latest anaconda module: `module load lang/python/anaconda`.
 -   To make your own environment for `openghg_inversions`, you should:
-    1.  Prefer the repository Pixi environment for new development installs: `git clone https://github.com/openghg/openghg_inversions.git`, `cd openghg_inversions`, then `pixi install -e dev`. This keeps `h5py`, `h5netcdf`, `netcdf4`, and HDF5 on a single conda-forge binary stack.
+    1.  Prefer the repository Pixi environment for new development installs: `git clone https://github.com/openghg/openghg_inversions.git`, `cd openghg_inversions`, then `pixi install -e dev`. This keeps `h5py`, `h5netcdf`, `netcdf4`, and HDF5 on a single conda-forge binary stack. On systems with access to the ACRG country files, run `OPENGHG_COUNTRY_FILE_SMOKE_DIR=/group/chem/acrg/LPDM/countries pixi run -e dev country-file-smoke` to check the real country-file HDF5 backends.
     2.  If Pixi is not available, make a conda env `conda create --name inv_env numpy` (note: installing `numpy` from `conda` will install `openblas`, which is a fast linear algebra library; these libraries are in non-standard locations on Blue Pebble, and `pip install numpy` will not find them.)
     3.  clone openghg_inversions: `git clone https://github.com/openghg/openghg_inversions.git`
     4.  `pip install openghg_inversions` (in the same directory where you just cloned `openghg_inversions`)

--- a/docs/usage/getting_started.rst
+++ b/docs/usage/getting_started.rst
@@ -178,6 +178,9 @@ TODO: update conda instructions
      ``cd openghg_inversions``, then ``pixi install -e dev``. This keeps
      ``h5py``, ``h5netcdf``, ``netcdf4``, and HDF5 on a single conda-forge
      binary stack.
+     On systems with access to the ACRG country files, run
+     ``OPENGHG_COUNTRY_FILE_SMOKE_DIR=/group/chem/acrg/LPDM/countries pixi run -e dev country-file-smoke``
+     to check the real country-file HDF5 backends.
   2. If Pixi is not available, make a conda env
      ``conda create --name inv_env numpy`` (note:
      installing ``numpy`` from ``conda`` will install ``openblas``,

--- a/docs/usage/installation.rst
+++ b/docs/usage/installation.rst
@@ -36,6 +36,23 @@ tools used by the repository:
    pixi run -e dev typecheck
    pixi run -e dev tox
 
+To run the optional real country-file HDF5 smoke check on a machine that
+can access the ACRG country files, set the country directory and run the
+Pixi task:
+
+.. code:: bash
+
+   OPENGHG_COUNTRY_FILE_SMOKE_DIR=/group/chem/acrg/LPDM/countries pixi run -e dev country-file-smoke
+
+The smoke check opens ``country_EUROPE_EEZ_PARIS_gapfilled.nc`` and
+``country_EUROPE.nc`` with xarray's default backend, ``h5netcdf``, and
+``netcdf4``, then exercises
+``openghg_inversions._country_file.load_country_dataset``. It prints the
+``xarray``, ``h5netcdf``, ``h5py``, and ``netCDF4`` versions and the
+per-engine result. Without ``OPENGHG_COUNTRY_FILE_SMOKE_DIR``, the
+real-file tests are skipped so uv/pip CI does not need access to cluster
+data.
+
 If you need to test against a local OpenGHG checkout, install only the
 local package code into the Pixi environment. The ``--no-deps`` flag is
 important because it prevents ``pip`` from replacing Pixi's conda-forge

--- a/openghg_inversions/_country_file.py
+++ b/openghg_inversions/_country_file.py
@@ -1,0 +1,71 @@
+"""Country file loading helpers."""
+
+from __future__ import annotations
+
+import warnings
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Literal
+
+import xarray as xr
+
+CountryFileEngine = Literal["default", "h5netcdf"]
+
+COUNTRY_FILE_ENGINE_ORDER: tuple[CountryFileEngine, ...] = ("default", "h5netcdf")
+COUNTRY_FILE_SELECTED_ENGINE_ATTR = "_openghg_inversions_country_file_engine"
+
+
+def _open_country_dataset(path: Path, engine: CountryFileEngine) -> xr.Dataset:
+    """Open a country-file dataset using a named xarray engine."""
+    if engine == "default":
+        return xr.open_dataset(path)
+
+    return xr.open_dataset(path, engine=engine)
+
+
+def _format_failures(failures: list[tuple[CountryFileEngine, BaseException]]) -> str:
+    return "; ".join(f"{engine}: {type(error).__name__}: {error}" for engine, error in failures)
+
+
+def load_country_dataset(
+    country_file: str | Path,
+    engines: Iterable[CountryFileEngine] = COUNTRY_FILE_ENGINE_ORDER,
+) -> xr.Dataset:
+    """Open and load a country file with a fallback for HDF5 backend issues.
+
+    Args:
+        country_file: NetCDF country file path.
+        engines: Ordered xarray backend labels to try. ``"default"`` uses xarray's
+            engine selection; any other value is passed as ``engine=...``.
+
+    Returns:
+        Loaded xarray Dataset with its file handle closed.
+
+    Raises:
+        OSError: if all configured backends fail to open the country file.
+    """
+    path = Path(country_file)
+    failures: list[tuple[CountryFileEngine, BaseException]] = []
+
+    for engine in engines:
+        try:
+            with _open_country_dataset(path, engine) as dataset:
+                loaded = dataset.load()
+        except Exception as error:
+            failures.append((engine, error))
+            continue
+
+        if failures:
+            warnings.warn(
+                "Falling back to xarray engine "
+                f"{engine!r} for country file {path} after {_format_failures(failures)}",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+
+        loaded.attrs[COUNTRY_FILE_SELECTED_ENGINE_ATTR] = engine
+        return loaded
+
+    raise OSError(f"Unable to open country file {path}. Tried {_format_failures(failures)}") from (
+        failures[-1][1] if failures else None
+    )

--- a/openghg_inversions/postprocessing/countries.py
+++ b/openghg_inversions/postprocessing/countries.py
@@ -13,6 +13,7 @@ from typing_extensions import Self
 import xarray as xr
 from openghg_inversions import convert, utils
 
+from openghg_inversions._country_file import load_country_dataset
 from openghg_inversions.array_ops import get_xr_dummies, sparse_xr_dot
 from openghg_inversions.utils import get_country_file_path
 from ._country_codes import CountryInfoList
@@ -369,7 +370,7 @@ class Countries:
         """
         country_file_path = get_country_file_path(country_file=country_file, domain=domain)
         return cls(
-            xr.open_dataset(country_file_path, engine="h5netcdf"),
+            load_country_dataset(country_file_path),
             country_code=country_code,
             country_selections=country_selections,
             country_regions=country_regions,

--- a/openghg_inversions/utils.py
+++ b/openghg_inversions/utils.py
@@ -7,6 +7,7 @@ conditions, and their sensitivities.
 Many functions in this submodule originated in the ACRG code base (in `acrg.name`).
 
 """
+
 import re
 from pathlib import Path
 from types import SimpleNamespace
@@ -18,6 +19,7 @@ import xarray as xr
 
 from openghg.analyse import combine_datasets as openghg_combine_datasets
 
+from openghg_inversions._country_file import load_country_dataset
 from openghg_inversions.config.paths import Paths
 
 
@@ -61,7 +63,7 @@ def open_ds(
     Args:
         path: Path to file to open.
         chunks: Size of chunks for each dimension, e.g. {'lat': 50, 'lon': 50}.
-            Opens dataset with dask, such that it is opened 'lazily' and all of the data 
+            Opens dataset with dask, such that it is opened 'lazily' and all of the data
             is not loaded into memory. Defaults to None - dataset is opened without dask.
         combine: Way in which the data should be combined (if using chunks), either:
             'by_coords': order the datasets before concatenating (default)
@@ -87,14 +89,14 @@ def read_netcdfs(
     verbose: bool = True,
 ) -> xr.Dataset:
     """Use xarray to open sequential netCDF files and concatenate them along the specified dimension.
-    
+
     Note: this function makes sure that file is closed after open_dataset call.
 
     Args:
         files: List of netCDF filenames.
         dim: Dimension of netCDF to use for concatenating the files. Default = "time".
         chunks: Size of chunks for each dimension, e.g. {'lat': 50, 'lon': 50}.
-            Opens dataset with dask, such that it is opened 'lazily' and all of the data 
+            Opens dataset with dask, such that it is opened 'lazily' and all of the data
             is not loaded into memory. Defaults to None - dataset is opened without dask.
         verbose: If True, print progress information.
 
@@ -151,7 +153,11 @@ def ncdf_encoding(ds_in: xr.Dataset) -> dict:
     for dv in ds_in.data_vars:
         if dtype_pat.match(ds_in[dv].data.dtype.str):
             do_not_compress.append(dv)
-    encoding = {var: {"zlib": True, "complevel": 5, "shuffle": True} for var in ds_in.data_vars if var not in do_not_compress}
+    encoding = {
+        var: {"zlib": True, "complevel": 5, "shuffle": True}
+        for var in ds_in.data_vars
+        if var not in do_not_compress
+    }
 
     return encoding
 
@@ -203,19 +209,19 @@ def get_country(domain: str, country_file: str | Path | None = None):
     """
     filename = get_country_file_path(country_file=country_file, domain=domain)
 
-    with xr.open_dataset(filename) as f:
-        lon = f.variables["lon"][:].values
-        lat = f.variables["lat"][:].values
+    f = load_country_dataset(filename)
+    lon = f.variables["lon"][:].values
+    lat = f.variables["lat"][:].values
 
-        # Get country indices and names
-        if "country" in f.variables:
-            country = f.variables["country"][:, :]
-        elif "region" in f.variables:
-            country = f.variables["region"][:, :]
-        else:
-            raise ValueError(f"Variables 'country' or 'region' not found in country file {filename}.")
+    # Get country indices and names
+    if "country" in f.variables:
+        country = f.variables["country"][:, :]
+    elif "region" in f.variables:
+        country = f.variables["region"][:, :]
+    else:
+        raise ValueError(f"Variables 'country' or 'region' not found in country file {filename}.")
 
-        name = f.variables["name"].values.astype(str)
+    name = f.variables["name"].values.astype(str)
 
     result = dict(
         lon=lon,
@@ -305,7 +311,9 @@ def _map_times_to_available_period_positions(
     missing = pd.Index(time_periods).difference(available_periods)
     if len(missing) > 0:
         period_label = "years" if period == "yearly" else "months"
-        raise ValueError(f"Observation {period_label} {list(missing.astype(str))} are missing from available flux periods.")
+        raise ValueError(
+            f"Observation {period_label} {list(missing.astype(str))} are missing from available flux periods."
+        )
 
     period_positions = {period_value: idx for idx, period_value in enumerate(available_periods)}
     return np.array([period_positions[period_value] for period_value in time_periods], dtype=int)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ dev = { features = ["dev", "jupyter"], solve-group = "default" }
 [tool.pixi.feature.dev.tasks]
 test = "pytest"
 test-xdist = "pytest -n 2 --dist=loadscope tests"
+country-file-smoke = "pytest -s tests/postprocessing/test_country_file_smoke.py"
 lint = "ruff check ."
 typecheck = "pyright"
 tox = "tox -p"
@@ -138,6 +139,7 @@ minversion = "6.0"
 testpaths = ["tests"]
 markers = [
   "create_frozen: tests that generate/update frozen regression outputs (not run by default)",
+  "country_file_smoke: optional real country-file HDF5 backend smoke tests",
   "slow: tests that take a long time",
 ]
 addopts = "-m 'not create_frozen and not slow'"

--- a/tests/postprocessing/test_countries.py
+++ b/tests/postprocessing/test_countries.py
@@ -1,7 +1,39 @@
 import pytest
+import xarray as xr
 
+import openghg_inversions._country_file as country_file_loader
 from openghg_inversions.postprocessing.countries import Countries, CountryRegions, paris_regions_dict
 from openghg_inversions.postprocessing._country_codes import CountryInfoList
+
+
+def test_countries_from_file_falls_back_to_h5netcdf(monkeypatch, europe_country_file):
+    """Check country loading falls back when xarray's default backend hits an HDF error."""
+    real_open_dataset = xr.open_dataset
+    open_calls = []
+
+    def open_dataset_with_default_failure(path, *args, **kwargs):
+        engine = kwargs.get("engine", "default")
+        open_calls.append(engine)
+
+        if "engine" not in kwargs:
+            raise OSError("[Errno -101] NetCDF: HDF error")
+
+        return real_open_dataset(path, *args, **kwargs)
+
+    monkeypatch.setattr(country_file_loader.xr, "open_dataset", open_dataset_with_default_failure)
+
+    with pytest.warns(RuntimeWarning, match="Falling back to xarray engine 'h5netcdf'"):
+        dataset = country_file_loader.load_country_dataset(europe_country_file)
+    assert open_calls == ["default", "h5netcdf"]
+    assert dataset.attrs[country_file_loader.COUNTRY_FILE_SELECTED_ENGINE_ATTR] == "h5netcdf"
+
+    open_calls.clear()
+    with pytest.warns(RuntimeWarning, match="Falling back to xarray engine 'h5netcdf'"):
+        countries = Countries.from_file(domain="EUROPE", country_file=europe_country_file)
+
+    assert open_calls == ["default", "h5netcdf"]
+    assert len(countries.country_selections) == len(dataset.name)
+
 
 def test_country_regions_missing_check():
     paris_regions_countries = CountryInfoList(
@@ -28,7 +60,7 @@ def test_country_regions_missing_check():
         ]
     )
 
-    paris_regions = CountryRegions(paris_regions_dict['europe'])
+    paris_regions = CountryRegions(paris_regions_dict["europe"])
 
     # check 1: "ITALY" vs "ITA" and "POLAND" vs "POL" doesn't affect check
     missing = paris_regions.region_countries_missing_from(paris_regions_countries)
@@ -44,30 +76,38 @@ def test_country_regions_missing_check():
 def test_country_regions_align(country_ds):
     """Check that aligning country regions defined with alpha3 codes results in definitions with input names
     for EUROPE domain."""
-    paris_regions = CountryRegions(paris_regions_dict['europe'])
+    paris_regions = CountryRegions(paris_regions_dict["europe"])
     countries_list = CountryInfoList(country_ds.name.values)
 
     assert list(paris_regions.align(countries_list).to_dict()["BELUX"]) == ["BELGIUM", "LUXEMBOURG"]
+
 
 @pytest.mark.parametrize("country_code", ["alpha2", "alpha3", None])
 def test_countries_matrix_with_regions(country_code, country_ds, europe_country_file):
     """Check that country regions combine with countries correctly in EUROPE domain."""
     countries = Countries.from_file(
-        domain="EUROPE", country_regions=paris_regions_dict['europe'], country_code=country_code,
-        country_file=europe_country_file
+        domain="EUROPE",
+        country_regions=paris_regions_dict["europe"],
+        country_code=country_code,
+        country_file=europe_country_file,
     )
 
-    assert len(countries.country_selections) == len(country_ds.name) + len(paris_regions_dict['europe'])
+    assert len(countries.country_selections) == len(country_ds.name) + len(paris_regions_dict["europe"])
+
 
 @pytest.mark.parametrize("country_code", ["alpha2", "alpha3", None])
 def test_countries_matrix_with_regions_EASTASIA(country_code, country_ds_eastasia, eastasia_country_file):
     """Check that country regions combine with countries correctly in EASTASIA domain."""
     countries = Countries.from_file(
-        domain="EASTASIA", country_regions=paris_regions_dict.get('eastasia'), country_code=country_code,
-        country_file=eastasia_country_file
+        domain="EASTASIA",
+        country_regions=paris_regions_dict.get("eastasia"),
+        country_code=country_code,
+        country_file=eastasia_country_file,
     )
 
-    assert len(countries.country_selections) == len(country_ds_eastasia.name) + len(paris_regions_dict.get('eastasia', []))
+    assert len(countries.country_selections) == len(country_ds_eastasia.name) + len(
+        paris_regions_dict.get("eastasia", [])
+    )
 
 
 @pytest.mark.parametrize("country_code", ["alpha2", "alpha3", None])

--- a/tests/postprocessing/test_country_file_smoke.py
+++ b/tests/postprocessing/test_country_file_smoke.py
@@ -1,0 +1,134 @@
+"""Optional smoke tests for real country-file HDF5 backend compatibility."""
+
+from __future__ import annotations
+
+import os
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+import pytest
+import xarray as xr
+
+from openghg_inversions._country_file import (
+    COUNTRY_FILE_ENGINE_ORDER,
+    COUNTRY_FILE_SELECTED_ENGINE_ATTR,
+    load_country_dataset,
+)
+
+COUNTRY_FILE_SMOKE_DIR_ENV = "OPENGHG_COUNTRY_FILE_SMOKE_DIR"
+COUNTRY_FILE_NAMES = (
+    "country_EUROPE_EEZ_PARIS_gapfilled.nc",
+    "country_EUROPE.nc",
+)
+ENGINES = (None, "h5netcdf", "netcdf4")
+
+pytestmark = pytest.mark.country_file_smoke
+
+
+def _engine_label(engine: str | None) -> str:
+    return "default" if engine is None else engine
+
+
+def _version(package: str) -> str:
+    try:
+        return version(package)
+    except PackageNotFoundError:
+        return "not installed"
+
+
+def _is_pixi_environment() -> bool:
+    return bool(os.environ.get("PIXI_ENVIRONMENT_NAME") or os.environ.get("PIXI_PROJECT_ROOT"))
+
+
+def _require_backend(engine: str | None) -> None:
+    if engine == "h5netcdf":
+        pytest.importorskip("h5netcdf")
+    elif engine == "netcdf4":
+        pytest.importorskip("netCDF4")
+
+
+def _country_file_path(country_file_smoke_dir: Path, file_name: str) -> Path:
+    path = country_file_smoke_dir / file_name
+    if not path.exists():
+        pytest.skip(f"Country-file smoke input {path} is not available")
+    return path
+
+
+def _summarise_dataset(dataset: xr.Dataset) -> str:
+    data_vars = ", ".join(str(var) for var in dataset.data_vars) or "<no data variables>"
+    sizes = ", ".join(f"{dim}={size}" for dim, size in dataset.sizes.items())
+    return f"sizes=({sizes}); data_vars=({data_vars})"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def print_country_file_dependency_versions() -> None:
+    versions = {
+        "xarray": _version("xarray"),
+        "h5netcdf": _version("h5netcdf"),
+        "h5py": _version("h5py"),
+        "netCDF4": _version("netCDF4"),
+    }
+    version_report = ", ".join(
+        f"{package}={package_version}" for package, package_version in versions.items()
+    )
+    print(f"country-file smoke dependency versions: {version_report}")
+
+
+@pytest.fixture(scope="module")
+def country_file_smoke_dir() -> Path:
+    smoke_dir = os.environ.get(COUNTRY_FILE_SMOKE_DIR_ENV)
+    if smoke_dir is None:
+        pytest.skip(f"Set {COUNTRY_FILE_SMOKE_DIR_ENV} to run real country-file smoke tests")
+
+    return Path(smoke_dir)
+
+
+@pytest.mark.parametrize("file_name", COUNTRY_FILE_NAMES)
+@pytest.mark.parametrize("engine", ENGINES, ids=_engine_label)
+def test_xarray_open_country_file_engine_matrix(
+    country_file_smoke_dir: Path,
+    file_name: str,
+    engine: str | None,
+) -> None:
+    """Open real country files with each xarray backend used during HDF5 debugging."""
+    _require_backend(engine)
+
+    path = _country_file_path(country_file_smoke_dir, file_name)
+    engine_label = _engine_label(engine)
+    kwargs = {} if engine is None else {"engine": engine}
+
+    try:
+        with xr.open_dataset(path, **kwargs) as dataset:
+            loaded = dataset.load()
+    except Exception as error:
+        print(f"{file_name} engine={engine_label}: failed {type(error).__name__}: {error}")
+        if not _is_pixi_environment():
+            pytest.xfail(f"{file_name} engine={engine_label} failed outside Pixi: {error}")
+        raise
+
+    print(f"{file_name} engine={engine_label}: ok {_summarise_dataset(loaded)}")
+    assert "country" in loaded.variables or "region" in loaded.variables
+
+
+@pytest.mark.parametrize("file_name", COUNTRY_FILE_NAMES)
+def test_load_country_dataset_real_files(
+    country_file_smoke_dir: Path,
+    file_name: str,
+) -> None:
+    """Exercise the shared country-file loader against real cluster inputs."""
+    path = _country_file_path(country_file_smoke_dir, file_name)
+
+    try:
+        dataset = load_country_dataset(path)
+    except Exception as error:
+        print(f"{file_name} load_country_dataset: failed {type(error).__name__}: {error}")
+        if not _is_pixi_environment():
+            pytest.xfail(f"{file_name} load_country_dataset failed outside Pixi: {error}")
+        raise
+
+    selected_engine = dataset.attrs[COUNTRY_FILE_SELECTED_ENGINE_ATTR]
+    print(
+        f"{file_name} load_country_dataset: ok selected_engine={selected_engine}; {_summarise_dataset(dataset)}"
+    )
+    assert selected_engine in COUNTRY_FILE_ENGINE_ORDER
+    assert "country" in dataset.variables or "region" in dataset.variables

--- a/tests/postprocessing/test_country_file_smoke.py
+++ b/tests/postprocessing/test_country_file_smoke.py
@@ -62,6 +62,9 @@ def _summarise_dataset(dataset: xr.Dataset) -> str:
 
 @pytest.fixture(scope="module", autouse=True)
 def print_country_file_dependency_versions() -> None:
+    if os.environ.get(COUNTRY_FILE_SMOKE_DIR_ENV) is None:
+        return
+
     versions = {
         "xarray": _version("xarray"),
         "h5netcdf": _version("h5netcdf"),
@@ -72,7 +75,6 @@ def print_country_file_dependency_versions() -> None:
         f"{package}={package_version}" for package, package_version in versions.items()
     )
     print(f"country-file smoke dependency versions: {version_report}")
-
 
 @pytest.fixture(scope="module")
 def country_file_smoke_dir() -> Path:


### PR DESCRIPTION
## Summary

Adds HDF5/country-file smoke and regression checks on top of the Pixi environment branch. This is stacked on #466 and should be merged after that Pixi setup lands.

## Details

- Adds `openghg_inversions._country_file.load_country_dataset`, which tries xarray's default backend first and falls back to `h5netcdf` with an explicit warning if the default backend hits an HDF5/NetCDF failure.
- Uses the shared loader from `Countries.from_file` and `utils.get_country`.
- Adds a synthetic regression test for the observed `[Errno -101] NetCDF: HDF error` default-engine failure path.
- Adds an optional real-file smoke test for `country_EUROPE_EEZ_PARIS_gapfilled.nc` and `country_EUROPE.nc`.
- Adds the Pixi task `pixi run -e dev country-file-smoke`; it skips unless `OPENGHG_COUNTRY_FILE_SMOKE_DIR` points at the real country-file directory, and prints xarray/h5netcdf/h5py/netCDF4 versions plus per-engine results.
- Documents the real-file smoke command in the README and install/getting-started docs.

## Validation

- `pixi run -e dev pytest tests/postprocessing/test_countries.py tests/postprocessing/test_country_file_smoke.py`
- `pixi run -e dev country-file-smoke` without `OPENGHG_COUNTRY_FILE_SMOKE_DIR` to verify skip behavior
- `OPENGHG_COUNTRY_FILE_SMOKE_DIR=/Users/bm13805/Documents/openghg_inversions/countries pixi run -e dev country-file-smoke` against the local EEZ file matching the BluePebble SHA-256
- `OPENGHG_COUNTRY_FILE_SMOKE_DIR=/private/tmp/openghg-country-file-smoke pixi run -e dev country-file-smoke` using local test-data copies to exercise the full engine matrix
- `pixi run -e dev lint`
- `pixi run -e dev pyright openghg_inversions/_country_file.py`
- `pixi run -e dev tox`

## Notes

The real EEZ file opens cleanly in the Pixi environment locally. The synthetic fallback test is still the local check that deliberately triggers the HDF error path.