### PR TITLE
Add latest PARIS templates and multisector total flux outputs

### DIFF
--- a/docs/plans/issue_405_paris_sector_outputs.md
+++ b/docs/plans/issue_405_paris_sector_outputs.md
@@ -1,0 +1,35 @@
+# Issue 405 PARIS Sector Outputs
+
+## Scope
+
+Track implementation progress for GitHub issue #405: sector-aware RHIME outputs and PARIS-compatible total outputs.
+
+## Decisions
+
+- The next release should keep the current PARIS schema as the default. Users must pass an explicit latest-template option to produce the new PARIS concentration v04 and flux v03 outputs.
+- Site/platform metadata should be resolved from observation metadata first. Likely sources are `ObsData.metadata`, `ObsData.data.attrs`, and, as fallback, `openghg_defs` site definitions through the `openghg` dependency.
+- The preferred multisector output should include per-sector variables where the PARIS template supports them. Total PARIS outputs should still be generated from reconstructed sector flux fields, not from summed scale factors.
+
+## Branch Plan
+
+1. `codex/405-paris-template-version`: add this planning note, import the uploaded CDL templates, and add template-version plumbing while preserving the current default.
+2. Single-sector latest PARIS branch: implement explicit latest-template concentration and flux outputs, including `platform`, observation `index`, `time_bnds`, new `mf_*` names, flux `time_bnds`, `cell_area`, and latest country variable names.
+3. Multisector total branch: reconstruct sector prior/posterior flux traces with each sector's own prior flux, sum reconstructed flux traces for total outputs, and route multisector `output_format="paris"` through total PARIS output creation.
+4. Per-sector PARIS branch: add sector-specific PARIS variables and a documented sector diagnostics dataset for variables that do not fit cleanly in the product files.
+
+## Progress
+
+- [x] Recorded decisions and branch plan.
+- [x] Added latest CDL templates in-tree.
+- [ ] Added explicit latest single-sector PARIS products.
+- [ ] Added sector-aware flux reconstruction.
+- [ ] Routed multisector PARIS outputs through total product creation.
+- [ ] Added per-sector PARIS variables and diagnostics.
+
+## Test Plan
+
+- Focused unit tests for template-version selection and legacy default behavior.
+- Single-sector latest-output tests for required v04/v03 variables and dimensions.
+- Synthetic multisector test where total posterior flux equals the sum of reconstructed sector posterior flux fields.
+- NetCDF write/read smoke tests for latest concentration and flux products.
+- Focused `uv run pytest` and `uv run ruff` checks on changed files, then full `tox -p` before review if time and resources allow.

--- a/docs/plans/issue_405_paris_sector_outputs.md
+++ b/docs/plans/issue_405_paris_sector_outputs.md
@@ -24,7 +24,7 @@ Track implementation progress for GitHub issue #405: sector-aware RHIME outputs 
 - [x] Added latest CDL templates in-tree.
 - [x] Added explicit latest single-sector PARIS products.
 - [x] Added sector-aware flux reconstruction.
-- [ ] Routed multisector PARIS outputs through total product creation.
+- [x] Routed multisector PARIS outputs through total product creation.
 - [ ] Added per-sector PARIS variables and diagnostics.
 
 ## Test Plan

--- a/docs/plans/issue_405_paris_sector_outputs.md
+++ b/docs/plans/issue_405_paris_sector_outputs.md
@@ -14,15 +14,16 @@ Track implementation progress for GitHub issue #405: sector-aware RHIME outputs 
 
 1. `codex/405-paris-template-version`: add this planning note, import the uploaded CDL templates, and add template-version plumbing while preserving the current default.
 2. Single-sector latest PARIS branch: implement explicit latest-template concentration and flux outputs, including `platform`, observation `index`, `time_bnds`, new `mf_*` names, flux `time_bnds`, `cell_area`, and latest country variable names.
-3. Multisector total branch: reconstruct sector prior/posterior flux traces with each sector's own prior flux, sum reconstructed flux traces for total outputs, and route multisector `output_format="paris"` through total PARIS output creation.
-4. Per-sector PARIS branch: add sector-specific PARIS variables and a documented sector diagnostics dataset for variables that do not fit cleanly in the product files.
+3. Sector reconstruction branch: reconstruct sector prior/posterior flux traces with each sector's own prior flux, sum reconstructed flux traces for total outputs, and move RHIME multisector diagnostics onto the postprocessing helper.
+4. Multisector total PARIS branch: route multisector `output_format="paris"` through total PARIS output creation.
+5. Per-sector PARIS branch: add sector-specific PARIS variables and a documented sector diagnostics dataset for variables that do not fit cleanly in the product files.
 
 ## Progress
 
 - [x] Recorded decisions and branch plan.
 - [x] Added latest CDL templates in-tree.
 - [x] Added explicit latest single-sector PARIS products.
-- [ ] Added sector-aware flux reconstruction.
+- [x] Added sector-aware flux reconstruction.
 - [ ] Routed multisector PARIS outputs through total product creation.
 - [ ] Added per-sector PARIS variables and diagnostics.
 

--- a/docs/plans/issue_405_paris_sector_outputs.md
+++ b/docs/plans/issue_405_paris_sector_outputs.md
@@ -21,7 +21,7 @@ Track implementation progress for GitHub issue #405: sector-aware RHIME outputs 
 
 - [x] Recorded decisions and branch plan.
 - [x] Added latest CDL templates in-tree.
-- [ ] Added explicit latest single-sector PARIS products.
+- [x] Added explicit latest single-sector PARIS products.
 - [ ] Added sector-aware flux reconstruction.
 - [ ] Routed multisector PARIS outputs through total product creation.
 - [ ] Added per-sector PARIS variables and diagnostics.

--- a/openghg_inversions/postprocessing/PARIS_Lagrangian_inversion_concentration_EUROPE_v04.cdl
+++ b/openghg_inversions/postprocessing/PARIS_Lagrangian_inversion_concentration_EUROPE_v04.cdl
@@ -1,0 +1,201 @@
+// 
+// placeholders to be replaced in long_name attributes and variable names
+// <species>:	species name in lower case no separators (e.g., ch4, n2o, hfc13a)
+netcdf InversionSystem_TransportModel_Domain_Experiment_Compound_Frequency_concentrations {
+dimensions:
+	index = 1 ;			// mandatory
+	percentile = 2 ;	// optional for systems that report non-Gaussian uncertainty
+	platform = 10 ; 	// mandatory
+	sector = 1 ;	// optional  
+	nbnds = 2 ; 		// mandatory
+variables:
+// characterising observation 
+	double time(index) ;						// mandatory
+		time:units = "days since 1970-01-01 00:00:00" ;
+		time:long_name = "time of mid of observation interval; UTC" ;
+		time:calendar = "proleptic_gregorian" ;
+        time:bounds = "time_bnds" ;
+		time:standard_name = "time" ; 
+    double time_bnds(index, nbnds) ; 		// mandatory 
+		time_bnds:long_name = "start and end points of each time step" ; 
+		time_bnds:calendar = "proleptic_gregorian" ;
+		time_bnds:units = "days since 1970-01-01 00:00:00" ;
+	double longitude(index) ; 				//mandatory
+        longitude:_FillValue = NaNf ;
+        longitude:long_name = "sample_longitude_in_decimal_degrees" ;
+        longitude:units = "degrees_east" ;
+        longitude:comment = "Longitude at which air sample was collected." ;
+		longitude:standard_name = "longitude" ; 
+	double latitude(index) ; 				// mandatory
+        latitude:_FillValue = NaNf ;
+        latitude:long_name = "sample_latitude_in_decimal_degrees" ;
+        latitude:units = "degrees_north" ;
+        latitude:comment = "Latitude at which air sample was collected." ;
+		latitude:standard_name = "latitude" ; 
+	float altitude(index) ; 				// mandatory 
+		altitude:_FillValue = NaNf ;
+        altitude:long_name = "sample_altitude_in_meters_above_sea_level" ;
+        altitude:units = "m" ;
+        altitude:comment = "Altitude (surface elevation plus sample intake height) at which air sample was collected" ;
+		altitude:standard_name = "altitude" ; 
+    float intake_height(index) ;			// optional 
+        intake_height:_FillValue = NaNf ;
+        intake_height:long_name = "Height above ground at which air sample was collected" ;
+        intake_height:units = "m" ;
+        intake_height:comment = "Sample intake height in meters above ground level (magl)" ;
+	float altitude_model(index) ; 				// optional 
+		altitude_model:_FillValue = NaNf ;
+        altitude_model:long_name = "altitude_in_meters_above_sea_level_in_model" ;
+        altitude_model:units = "m" ;
+        altitude_model:comment = "Altitude (surface elevation plus sample intake height) at which model was evaluated" ;
+		altitude_model:standard_name = "altitude" ; 
+    float intake_height_model(index) ;			// optional 
+        intake_height_model:_FillValue = NaNf ;
+        intake_height_model:long_name = "Height above model ground at which model concentrations were evaluated" ;
+        intake_height_model:units = "m" ;
+        intake_height_model:comment = "Model intake (release) height in meters above model ground level (magl) at which model fields were evaluated or Lagrangian trajectories were initialised (released). May differ from sample intake_height for sites in complex terrain." ;
+	short number_of_identifier(index) ; 
+		number_of_identifier:_FillValue = -9 ;
+		number_of_identifier:long_name = "Index of identifier of observing platform" ;
+		number_of_identifier:units = "1" ;
+	short assimilation_flag(index) ; 					// optional 
+		assimilation_flag:units = "1" ; 
+		assimilation_flag:_FillValue = -9 ; 
+		assimilation_flag:long_name = "indicating whether observation was used in inversion/assimilation. 0: not used; 1: used" ; 
+		assimilation_flag:comment = "Valid values: 0: not used; 1: used" ; 
+
+// observation and uncertainty
+	float mf_observed(index) ;				// mandatory 
+		mf_observed:units = "mol mol-1" ;
+		mf_observed:_FillValue = NaNf ;
+		mf_observed:long_name = "observed mole fraction of <species> in dry air" ;
+	float stdev_mf_observed_repeatability(index) ;		// optional
+		stdev_mf_observed_repeatability:units = "mol mol-1" ;
+		stdev_mf_observed_repeatability:_FillValue = NaNf ;
+		stdev_mf_observed_repeatability:long_name = "repeatability uncertainty of observed mole fraction" ;
+		stdev_mf_observed_repeatability:comment = "understood as combined analytical uncertainty";
+	float stdev_mf_observed_variability(index) ;		// optional 
+		stdev_mf_observed_variability:units = "mol mol-1" ;
+		stdev_mf_observed_variability:_FillValue = NaNf ;
+		stdev_mf_observed_variability:long_name = "variability of observed mole fraction within aggregation interval" ;
+	float stdev_mf_model(index) ;						// optional 
+		stdev_mf_model:units = "mol mol-1" ;
+		stdev_mf_model:_FillValue = NaNf ;
+		stdev_mf_model:long_name = "model uncertainty of simulated mole fraction" ;
+	float stdev_mf_total(index) ;						// mandatory 
+		stdev_mf_total:units = "mol mol-1" ;
+		stdev_mf_total:_FillValue = NaNf ;
+		stdev_mf_total:long_name = "total model-data-mismatch uncertainty applied in inversion" ;
+// simulated mole fractions
+	// mf_prior and mf_posterior contain the complete simulated concentration, this is the sum of 
+	// the regional contribution within the transport domain (mf_posterior_regional, not given 
+	// in file) and a boundary (baseline) concentration (given as mf_prior_bc and mf_posterior_bc), 
+	// i.e. mf_posterior = mf_posterior_regional + mf_posterior_bc.
+	float mf_prior(index) ;				// mandatory
+		mf_prior:units = "mol mol-1" ;
+		mf_prior:_FillValue = NaNf ;
+		mf_prior:long_name = "prior simulated mole fraction of <species> in dry air" ;
+	float mf_posterior(index) ;			// mandatory
+		mf_posterior:units = "mol mol-1" ;
+		mf_posterior:_FillValue = NaNf ;
+		mf_posterior:long_name = "posterior simulated mole fraction of <species> in dry air" ;
+
+	//  individual sector contributions	(optional); the sum should add up to mf_posterior_regional, which is not included in file
+	float mf_sector_name_prior(index) ;				// optional 
+		mf_sector_name_prior:units = "mol mol-1" ;
+		mf_sector_name_prior:_FillValue = NaNf ;
+		mf_sector_name_prior:long_name = "prior simulated mole fraction of <species> in dry air from <sector_name>" ;
+	float mf_sector_name_posterior(index) ;			// optional
+		mf_sector_name_posterior:units = "mol mol-1" ;
+		mf_sector_name_posterior:_FillValue = NaNf ;
+		mf_sector_name_posterior:long_name = "posterior simulated mole fraction of <species> in dry air from <sector_name>" ;
+
+	// mf_bc_prior and mf_bc_posterior should contain boundary condition (baseline) concentrations 
+	// and a concentration bias by site for systems that solve for it, 
+	// i.e. mf_bc_posterior = mf_bias_posterior + mf_boundary_posterior (the latter not given in file)
+	float mf_bc_prior(index) ;			// mandatory
+		mf_bc_prior:units = "mol mol-1" ;
+		mf_bc_prior:_FillValue = NaNf ;
+		mf_bc_prior:long_name = "prior simulated boundary condition mole fraction including site bias" ;
+	float mf_bc_posterior(index) ;		// mandatory
+		mf_bc_posterior:units = "mol mol-1" ;
+		mf_bc_posterior:_FillValue = NaNf ;
+		mf_bc_posterior:long_name = "posterior simulated boundary condition mole fraction including site bias" ;
+	// mf_prior_bias is an optional variable used in systems that solve for a concentration bias by site
+    float mf_bias_prior(index) ;			// optional
+        mf_bias_prior:units = "mol mol-1" ;
+        mf_bias_prior:_FillValue = NaNf ;
+        mf_bias_prior:long_name = "prior simulated mole fraction site bias" ;
+	// mf_posterior_bias is an optional variable used in systems that solve for a concentration bias by site
+	float mf_bias_posterior(index) ;		// optional 
+        mf_bias_posterior:units = "mol mol-1" ;
+        mf_bias_posterior:_FillValue = NaNf ;
+        mf_bias_posterior:long_name = "posterior simulated mole fraction site bias" ;
+	// mf_prior_outer and mf_posterior_outer should contain concentration contributions 
+	// for regions outside the main inversion domain but included in the transport domain. 
+	// Optionally given for systems that solve for such contributions (e.g., InTEM, ELRIS, RHIME). 
+	// mf_prior_outer and mf_posterior_outer are part of mf_prior_regional 
+	// and mf_posterior_regional, respectively, 
+	// i.e. mf_posterior_regional = mf_posterior_outer + mf_posterior_inversionDomain (the latter not given in file)
+	float mf_outer_prior(index) ;			// optional 
+		mf_outer_prior:units = "mol mol-1" ;
+		mf_outer_prior:_FillValue = NaNf ;
+		mf_outer_prior:long_name = "prior simulated mole fraction contribution from distant regions" ;
+	float mf_outer_posterior(index) ;		// optional 
+		mf_outer_posterior:units = "mol mol-1" ;
+		mf_outer_posterior:_FillValue = NaNf ;
+		mf_outer_posterior:long_name = "posterior simulated mole fraction contribution from distant regions" ;
+
+	// Simulated uncertainty propagated from state vector uncertainy only (does not include transport uncertainy)
+	// Either given as standard deviation or percentile range for non-Gaussian state vectors. 
+	float stdev_mf_prior(index) ;			// optional 
+		stdev_mf_prior:units = "mol mol-1" ;
+		stdev_mf_prior:_FillValue = NaNf ;
+		stdev_mf_prior:long_name = "standard deviation of prior simulated mole fractions due to state vector uncertainty" ;
+	float stdev_mf_posterior(index) ;		// optional 
+		stdev_mf_posterior:units = "mol mol-1" ;
+		stdev_mf_posterior:_FillValue = NaNf ;
+		stdev_mf_posterior:long_name = "standard deviation of posterior simulated mole fractions due to state vector uncertainty" ;
+
+	float percentile_mf_prior(index, percentile) ;	// optional
+		percentile_mf_prior:units = "mol mol-1" ;
+		percentile_mf_prior:_FillValue = NaNf ;
+		percentile_mf_prior:long_name = "percentile of prior simulated mole fraction due to state vector uncertainty" ;
+	float percentile_mf_posterior(index, percentile) ;	// optional
+		percentile_mf_posterior:units = "mol mol-1" ;
+		percentile_mf_posterior:_FillValue = NaNf ;
+		percentile_mf_posterior:long_name = "percentile of posterior simulated mole fraction due to state vector uncertainty" ;
+
+// AUXILIARY VARIABLES 
+	// alternatively to string variables use character array. String variables require netcdf 4!
+	string platform(platform) ;		// mandatory
+		platform:long_name = "identifier of observing platform; e.g., 3 letter ID for surface in-situ sites plus inlet height above ground: MHD-10" ;
+	// sector names should only contain lower case letters (no separator characters), since they should be used in variable names
+	// optional when reporting separate fluxes by sector
+	string sector(sector) ;	// optional
+		sector:long_name = "short name of flux sector" ;
+		sector:comment ="brief definition of which emissions each sector contains" ; 
+	double percentile(percentile) ;			// optional if non-Gassian uncertainties are used
+		percentile:units = "1" ;
+		percentile:long_name = "reported percentiles for non-Gaussian probability distribution functions" ;
+
+// global attributes:
+		:Conventions = "CF-1.8" ;
+		:title = "In-situ mole fractions at sites: observed and simulated" ;
+		:institution = "Empa, Switzerland" ;
+		:source = "Trace gas concentrations from observations and transport simulations / inverse estimation." ;
+		:creator = "Stephan Henne" ;
+		:creation_date = "2024-01-11" ;
+		:contact = "stephan.henne@empa.ch" ; 
+		:transport_model = "NAME" ;
+		:transport_model_version = "" ;
+		:inversion_system = "ELRIS" ;
+		:inversion_system_version = "1.2.0" ;
+		:experiment = "EDGARprior" ;
+        :project = "Process Attribution of Regional emISsions (PARIS)" ;
+		:references = "" ;
+		:comment = "" ; //	use "comment" for a comprehensive description of the dataset (like abstract for a paper) or use "summary" for this description and "comment" for any other comment and information  
+		:summary = "" ; 
+		:license = "CC-BY-4.0" ;
+        :history = "2024-01-11 21:35:03 saved from ELRIS R package" ;
+}

--- a/openghg_inversions/postprocessing/PARIS_Lagrangian_inversion_concentration_EUROPE_v04.cdl
+++ b/openghg_inversions/postprocessing/PARIS_Lagrangian_inversion_concentration_EUROPE_v04.cdl
@@ -1,4 +1,4 @@
-// 
+//
 // placeholders to be replaced in long_name attributes and variable names
 // <species>:	species name in lower case no separators (e.g., ch4, n2o, hfc13a)
 netcdf InversionSystem_TransportModel_Domain_Experiment_Compound_Frequency_concentrations {
@@ -6,18 +6,18 @@ dimensions:
 	index = 1 ;			// mandatory
 	percentile = 2 ;	// optional for systems that report non-Gaussian uncertainty
 	platform = 10 ; 	// mandatory
-	sector = 1 ;	// optional  
+	sector = 1 ;	// optional
 	nbnds = 2 ; 		// mandatory
 variables:
-// characterising observation 
+// characterising observation
 	double time(index) ;						// mandatory
 		time:units = "days since 1970-01-01 00:00:00" ;
 		time:long_name = "time of mid of observation interval; UTC" ;
 		time:calendar = "proleptic_gregorian" ;
         time:bounds = "time_bnds" ;
-		time:standard_name = "time" ; 
-    double time_bnds(index, nbnds) ; 		// mandatory 
-		time_bnds:long_name = "start and end points of each time step" ; 
+		time:standard_name = "time" ;
+    double time_bnds(index, nbnds) ; 		// mandatory
+		time_bnds:long_name = "start and end points of each time step" ;
 		time_bnds:calendar = "proleptic_gregorian" ;
 		time_bnds:units = "days since 1970-01-01 00:00:00" ;
 	double longitude(index) ; 				//mandatory
@@ -25,47 +25,47 @@ variables:
         longitude:long_name = "sample_longitude_in_decimal_degrees" ;
         longitude:units = "degrees_east" ;
         longitude:comment = "Longitude at which air sample was collected." ;
-		longitude:standard_name = "longitude" ; 
+		longitude:standard_name = "longitude" ;
 	double latitude(index) ; 				// mandatory
         latitude:_FillValue = NaNf ;
         latitude:long_name = "sample_latitude_in_decimal_degrees" ;
         latitude:units = "degrees_north" ;
         latitude:comment = "Latitude at which air sample was collected." ;
-		latitude:standard_name = "latitude" ; 
-	float altitude(index) ; 				// mandatory 
+		latitude:standard_name = "latitude" ;
+	float altitude(index) ; 				// mandatory
 		altitude:_FillValue = NaNf ;
         altitude:long_name = "sample_altitude_in_meters_above_sea_level" ;
         altitude:units = "m" ;
         altitude:comment = "Altitude (surface elevation plus sample intake height) at which air sample was collected" ;
-		altitude:standard_name = "altitude" ; 
-    float intake_height(index) ;			// optional 
+		altitude:standard_name = "altitude" ;
+    float intake_height(index) ;			// optional
         intake_height:_FillValue = NaNf ;
         intake_height:long_name = "Height above ground at which air sample was collected" ;
         intake_height:units = "m" ;
         intake_height:comment = "Sample intake height in meters above ground level (magl)" ;
-	float altitude_model(index) ; 				// optional 
+	float altitude_model(index) ; 				// optional
 		altitude_model:_FillValue = NaNf ;
         altitude_model:long_name = "altitude_in_meters_above_sea_level_in_model" ;
         altitude_model:units = "m" ;
         altitude_model:comment = "Altitude (surface elevation plus sample intake height) at which model was evaluated" ;
-		altitude_model:standard_name = "altitude" ; 
-    float intake_height_model(index) ;			// optional 
+		altitude_model:standard_name = "altitude" ;
+    float intake_height_model(index) ;			// optional
         intake_height_model:_FillValue = NaNf ;
         intake_height_model:long_name = "Height above model ground at which model concentrations were evaluated" ;
         intake_height_model:units = "m" ;
         intake_height_model:comment = "Model intake (release) height in meters above model ground level (magl) at which model fields were evaluated or Lagrangian trajectories were initialised (released). May differ from sample intake_height for sites in complex terrain." ;
-	short number_of_identifier(index) ; 
+	short number_of_identifier(index) ;
 		number_of_identifier:_FillValue = -9 ;
 		number_of_identifier:long_name = "Index of identifier of observing platform" ;
 		number_of_identifier:units = "1" ;
-	short assimilation_flag(index) ; 					// optional 
-		assimilation_flag:units = "1" ; 
-		assimilation_flag:_FillValue = -9 ; 
-		assimilation_flag:long_name = "indicating whether observation was used in inversion/assimilation. 0: not used; 1: used" ; 
-		assimilation_flag:comment = "Valid values: 0: not used; 1: used" ; 
+	short assimilation_flag(index) ; 					// optional
+		assimilation_flag:units = "1" ;
+		assimilation_flag:_FillValue = -9 ;
+		assimilation_flag:long_name = "indicating whether observation was used in inversion/assimilation. 0: not used; 1: used" ;
+		assimilation_flag:comment = "Valid values: 0: not used; 1: used" ;
 
 // observation and uncertainty
-	float mf_observed(index) ;				// mandatory 
+	float mf_observed(index) ;				// mandatory
 		mf_observed:units = "mol mol-1" ;
 		mf_observed:_FillValue = NaNf ;
 		mf_observed:long_name = "observed mole fraction of <species> in dry air" ;
@@ -74,22 +74,22 @@ variables:
 		stdev_mf_observed_repeatability:_FillValue = NaNf ;
 		stdev_mf_observed_repeatability:long_name = "repeatability uncertainty of observed mole fraction" ;
 		stdev_mf_observed_repeatability:comment = "understood as combined analytical uncertainty";
-	float stdev_mf_observed_variability(index) ;		// optional 
+	float stdev_mf_observed_variability(index) ;		// optional
 		stdev_mf_observed_variability:units = "mol mol-1" ;
 		stdev_mf_observed_variability:_FillValue = NaNf ;
 		stdev_mf_observed_variability:long_name = "variability of observed mole fraction within aggregation interval" ;
-	float stdev_mf_model(index) ;						// optional 
+	float stdev_mf_model(index) ;						// optional
 		stdev_mf_model:units = "mol mol-1" ;
 		stdev_mf_model:_FillValue = NaNf ;
 		stdev_mf_model:long_name = "model uncertainty of simulated mole fraction" ;
-	float stdev_mf_total(index) ;						// mandatory 
+	float stdev_mf_total(index) ;						// mandatory
 		stdev_mf_total:units = "mol mol-1" ;
 		stdev_mf_total:_FillValue = NaNf ;
 		stdev_mf_total:long_name = "total model-data-mismatch uncertainty applied in inversion" ;
 // simulated mole fractions
-	// mf_prior and mf_posterior contain the complete simulated concentration, this is the sum of 
-	// the regional contribution within the transport domain (mf_posterior_regional, not given 
-	// in file) and a boundary (baseline) concentration (given as mf_prior_bc and mf_posterior_bc), 
+	// mf_prior and mf_posterior contain the complete simulated concentration, this is the sum of
+	// the regional contribution within the transport domain (mf_posterior_regional, not given
+	// in file) and a boundary (baseline) concentration (given as mf_prior_bc and mf_posterior_bc),
 	// i.e. mf_posterior = mf_posterior_regional + mf_posterior_bc.
 	float mf_prior(index) ;				// mandatory
 		mf_prior:units = "mol mol-1" ;
@@ -101,7 +101,7 @@ variables:
 		mf_posterior:long_name = "posterior simulated mole fraction of <species> in dry air" ;
 
 	//  individual sector contributions	(optional); the sum should add up to mf_posterior_regional, which is not included in file
-	float mf_sector_name_prior(index) ;				// optional 
+	float mf_sector_name_prior(index) ;				// optional
 		mf_sector_name_prior:units = "mol mol-1" ;
 		mf_sector_name_prior:_FillValue = NaNf ;
 		mf_sector_name_prior:long_name = "prior simulated mole fraction of <species> in dry air from <sector_name>" ;
@@ -110,8 +110,8 @@ variables:
 		mf_sector_name_posterior:_FillValue = NaNf ;
 		mf_sector_name_posterior:long_name = "posterior simulated mole fraction of <species> in dry air from <sector_name>" ;
 
-	// mf_bc_prior and mf_bc_posterior should contain boundary condition (baseline) concentrations 
-	// and a concentration bias by site for systems that solve for it, 
+	// mf_bc_prior and mf_bc_posterior should contain boundary condition (baseline) concentrations
+	// and a concentration bias by site for systems that solve for it,
 	// i.e. mf_bc_posterior = mf_bias_posterior + mf_boundary_posterior (the latter not given in file)
 	float mf_bc_prior(index) ;			// mandatory
 		mf_bc_prior:units = "mol mol-1" ;
@@ -127,32 +127,32 @@ variables:
         mf_bias_prior:_FillValue = NaNf ;
         mf_bias_prior:long_name = "prior simulated mole fraction site bias" ;
 	// mf_posterior_bias is an optional variable used in systems that solve for a concentration bias by site
-	float mf_bias_posterior(index) ;		// optional 
+	float mf_bias_posterior(index) ;		// optional
         mf_bias_posterior:units = "mol mol-1" ;
         mf_bias_posterior:_FillValue = NaNf ;
         mf_bias_posterior:long_name = "posterior simulated mole fraction site bias" ;
-	// mf_prior_outer and mf_posterior_outer should contain concentration contributions 
-	// for regions outside the main inversion domain but included in the transport domain. 
-	// Optionally given for systems that solve for such contributions (e.g., InTEM, ELRIS, RHIME). 
-	// mf_prior_outer and mf_posterior_outer are part of mf_prior_regional 
-	// and mf_posterior_regional, respectively, 
+	// mf_prior_outer and mf_posterior_outer should contain concentration contributions
+	// for regions outside the main inversion domain but included in the transport domain.
+	// Optionally given for systems that solve for such contributions (e.g., InTEM, ELRIS, RHIME).
+	// mf_prior_outer and mf_posterior_outer are part of mf_prior_regional
+	// and mf_posterior_regional, respectively,
 	// i.e. mf_posterior_regional = mf_posterior_outer + mf_posterior_inversionDomain (the latter not given in file)
-	float mf_outer_prior(index) ;			// optional 
+	float mf_outer_prior(index) ;			// optional
 		mf_outer_prior:units = "mol mol-1" ;
 		mf_outer_prior:_FillValue = NaNf ;
 		mf_outer_prior:long_name = "prior simulated mole fraction contribution from distant regions" ;
-	float mf_outer_posterior(index) ;		// optional 
+	float mf_outer_posterior(index) ;		// optional
 		mf_outer_posterior:units = "mol mol-1" ;
 		mf_outer_posterior:_FillValue = NaNf ;
 		mf_outer_posterior:long_name = "posterior simulated mole fraction contribution from distant regions" ;
 
 	// Simulated uncertainty propagated from state vector uncertainy only (does not include transport uncertainy)
-	// Either given as standard deviation or percentile range for non-Gaussian state vectors. 
-	float stdev_mf_prior(index) ;			// optional 
+	// Either given as standard deviation or percentile range for non-Gaussian state vectors.
+	float stdev_mf_prior(index) ;			// optional
 		stdev_mf_prior:units = "mol mol-1" ;
 		stdev_mf_prior:_FillValue = NaNf ;
 		stdev_mf_prior:long_name = "standard deviation of prior simulated mole fractions due to state vector uncertainty" ;
-	float stdev_mf_posterior(index) ;		// optional 
+	float stdev_mf_posterior(index) ;		// optional
 		stdev_mf_posterior:units = "mol mol-1" ;
 		stdev_mf_posterior:_FillValue = NaNf ;
 		stdev_mf_posterior:long_name = "standard deviation of posterior simulated mole fractions due to state vector uncertainty" ;
@@ -166,7 +166,7 @@ variables:
 		percentile_mf_posterior:_FillValue = NaNf ;
 		percentile_mf_posterior:long_name = "percentile of posterior simulated mole fraction due to state vector uncertainty" ;
 
-// AUXILIARY VARIABLES 
+// AUXILIARY VARIABLES
 	// alternatively to string variables use character array. String variables require netcdf 4!
 	string platform(platform) ;		// mandatory
 		platform:long_name = "identifier of observing platform; e.g., 3 letter ID for surface in-situ sites plus inlet height above ground: MHD-10" ;
@@ -174,7 +174,7 @@ variables:
 	// optional when reporting separate fluxes by sector
 	string sector(sector) ;	// optional
 		sector:long_name = "short name of flux sector" ;
-		sector:comment ="brief definition of which emissions each sector contains" ; 
+		sector:comment ="brief definition of which emissions each sector contains" ;
 	double percentile(percentile) ;			// optional if non-Gassian uncertainties are used
 		percentile:units = "1" ;
 		percentile:long_name = "reported percentiles for non-Gaussian probability distribution functions" ;
@@ -186,7 +186,7 @@ variables:
 		:source = "Trace gas concentrations from observations and transport simulations / inverse estimation." ;
 		:creator = "Stephan Henne" ;
 		:creation_date = "2024-01-11" ;
-		:contact = "stephan.henne@empa.ch" ; 
+		:contact = "stephan.henne@empa.ch" ;
 		:transport_model = "NAME" ;
 		:transport_model_version = "" ;
 		:inversion_system = "ELRIS" ;
@@ -194,8 +194,8 @@ variables:
 		:experiment = "EDGARprior" ;
         :project = "Process Attribution of Regional emISsions (PARIS)" ;
 		:references = "" ;
-		:comment = "" ; //	use "comment" for a comprehensive description of the dataset (like abstract for a paper) or use "summary" for this description and "comment" for any other comment and information  
-		:summary = "" ; 
+		:comment = "" ; //	use "comment" for a comprehensive description of the dataset (like abstract for a paper) or use "summary" for this description and "comment" for any other comment and information
+		:summary = "" ;
 		:license = "CC-BY-4.0" ;
         :history = "2024-01-11 21:35:03 saved from ELRIS R package" ;
 }

--- a/openghg_inversions/postprocessing/PARIS_Lagrangian_inversion_flux_EUROPE_v03.cdl
+++ b/openghg_inversions/postprocessing/PARIS_Lagrangian_inversion_flux_EUROPE_v03.cdl
@@ -1,0 +1,404 @@
+// 
+// placeholders to be replaced in long_name attributes and variable names
+// <species>:	species name in lower case no separators (e.g., ch4, n2o, hfc13a)
+// <sector_name>:	name of flux sector (lower case no separators), (e.g., agriculture, waste, energy, industry); Given without '<>' in variable names!
+// 
+netcdf PARIS_Lagrangian_inversion_flux {
+dimensions:
+	longitude = 391 ;	// mandatory
+	latitude = 293 ;	// mandatory
+	time = 1 ;			// mandatory
+// percentile is optional for systems that report non-Gaussian uncertainty
+	percentile = 2 ;	// optional
+	country = 22 ;	    // mandatory
+	sector = 1 ;	    // optional  
+    nbnds = 2 ; 		// mandatory
+variables:
+	double longitude(longitude) ;	// mandatory
+		longitude:units = "degrees_east" ;
+		longitude:long_name = "longitude of grid cell centre" ;
+		longitude:standard_name = "longitude" ; 
+		longitude:axis = "X" ; 
+	double latitude(latitude) ;		// mandatory
+		latitude:units = "degrees_north" ;
+		latitude:long_name = "latitude of grid cell centre" ;
+		latitude:standard_name = "latitude" ;
+		latitude:axis = "Y" ; 
+	double time(time) ;				// mandatory
+		time:units = "days since 1970-01-01 00:00:00" ;
+		time:long_name = "mid of flux interval in UTC" ;
+        time:standard_name = "time" ; 
+		time:calendar = "proleptic_gregorian" ;
+        time:axis = "T" ; 
+        time:bounds = "time_bnds";
+// percentile is optional for systems that report non-Gaussian uncertainty
+	double percentile(percentile) ;	// optional 
+		percentile:units = "1" ;
+		percentile:long_name = "percentile of flux pdf" ;
+    double time_bnds(time, nbnds) ; // mandatory
+		time_bnds:long_name = "start and end points of each time step" ; 
+		time_bnds:calendar = "proleptic_gregorian" ;
+		time_bnds:units = "days since 1970-01-01 00:00:00" ;
+//
+// TOTAL FLUX ON SPATIAL GRID
+//	'total' variables should be present even if fluxes by sector are given separately
+	float flux_total_prior(time, latitude, longitude) ;	// mandatory
+		flux_total_prior:units = "mol m-2 s-1" ;
+		flux_total_prior:_FillValue = NaNf ;
+		flux_total_prior:long_name = "prior total <species> fluxes" ;
+		flux_total_prior:cell_methods = "time:mean area:mean" ;
+	float flux_total_posterior(time, latitude, longitude) ;	// mandatory
+		flux_total_posterior:units = "mol m-2 s-1" ;
+		flux_total_posterior:_FillValue = NaNf ;
+		flux_total_posterior:long_name = "posterior total <species> fluxes" ;
+		flux_total_posterior:cell_methods = "time:mean area:mean" ;
+// UNCERTAINTY OF TOTAL FLUX ON SPATIAL GRID
+	// by default, uncertainty should be reported as standard deviation (1-sigma) around the mean, alternatively percentiles can be given in 'percentile' variables
+	float stdev_flux_total_prior(time, latitude, longitude) ;	// conditional (mandatory if percentile_flux_total_prior missing)
+		stdev_flux_total_prior:units = "mol m-2 s-1" ;
+		stdev_flux_total_prior:_FillValue = NaNf ;
+		stdev_flux_total_prior:long_name = "standard deviation of prior total <species> fluxes" ;
+		stdev_flux_total_prior:cell_methods = "time:mean area:mean" ;
+	float stdev_flux_total_posterior(time, latitude, longitude) ;	// conditional (mandatory if percentile_flux_total_posterior missing)
+		stdev_flux_total_posterior:units = "mol m-2 s-1" ;
+		stdev_flux_total_posterior:_FillValue = NaNf ;
+		stdev_flux_total_posterior:long_name = "standard deviation of posterior total <species> fluxes" ;
+		stdev_flux_total_posterior:cell_methods = "time:mean area:mean" ;
+	// 'percentile' variables are optional for systems that report non-Gaussian uncertainty and do not report 'stdev' variables
+	float percentile_flux_total_prior(time, percentile, latitude, longitude) ;	// conditional (mandatory if stdev_flux_total_prior missing)
+		percentile_flux_total_prior:units = "mol m-2 s-1" ;
+		percentile_flux_total_prior:_FillValue = NaNf ;
+		percentile_flux_total_prior:long_name = "percentiles of prior total <species> fluxes" ;
+		percentile_flux_total_prior:cell_methods = "time:mean percentile:point area:mean" ;
+	float percentile_flux_total_posterior(time, percentile, latitude, longitude) ; // conditional (mandatory if stdev_flux_total_posterior missing)
+		percentile_flux_total_posterior:units = "mol m-2 s-1" ;
+		percentile_flux_total_posterior:_FillValue = NaNf ;
+		percentile_flux_total_posterior:long_name = "percentiles of posterior total <species> fluxes" ;
+		percentile_flux_total_posterior:cell_methods = "time:mean percentile:point area:mean" ;
+//
+// FLUX ON SPATIAL GRID BY SECTOR (one set of variables per sector)
+	//  all sector variables are optional. However, if a sector is given the same variables as for the total are mandatory.
+	//	'sector' variables are optional for systems that give fluxes by sector ; 
+	//  sector names should be given in the sector_names variable: typical names may be 'agriculture', 'energy' 'waste', 'industry'
+	//	'sector' needs to be replaced by the individual names 
+	float flux_sector_name_prior(time, latitude, longitude) ;		
+		flux_sector_name_prior:units = "mol m-2 s-1" ;
+		flux_sector_name_prior:_FillValue = NaNf ;
+		flux_sector_name_prior:long_name = "prior <species> fluxes from sector_name" ;
+		flux_sector_name_prior:cell_methods = "time:mean area:mean" ;
+	float flux_sector_name_posterior(time, latitude, longitude) ;
+		flux_sector_name_posterior:units = "mol m-2 s-1" ;
+		flux_sector_name_posterior:_FillValue = NaNf ;
+		flux_sector_name_posterior:long_name = "posterior <species> fluxes from <sector_name>" ;
+		flux_sector_name_posterior:cell_methods = "time:mean area:mean" ;
+// UNCERTAINTY OF FLUX ON SPATIAL GRID BY SECTOR
+	// by default, uncertainty should be reported as standard deviation (1-sigma) around the mean, alternatively percentiles can be given in 'percentile' variables
+	float stdev_flux_sector_name_prior(time, latitude, longitude) ;
+		stdev_flux_sector_name_prior:units = "mol m-2 s-1" ;
+		stdev_flux_sector_name_prior:_FillValue = NaNf ;
+		stdev_flux_sector_name_prior:long_name = "standard deviation prior <species> fluxes from <sector_name>" ;
+		stdev_flux_sector_name_prior:cell_methods = "time:mean area:mean" ;
+	float stdev_flux_sector_name_posterior(time, latitude, longitude) ;
+		stdev_flux_sector_name_posterior:units = "mol m-2 s-1" ;
+		stdev_flux_sector_name_posterior:_FillValue = NaNf ;
+		stdev_flux_sector_name_posterior:long_name = "standard deviation posterior <species> fluxes from <sector_name>" ;
+		stdev_flux_sector_name_posterior:cell_methods = "time:mean area:mean" ;
+	float percentile_flux_sector_name_prior(time, percentile, latitude, longitude) ;
+		percentile_flux_sector_name_prior:units = "mol m-2 s-1" ;
+		percentile_flux_sector_name_prior:_FillValue = NaNf ;
+		percentile_flux_sector_name_prior:long_name = "percentiles of prior <species> fluxes from <sector_name>" ;
+		percentile_flux_sector_name_prior:cell_methods = "time:mean percentile:point area:mean" ;
+	float percentile_flux_sector_name_posterior(time, percentile, latitude, longitude) ;
+		percentile_flux_sector_name_posterior:units = "mol m-2 s-1" ;
+		percentile_flux_sector_name_posterior:_FillValue = NaNf ;
+		percentile_flux_sector_name_posterior:long_name = "percentiles of posterior <species> fluxes from <sector_name>" ;
+		percentile_flux_sector_name_posterior:cell_methods = "time:mean percentile:point area:mean" ;
+//
+// TOTAL FLUX AND UNCERTAINTY ON REDUCED SPATIAL GRID
+	// optional for inversions that solve the state vector on a reduced grid
+	float flux_total_prior_inversion_grid(time, latitude, longitude) ;
+		flux_total_prior_inversion_grid:units = "mol m-2 s-1" ;
+		flux_total_prior_inversion_grid:_FillValue = NaNf ;
+		flux_total_prior_inversion_grid:long_name = "prior total <species> fluxes on the inversion grid" ;
+		flux_total_prior_inversion_grid:cell_methods = "time:mean area:mean" ; 
+    float flux_total_posterior_inversion_grid(time, latitude, longitude) ;
+		flux_total_posterior_inversion_grid:units = "mol m-2 s-1" ;
+		flux_total_posterior_inversion_grid:_FillValue = NaNf ;
+		flux_total_posterior_inversion_grid:long_name = "posterior total <species> fluxes on the inversion grid" ;
+		flux_total_posterior_inversion_grid:cell_methods = "time:mean area:mean" ;
+	// by default, uncertainty should be reported as standard deviation (1-sigma) around the mean, alternatively percentiles can be given in 'percentile' variables
+	float stdev_flux_total_prior_inversion_grid(time, latitude, longitude) ;
+		stdev_flux_total_prior_inversion_grid:units = "mol m-2 s-1" ;
+		stdev_flux_total_prior_inversion_grid:_FillValue = NaNf ;
+		stdev_flux_total_prior_inversion_grid:long_name = "standard deviation of prior total <species> fluxes on the inversion grid" ;
+		stdev_flux_total_prior_inversion_grid:cell_methods = "time:mean area:mean" ; 
+    float stdev_flux_total_posterior_inversion_grid(time, latitude, longitude) ;
+		stdev_flux_total_posterior_inversion_grid:units = "mol m-2 s-1" ;
+		stdev_flux_total_posterior_inversion_grid:_FillValue = NaNf ;
+		stdev_flux_total_posterior_inversion_grid:long_name = "standard deviation of posterior total <species> fluxes on the inversion grid" ;
+		stdev_flux_total_posterior_inversion_grid:cell_methods = "time:mean area:mean" ;
+
+	float percentile_flux_total_prior_inversion_grid(time, percentile, latitude, longitude) ;
+		percentile_flux_total_prior_inversion_grid:units = "mol m-2 s-1" ;
+		percentile_flux_total_prior_inversion_grid:_FillValue = NaNf ;
+		percentile_flux_total_prior_inversion_grid:long_name = "percentiles of prior total <species> fluxes on the inversion grid" ;
+		percentile_flux_total_prior_inversion_grid:cell_methods = "time:mean percentile:point area:mean" ;
+	float percentile_flux_total_posterior_inversion_grid(time, percentile, latitude, longitude) ;
+		percentile_flux_total_posterior_inversion_grid:units = "mol m-2 s-1" ;
+		percentile_flux_total_posterior_inversion_grid:_FillValue = NaNf ;
+		percentile_flux_total_posterior_inversion_grid:long_name = "percentiles of posterior total <species> fluxes on the inversion grid" ;
+		percentile_flux_total_posterior_inversion_grid:cell_methods = "time:mean percentile:point area:mean" ;
+//
+// FLUX AND UNCERTAINTY ON REDUCED SPATIAL GRID BY SECTOR
+	// optional for inversions that solve the state vector on a reduced grid 
+	float flux_sector_name_prior_inversion_grid(time, latitude, longitude) ;
+		flux_sector_name_prior_inversion_grid:units = "mol m-2 s-1" ;
+		flux_sector_name_prior_inversion_grid:_FillValue = NaNf ;
+		flux_sector_name_prior_inversion_grid:long_name = "prior flux of <species> for <sector_name> on the inversion grid" ;
+		flux_sector_name_prior_inversion_grid:cell_methods = "time:mean area:mean" ; 
+    float flux_sector_name_posterior_inversion_grid(time, latitude, longitude) ;
+		flux_sector_name_posterior_inversion_grid:units = "mol m-2 s-1" ;
+		flux_sector_name_posterior_inversion_grid:_FillValue = NaNf ;
+		flux_sector_name_posterior_inversion_grid:long_name = "posterior flux of  <species> for <sector_name> on the inversion grid" ;
+		flux_sector_name_posterior_inversion_grid:cell_methods = "time:mean area:mean" ;
+	// by default, uncertainty should be reported as standard deviation (1-sigma) around the mean, alternatively percentiles can be given in 'percentile' variables
+	float stdev_flux_sector_name_prior_inversion_grid(time, latitude, longitude) ;
+		stdev_flux_sector_name_prior_inversion_grid:units = "mol m-2 s-1" ;
+		stdev_flux_sector_name_prior_inversion_grid:_FillValue = NaNf ;
+		stdev_flux_sector_name_prior_inversion_grid:long_name = "standard deviation of prior flux of <species> for <sector_name> on the inversion grid" ;
+		stdev_flux_sector_name_prior_inversion_grid:cell_methods = "time:mean area:mean" ; 
+    float stdev_flux_sector_name_posterior_inversion_grid(time, latitude, longitude) ;
+		stdev_flux_sector_name_posterior_inversion_grid:units = "mol m-2 s-1" ;
+		stdev_flux_sector_name_posterior_inversion_grid:_FillValue = NaNf ;
+		stdev_flux_sector_name_posterior_inversion_grid:long_name = "standard deviation of posterior flux of <species> for <sector_name> on the inversion grid" ;
+		stdev_flux_sector_name_posterior_inversion_grid:cell_methods = "time:mean area:mean" ;
+
+	float percentile_flux_sector_name_prior_inversion_grid(time, percentile, latitude, longitude) ;
+		percentile_flux_sector_name_prior_inversion_grid:units = "mol m-2 s-1" ;
+		percentile_flux_sector_name_prior_inversion_grid:_FillValue = NaNf ;
+		percentile_flux_sector_name_prior_inversion_grid:long_name = "percentiles of prior flux of <species> for <sector_name> on the inversion grid" ;
+		percentile_flux_sector_name_prior_inversion_grid:cell_methods = "time:mean percentile:point area:mean" ;
+	float percentile_flux_sector_name_posterior_inversion_grid(time, percentile, latitude, longitude) ;
+		percentile_flux_sector_name_posterior_inversion_grid:units = "mol m-2 s-1" ;
+		percentile_flux_sector_name_posterior_inversion_grid:_FillValue = NaNf ;
+		percentile_flux_sector_name_posterior_inversion_grid:long_name = "percentiles of posterior flux of <species> for <sector_name> on the inversion grid" ;
+		percentile_flux_sector_name_posterior_inversion_grid:cell_methods = "time:mean percentile:point area:mean" ;
+
+//	TOTAL FLUX BY COUNTRY
+	float flux_total_prior_country(time, country) ;	// mandatory
+		flux_total_prior_country:units = "kg yr-1" ;
+		flux_total_prior_country:_FillValue = NaNf ;
+		flux_total_prior_country:long_name = "country-total prior <species> fluxes" ;
+		flux_total_prior_country:cell_methods = "time:mean country:point" ;
+	float flux_total_posterior_country(time, country) ;	// mandatory
+		flux_total_posterior_country:units = "kg yr-1" ;
+		flux_total_posterior_country:_FillValue = NaNf ;
+		flux_total_posterior_country:long_name = "country-total posterior <species> fluxes" ;
+		flux_total_posterior_country:cell_methods = "time:mean country:point" ;
+	float stdev_flux_total_prior_country(time, country) ;	// conditional (mandatory if percentile_flux_total_prior_country missing)
+		stdev_flux_total_prior_country:units = "kg yr-1" ;
+		stdev_flux_total_prior_country:_FillValue = NaNf ;
+		stdev_flux_total_prior_country:long_name = "standard deviation of country-total prior <species> fluxes" ;
+		stdev_flux_total_prior_country:cell_methods = "time:mean country:point" ;
+	float stdev_flux_total_posterior_country(time, country) ; // conditional (mandatory if percentile_flux_total_posterior_country missing)
+		stdev_flux_total_posterior_country:units = "kg yr-1" ;
+		stdev_flux_total_posterior_country:_FillValue = NaNf ;
+		stdev_flux_total_posterior_country:long_name = "standard deviation of country-total posterior <species> fluxes" ;
+		stdev_flux_total_posterior_country:cell_methods = "time:mean country:point" ;
+	// covariance between countries 
+	float covariance_flux_total_posterior_country(time, country, country) ;	// mandatory
+		covariance_flux_total_posterior_country:units = "kg2 yr-2" ;
+		covariance_flux_total_posterior_country:_FillValue = NaNf ;
+		covariance_flux_total_posterior_country:long_name = "covariance of country-total posterior <species> fluxes" ;
+		covariance_flux_total_posterior_country:cell_methods = "time:mean country:point country:point" ;
+	float percentile_flux_total_prior_country(time, percentile, country) ;
+		percentile_flux_total_prior_country:units = "kg yr-1" ;
+		percentile_flux_total_prior_country:_FillValue = NaNf ;
+		percentile_flux_total_prior_country:long_name = "percentiles of country-total prior <species> fluxes" ;
+		percentile_flux_total_prior_country:cell_methods = "time:mean percentile:point country:point" ;
+	float percentile_flux_total_posterior_country(time, percentile, country) ;
+		percentile_flux_total_posterior_country:units = "kg yr-1" ;
+		percentile_flux_total_posterior_country:_FillValue = NaNf ;
+		percentile_flux_total_posterior_country:long_name = "percentiles of country-total posterior <species> fluxes" ;
+		percentile_flux_total_posterior_country:cell_methods = "time:mean percentile:point country:point" ;
+//	FLUX BY SECTOR AND COUNTRY
+	float flux_sector_name_prior_country(time, country) ; // optional
+		flux_sector_name_prior_country:units = "kg yr-1" ;
+		flux_sector_name_prior_country:_FillValue = NaNf ;
+		flux_sector_name_prior_country:long_name = "country-<sector_name> prior <species> fluxes" ;
+		flux_sector_name_prior_country:cell_methods = "time:mean country:point" ;
+	float flux_sector_name_posterior_country(time, country) ; // optional
+		flux_sector_name_posterior_country:units = "kg yr-1" ;
+		flux_sector_name_posterior_country:_FillValue = NaNf ;
+		flux_sector_name_posterior_country:long_name = "country-<sector_name> posterior <species> fluxes" ;
+		flux_sector_name_posterior_country:cell_methods = "time:mean country:point" ;
+	float stdev_flux_sector_name_prior_country(time, country) ; // optional
+		stdev_flux_sector_name_prior_country:units = "kg yr-1" ;
+		stdev_flux_sector_name_prior_country:_FillValue = NaNf ;
+		stdev_flux_sector_name_prior_country:long_name = "standard deviation of country-<sector_name> prior <species> fluxes" ;
+		stdev_flux_sector_name_prior_country:cell_methods = "time:mean country:point" ;
+	float stdev_flux_sector_name_posterior_country(time, country) ; // optional
+		stdev_flux_sector_name_posterior_country:units = "kg yr-1" ;
+		stdev_flux_sector_name_posterior_country:_FillValue = NaNf ;
+		stdev_flux_sector_name_posterior_country:long_name = "standard deviation of country-<sector_name> posterior <species> fluxes" ;
+		stdev_flux_sector_name_posterior_country:cell_methods = "time:mean country:point" ;
+	// covariance within each sector between countries
+	float covariance_flux_sector_name_posterior_country(time, country, country) ; // optional
+		covariance_flux_sector_name_posterior_country:units = "kg2 yr-2" ;
+		covariance_flux_sector_name_posterior_country:_FillValue = NaNf ;
+		covariance_flux_sector_name_posterior_country:long_name = "covariance of posterior <species> fluxes of <sector_name> between countries" ;
+		covariance_flux_sector_name_posterior_country:cell_methods = "time:mean country:point country:point" ;
+	float percentile_flux_sector_name_prior_country(time, percentile, country) ; // optional
+		percentile_flux_sector_name_prior_country:units = "kg yr-1" ;
+		percentile_flux_sector_name_prior_country:_FillValue = NaNf ;
+		percentile_flux_sector_name_prior_country:long_name = "percentiles of country-<sector_name> prior <species> fluxes" ;
+		percentile_flux_sector_name_prior_country:cell_methods = "time:mean percentile:point country:point" ;
+	float percentile_flux_sector_name_posterior_country(time, percentile, country) ; // optional
+		percentile_flux_sector_name_posterior_country:units = "kg yr-1" ;
+		percentile_flux_sector_name_posterior_country:_FillValue = NaNf ;
+		percentile_flux_sector_name_posterior_country:long_name = "percentiles of country-<sector_name> posterior <species> fluxes" ;
+		percentile_flux_sector_name_posterior_country:cell_methods = "time:mean percentile:point country:point" ;
+	// covariance within each country between sectors
+	float covariance_flux_sectors_posterior_country(time, country, sector, sector) ; // optional
+		covariance_flux_sectors_posterior_country:units = "kg2 yr-2" ;
+		covariance_flux_sectors_posterior_country:_FillValue = NaNf ;
+		covariance_flux_sectors_posterior_country:long_name = "covariance of posterior <species> fluxes within each country between sectors " ;
+		covariance_flux_sectors_posterior_country:cell_methods = "time:mean country:point sector:point sector:point" ;
+
+
+//	AUXILIARY VARIABLES
+	// Country abbreviation 
+	// alternatively to string variables use character array. String variables require netcdf 4!
+	string country(country) ;	// mandatory 
+		country:long_name = "country_ISO_3166_1_alpha3" ;
+	// sector names should only contain lower case letters (no separator characters), since they should be used in variable names
+	// optional when reporting separate fluxes by sector
+	string sector(sector) ;	// optional
+		sector:long_name = "short name of flux sector" ;
+		sector:comment ="brief definition of which emissions each sector contains" ; 
+	//	
+	float country_fraction(country, latitude, longitude) ;	// mandatory
+		country_fraction:units = "1" ;
+		country_fraction:_FillValue = NaNf ;
+		country_fraction:long_name = "fraction of grid cell associated to country" ;
+		country_fraction:standard_name = "area_fraction" ; 
+	//
+	float cell_area(latitude, longitude) ;	// mandatory
+		cell_area:units = "m2" ;
+		cell_area:_FillValue = NaNf ;
+		cell_area:long_name = "surface area of grid cell" ;
+		cell_area:standard_name = "cell_area" ;
+
+
+// global attributes:
+        :title = "GHG flux distribution and country totals" ;
+		:institution = "Empa, Switzerland" ;
+		:source = "Estimated flux from trace gas observations transport simulations and inversion code." ;
+		:creator = "Stephan Henne" ;
+		:creation_date = "2024-01-11" ;
+		:contact = "stephan.henne@empa.ch" ; 
+        :frequency = "yearly" ; 
+		:geospatial_lat_resolution = "0.234 degree" ; 
+        :geospatial_lon_resolution = "0.352 degree" ;
+		:transport_model = "NAME" ;
+        :transport_model_version = "" ; 
+        :inversion_system = "ELRIS" ; 
+        :inversion_system_version ="1.2.0" ;
+		:experiment = "EDGARprior" ;
+        :project = "Process Attribution of Regional emISsions (PARIS)" ;
+        :Conventions = "CF-1.8" ; 
+		:references = "Inversion code based on\n",
+			" Stohl et al., Atmos. Chem. Phys., 2009, doi:10.5194/acp-9-1597-2009\n",
+			" Henne et al., Atmos. Chem. Phys., 2016, doi:10.5194/acp-16-3683-2016" ;
+		:comment = "" ; //	use "comment" for a comprehensive description of the dataset (like abstract for a paper) or use "summary" for this description and "comment" for any other comment and information  
+		:summary = "" ; 
+        :license = "CC-BY-4.0" ;
+        :history = "2024-01-11 21:35:03 saved from ELRIS R package" ;
+
+data: 
+        percentile = 0.025, 0.975 ;
+        country = "AUT", "BEL", "CHE", "CZE", "DEU", "DNK", "ESP", "FIN", "FRA", "GBR", "HRV", "HUN", 
+                  "IRL", "ITA", "LUX", "NLD", "NOR", "POL", "PRT", "SVK", "SVN", "SWE" ;
+        longitude = -97.9, -97.548, -97.196, -96.844, -96.492, -96.14, -95.788, -95.436, 
+                    -95.084, -94.732, -94.38, -94.028, -93.676, -93.324, -92.972, -92.62, 
+                    -92.268, -91.916, -91.564, -91.212, -90.86, -90.508, -90.156, -89.804, 
+                    -89.452, -89.1, -88.748, -88.396, -88.044, -87.692, -87.34, -86.988, 
+                    -86.636, -86.284, -85.932, -85.58, -85.228, -84.876, -84.524, -84.172, 
+                    -83.82, -83.468, -83.116, -82.764, -82.412, -82.06, -81.708, -81.356, 
+                    -81.004, -80.652, -80.3, -79.948, -79.596, -79.244, -78.892, -78.54, 
+                    -78.188, -77.836, -77.484, -77.132, -76.78, -76.428, -76.076, -75.724, 
+                    -75.372, -75.02, -74.668, -74.316, -73.964, -73.612, -73.26, -72.908, 
+                    -72.556, -72.204, -71.852, -71.5, -71.148, -70.796, -70.444, -70.092, 
+                    -69.74, -69.388, -69.036, -68.684, -68.332, -67.98, -67.628, -67.276, 
+                    -66.924, -66.572, -66.22, -65.868, -65.516, -65.164, -64.812, -64.46, 
+                    -64.108, -63.756, -63.404, -63.052, -62.7, -62.348, -61.996, -61.644, 
+                    -61.292, -60.94, -60.588, -60.236, -59.884, -59.532, -59.18, -58.828, 
+                    -58.476, -58.124, -57.772, -57.42, -57.068, -56.716, -56.364, -56.012, 
+                    -55.66, -55.308, -54.956, -54.604, -54.252, -53.9, -53.548, -53.196, 
+                    -52.844, -52.492, -52.14, -51.788, -51.436, -51.084, -50.732, -50.38, 
+                    -50.028, -49.676, -49.324, -48.972, -48.62, -48.268, -47.916, -47.564, 
+                    -47.212, -46.86, -46.508, -46.156, -45.804, -45.452, -45.1, -44.748, 
+                    -44.396, -44.044, -43.692, -43.34, -42.988, -42.636, -42.284, -41.932, 
+                    -41.58, -41.228, -40.876, -40.524, -40.172, -39.82, -39.468, -39.116, 
+                    -38.764, -38.412, -38.06, -37.708, -37.356, -37.004, -36.652, -36.3, 
+                    -35.948, -35.596, -35.244, -34.892, -34.54, -34.188, -33.836, -33.484, 
+                    -33.132, -32.78, -32.428, -32.076, -31.724, -31.372, -31.02, -30.668, 
+                    -30.316, -29.964, -29.612, -29.26, -28.908, -28.556, -28.204, -27.852, 
+                    -27.5, -27.148, -26.796, -26.444, -26.092, -25.74, -25.388, -25.036, 
+                    -24.684, -24.332, -23.98, -23.628, -23.276, -22.924, -22.572, -22.22, 
+                    -21.868, -21.516, -21.164, -20.812, -20.46, -20.108, -19.756, -19.404, 
+                    -19.052, -18.7, -18.348, -17.996, -17.644, -17.292, -16.94, -16.588, 
+                    -16.236, -15.884, -15.532, -15.18, -14.828, -14.476, -14.124, -13.772, 
+                    -13.42, -13.068, -12.716, -12.364, -12.012, -11.66, -11.308, -10.956, 
+                    -10.604, -10.252, -9.900, -9.548, -9.196, -8.844, -8.492, -8.140, 
+                    -7.788, -7.436, -7.084, -6.732, -6.380, -6.028, -5.676, -5.324, 
+                    -4.972, -4.62, -4.268, -3.916, -3.564, -3.212, -2.860, -2.508, 
+                    -2.156, -1.804, -1.452, -1.100, -0.748, -0.396, -0.044, 0.308, 0.660, 
+                    1.012, 1.364, 1.716, 2.068, 2.42, 2.772, 3.124, 3.476, 
+                    3.828, 4.18, 4.532, 4.884, 5.236, 5.588, 5.94, 6.292, 
+                    6.644, 6.996, 7.348, 7.7, 8.052, 8.404, 8.756, 9.108, 
+                    9.46, 9.812, 10.164, 10.516, 10.868, 11.22, 
+                    11.572, 11.924, 12.276, 12.628, 12.98, 13.332, 13.684, 14.036, 14.388, 
+                    14.74, 15.092, 15.444, 15.796, 16.148, 16.5, 16.852, 17.204, 17.556, 
+                    17.908, 18.26, 18.612, 18.964, 19.316, 19.668, 20.02, 20.372, 20.724, 
+                    21.076, 21.428, 21.78, 22.132, 22.484, 22.836, 23.188, 23.54, 23.892, 
+                    24.244, 24.596, 24.948, 25.3, 25.652, 26.004, 26.356, 26.708, 27.06, 
+                    27.412, 27.764, 28.116, 28.468, 28.82, 29.172, 29.524, 29.876, 30.228, 
+                    30.58, 30.932, 31.284, 31.636, 31.988, 32.34, 32.692, 33.044, 33.396, 
+                    33.748, 34.1, 34.452, 34.804, 35.156, 35.508, 35.86, 36.212, 36.564, 
+                    36.916, 37.268, 37.62, 37.972, 38.324, 38.676, 39.028, 39.38 ;
+        latitude = 10.729, 10.963, 11.197, 11.431, 11.665, 11.899, 12.133, 12.367, 
+                  12.601, 12.835, 13.069, 13.303, 13.537, 13.771, 14.005, 14.239, 14.473, 
+                  14.707, 14.941, 15.175, 15.409, 15.643, 15.877, 16.111, 16.345, 16.579, 
+                  16.813, 17.047, 17.281, 17.515, 17.749, 17.983, 18.217, 18.451, 18.685, 
+                  18.919, 19.153, 19.387, 19.621, 19.855, 20.089, 20.323, 20.557, 20.791, 
+                  21.025, 21.259, 21.493, 21.727, 21.961, 22.195, 22.429, 22.663, 22.897, 
+                  23.131, 23.365, 23.599, 23.833, 24.067, 24.301, 24.535, 24.769, 25.003, 
+                  25.237, 25.471, 25.705, 25.939, 26.173, 26.407, 26.641, 26.875, 27.109, 
+                  27.343, 27.577, 27.811, 28.045, 28.279, 28.513, 28.747, 28.981, 29.215, 
+                  29.449, 29.683, 29.917, 30.151, 30.385, 30.619, 30.853, 31.087, 31.321, 
+                  31.555, 31.789, 32.023, 32.257, 32.491, 32.725, 32.959, 33.193, 33.427, 
+                  33.661, 33.895, 34.129, 34.363, 34.597, 34.831, 35.065, 35.299, 35.533, 
+                  35.767, 36.001, 36.235, 36.469, 36.703, 36.937, 37.171, 37.405, 37.639, 
+                  37.873, 38.107, 38.341, 38.575, 38.809, 39.043, 39.277, 39.511, 39.745, 
+                  39.979, 40.213, 40.447, 40.681, 40.915, 41.149, 41.383, 41.617, 41.851, 
+                  42.085, 42.319, 42.553, 42.787, 43.021, 43.255, 43.489, 43.723, 43.957, 
+                  44.191, 44.425, 44.659, 44.893, 45.127, 45.361, 45.595, 45.829, 46.063, 
+                  46.297, 46.531, 46.765, 46.999, 47.233, 47.467, 47.701, 47.935, 48.169, 
+                  48.403, 48.637, 48.871, 49.105, 49.339, 49.573, 49.807, 50.041, 50.275, 
+                  50.509, 50.743, 50.977, 51.211, 51.445, 51.679, 51.913, 52.147, 52.381, 
+                  52.615, 52.849, 53.083, 53.317, 53.551, 53.785, 54.019, 54.253, 54.487, 
+                  54.721, 54.955, 55.189, 55.423, 55.657, 55.891, 56.125, 56.359, 56.593, 
+                  56.827, 57.061, 57.295, 57.529, 57.763, 57.997, 58.231, 58.465, 58.699, 
+                  58.933, 59.167, 59.401, 59.635, 59.869, 60.103, 60.337, 60.571, 60.805, 
+                  61.039, 61.273, 61.507, 61.741, 61.975, 62.209, 62.443, 62.677, 62.911, 
+                  63.145, 63.379, 63.613, 63.847, 64.081, 64.315, 64.549, 64.783, 65.017, 
+                  65.251, 65.485, 65.719, 65.953, 66.187, 66.421, 66.655, 66.889, 67.123, 
+                  67.357, 67.591, 67.825, 68.059, 68.293, 68.527, 68.761, 68.995, 69.229, 
+                  69.463, 69.697, 69.931, 70.165, 70.399, 70.633, 70.867, 71.101, 71.335, 
+                  71.569, 71.803, 72.037, 72.271, 72.505, 72.739, 72.973, 73.207, 73.441, 
+                  73.675, 73.909, 74.143, 74.377, 74.611, 74.845, 75.079, 75.313, 75.547, 
+                  75.781, 76.015, 76.249, 76.483, 76.717, 76.951, 77.185, 77.419, 77.653, 
+                  77.887, 78.121, 78.355, 78.589, 78.823, 79.057 ;
+
+}

--- a/openghg_inversions/postprocessing/PARIS_Lagrangian_inversion_flux_EUROPE_v03.cdl
+++ b/openghg_inversions/postprocessing/PARIS_Lagrangian_inversion_flux_EUROPE_v03.cdl
@@ -1,8 +1,8 @@
-// 
+//
 // placeholders to be replaced in long_name attributes and variable names
 // <species>:	species name in lower case no separators (e.g., ch4, n2o, hfc13a)
 // <sector_name>:	name of flux sector (lower case no separators), (e.g., agriculture, waste, energy, industry); Given without '<>' in variable names!
-// 
+//
 netcdf PARIS_Lagrangian_inversion_flux {
 dimensions:
 	longitude = 391 ;	// mandatory
@@ -11,32 +11,32 @@ dimensions:
 // percentile is optional for systems that report non-Gaussian uncertainty
 	percentile = 2 ;	// optional
 	country = 22 ;	    // mandatory
-	sector = 1 ;	    // optional  
+	sector = 1 ;	    // optional
     nbnds = 2 ; 		// mandatory
 variables:
 	double longitude(longitude) ;	// mandatory
 		longitude:units = "degrees_east" ;
 		longitude:long_name = "longitude of grid cell centre" ;
-		longitude:standard_name = "longitude" ; 
-		longitude:axis = "X" ; 
+		longitude:standard_name = "longitude" ;
+		longitude:axis = "X" ;
 	double latitude(latitude) ;		// mandatory
 		latitude:units = "degrees_north" ;
 		latitude:long_name = "latitude of grid cell centre" ;
 		latitude:standard_name = "latitude" ;
-		latitude:axis = "Y" ; 
+		latitude:axis = "Y" ;
 	double time(time) ;				// mandatory
 		time:units = "days since 1970-01-01 00:00:00" ;
 		time:long_name = "mid of flux interval in UTC" ;
-        time:standard_name = "time" ; 
+        time:standard_name = "time" ;
 		time:calendar = "proleptic_gregorian" ;
-        time:axis = "T" ; 
+        time:axis = "T" ;
         time:bounds = "time_bnds";
 // percentile is optional for systems that report non-Gaussian uncertainty
-	double percentile(percentile) ;	// optional 
+	double percentile(percentile) ;	// optional
 		percentile:units = "1" ;
 		percentile:long_name = "percentile of flux pdf" ;
     double time_bnds(time, nbnds) ; // mandatory
-		time_bnds:long_name = "start and end points of each time step" ; 
+		time_bnds:long_name = "start and end points of each time step" ;
 		time_bnds:calendar = "proleptic_gregorian" ;
 		time_bnds:units = "days since 1970-01-01 00:00:00" ;
 //
@@ -78,10 +78,10 @@ variables:
 //
 // FLUX ON SPATIAL GRID BY SECTOR (one set of variables per sector)
 	//  all sector variables are optional. However, if a sector is given the same variables as for the total are mandatory.
-	//	'sector' variables are optional for systems that give fluxes by sector ; 
+	//	'sector' variables are optional for systems that give fluxes by sector ;
 	//  sector names should be given in the sector_names variable: typical names may be 'agriculture', 'energy' 'waste', 'industry'
-	//	'sector' needs to be replaced by the individual names 
-	float flux_sector_name_prior(time, latitude, longitude) ;		
+	//	'sector' needs to be replaced by the individual names
+	float flux_sector_name_prior(time, latitude, longitude) ;
 		flux_sector_name_prior:units = "mol m-2 s-1" ;
 		flux_sector_name_prior:_FillValue = NaNf ;
 		flux_sector_name_prior:long_name = "prior <species> fluxes from sector_name" ;
@@ -120,7 +120,7 @@ variables:
 		flux_total_prior_inversion_grid:units = "mol m-2 s-1" ;
 		flux_total_prior_inversion_grid:_FillValue = NaNf ;
 		flux_total_prior_inversion_grid:long_name = "prior total <species> fluxes on the inversion grid" ;
-		flux_total_prior_inversion_grid:cell_methods = "time:mean area:mean" ; 
+		flux_total_prior_inversion_grid:cell_methods = "time:mean area:mean" ;
     float flux_total_posterior_inversion_grid(time, latitude, longitude) ;
 		flux_total_posterior_inversion_grid:units = "mol m-2 s-1" ;
 		flux_total_posterior_inversion_grid:_FillValue = NaNf ;
@@ -131,7 +131,7 @@ variables:
 		stdev_flux_total_prior_inversion_grid:units = "mol m-2 s-1" ;
 		stdev_flux_total_prior_inversion_grid:_FillValue = NaNf ;
 		stdev_flux_total_prior_inversion_grid:long_name = "standard deviation of prior total <species> fluxes on the inversion grid" ;
-		stdev_flux_total_prior_inversion_grid:cell_methods = "time:mean area:mean" ; 
+		stdev_flux_total_prior_inversion_grid:cell_methods = "time:mean area:mean" ;
     float stdev_flux_total_posterior_inversion_grid(time, latitude, longitude) ;
 		stdev_flux_total_posterior_inversion_grid:units = "mol m-2 s-1" ;
 		stdev_flux_total_posterior_inversion_grid:_FillValue = NaNf ;
@@ -150,12 +150,12 @@ variables:
 		percentile_flux_total_posterior_inversion_grid:cell_methods = "time:mean percentile:point area:mean" ;
 //
 // FLUX AND UNCERTAINTY ON REDUCED SPATIAL GRID BY SECTOR
-	// optional for inversions that solve the state vector on a reduced grid 
+	// optional for inversions that solve the state vector on a reduced grid
 	float flux_sector_name_prior_inversion_grid(time, latitude, longitude) ;
 		flux_sector_name_prior_inversion_grid:units = "mol m-2 s-1" ;
 		flux_sector_name_prior_inversion_grid:_FillValue = NaNf ;
 		flux_sector_name_prior_inversion_grid:long_name = "prior flux of <species> for <sector_name> on the inversion grid" ;
-		flux_sector_name_prior_inversion_grid:cell_methods = "time:mean area:mean" ; 
+		flux_sector_name_prior_inversion_grid:cell_methods = "time:mean area:mean" ;
     float flux_sector_name_posterior_inversion_grid(time, latitude, longitude) ;
 		flux_sector_name_posterior_inversion_grid:units = "mol m-2 s-1" ;
 		flux_sector_name_posterior_inversion_grid:_FillValue = NaNf ;
@@ -166,7 +166,7 @@ variables:
 		stdev_flux_sector_name_prior_inversion_grid:units = "mol m-2 s-1" ;
 		stdev_flux_sector_name_prior_inversion_grid:_FillValue = NaNf ;
 		stdev_flux_sector_name_prior_inversion_grid:long_name = "standard deviation of prior flux of <species> for <sector_name> on the inversion grid" ;
-		stdev_flux_sector_name_prior_inversion_grid:cell_methods = "time:mean area:mean" ; 
+		stdev_flux_sector_name_prior_inversion_grid:cell_methods = "time:mean area:mean" ;
     float stdev_flux_sector_name_posterior_inversion_grid(time, latitude, longitude) ;
 		stdev_flux_sector_name_posterior_inversion_grid:units = "mol m-2 s-1" ;
 		stdev_flux_sector_name_posterior_inversion_grid:_FillValue = NaNf ;
@@ -205,7 +205,7 @@ variables:
 		stdev_flux_total_posterior_country:_FillValue = NaNf ;
 		stdev_flux_total_posterior_country:long_name = "standard deviation of country-total posterior <species> fluxes" ;
 		stdev_flux_total_posterior_country:cell_methods = "time:mean country:point" ;
-	// covariance between countries 
+	// covariance between countries
 	float covariance_flux_total_posterior_country(time, country, country) ;	// mandatory
 		covariance_flux_total_posterior_country:units = "kg2 yr-2" ;
 		covariance_flux_total_posterior_country:_FillValue = NaNf ;
@@ -267,21 +267,21 @@ variables:
 
 
 //	AUXILIARY VARIABLES
-	// Country abbreviation 
+	// Country abbreviation
 	// alternatively to string variables use character array. String variables require netcdf 4!
-	string country(country) ;	// mandatory 
+	string country(country) ;	// mandatory
 		country:long_name = "country_ISO_3166_1_alpha3" ;
 	// sector names should only contain lower case letters (no separator characters), since they should be used in variable names
 	// optional when reporting separate fluxes by sector
 	string sector(sector) ;	// optional
 		sector:long_name = "short name of flux sector" ;
-		sector:comment ="brief definition of which emissions each sector contains" ; 
-	//	
+		sector:comment ="brief definition of which emissions each sector contains" ;
+	//
 	float country_fraction(country, latitude, longitude) ;	// mandatory
 		country_fraction:units = "1" ;
 		country_fraction:_FillValue = NaNf ;
 		country_fraction:long_name = "fraction of grid cell associated to country" ;
-		country_fraction:standard_name = "area_fraction" ; 
+		country_fraction:standard_name = "area_fraction" ;
 	//
 	float cell_area(latitude, longitude) ;	// mandatory
 		cell_area:units = "m2" ;
@@ -296,109 +296,109 @@ variables:
 		:source = "Estimated flux from trace gas observations transport simulations and inversion code." ;
 		:creator = "Stephan Henne" ;
 		:creation_date = "2024-01-11" ;
-		:contact = "stephan.henne@empa.ch" ; 
-        :frequency = "yearly" ; 
-		:geospatial_lat_resolution = "0.234 degree" ; 
+		:contact = "stephan.henne@empa.ch" ;
+        :frequency = "yearly" ;
+		:geospatial_lat_resolution = "0.234 degree" ;
         :geospatial_lon_resolution = "0.352 degree" ;
 		:transport_model = "NAME" ;
-        :transport_model_version = "" ; 
-        :inversion_system = "ELRIS" ; 
+        :transport_model_version = "" ;
+        :inversion_system = "ELRIS" ;
         :inversion_system_version ="1.2.0" ;
 		:experiment = "EDGARprior" ;
         :project = "Process Attribution of Regional emISsions (PARIS)" ;
-        :Conventions = "CF-1.8" ; 
+        :Conventions = "CF-1.8" ;
 		:references = "Inversion code based on\n",
 			" Stohl et al., Atmos. Chem. Phys., 2009, doi:10.5194/acp-9-1597-2009\n",
 			" Henne et al., Atmos. Chem. Phys., 2016, doi:10.5194/acp-16-3683-2016" ;
-		:comment = "" ; //	use "comment" for a comprehensive description of the dataset (like abstract for a paper) or use "summary" for this description and "comment" for any other comment and information  
-		:summary = "" ; 
+		:comment = "" ; //	use "comment" for a comprehensive description of the dataset (like abstract for a paper) or use "summary" for this description and "comment" for any other comment and information
+		:summary = "" ;
         :license = "CC-BY-4.0" ;
         :history = "2024-01-11 21:35:03 saved from ELRIS R package" ;
 
-data: 
+data:
         percentile = 0.025, 0.975 ;
-        country = "AUT", "BEL", "CHE", "CZE", "DEU", "DNK", "ESP", "FIN", "FRA", "GBR", "HRV", "HUN", 
+        country = "AUT", "BEL", "CHE", "CZE", "DEU", "DNK", "ESP", "FIN", "FRA", "GBR", "HRV", "HUN",
                   "IRL", "ITA", "LUX", "NLD", "NOR", "POL", "PRT", "SVK", "SVN", "SWE" ;
-        longitude = -97.9, -97.548, -97.196, -96.844, -96.492, -96.14, -95.788, -95.436, 
-                    -95.084, -94.732, -94.38, -94.028, -93.676, -93.324, -92.972, -92.62, 
-                    -92.268, -91.916, -91.564, -91.212, -90.86, -90.508, -90.156, -89.804, 
-                    -89.452, -89.1, -88.748, -88.396, -88.044, -87.692, -87.34, -86.988, 
-                    -86.636, -86.284, -85.932, -85.58, -85.228, -84.876, -84.524, -84.172, 
-                    -83.82, -83.468, -83.116, -82.764, -82.412, -82.06, -81.708, -81.356, 
-                    -81.004, -80.652, -80.3, -79.948, -79.596, -79.244, -78.892, -78.54, 
-                    -78.188, -77.836, -77.484, -77.132, -76.78, -76.428, -76.076, -75.724, 
-                    -75.372, -75.02, -74.668, -74.316, -73.964, -73.612, -73.26, -72.908, 
-                    -72.556, -72.204, -71.852, -71.5, -71.148, -70.796, -70.444, -70.092, 
-                    -69.74, -69.388, -69.036, -68.684, -68.332, -67.98, -67.628, -67.276, 
-                    -66.924, -66.572, -66.22, -65.868, -65.516, -65.164, -64.812, -64.46, 
-                    -64.108, -63.756, -63.404, -63.052, -62.7, -62.348, -61.996, -61.644, 
-                    -61.292, -60.94, -60.588, -60.236, -59.884, -59.532, -59.18, -58.828, 
-                    -58.476, -58.124, -57.772, -57.42, -57.068, -56.716, -56.364, -56.012, 
-                    -55.66, -55.308, -54.956, -54.604, -54.252, -53.9, -53.548, -53.196, 
-                    -52.844, -52.492, -52.14, -51.788, -51.436, -51.084, -50.732, -50.38, 
-                    -50.028, -49.676, -49.324, -48.972, -48.62, -48.268, -47.916, -47.564, 
-                    -47.212, -46.86, -46.508, -46.156, -45.804, -45.452, -45.1, -44.748, 
-                    -44.396, -44.044, -43.692, -43.34, -42.988, -42.636, -42.284, -41.932, 
-                    -41.58, -41.228, -40.876, -40.524, -40.172, -39.82, -39.468, -39.116, 
-                    -38.764, -38.412, -38.06, -37.708, -37.356, -37.004, -36.652, -36.3, 
-                    -35.948, -35.596, -35.244, -34.892, -34.54, -34.188, -33.836, -33.484, 
-                    -33.132, -32.78, -32.428, -32.076, -31.724, -31.372, -31.02, -30.668, 
-                    -30.316, -29.964, -29.612, -29.26, -28.908, -28.556, -28.204, -27.852, 
-                    -27.5, -27.148, -26.796, -26.444, -26.092, -25.74, -25.388, -25.036, 
-                    -24.684, -24.332, -23.98, -23.628, -23.276, -22.924, -22.572, -22.22, 
-                    -21.868, -21.516, -21.164, -20.812, -20.46, -20.108, -19.756, -19.404, 
-                    -19.052, -18.7, -18.348, -17.996, -17.644, -17.292, -16.94, -16.588, 
-                    -16.236, -15.884, -15.532, -15.18, -14.828, -14.476, -14.124, -13.772, 
-                    -13.42, -13.068, -12.716, -12.364, -12.012, -11.66, -11.308, -10.956, 
-                    -10.604, -10.252, -9.900, -9.548, -9.196, -8.844, -8.492, -8.140, 
-                    -7.788, -7.436, -7.084, -6.732, -6.380, -6.028, -5.676, -5.324, 
-                    -4.972, -4.62, -4.268, -3.916, -3.564, -3.212, -2.860, -2.508, 
-                    -2.156, -1.804, -1.452, -1.100, -0.748, -0.396, -0.044, 0.308, 0.660, 
-                    1.012, 1.364, 1.716, 2.068, 2.42, 2.772, 3.124, 3.476, 
-                    3.828, 4.18, 4.532, 4.884, 5.236, 5.588, 5.94, 6.292, 
-                    6.644, 6.996, 7.348, 7.7, 8.052, 8.404, 8.756, 9.108, 
-                    9.46, 9.812, 10.164, 10.516, 10.868, 11.22, 
-                    11.572, 11.924, 12.276, 12.628, 12.98, 13.332, 13.684, 14.036, 14.388, 
-                    14.74, 15.092, 15.444, 15.796, 16.148, 16.5, 16.852, 17.204, 17.556, 
-                    17.908, 18.26, 18.612, 18.964, 19.316, 19.668, 20.02, 20.372, 20.724, 
-                    21.076, 21.428, 21.78, 22.132, 22.484, 22.836, 23.188, 23.54, 23.892, 
-                    24.244, 24.596, 24.948, 25.3, 25.652, 26.004, 26.356, 26.708, 27.06, 
-                    27.412, 27.764, 28.116, 28.468, 28.82, 29.172, 29.524, 29.876, 30.228, 
-                    30.58, 30.932, 31.284, 31.636, 31.988, 32.34, 32.692, 33.044, 33.396, 
-                    33.748, 34.1, 34.452, 34.804, 35.156, 35.508, 35.86, 36.212, 36.564, 
+        longitude = -97.9, -97.548, -97.196, -96.844, -96.492, -96.14, -95.788, -95.436,
+                    -95.084, -94.732, -94.38, -94.028, -93.676, -93.324, -92.972, -92.62,
+                    -92.268, -91.916, -91.564, -91.212, -90.86, -90.508, -90.156, -89.804,
+                    -89.452, -89.1, -88.748, -88.396, -88.044, -87.692, -87.34, -86.988,
+                    -86.636, -86.284, -85.932, -85.58, -85.228, -84.876, -84.524, -84.172,
+                    -83.82, -83.468, -83.116, -82.764, -82.412, -82.06, -81.708, -81.356,
+                    -81.004, -80.652, -80.3, -79.948, -79.596, -79.244, -78.892, -78.54,
+                    -78.188, -77.836, -77.484, -77.132, -76.78, -76.428, -76.076, -75.724,
+                    -75.372, -75.02, -74.668, -74.316, -73.964, -73.612, -73.26, -72.908,
+                    -72.556, -72.204, -71.852, -71.5, -71.148, -70.796, -70.444, -70.092,
+                    -69.74, -69.388, -69.036, -68.684, -68.332, -67.98, -67.628, -67.276,
+                    -66.924, -66.572, -66.22, -65.868, -65.516, -65.164, -64.812, -64.46,
+                    -64.108, -63.756, -63.404, -63.052, -62.7, -62.348, -61.996, -61.644,
+                    -61.292, -60.94, -60.588, -60.236, -59.884, -59.532, -59.18, -58.828,
+                    -58.476, -58.124, -57.772, -57.42, -57.068, -56.716, -56.364, -56.012,
+                    -55.66, -55.308, -54.956, -54.604, -54.252, -53.9, -53.548, -53.196,
+                    -52.844, -52.492, -52.14, -51.788, -51.436, -51.084, -50.732, -50.38,
+                    -50.028, -49.676, -49.324, -48.972, -48.62, -48.268, -47.916, -47.564,
+                    -47.212, -46.86, -46.508, -46.156, -45.804, -45.452, -45.1, -44.748,
+                    -44.396, -44.044, -43.692, -43.34, -42.988, -42.636, -42.284, -41.932,
+                    -41.58, -41.228, -40.876, -40.524, -40.172, -39.82, -39.468, -39.116,
+                    -38.764, -38.412, -38.06, -37.708, -37.356, -37.004, -36.652, -36.3,
+                    -35.948, -35.596, -35.244, -34.892, -34.54, -34.188, -33.836, -33.484,
+                    -33.132, -32.78, -32.428, -32.076, -31.724, -31.372, -31.02, -30.668,
+                    -30.316, -29.964, -29.612, -29.26, -28.908, -28.556, -28.204, -27.852,
+                    -27.5, -27.148, -26.796, -26.444, -26.092, -25.74, -25.388, -25.036,
+                    -24.684, -24.332, -23.98, -23.628, -23.276, -22.924, -22.572, -22.22,
+                    -21.868, -21.516, -21.164, -20.812, -20.46, -20.108, -19.756, -19.404,
+                    -19.052, -18.7, -18.348, -17.996, -17.644, -17.292, -16.94, -16.588,
+                    -16.236, -15.884, -15.532, -15.18, -14.828, -14.476, -14.124, -13.772,
+                    -13.42, -13.068, -12.716, -12.364, -12.012, -11.66, -11.308, -10.956,
+                    -10.604, -10.252, -9.900, -9.548, -9.196, -8.844, -8.492, -8.140,
+                    -7.788, -7.436, -7.084, -6.732, -6.380, -6.028, -5.676, -5.324,
+                    -4.972, -4.62, -4.268, -3.916, -3.564, -3.212, -2.860, -2.508,
+                    -2.156, -1.804, -1.452, -1.100, -0.748, -0.396, -0.044, 0.308, 0.660,
+                    1.012, 1.364, 1.716, 2.068, 2.42, 2.772, 3.124, 3.476,
+                    3.828, 4.18, 4.532, 4.884, 5.236, 5.588, 5.94, 6.292,
+                    6.644, 6.996, 7.348, 7.7, 8.052, 8.404, 8.756, 9.108,
+                    9.46, 9.812, 10.164, 10.516, 10.868, 11.22,
+                    11.572, 11.924, 12.276, 12.628, 12.98, 13.332, 13.684, 14.036, 14.388,
+                    14.74, 15.092, 15.444, 15.796, 16.148, 16.5, 16.852, 17.204, 17.556,
+                    17.908, 18.26, 18.612, 18.964, 19.316, 19.668, 20.02, 20.372, 20.724,
+                    21.076, 21.428, 21.78, 22.132, 22.484, 22.836, 23.188, 23.54, 23.892,
+                    24.244, 24.596, 24.948, 25.3, 25.652, 26.004, 26.356, 26.708, 27.06,
+                    27.412, 27.764, 28.116, 28.468, 28.82, 29.172, 29.524, 29.876, 30.228,
+                    30.58, 30.932, 31.284, 31.636, 31.988, 32.34, 32.692, 33.044, 33.396,
+                    33.748, 34.1, 34.452, 34.804, 35.156, 35.508, 35.86, 36.212, 36.564,
                     36.916, 37.268, 37.62, 37.972, 38.324, 38.676, 39.028, 39.38 ;
-        latitude = 10.729, 10.963, 11.197, 11.431, 11.665, 11.899, 12.133, 12.367, 
-                  12.601, 12.835, 13.069, 13.303, 13.537, 13.771, 14.005, 14.239, 14.473, 
-                  14.707, 14.941, 15.175, 15.409, 15.643, 15.877, 16.111, 16.345, 16.579, 
-                  16.813, 17.047, 17.281, 17.515, 17.749, 17.983, 18.217, 18.451, 18.685, 
-                  18.919, 19.153, 19.387, 19.621, 19.855, 20.089, 20.323, 20.557, 20.791, 
-                  21.025, 21.259, 21.493, 21.727, 21.961, 22.195, 22.429, 22.663, 22.897, 
-                  23.131, 23.365, 23.599, 23.833, 24.067, 24.301, 24.535, 24.769, 25.003, 
-                  25.237, 25.471, 25.705, 25.939, 26.173, 26.407, 26.641, 26.875, 27.109, 
-                  27.343, 27.577, 27.811, 28.045, 28.279, 28.513, 28.747, 28.981, 29.215, 
-                  29.449, 29.683, 29.917, 30.151, 30.385, 30.619, 30.853, 31.087, 31.321, 
-                  31.555, 31.789, 32.023, 32.257, 32.491, 32.725, 32.959, 33.193, 33.427, 
-                  33.661, 33.895, 34.129, 34.363, 34.597, 34.831, 35.065, 35.299, 35.533, 
-                  35.767, 36.001, 36.235, 36.469, 36.703, 36.937, 37.171, 37.405, 37.639, 
-                  37.873, 38.107, 38.341, 38.575, 38.809, 39.043, 39.277, 39.511, 39.745, 
-                  39.979, 40.213, 40.447, 40.681, 40.915, 41.149, 41.383, 41.617, 41.851, 
-                  42.085, 42.319, 42.553, 42.787, 43.021, 43.255, 43.489, 43.723, 43.957, 
-                  44.191, 44.425, 44.659, 44.893, 45.127, 45.361, 45.595, 45.829, 46.063, 
-                  46.297, 46.531, 46.765, 46.999, 47.233, 47.467, 47.701, 47.935, 48.169, 
-                  48.403, 48.637, 48.871, 49.105, 49.339, 49.573, 49.807, 50.041, 50.275, 
-                  50.509, 50.743, 50.977, 51.211, 51.445, 51.679, 51.913, 52.147, 52.381, 
-                  52.615, 52.849, 53.083, 53.317, 53.551, 53.785, 54.019, 54.253, 54.487, 
-                  54.721, 54.955, 55.189, 55.423, 55.657, 55.891, 56.125, 56.359, 56.593, 
-                  56.827, 57.061, 57.295, 57.529, 57.763, 57.997, 58.231, 58.465, 58.699, 
-                  58.933, 59.167, 59.401, 59.635, 59.869, 60.103, 60.337, 60.571, 60.805, 
-                  61.039, 61.273, 61.507, 61.741, 61.975, 62.209, 62.443, 62.677, 62.911, 
-                  63.145, 63.379, 63.613, 63.847, 64.081, 64.315, 64.549, 64.783, 65.017, 
-                  65.251, 65.485, 65.719, 65.953, 66.187, 66.421, 66.655, 66.889, 67.123, 
-                  67.357, 67.591, 67.825, 68.059, 68.293, 68.527, 68.761, 68.995, 69.229, 
-                  69.463, 69.697, 69.931, 70.165, 70.399, 70.633, 70.867, 71.101, 71.335, 
-                  71.569, 71.803, 72.037, 72.271, 72.505, 72.739, 72.973, 73.207, 73.441, 
-                  73.675, 73.909, 74.143, 74.377, 74.611, 74.845, 75.079, 75.313, 75.547, 
-                  75.781, 76.015, 76.249, 76.483, 76.717, 76.951, 77.185, 77.419, 77.653, 
+        latitude = 10.729, 10.963, 11.197, 11.431, 11.665, 11.899, 12.133, 12.367,
+                  12.601, 12.835, 13.069, 13.303, 13.537, 13.771, 14.005, 14.239, 14.473,
+                  14.707, 14.941, 15.175, 15.409, 15.643, 15.877, 16.111, 16.345, 16.579,
+                  16.813, 17.047, 17.281, 17.515, 17.749, 17.983, 18.217, 18.451, 18.685,
+                  18.919, 19.153, 19.387, 19.621, 19.855, 20.089, 20.323, 20.557, 20.791,
+                  21.025, 21.259, 21.493, 21.727, 21.961, 22.195, 22.429, 22.663, 22.897,
+                  23.131, 23.365, 23.599, 23.833, 24.067, 24.301, 24.535, 24.769, 25.003,
+                  25.237, 25.471, 25.705, 25.939, 26.173, 26.407, 26.641, 26.875, 27.109,
+                  27.343, 27.577, 27.811, 28.045, 28.279, 28.513, 28.747, 28.981, 29.215,
+                  29.449, 29.683, 29.917, 30.151, 30.385, 30.619, 30.853, 31.087, 31.321,
+                  31.555, 31.789, 32.023, 32.257, 32.491, 32.725, 32.959, 33.193, 33.427,
+                  33.661, 33.895, 34.129, 34.363, 34.597, 34.831, 35.065, 35.299, 35.533,
+                  35.767, 36.001, 36.235, 36.469, 36.703, 36.937, 37.171, 37.405, 37.639,
+                  37.873, 38.107, 38.341, 38.575, 38.809, 39.043, 39.277, 39.511, 39.745,
+                  39.979, 40.213, 40.447, 40.681, 40.915, 41.149, 41.383, 41.617, 41.851,
+                  42.085, 42.319, 42.553, 42.787, 43.021, 43.255, 43.489, 43.723, 43.957,
+                  44.191, 44.425, 44.659, 44.893, 45.127, 45.361, 45.595, 45.829, 46.063,
+                  46.297, 46.531, 46.765, 46.999, 47.233, 47.467, 47.701, 47.935, 48.169,
+                  48.403, 48.637, 48.871, 49.105, 49.339, 49.573, 49.807, 50.041, 50.275,
+                  50.509, 50.743, 50.977, 51.211, 51.445, 51.679, 51.913, 52.147, 52.381,
+                  52.615, 52.849, 53.083, 53.317, 53.551, 53.785, 54.019, 54.253, 54.487,
+                  54.721, 54.955, 55.189, 55.423, 55.657, 55.891, 56.125, 56.359, 56.593,
+                  56.827, 57.061, 57.295, 57.529, 57.763, 57.997, 58.231, 58.465, 58.699,
+                  58.933, 59.167, 59.401, 59.635, 59.869, 60.103, 60.337, 60.571, 60.805,
+                  61.039, 61.273, 61.507, 61.741, 61.975, 62.209, 62.443, 62.677, 62.911,
+                  63.145, 63.379, 63.613, 63.847, 64.081, 64.315, 64.549, 64.783, 65.017,
+                  65.251, 65.485, 65.719, 65.953, 66.187, 66.421, 66.655, 66.889, 67.123,
+                  67.357, 67.591, 67.825, 68.059, 68.293, 68.527, 68.761, 68.995, 69.229,
+                  69.463, 69.697, 69.931, 70.165, 70.399, 70.633, 70.867, 71.101, 71.335,
+                  71.569, 71.803, 72.037, 72.271, 72.505, 72.739, 72.973, 73.207, 73.441,
+                  73.675, 73.909, 74.143, 74.377, 74.611, 74.845, 75.079, 75.313, 75.547,
+                  75.781, 76.015, 76.249, 76.483, 76.717, 76.951, 77.185, 77.419, 77.653,
                   77.887, 78.121, 78.355, 78.589, 78.823, 79.057 ;
 
 }

--- a/openghg_inversions/postprocessing/make_outputs.py
+++ b/openghg_inversions/postprocessing/make_outputs.py
@@ -1,10 +1,12 @@
 from pathlib import Path
-from typing import Any, Literal, cast
+from collections.abc import Mapping
+from typing import Any, Literal, NamedTuple, cast
 
 import numpy as np
 import pandas as pd
 import xarray as xr
 
+from openghg_inversions.basis.basis_functions import BasisFunctions
 from openghg_inversions.postprocessing.countries import Countries, paris_regions_dict
 from openghg_inversions.postprocessing._basis_products import (
     reconstruct_flux_stats,
@@ -42,10 +44,91 @@ TRACE_GROUP_SUFFIXES = (
 _PRODUCT_METADATA_FIELDS = Literal["species", "domain", "start_date", "end_date"]
 
 
+class OutputSector(NamedTuple):
+    """Sector metadata needed for postprocessing reconstruction."""
+
+    name: str
+    flux_source: str
+    variable_suffix: str
+
+
 def _require_single_sector_output(inv_out: InversionOutput, product_name: str) -> None:
     """Require single-sector input for a product that has not migrated to multisector."""
     if inv_out.is_multisector:
         raise ValueError(f"{product_name} supports only single-sector RHIME outputs.")
+
+
+def _multisector_output_sectors(inv_out: InversionOutput) -> list[OutputSector]:
+    """Return sector metadata from a multisector ``InversionOutput``."""
+    raw_sectors = inv_out.model_metadata.get("sectors")
+    if not raw_sectors:
+        raise ValueError("Multisector postprocessing requires sector metadata in model_metadata['sectors'].")
+
+    sectors: list[OutputSector] = []
+    for raw_sector in raw_sectors:
+        if isinstance(raw_sector, Mapping):
+            name = raw_sector.get("name")
+            flux_source = raw_sector.get("flux_source")
+            variable_suffix = raw_sector.get("variable_suffix")
+        else:
+            name = getattr(raw_sector, "name", None)
+            flux_source = getattr(raw_sector, "flux_source", None)
+            variable_suffix = getattr(raw_sector, "variable_suffix", None)
+        if name is None or flux_source is None or variable_suffix is None:
+            raise ValueError("Sector metadata must include 'name', 'flux_source', and 'variable_suffix'.")
+        sectors.append(OutputSector(str(name), str(flux_source), str(variable_suffix)))
+
+    return sectors
+
+
+def _sector_scale_trace(inv_out: InversionOutput, sector: OutputSector) -> xr.Dataset:
+    """Return one sector's scale trace renamed to the standard single-sector base name."""
+    base_name = f"x_{sector.variable_suffix}"
+    trace = inv_out.trace_dataset()
+    rename: dict[str, str] = {}
+    for suffix in TRACE_GROUP_SUFFIXES:
+        data_var = f"{base_name}{suffix}"
+        if data_var in trace:
+            rename[data_var] = f"x{suffix}"
+
+    if not rename:
+        raise ValueError(f"Could not find flux scale trace variable for sector {sector.name!r}.")
+
+    return trace[list(rename)].rename(rename)
+
+
+def _sector_flux(inv_out: InversionOutput, sector: OutputSector) -> xr.DataArray:
+    """Return prior flux for one sector."""
+    flux = inv_out.flux
+    if "source" in flux.dims:
+        return flux.sel(source=sector.flux_source, drop=True)
+    return flux
+
+
+def _sector_basis_functions(
+    inv_out: InversionOutput,
+    sector: OutputSector,
+    trace: xr.Dataset,
+) -> BasisFunctions:
+    """Return a basis object whose state dimension matches one sector trace."""
+    sector_flux = _sector_flux(inv_out, sector)
+    flat_basis = inv_out.basis_functions.flat_basis()
+    if not isinstance(flat_basis, dict):
+        return inv_out.basis_functions.with_flux(sector_flux)
+
+    try:
+        sector_basis = flat_basis[sector.flux_source]
+    except KeyError as exc:
+        raise ValueError(
+            f"BasisFunctions object is missing basis for sector flux source {sector.flux_source!r}."
+        ) from exc
+
+    return BasisFunctions.from_flat_basis(
+        basis_flat=sector_basis,
+        flux=sector_flux,
+        operator_kwargs={"state_dim": _state_chunk_dim(trace, inv_out)},
+        metadata=inv_out.basis_functions.metadata,
+    )
 
 
 def _require_output_metadata(
@@ -171,6 +254,153 @@ def _state_chunk_dim(trace: xr.Dataset, inv_out: InversionOutput) -> str:
     raise ValueError(f"Could not find basis state dimension in trace dims {tuple(trace.dims)}.")
 
 
+def _stats_args_with_defaults(
+    stats: list[str] | None,
+    stats_args: dict | None,
+    *,
+    chunk_dim: str | None = None,
+) -> dict:
+    """Return a copied stats kwargs dictionary with standard optional entries."""
+    result = dict(stats_args or {})
+    if stats is not None:
+        result["stats"] = stats
+    if chunk_dim is not None:
+        result["chunk_dim"] = chunk_dim
+    return result
+
+
+def _rename_sector_flux_vars(ds: xr.Dataset, sector: OutputSector, *, total: bool = False) -> xr.Dataset:
+    """Rename standard flux output variables with sector or total labels."""
+    label = "total" if total else sector.variable_suffix
+    rename = {}
+    for data_var in ds.data_vars:
+        name = str(data_var)
+        if name.startswith("flux_"):
+            rename[name] = name.replace("flux_", f"flux_{label}_", 1)
+        elif name.startswith("scaling_"):
+            rename[name] = name.replace("scaling_", f"scaling_{label}_", 1)
+    return ds.rename(rename)
+
+
+def _sector_flux_trace_dataset(
+    inv_out: InversionOutput,
+    sector: OutputSector,
+    *,
+    report_flux_on_inversion_grid: bool,
+) -> xr.Dataset:
+    """Return one sector's per-draw reconstructed flux trace."""
+    trace = _sector_scale_trace(inv_out, sector)
+    basis_functions = _sector_basis_functions(inv_out, sector, trace)
+    sector_flux = _sector_flux(inv_out, sector)
+    reconstructed = reconstruct_flux_stats(
+        basis_functions,
+        sector_flux,
+        trace,
+        report_flux_on_inversion_grid=report_flux_on_inversion_grid,
+    )
+    reconstructed = rename_by_replacement(reconstructed, "x", "flux")
+    return _rename_sector_flux_vars(reconstructed, sector)
+
+
+def _sector_scale_factor_stats(
+    inv_out: InversionOutput,
+    sector: OutputSector,
+    stats_args: dict,
+) -> xr.Dataset:
+    """Return one sector's gridded scale-factor statistics."""
+    trace = _sector_scale_trace(inv_out, sector)
+    basis_functions = _sector_basis_functions(inv_out, sector, trace)
+    scale_stats = calculate_stats(trace, **stats_args)
+    result = reconstruct_scale_factor_stats(basis_functions, scale_stats)
+    for data_var in result.data_vars:
+        if data_var in scale_stats.data_vars:
+            result[data_var].attrs = scale_stats[data_var].attrs
+            result[data_var].attrs["long_name"] = result[data_var].attrs["long_name"].replace("trace_of_", "")
+    result = rename_by_replacement(result, "x", "scaling")
+    return _rename_sector_flux_vars(result, sector)
+
+
+def _set_multisector_flux_attrs(
+    ds: xr.Dataset, inv_out: InversionOutput, sectors: list[OutputSector]
+) -> xr.Dataset:
+    """Restore units and readable long names on multisector flux variables."""
+    default_units = inv_out.flux.attrs.get("units", "")
+    sector_units = {
+        sector.variable_suffix: _sector_flux(inv_out, sector).attrs.get("units", default_units)
+        for sector in sectors
+    }
+    total_units = next(iter(sector_units.values()), default_units)
+
+    for data_var in ds.data_vars:
+        name = str(data_var)
+        if name.startswith("flux_total_"):
+            ds[data_var].attrs["units"] = total_units
+            ds[data_var].attrs["long_name"] = name.replace("_", " ")
+            continue
+
+        for sector in sectors:
+            if name.startswith(f"flux_{sector.variable_suffix}_"):
+                ds[data_var].attrs["units"] = sector_units[sector.variable_suffix]
+                ds[data_var].attrs["long_name"] = name.replace(
+                    f"flux_{sector.variable_suffix}_",
+                    f"{sector.name} flux ",
+                    1,
+                ).replace("_", " ")
+                break
+
+    return ds
+
+
+def make_sector_flux_outputs(
+    inv_out: InversionOutput,
+    stats: list[str] | None = None,
+    stats_args: dict | None = None,
+    include_scale_factors: bool = True,
+    report_flux_on_inversion_grid: bool = True,
+) -> xr.Dataset:
+    """Return multisector flux statistics by sector plus correctly reconstructed total flux statistics."""
+    if not inv_out.is_multisector:
+        raise ValueError("Sector flux postprocessing requires multisector RHIME outputs.")
+
+    sectors = _multisector_output_sectors(inv_out)
+    sample_trace = _sector_scale_trace(inv_out, sectors[0])
+    scale_stats_args = _stats_args_with_defaults(
+        stats,
+        stats_args,
+        chunk_dim=_state_chunk_dim(sample_trace, inv_out),
+    )
+    flux_stats_args = _stats_args_with_defaults(stats, stats_args)
+
+    sector_flux_traces = [
+        _sector_flux_trace_dataset(
+            inv_out,
+            sector,
+            report_flux_on_inversion_grid=report_flux_on_inversion_grid,
+        )
+        for sector in sectors
+    ]
+    total_flux_trace = xr.concat(
+        [
+            dataset.rename(
+                {
+                    data_var: str(data_var).replace(f"flux_{sector.variable_suffix}_", "flux_total_", 1)
+                    for data_var in dataset.data_vars
+                }
+            )
+            for sector, dataset in zip(sectors, sector_flux_traces, strict=True)
+        ],
+        dim="sector",
+    ).sum("sector")
+
+    outputs = [calculate_stats(total_flux_trace, **flux_stats_args)]
+    for sector, flux_trace in zip(sectors, sector_flux_traces, strict=True):
+        outputs.append(calculate_stats(flux_trace, **flux_stats_args))
+        if include_scale_factors:
+            outputs.append(_sector_scale_factor_stats(inv_out, sector, scale_stats_args))
+
+    return _set_multisector_flux_attrs(xr.merge(outputs), inv_out, sectors).as_numpy()
+
+
 def make_flux_outputs(
     inv_out: InversionOutput,
     stats: list[str] | None = None,
@@ -203,6 +433,15 @@ def make_flux_outputs(
         xr.Dataset with computed flux stats.
 
     """
+    if inv_out.is_multisector:
+        return make_sector_flux_outputs(
+            inv_out,
+            stats=stats,
+            stats_args=stats_args,
+            include_scale_factors=include_scale_factors,
+            report_flux_on_inversion_grid=report_flux_on_inversion_grid,
+        )
+
     _require_single_sector_output(inv_out, "Flux postprocessing")
     trace = _rename_trace_roles(
         inv_out.trace_dataset(var_roles="flux_scale"),
@@ -210,13 +449,7 @@ def make_flux_outputs(
         {"flux_scale": "x"},
     )
 
-    if stats_args is None:
-        stats_args = {}
-
-    if stats is not None:
-        stats_args["stats"] = stats
-
-    stats_args["chunk_dim"] = _state_chunk_dim(trace, inv_out)
+    stats_args = _stats_args_with_defaults(stats, stats_args, chunk_dim=_state_chunk_dim(trace, inv_out))
     stats_ds = calculate_stats(trace, **stats_args)
 
     flux_stats = reconstruct_flux_stats(

--- a/openghg_inversions/postprocessing/make_outputs.py
+++ b/openghg_inversions/postprocessing/make_outputs.py
@@ -389,6 +389,7 @@ def make_concentration_outputs(
 def make_country_outputs(
     inv_out: InversionOutput,
     country_file: str | Path | None = None,
+    country_selections: list[str] | None = None,
     country_regions: str | Path | dict[str, list[str]] | Literal["paris"] | None = None,
     stats: list[str] | None = None,
     stats_args: dict | None = None,
@@ -401,6 +402,7 @@ def make_country_outputs(
         country_file: Path to country definition file. If None, the default
             country file location and the domain of the inversion output will be used
             to try to find a suitable country file.
+        country_selections: Optional country names or country codes to report.
         country_regions: Dict mapping country region names (e.g. "BENELUX") to a
             list of (country codes) of the countries comprising that regions (e.g.
             ["BEL", "NLD", "LUX"]).
@@ -435,6 +437,7 @@ def make_country_outputs(
     countries = Countries.from_file(
         country_file=country_file,
         country_code=country_code,
+        country_selections=country_selections,
         country_regions=country_regions,
         domain=domain,
         drop_missing_regions=drop_missing_regions,

--- a/openghg_inversions/postprocessing/make_outputs.py
+++ b/openghg_inversions/postprocessing/make_outputs.py
@@ -351,26 +351,15 @@ def _set_multisector_flux_attrs(
     return ds
 
 
-def make_sector_flux_outputs(
+def _multisector_flux_trace_parts(
     inv_out: InversionOutput,
-    stats: list[str] | None = None,
-    stats_args: dict | None = None,
-    include_scale_factors: bool = True,
     report_flux_on_inversion_grid: bool = True,
-) -> xr.Dataset:
-    """Return multisector flux statistics by sector plus correctly reconstructed total flux statistics."""
+) -> tuple[list[OutputSector], list[xr.Dataset], xr.Dataset]:
+    """Return sector metadata, sector flux traces, and total flux trace."""
     if not inv_out.is_multisector:
         raise ValueError("Sector flux postprocessing requires multisector RHIME outputs.")
 
     sectors = _multisector_output_sectors(inv_out)
-    sample_trace = _sector_scale_trace(inv_out, sectors[0])
-    scale_stats_args = _stats_args_with_defaults(
-        stats,
-        stats_args,
-        chunk_dim=_state_chunk_dim(sample_trace, inv_out),
-    )
-    flux_stats_args = _stats_args_with_defaults(stats, stats_args)
-
     sector_flux_traces = [
         _sector_flux_trace_dataset(
             inv_out,
@@ -391,6 +380,41 @@ def make_sector_flux_outputs(
         ],
         dim="sector",
     ).sum("sector")
+
+    return sectors, sector_flux_traces, total_flux_trace
+
+
+def make_multisector_flux_trace_outputs(
+    inv_out: InversionOutput,
+    report_flux_on_inversion_grid: bool = True,
+) -> xr.Dataset:
+    """Return per-draw reconstructed sector and total flux traces for multisector outputs."""
+    _, sector_flux_traces, total_flux_trace = _multisector_flux_trace_parts(
+        inv_out,
+        report_flux_on_inversion_grid=report_flux_on_inversion_grid,
+    )
+    return xr.merge([total_flux_trace, *sector_flux_traces]).as_numpy()
+
+
+def make_sector_flux_outputs(
+    inv_out: InversionOutput,
+    stats: list[str] | None = None,
+    stats_args: dict | None = None,
+    include_scale_factors: bool = True,
+    report_flux_on_inversion_grid: bool = True,
+) -> xr.Dataset:
+    """Return multisector flux statistics by sector plus correctly reconstructed total flux statistics."""
+    sectors, sector_flux_traces, total_flux_trace = _multisector_flux_trace_parts(
+        inv_out,
+        report_flux_on_inversion_grid=report_flux_on_inversion_grid,
+    )
+    sample_trace = _sector_scale_trace(inv_out, sectors[0])
+    scale_stats_args = _stats_args_with_defaults(
+        stats,
+        stats_args,
+        chunk_dim=_state_chunk_dim(sample_trace, inv_out),
+    )
+    flux_stats_args = _stats_args_with_defaults(stats, stats_args)
 
     outputs = [calculate_stats(total_flux_trace, **flux_stats_args)]
     for sector, flux_trace in zip(sectors, sector_flux_traces, strict=True):

--- a/openghg_inversions/postprocessing/make_paris_outputs.py
+++ b/openghg_inversions/postprocessing/make_paris_outputs.py
@@ -12,6 +12,8 @@ import pandas as pd
 import xarray as xr
 
 from openghg.util import timestamp_now  # pyright: ignore[reportPrivateImportUsage]
+from openghg_inversions import convert
+from openghg_inversions.array_ops import align_sparse_lat_lon, sparse_xr_dot
 from openghg_inversions.config.version import code_version
 from openghg_inversions.postprocessing.countries import Countries
 from openghg_inversions.postprocessing.inversion_output import InversionOutput
@@ -19,9 +21,10 @@ from openghg_inversions.postprocessing.make_outputs import (
     make_concentration_outputs,
     make_flux_outputs,
     make_country_outputs,
+    make_multisector_flux_trace_outputs,
     observation_and_error_outputs,
 )
-from openghg_inversions.postprocessing.stats import stats_functions
+from openghg_inversions.postprocessing.stats import calculate_stats, stats_functions
 
 
 # path to `paris_formatting` submodule
@@ -97,9 +100,9 @@ var_pat = re.compile(r"\s*[a-z]+ ([a-zA-Z_]+)\(.*\)")
 attr_pat = re.compile(r"\s+([a-zA-Z_]+):([a-zA-Z_]+)\s*=\s*([^;]+)")
 
 
-def _require_paris_metadata(inv_out: InversionOutput) -> tuple[str, str]:
+def _require_paris_metadata(inv_out: InversionOutput, *, allow_multisector: bool = False) -> tuple[str, str]:
     """Return metadata required by current PARIS products."""
-    if inv_out.is_multisector:
+    if inv_out.is_multisector and not allow_multisector:
         raise ValueError("PARIS postprocessing supports only single-sector RHIME outputs.")
 
     species = inv_out.species
@@ -721,14 +724,63 @@ def _latest_paris_countries(country_file: str | Path | None, domain: str) -> Cou
     return countries
 
 
+def _multisector_country_trace_kg(inv_out: InversionOutput, countries: Countries, species: str) -> xr.Dataset:
+    """Return multisector total country flux traces in kg/yr from reconstructed total flux."""
+    total_flux_trace = make_multisector_flux_trace_outputs(
+        inv_out,
+        report_flux_on_inversion_grid=False,
+    )[["flux_total_prior", "flux_total_posterior"]].rename(
+        {
+            "flux_total_prior": "country_prior",
+            "flux_total_posterior": "country_posterior",
+        }
+    )
+    country_weights = countries.matrix.as_numpy() * countries.area_grid.as_numpy()
+    country_weights = align_sparse_lat_lon(country_weights, total_flux_trace["country_posterior"])
+    country_trace = sparse_xr_dot(country_weights, total_flux_trace, dim=["lat", "lon"])
+    country_trace = country_trace * 365 * 24 * 3600 * convert.molar_mass(species) * 1e-3
+    return country_trace.reindex(country=list(PARIS_LATEST_COUNTRIES))
+
+
+def _latest_country_outputs(
+    inv_out: InversionOutput,
+    countries: Countries,
+    species: str,
+    stats: list[str],
+    stats_args: dict[str, Any],
+    country_file: str | Path | None,
+) -> xr.Dataset:
+    """Return latest PARIS country statistics for single- or multisector outputs."""
+    if inv_out.is_multisector:
+        country_trace = _multisector_country_trace_kg(inv_out, countries, species)
+        country_stats_args = dict(stats_args)
+        country_stats_args["stats"] = stats
+        return calculate_stats(country_trace, **country_stats_args)
+
+    country_outs = make_country_outputs(
+        inv_out,
+        country_file=country_file,
+        country_selections=list(PARIS_LATEST_COUNTRIES),
+        stats=stats,
+        stats_args=stats_args,
+        country_code="alpha3",
+    )
+    return (country_outs * 1e-3).reindex(country=list(PARIS_LATEST_COUNTRIES))
+
+
 def _country_posterior_covariance_kg(
     inv_out: InversionOutput,
     countries: Countries,
+    species: str,
     flux_frequency: Literal["monthly", "yearly"] | str,
 ) -> np.ndarray:
     """Return posterior country-total covariance in kg2 yr-2."""
-    country_trace = countries.get_country_trace(inv_out=inv_out)
-    posterior = country_trace["country_posterior"] * 1e-3
+    if inv_out.is_multisector:
+        country_trace = _multisector_country_trace_kg(inv_out, countries, species)
+        posterior = country_trace["country_posterior"]
+    else:
+        country_trace = countries.get_country_trace(inv_out=inv_out)
+        posterior = country_trace["country_posterior"] * 1e-3
     flux_period = _flux_frequency_to_offset(flux_frequency)
     flux_times = list(pd.to_datetime(posterior.flux_time.values))
     _, _, valid_indices = _flux_interval_midpoints_and_bounds(
@@ -900,7 +952,7 @@ def paris_flux_output_latest(
     if time_point != "midpoint":
         raise ValueError("Latest PARIS flux output requires midpoint time coordinates and time bounds.")
 
-    species, domain = _require_paris_metadata(inv_out)
+    species, domain = _require_paris_metadata(inv_out, allow_multisector=True)
     stats = ["kde_mode", "stdev", "quantiles"] if report_mode else ["mean", "stdev", "quantiles"]
     stats_args = {"quantiles__quantiles": [0.159, 0.841]}
 
@@ -911,27 +963,31 @@ def paris_flux_output_latest(
         report_flux_on_inversion_grid=False,
         include_scale_factors=False,
     )
-    country_outs = make_country_outputs(
+    countries = _latest_paris_countries(country_file=country_file, domain=domain)
+    if inv_out.is_multisector:
+        flux_outs = flux_outs[
+            [data_var for data_var in flux_outs.data_vars if str(data_var).startswith("flux_total_")]
+        ]
+    country_outs = _latest_country_outputs(
         inv_out,
-        country_file=country_file,
-        country_selections=list(PARIS_LATEST_COUNTRIES),
+        countries=countries,
+        species=species,
         stats=stats,
         stats_args=stats_args,
-        country_code="alpha3",
+        country_file=country_file,
     )
-    country_outs = (country_outs * 1e-3).reindex(country=list(PARIS_LATEST_COUNTRIES))
-
-    countries = _latest_paris_countries(country_file=country_file, domain=domain)
     country_fraction = countries.matrix.as_numpy().rename("country_fraction")
     cell_area = countries.area_grid.as_numpy().rename("cell_area")
     country_covariance = _country_posterior_covariance_kg(
         inv_out,
         countries=countries,
+        species=species,
         flux_frequency=flux_frequency,
     )
 
     def flux_renamer(name: str) -> str:
-        name = name.replace("flux_", "flux_total_", 1)
+        if not name.startswith("flux_total_"):
+            name = name.replace("flux_", "flux_total_", 1)
         if "quantile" in name:
             name = "percentile_" + name.replace("_quantile", "")
         elif name.endswith("_stdev"):
@@ -985,15 +1041,23 @@ def paris_flux_output_latest(
 
     if inversion_grid:
         inversion_grid_flux_rename_dict = {v: f"{v}_inversion_grid" for v in flux_rename_dict.values()}
+        inversion_grid_flux_outs_raw = make_flux_outputs(
+            inv_out,
+            stats=stats,
+            stats_args=stats_args,
+            report_flux_on_inversion_grid=True,
+            include_scale_factors=False,
+        )
+        if inv_out.is_multisector:
+            inversion_grid_flux_outs_raw = inversion_grid_flux_outs_raw[
+                [
+                    data_var
+                    for data_var in inversion_grid_flux_outs_raw.data_vars
+                    if str(data_var).startswith("flux_total_")
+                ]
+            ]
         inversion_grid_flux_outs = (
-            make_flux_outputs(
-                inv_out,
-                stats=stats,
-                stats_args=stats_args,
-                report_flux_on_inversion_grid=True,
-                include_scale_factors=False,
-            )
-            .rename(dim_rename_dict)
+            inversion_grid_flux_outs_raw.rename(dim_rename_dict)
             .pipe(_assign_flux_time_bounds, flux_frequency, inv_out.start_time, inv_out.end_time)
             .pipe(_convert_flux_time_and_bounds_to_epoch_days)
             .rename(flux_rename_dict)

--- a/openghg_inversions/postprocessing/make_paris_outputs.py
+++ b/openghg_inversions/postprocessing/make_paris_outputs.py
@@ -1,8 +1,11 @@
 from pathlib import Path
 import getpass
+import json
+import math
 import re
 from collections.abc import Hashable
-from typing import Any, Literal, NamedTuple
+import warnings
+from typing import Any, Literal, NamedTuple, cast
 
 import numpy as np
 import pandas as pd
@@ -34,6 +37,32 @@ class ParisTemplateFiles(NamedTuple):
     concentration_version: str
     flux: Path
     flux_version: str
+
+
+PARIS_LATEST_COUNTRIES = (
+    "AUT",
+    "BEL",
+    "CHE",
+    "CZE",
+    "DEU",
+    "DNK",
+    "ESP",
+    "FIN",
+    "FRA",
+    "GBR",
+    "HRV",
+    "HUN",
+    "IRL",
+    "ITA",
+    "LUX",
+    "NLD",
+    "NOR",
+    "POL",
+    "PRT",
+    "SVK",
+    "SVN",
+    "SWE",
+)
 
 
 DEFAULT_PARIS_TEMPLATE_VERSION: ParisTemplateVersion = "legacy"
@@ -103,6 +132,176 @@ def get_data_var_attrs(template_file: str | Path, species: str | None = None) ->
                     attr_dict[m.group(1)][m.group(2)] = val
 
     return attr_dict
+
+
+def _site_info_for_site(site: str) -> dict[str, Any]:
+    """Return site metadata from ``openghg_defs`` when available."""
+    try:
+        from openghg_defs import site_info_file
+    except ImportError:
+        return {}
+
+    try:
+        site_info = json.loads(Path(site_info_file).read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+    provider_info = site_info.get(site.upper(), {})
+    if not isinstance(provider_info, dict) or not provider_info:
+        return {}
+
+    first_provider = next(iter(provider_info.values()))
+    return first_provider if isinstance(first_provider, dict) else {}
+
+
+def _as_float_or_nan(value: object) -> float:
+    """Best-effort conversion of scalar metadata values to float."""
+    if value is None:
+        return np.nan
+    if isinstance(value, str):
+        match = re.search(r"[-+]?\d*\.?\d+", value)
+        if match is None:
+            return np.nan
+        value = match.group(0)
+    else:
+        value = str(value)
+    try:
+        converted = float(value)
+    except (TypeError, ValueError):
+        return np.nan
+    return converted if math.isfinite(converted) else np.nan
+
+
+def _measurement_values(inv_out: InversionOutput, names: tuple[str, ...], size: int) -> np.ndarray | None:
+    """Return a 1-D measurement-aligned variable from inversion inputs."""
+    for name in names:
+        if name not in inv_out.inv_inputs:
+            continue
+        data = inv_out.inv_inputs[name]
+        if "nmeasure" not in data.dims or data.sizes["nmeasure"] != size:
+            continue
+        return np.asarray(data.values)
+    return None
+
+
+def _numeric_measurement_values(
+    inv_out: InversionOutput,
+    names: tuple[str, ...],
+    size: int,
+) -> np.ndarray | None:
+    """Return measurement-aligned numeric metadata values from inversion inputs."""
+    values = _measurement_values(inv_out, names, size)
+    if values is None:
+        return None
+    return np.asarray([_as_float_or_nan(value) for value in values], dtype="float32")
+
+
+def _datetime_values_to_epoch_days(values: object) -> np.ndarray:
+    """Convert datetime-like values to days since the Unix epoch."""
+    array = np.asarray(values)
+    flat = pd.to_datetime(array.reshape(-1))
+    converted = (flat - pd.Timestamp("1970-01-01")) / pd.Timedelta("1d")
+    return np.asarray(converted, dtype="float64").reshape(array.shape)
+
+
+def _time_period_to_timedelta(period: str | None) -> pd.Timedelta:
+    """Parse a period string, falling back to zero for unsupported calendar periods."""
+    if period is None:
+        return cast(pd.Timedelta, pd.Timedelta(0))
+    try:
+        delta = pd.to_timedelta(period)
+    except ValueError:
+        return cast(pd.Timedelta, pd.Timedelta(0))
+    return delta if isinstance(delta, pd.Timedelta) else cast(pd.Timedelta, pd.Timedelta(0))
+
+
+def _add_observation_time_bounds(ds: xr.Dataset, obs_avg_period: str | None) -> xr.Dataset:
+    """Assign midpoint observation times and start/end bounds on latest PARIS concentration output."""
+    period = _time_period_to_timedelta(obs_avg_period)
+    start_times = pd.to_datetime(ds["time"].values)
+    end_times = start_times + period
+    midpoint_times = start_times + period / 2
+    time_bnds = np.stack([start_times, end_times], axis=1)
+    return ds.assign_coords(time=("index", midpoint_times)).assign(time_bnds=(("index", "nbnds"), time_bnds))
+
+
+def _convert_time_and_bounds_to_epoch_days(ds: xr.Dataset) -> xr.Dataset:
+    """Convert ``time`` and optional ``time_bnds`` to days since 1970-01-01."""
+    result = ds.assign_coords(time=("index", _datetime_values_to_epoch_days(ds["time"].values)))
+    if "time_bnds" in result:
+        result["time_bnds"] = (
+            result["time_bnds"].dims,
+            _datetime_values_to_epoch_days(result.time_bnds.values),
+        )
+    return result
+
+
+def _platform_metadata(inv_out: InversionOutput, site_values: np.ndarray, size: int) -> xr.Dataset:
+    """Build platform identifiers and sample location fields for latest concentration output."""
+    raw_height_values = _measurement_values(inv_out, ("inlet_height", "inlet"), size)
+    intake_height = _numeric_measurement_values(inv_out, ("inlet_height", "inlet"), size)
+
+    platform_labels: list[str] = []
+    platform_index: list[int] = []
+    label_to_index: dict[str, int] = {}
+
+    for i, site in enumerate(site_values):
+        site_label = str(site)
+        height_label = None
+        if raw_height_values is not None:
+            raw_height = raw_height_values[i]
+            if raw_height is not None and str(raw_height).lower() != "nan":
+                height_label = str(raw_height)
+        label = f"{site_label}-{height_label}" if height_label else site_label
+        if label not in label_to_index:
+            label_to_index[label] = len(platform_labels)
+            platform_labels.append(label)
+        platform_index.append(label_to_index[label])
+
+    site_metadata = [_site_info_for_site(str(site)) for site in site_values]
+    longitude = _numeric_measurement_values(inv_out, ("longitude", "lon"), size)
+    latitude = _numeric_measurement_values(inv_out, ("latitude", "lat"), size)
+    altitude = _numeric_measurement_values(inv_out, ("altitude", "height_station_masl"), size)
+
+    if longitude is None:
+        longitude = np.asarray(
+            [_as_float_or_nan(metadata.get("longitude")) for metadata in site_metadata],
+            dtype="float64",
+        )
+    if latitude is None:
+        latitude = np.asarray(
+            [_as_float_or_nan(metadata.get("latitude")) for metadata in site_metadata],
+            dtype="float64",
+        )
+    if altitude is None:
+        altitude = np.asarray(
+            [_as_float_or_nan(metadata.get("height_station_masl")) for metadata in site_metadata],
+            dtype="float32",
+        )
+    if intake_height is None:
+        intake_height = np.full(size, np.nan, dtype="float32")
+
+    altitude_model = _numeric_measurement_values(inv_out, ("altitude_model",), size)
+    if altitude_model is None:
+        altitude_model = altitude.astype("float32", copy=True)
+
+    intake_height_model = _numeric_measurement_values(inv_out, ("intake_height_model", "fp_height"), size)
+    if intake_height_model is None:
+        intake_height_model = intake_height.astype("float32", copy=True)
+
+    return xr.Dataset(
+        {
+            "longitude": ("index", longitude),
+            "latitude": ("index", latitude),
+            "altitude": ("index", altitude),
+            "intake_height": ("index", intake_height),
+            "altitude_model": ("index", altitude_model),
+            "intake_height_model": ("index", intake_height_model),
+            "number_of_identifier": ("index", np.asarray(platform_index, dtype="int16")),
+            "assimilation_flag": ("index", np.ones(size, dtype="int16")),
+        },
+        coords={"platform": ("platform", np.asarray(platform_labels, dtype=object))},
+    )
 
 
 def make_global_attrs(
@@ -201,6 +400,13 @@ def paris_concentration_outputs(
 
     TODO: add offset
     """
+    if template_version == "latest":
+        return paris_concentration_outputs_latest(
+            inv_out,
+            report_mode=report_mode,
+            obs_avg_period=obs_avg_period,
+        )
+
     stats = ["kde_mode", "quantiles"] if report_mode else ["mean", "quantiles"]
 
     stats_args = {"quantiles__quantiles": [0.159, 0.841]}
@@ -287,6 +493,118 @@ def paris_concentration_outputs(
     return _cast_float_data_vars_to_float32(result)
 
 
+def paris_concentration_outputs_latest(
+    inv_out: InversionOutput,
+    report_mode: bool = False,
+    obs_avg_period: str = "4h",
+) -> xr.Dataset:
+    """Create single-sector PARIS concentration outputs for the latest CDL template."""
+    species, domain = _require_paris_metadata(inv_out)
+    stats = ["kde_mode", "stdev", "quantiles"] if report_mode else ["mean", "stdev", "quantiles"]
+    stats_args = {"quantiles__quantiles": [0.159, 0.841]}
+
+    obs_and_errs_raw = observation_and_error_outputs(inv_out)
+    existing_vars = set(obs_and_errs_raw.data_vars)
+    rename_map = {
+        "y_obs": "mf_observed",
+        "y_obs_repeatability": "stdev_mf_observed_repeatability",
+        "y_obs_variability": "stdev_mf_observed_variability",
+        "model_error": "stdev_mf_model",
+        "total_error": "stdev_mf_total",
+    }
+    obs_and_errs = obs_and_errs_raw.rename(
+        {name: output_name for name, output_name in rename_map.items() if name in existing_vars}
+    ).drop_vars(
+        [
+            name
+            for name in (
+                "y_obs_error",
+                "y_obs_prior_factor",
+                "y_obs_prior_upper_level_factor",
+            )
+            if name in obs_and_errs_raw
+        ]
+    )
+
+    conc_outputs = make_concentration_outputs(
+        inv_out,
+        stats=stats,
+        stats_args=stats_args,
+        combine_bc_and_offset=True,
+    )
+
+    def renamer(name: str) -> str | None:
+        when = "posterior" if "posterior" in name else "prior"
+        if "quantile" in name:
+            prefix = "percentile_"
+        elif "stdev" in name:
+            prefix = "stdev_"
+        else:
+            prefix = ""
+
+        if name.startswith("y_"):
+            return f"{prefix}mf_{when}"
+        if name.startswith("mu_bc_") and not prefix:
+            return f"mf_bc_{when}"
+        if name.startswith("offset_") and not prefix:
+            return f"mf_bias_{when}"
+        return None
+
+    rename_dict = {"quantile": "percentile"}
+    keep_vars = []
+    for data_var in conc_outputs.data_vars:
+        output_name = renamer(str(data_var))
+        if output_name is not None:
+            rename_dict[str(data_var)] = output_name
+            keep_vars.append(data_var)
+
+    conc_outputs = conc_outputs[keep_vars].rename(rename_dict)
+    result = xr.merge([obs_and_errs, conc_outputs])
+
+    if "y_obs_prior_factor" in obs_and_errs_raw and "y_obs_prior_upper_level_factor" in obs_and_errs_raw:
+        with xr.set_options(keep_attrs="default"):
+            factor = (
+                obs_and_errs_raw["y_obs_prior_factor"] + obs_and_errs_raw["y_obs_prior_upper_level_factor"]
+            )
+        for name in (
+            "mf_observed",
+            "mf_prior",
+            "mf_posterior",
+            "percentile_mf_prior",
+            "percentile_mf_posterior",
+            "mf_bc_prior",
+            "mf_bc_posterior",
+        ):
+            if name in result:
+                result[name] = result[name] + factor
+
+    if "nmeasure" in result.dims:
+        result = result.reset_index("nmeasure").rename({"nmeasure": "index"})
+    else:
+        result = result.rename({"time": "index"})
+
+    size = result.sizes["index"]
+    site_values = np.asarray(result["site"].values) if "site" in result else np.asarray(["unknown"] * size)
+    platform_metadata = _platform_metadata(inv_out, site_values, size)
+
+    template_files = paris_template_files("latest")
+    conc_attrs = get_data_var_attrs(template_files.concentration, species)
+    units = float(obs_and_errs_raw["y_obs"].attrs["units"].split(" ")[0])
+
+    result = (
+        xr.merge([result, platform_metadata])
+        .pipe(_add_observation_time_bounds, obs_avg_period)
+        .pipe(_convert_time_and_bounds_to_epoch_days)
+        .pipe(add_variable_attrs, conc_attrs, units)
+        .transpose("index", "percentile", "platform", "nbnds", missing_dims="ignore")
+    )
+
+    result.attrs = make_global_attrs("conc", species=species, domain=domain)
+    result.attrs["paris_concentration_template_version"] = template_files.concentration_version
+
+    return result.as_numpy()
+
+
 def _flux_frequency_to_offset(flux_frequency: str) -> pd.DateOffset | pd.Timedelta:
     """Convert a flux frequency string to a calendar-aware pandas offset."""
     if flux_frequency == "monthly":
@@ -337,6 +655,109 @@ def _flux_interval_midpoints(
     return midpoints, valid_indices
 
 
+def _flux_interval_midpoints_and_bounds(
+    flux_times: list[pd.Timestamp],
+    flux_period: pd.DateOffset | pd.Timedelta,
+    inv_start: pd.Timestamp,
+    inv_end: pd.Timestamp,
+) -> tuple[list[pd.Timestamp], list[tuple[pd.Timestamp, pd.Timestamp]], list[int]]:
+    """Compute clipped flux interval midpoints, bounds, and retained indices."""
+    midpoints = []
+    bounds = []
+    valid_indices = []
+    for i, ft in enumerate(flux_times):
+        overlap_start = max(ft, inv_start)
+        overlap_end = min(ft + flux_period, inv_end)
+        if overlap_end > overlap_start:
+            midpoints.append(overlap_start + (overlap_end - overlap_start) / 2)
+            bounds.append((overlap_start, overlap_end))
+            valid_indices.append(i)
+    return midpoints, bounds, valid_indices
+
+
+def _assign_flux_time_bounds(
+    ds: xr.Dataset,
+    flux_frequency: Literal["monthly", "yearly"] | str,
+    inv_start: pd.Timestamp,
+    inv_end: pd.Timestamp,
+) -> xr.Dataset:
+    """Assign midpoint flux times and clipped interval bounds for latest PARIS flux output."""
+    flux_period = _flux_frequency_to_offset(flux_frequency)
+    flux_times = list(pd.to_datetime(ds.time.values))
+    midpoints, bounds, valid_indices = _flux_interval_midpoints_and_bounds(
+        flux_times,
+        flux_period,
+        inv_start,
+        inv_end,
+    )
+    time_bnds = np.asarray(bounds, dtype="datetime64[ns]")
+    return (
+        ds.isel(time=valid_indices)
+        .assign_coords(time=midpoints)
+        .assign(time_bnds=(("time", "nbnds"), time_bnds))
+    )
+
+
+def _convert_flux_time_and_bounds_to_epoch_days(ds: xr.Dataset) -> xr.Dataset:
+    """Convert flux ``time`` and ``time_bnds`` to days since 1970-01-01."""
+    result = ds.assign_coords(time=("time", _datetime_values_to_epoch_days(ds["time"].values)))
+    if "time_bnds" in result:
+        result["time_bnds"] = (
+            result["time_bnds"].dims,
+            _datetime_values_to_epoch_days(result.time_bnds.values),
+        )
+    return result
+
+
+def _latest_paris_countries(country_file: str | Path | None, domain: str) -> Countries:
+    """Return country metadata for the latest PARIS CDL country list."""
+    countries = Countries.from_file(
+        country_file=country_file,
+        country_code="alpha3",
+        country_selections=list(PARIS_LATEST_COUNTRIES),
+        domain=domain,
+    )
+    countries.matrix = countries.matrix.reindex(country=list(PARIS_LATEST_COUNTRIES))
+    return countries
+
+
+def _country_posterior_covariance_kg(
+    inv_out: InversionOutput,
+    countries: Countries,
+    flux_frequency: Literal["monthly", "yearly"] | str,
+) -> np.ndarray:
+    """Return posterior country-total covariance in kg2 yr-2."""
+    country_trace = countries.get_country_trace(inv_out=inv_out)
+    posterior = country_trace["country_posterior"] * 1e-3
+    flux_period = _flux_frequency_to_offset(flux_frequency)
+    flux_times = list(pd.to_datetime(posterior.flux_time.values))
+    _, _, valid_indices = _flux_interval_midpoints_and_bounds(
+        flux_times,
+        flux_period,
+        inv_out.start_time,
+        inv_out.end_time,
+    )
+
+    values = posterior.isel(flux_time=valid_indices).transpose("flux_time", "country", "draw").values
+    if values.shape[2] < 2:
+        return np.full((values.shape[0], values.shape[1], values.shape[1]), np.nan, dtype="float32")
+
+    centered = values - values.mean(axis=2, keepdims=True)
+    return np.einsum("tcd,ted->tce", centered, centered) / (values.shape[2] - 1)
+
+
+def _add_country_covariance(result: xr.Dataset, covariance: np.ndarray, attrs: dict[str, Any]) -> xr.Dataset:
+    """Add latest PARIS country covariance with the duplicate country dimension required by the template."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        result["covariance_flux_total_posterior_country"] = (
+            ("time", "country", "country"),
+            covariance,
+        )
+    result["covariance_flux_total_posterior_country"].attrs = attrs
+    return result
+
+
 def paris_flux_output(
     inv_out: InversionOutput,
     country_file: str | Path | None = None,
@@ -346,6 +767,16 @@ def paris_flux_output(
     flux_frequency: Literal["monthly", "yearly"] | str = "yearly",
     template_version: ParisTemplateVersion = DEFAULT_PARIS_TEMPLATE_VERSION,
 ) -> xr.Dataset:
+    if template_version == "latest":
+        return paris_flux_output_latest(
+            inv_out,
+            country_file=country_file,
+            time_point=time_point,
+            report_mode=report_mode,
+            inversion_grid=inversion_grid,
+            flux_frequency=flux_frequency,
+        )
+
     species, domain = _require_paris_metadata(inv_out)
     stats = ["kde_mode", "quantiles"] if report_mode else ["mean", "quantiles"]
 
@@ -455,6 +886,132 @@ def paris_flux_output(
     result.attrs["paris_flux_template_version"] = template_files.flux_version
 
     return _cast_float_data_vars_to_float32(result).as_numpy()
+
+
+def paris_flux_output_latest(
+    inv_out: InversionOutput,
+    country_file: str | Path | None = None,
+    time_point: Literal["start", "midpoint"] = "midpoint",
+    report_mode: bool = False,
+    inversion_grid: bool = True,
+    flux_frequency: Literal["monthly", "yearly"] | str = "yearly",
+) -> xr.Dataset:
+    """Create single-sector PARIS flux outputs for the latest CDL template."""
+    if time_point != "midpoint":
+        raise ValueError("Latest PARIS flux output requires midpoint time coordinates and time bounds.")
+
+    species, domain = _require_paris_metadata(inv_out)
+    stats = ["kde_mode", "stdev", "quantiles"] if report_mode else ["mean", "stdev", "quantiles"]
+    stats_args = {"quantiles__quantiles": [0.159, 0.841]}
+
+    flux_outs = make_flux_outputs(
+        inv_out,
+        stats=stats,
+        stats_args=stats_args,
+        report_flux_on_inversion_grid=False,
+        include_scale_factors=False,
+    )
+    country_outs = make_country_outputs(
+        inv_out,
+        country_file=country_file,
+        country_selections=list(PARIS_LATEST_COUNTRIES),
+        stats=stats,
+        stats_args=stats_args,
+        country_code="alpha3",
+    )
+    country_outs = (country_outs * 1e-3).reindex(country=list(PARIS_LATEST_COUNTRIES))
+
+    countries = _latest_paris_countries(country_file=country_file, domain=domain)
+    country_fraction = countries.matrix.as_numpy().rename("country_fraction")
+    cell_area = countries.area_grid.as_numpy().rename("cell_area")
+    country_covariance = _country_posterior_covariance_kg(
+        inv_out,
+        countries=countries,
+        flux_frequency=flux_frequency,
+    )
+
+    def flux_renamer(name: str) -> str:
+        name = name.replace("flux_", "flux_total_", 1)
+        if "quantile" in name:
+            name = "percentile_" + name.replace("_quantile", "")
+        elif name.endswith("_stdev"):
+            name = "stdev_" + name.removesuffix("_stdev")
+        for stats_func_name in stats_functions:
+            if name.endswith(f"_{stats_func_name}"):
+                name = name.removesuffix(f"_{stats_func_name}")
+        return name
+
+    def country_renamer(name: str) -> str:
+        suffix = name.removeprefix("country_")
+        if "quantile" in suffix:
+            suffix = suffix.replace("_quantile", "")
+            return f"percentile_flux_total_{suffix}_country"
+        if suffix.endswith("_stdev"):
+            suffix = suffix.removesuffix("_stdev")
+            return f"stdev_flux_total_{suffix}_country"
+        for stats_func_name in stats_functions:
+            if suffix.endswith(f"_{stats_func_name}"):
+                suffix = suffix.removesuffix(f"_{stats_func_name}")
+        return f"flux_total_{suffix}_country"
+
+    flux_rename_dict = {str(dv): flux_renamer(str(dv)) for dv in flux_outs.data_vars}
+    country_rename_dict = {str(dv): country_renamer(str(dv)) for dv in country_outs.data_vars}
+
+    dim_rename_dict = {"quantile": "percentile", "flux_time": "time"}
+    if "lat" in flux_outs.dims:
+        dim_rename_dict["lat"] = "latitude"
+    if "lon" in flux_outs.dims:
+        dim_rename_dict["lon"] = "longitude"
+
+    template_files = paris_template_files("latest")
+    emissions_attrs = get_data_var_attrs(template_files.flux, species)
+
+    result = (
+        xr.merge(
+            [
+                flux_outs,
+                country_outs,
+                country_fraction.reindex_like(flux_outs),
+                cell_area.reindex_like(flux_outs),
+            ],
+            join="outer",
+        )
+        .rename(dim_rename_dict)
+        .pipe(_assign_flux_time_bounds, flux_frequency, inv_out.start_time, inv_out.end_time)
+        .pipe(_convert_flux_time_and_bounds_to_epoch_days)
+        .rename({**flux_rename_dict, **country_rename_dict})
+        .pipe(add_variable_attrs, emissions_attrs)
+    )
+
+    if inversion_grid:
+        inversion_grid_flux_rename_dict = {v: f"{v}_inversion_grid" for v in flux_rename_dict.values()}
+        inversion_grid_flux_outs = (
+            make_flux_outputs(
+                inv_out,
+                stats=stats,
+                stats_args=stats_args,
+                report_flux_on_inversion_grid=True,
+                include_scale_factors=False,
+            )
+            .rename(dim_rename_dict)
+            .pipe(_assign_flux_time_bounds, flux_frequency, inv_out.start_time, inv_out.end_time)
+            .pipe(_convert_flux_time_and_bounds_to_epoch_days)
+            .rename(flux_rename_dict)
+            .pipe(add_variable_attrs, emissions_attrs)
+            .rename(inversion_grid_flux_rename_dict)
+        )
+        result = result.merge(inversion_grid_flux_outs)
+
+    result = result.transpose("time", "percentile", "country", "latitude", "longitude", "nbnds").as_numpy()
+    result = _add_country_covariance(
+        result,
+        country_covariance,
+        emissions_attrs.get("covariance_flux_total_posterior_country", {}),
+    )
+    result.attrs = make_global_attrs("flux", species=species, domain=domain)
+    result.attrs["paris_flux_template_version"] = template_files.flux_version
+
+    return result
 
 
 def infer_flux_frequency(flux: xr.DataArray) -> str:

--- a/openghg_inversions/postprocessing/make_paris_outputs.py
+++ b/openghg_inversions/postprocessing/make_paris_outputs.py
@@ -97,7 +97,15 @@ def paris_template_files(template_version: ParisTemplateVersion) -> ParisTemplat
 
 
 var_pat = re.compile(r"\s*[a-z]+ ([a-zA-Z_]+)\(.*\)")
+var_type_pat = re.compile(r"\s*([a-z]+) ([a-zA-Z_]+)\(.*\)")
 attr_pat = re.compile(r"\s+([a-zA-Z_]+):([a-zA-Z_]+)\s*=\s*([^;]+)")
+NETCDF_TO_NUMPY_DTYPE = {
+    "byte": "int8",
+    "short": "int16",
+    "int": "int32",
+    "float": "float32",
+    "double": "float64",
+}
 
 
 def _require_paris_metadata(inv_out: InversionOutput, *, allow_multisector: bool = False) -> tuple[str, str]:
@@ -135,6 +143,26 @@ def get_data_var_attrs(template_file: str | Path, species: str | None = None) ->
                     attr_dict[m.group(1)][m.group(2)] = val
 
     return attr_dict
+
+
+def get_data_var_dtypes(template_file: str | Path) -> dict[str, str]:
+    """Extract numeric variable dtypes from a CDL template file."""
+    dtype_dict: dict[str, str] = {}
+
+    with open(template_file) as f:
+        in_vars = False
+        for line in f.readlines():
+            if line.startswith("variables"):
+                in_vars = True
+            if not in_vars:
+                continue
+            if (m := var_type_pat.match(line)) is None:
+                continue
+            netcdf_type, var_name = m.groups()
+            if netcdf_type in NETCDF_TO_NUMPY_DTYPE:
+                dtype_dict[var_name] = NETCDF_TO_NUMPY_DTYPE[netcdf_type]
+
+    return dtype_dict
 
 
 def _site_info_for_site(site: str) -> dict[str, Any]:
@@ -379,6 +407,23 @@ def _cast_float_data_vars_to_float32(ds: xr.Dataset) -> xr.Dataset:
     return ds.assign(updates) if updates else ds
 
 
+def _astype_data_array(da: xr.DataArray, dtype: str) -> xr.DataArray:
+    """Cast a DataArray, including template-required duplicate-dimension variables."""
+    if len(set(da.dims)) == len(da.dims):
+        return da.astype(dtype)
+    return da.copy(data=da.data.astype(dtype))
+
+
+def _cast_data_vars_to_template_dtypes(ds: xr.Dataset, template_file: str | Path) -> xr.Dataset:
+    """Cast PARIS data variables to numeric dtypes declared by a CDL template."""
+    updates: dict[Hashable, xr.DataArray] = {}
+    for name, dtype in get_data_var_dtypes(template_file).items():
+        if name in ds.data_vars and ds[name].dtype != np.dtype(dtype):
+            updates[name] = _astype_data_array(ds[name], dtype)
+
+    return ds.assign(updates) if updates else ds
+
+
 def convert_time_to_unix_epoch(x: xr.Dataset, units: str = "1s") -> xr.Dataset:
     """Convert `time` coordinate of xarray Dataset or DataArray to number of "units" since 1 Jan 1970 (the "UNIX epoch")."""
     time_converted = (pd.DatetimeIndex(x.time) - pd.Timestamp("1970-01-01")) / pd.Timedelta(units)
@@ -586,6 +631,15 @@ def paris_concentration_outputs_latest(
     else:
         result = result.rename({"time": "index"})
 
+    # The latest template requires these fields even when no baseline was solved.
+    # No-BC runs currently have no baseline time series to report, so record it as missing.
+    reference_mf = next(
+        result[name] for name in ("mf_prior", "mf_posterior", "mf_observed") if name in result
+    )
+    for name in ("mf_bc_prior", "mf_bc_posterior"):
+        if name not in result:
+            result[name] = xr.full_like(reference_mf, np.nan, dtype="float32")
+
     size = result.sizes["index"]
     site_values = np.asarray(result["site"].values) if "site" in result else np.asarray(["unknown"] * size)
     platform_metadata = _platform_metadata(inv_out, site_values, size)
@@ -605,7 +659,7 @@ def paris_concentration_outputs_latest(
     result.attrs = make_global_attrs("conc", species=species, domain=domain)
     result.attrs["paris_concentration_template_version"] = template_files.concentration_version
 
-    return result.as_numpy()
+    return _cast_data_vars_to_template_dtypes(result, template_files.concentration).as_numpy()
 
 
 def _flux_frequency_to_offset(flux_frequency: str) -> pd.DateOffset | pd.Timedelta:
@@ -1027,8 +1081,8 @@ def paris_flux_output_latest(
             [
                 flux_outs,
                 country_outs,
-                country_fraction.reindex_like(flux_outs),
-                cell_area.reindex_like(flux_outs),
+                align_sparse_lat_lon(country_fraction, flux_outs),
+                align_sparse_lat_lon(cell_area, flux_outs),
             ],
             join="outer",
         )
@@ -1075,7 +1129,7 @@ def paris_flux_output_latest(
     result.attrs = make_global_attrs("flux", species=species, domain=domain)
     result.attrs["paris_flux_template_version"] = template_files.flux_version
 
-    return result
+    return _cast_data_vars_to_template_dtypes(result, template_files.flux)
 
 
 def infer_flux_frequency(flux: xr.DataArray) -> str:

--- a/openghg_inversions/postprocessing/make_paris_outputs.py
+++ b/openghg_inversions/postprocessing/make_paris_outputs.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import getpass
 import re
 from collections.abc import Hashable
-from typing import Any, Literal
+from typing import Any, Literal, NamedTuple
 
 import numpy as np
 import pandas as pd
@@ -24,9 +24,44 @@ from openghg_inversions.postprocessing.stats import stats_functions
 # path to `paris_formatting` submodule
 paris_formatting_path = Path(__file__).parent
 
-# paths to template files
-conc_template_path = paris_formatting_path / "PARIS_Lagrangian_inversion_concentration_EUROPE_v03.cdl"
-flux_template_path = paris_formatting_path / "PARIS_Lagrangian_inversion_flux_EUROPE.cdl"
+ParisTemplateVersion = Literal["legacy", "latest"]
+
+
+class ParisTemplateFiles(NamedTuple):
+    """CDL templates used for one PARIS output schema version."""
+
+    concentration: Path
+    concentration_version: str
+    flux: Path
+    flux_version: str
+
+
+DEFAULT_PARIS_TEMPLATE_VERSION: ParisTemplateVersion = "legacy"
+PARIS_TEMPLATE_FILES: dict[ParisTemplateVersion, ParisTemplateFiles] = {
+    "legacy": ParisTemplateFiles(
+        concentration=paris_formatting_path / "PARIS_Lagrangian_inversion_concentration_EUROPE_v03.cdl",
+        concentration_version="v03",
+        flux=paris_formatting_path / "PARIS_Lagrangian_inversion_flux_EUROPE.cdl",
+        flux_version="legacy",
+    ),
+    "latest": ParisTemplateFiles(
+        concentration=paris_formatting_path / "PARIS_Lagrangian_inversion_concentration_EUROPE_v04.cdl",
+        concentration_version="v04",
+        flux=paris_formatting_path / "PARIS_Lagrangian_inversion_flux_EUROPE_v03.cdl",
+        flux_version="v03",
+    ),
+}
+
+
+def paris_template_files(template_version: ParisTemplateVersion) -> ParisTemplateFiles:
+    """Return CDL template paths for a PARIS output schema version."""
+    try:
+        return PARIS_TEMPLATE_FILES[template_version]
+    except KeyError as exc:
+        raise ValueError(
+            f"Unsupported PARIS template version {template_version!r}; "
+            f"expected one of {sorted(PARIS_TEMPLATE_FILES)!r}."
+        ) from exc
 
 
 var_pat = re.compile(r"\s*[a-z]+ ([a-zA-Z_]+)\(.*\)")
@@ -157,7 +192,10 @@ def shift_measurement_time_to_midpoint(ds: xr.Dataset, period: str = "4h") -> xr
 
 
 def paris_concentration_outputs(
-    inv_out: InversionOutput, report_mode: bool = False, obs_avg_period: str = "4h"
+    inv_out: InversionOutput,
+    report_mode: bool = False,
+    obs_avg_period: str = "4h",
+    template_version: ParisTemplateVersion = DEFAULT_PARIS_TEMPLATE_VERSION,
 ) -> xr.Dataset:
     """Create PARIS concentration outputs.
 
@@ -212,7 +250,8 @@ def paris_concentration_outputs(
     if "qYapost_bias" in conc_outputs.data_vars:
         conc_outputs = conc_outputs.drop_vars(["qYapost_bias", "qYapriori_bias"])
 
-    conc_attrs = get_data_var_attrs(conc_template_path)
+    template_files = paris_template_files(template_version)
+    conc_attrs = get_data_var_attrs(template_files.concentration)
 
     units = float(obs_and_errs_raw["y_obs"].attrs["units"].split(" ")[0])
 
@@ -243,6 +282,7 @@ def paris_concentration_outputs(
     result.sitenames.attrs["long_name"] = "identifier of site"
 
     result.attrs = make_global_attrs("conc")
+    result.attrs["paris_concentration_template_version"] = template_files.concentration_version
 
     return _cast_float_data_vars_to_float32(result)
 
@@ -304,6 +344,7 @@ def paris_flux_output(
     report_mode: bool = False,
     inversion_grid: bool = True,
     flux_frequency: Literal["monthly", "yearly"] | str = "yearly",
+    template_version: ParisTemplateVersion = DEFAULT_PARIS_TEMPLATE_VERSION,
 ) -> xr.Dataset:
     species, domain = _require_paris_metadata(inv_out)
     stats = ["kde_mode", "quantiles"] if report_mode else ["mean", "quantiles"]
@@ -318,7 +359,8 @@ def paris_flux_output(
         include_scale_factors=False,
     )
 
-    emissions_attrs = get_data_var_attrs(flux_template_path, species)
+    template_files = paris_template_files(template_version)
+    emissions_attrs = get_data_var_attrs(template_files.flux, species)
     country_outs = make_country_outputs(
         inv_out,
         country_file=country_file,
@@ -410,6 +452,7 @@ def paris_flux_output(
     result = result.transpose("time", "percentile", "country", "latitude", "longitude")
 
     result.attrs = make_global_attrs("flux")
+    result.attrs["paris_flux_template_version"] = template_files.flux_version
 
     return _cast_float_data_vars_to_float32(result).as_numpy()
 
@@ -483,10 +526,16 @@ def make_paris_outputs(
     inversion_grid: bool = True,
     obs_avg_period: str = "4h",
     domain: str | None = None,
+    template_version: ParisTemplateVersion = DEFAULT_PARIS_TEMPLATE_VERSION,
 ) -> tuple[xr.Dataset, xr.Dataset]:
     # infer flux frequency
     flux_frequency = infer_flux_frequency(inv_out.flux)
-    conc_outs = paris_concentration_outputs(inv_out, report_mode=report_mode, obs_avg_period=obs_avg_period)
+    conc_outs = paris_concentration_outputs(
+        inv_out,
+        report_mode=report_mode,
+        obs_avg_period=obs_avg_period,
+        template_version=template_version,
+    )
     flux_outs = paris_flux_output(
         inv_out,
         report_mode=report_mode,
@@ -494,6 +543,7 @@ def make_paris_outputs(
         inversion_grid=inversion_grid,
         time_point=time_point,
         flux_frequency=flux_frequency,
+        template_version=template_version,
     )
 
     return flux_outs, conc_outs

--- a/openghg_inversions/rhime/outputs.py
+++ b/openghg_inversions/rhime/outputs.py
@@ -10,7 +10,6 @@ import arviz as az
 import xarray as xr
 
 from openghg_inversions._timing import timed
-from openghg_inversions.array_ops import sparse_xr_dot
 from openghg_inversions.inversion_data import RhimePreparedInputs
 from openghg_inversions.models import RhimeModelSpec
 from openghg_inversions.postprocessing.inversion_output import (
@@ -109,25 +108,6 @@ def _save_inferencedata(idata: az.InferenceData, path: str | Path) -> None:
     raise RuntimeError(
         f"Could not save RHIME trace to {path}. Tried h5netcdf, ArviZ default, and netcdf4:\n{joined_failures}"
     )
-
-
-def _materialise_basis_and_flux_for_output(
-    prepared: RhimePreparedInputs,
-) -> tuple[xr.DataArray, xr.DataArray]:
-    """Return materialised arrays for transitional output adapters.
-
-    TODO(#383/#429): postprocessing should consume ``BasisFunctions`` directly
-    rather than requiring the runner to materialise a flat basis and flux.
-    """
-    basis = prepared.basis_functions.operator.basis_matrix
-    current_state_dim = prepared.basis_functions.operator.meta.state_dim
-    if current_state_dim != "region":
-        basis = basis.rename({current_state_dim: "region"})
-    region_coord = prepared.inv_inputs.region
-    if region_coord.name is None:
-        raise ValueError("prepared.inv_inputs.region must be named so it can be used for reindexing.")
-    basis = basis.reindex({region_coord.name: region_coord})
-    return basis, prepared.basis_functions.flux
 
 
 def _make_inversion_output(
@@ -314,42 +294,17 @@ def make_standard_output_bundle(
 
 
 def _make_multisector_flux_diagnostics(
-    *,
-    idata: az.InferenceData,
-    prepared: RhimePreparedInputs,
-    model_spec: RhimeModelSpec,
+    inv_out: InversionOutput,
 ) -> xr.Dataset:
-    """Create provisional sector-aware posterior flux diagnostics.
+    """Create sector-aware flux diagnostics with the shared postprocessing layer."""
+    from openghg_inversions.postprocessing.make_outputs import make_sector_flux_outputs
 
-    TODO(#398/#429): replace this runner-local special case with
-    sector-aware postprocessing once the modern output layer supports multiple
-    sectors and ``BasisFunctions`` reconstruction directly.
-
-    Args:
-        idata: InferenceData returned by RHIME sampling.
-        prepared: Prepared RHIME input object containing retained basis functions.
-        model_spec: Model spec containing sector names and variable suffixes.
-
-    Returns:
-        Dataset containing posterior mean scaling factors, sector posterior flux
-        means, and total posterior flux mean.
-    """
-    basis, flux = _materialise_basis_and_flux_for_output(prepared)
-    posterior_flux = []
-    posterior_scaling = []
-
-    for sector in model_spec.sectors:
-        x_name = f"x_{sector.variable_suffix}"
-        x_mean = cast(Any, idata).posterior[x_name].mean(("chain", "draw"))
-        scale_grid = sparse_xr_dot(basis, x_mean)
-        sector_flux = flux.sel(source=sector.flux_source) if "source" in flux.dims else flux
-        posterior_scaling.append(scale_grid.expand_dims(sector=[sector.name]))
-        posterior_flux.append((scale_grid * sector_flux).expand_dims(sector=[sector.name]))
-
-    scaling = xr.concat(posterior_scaling, dim="sector").rename("posterior_scaling_mean")
-    flux_by_sector = xr.concat(posterior_flux, dim="sector").rename("posterior_flux_mean")
-    total_flux = flux_by_sector.sum("sector").rename("posterior_flux_total_mean")
-    return xr.merge([scaling, flux_by_sector, total_flux])
+    return make_sector_flux_outputs(
+        inv_out,
+        stats=["mean"],
+        include_scale_factors=True,
+        report_flux_on_inversion_grid=False,
+    )
 
 
 def make_multisector_output_bundle(
@@ -361,24 +316,21 @@ def make_multisector_output_bundle(
     prepared: RhimePreparedInputs,
 ) -> RhimeOutputBundle:
     """Create and optionally save transitional multi-sector RHIME outputs."""
+    with timed("rhime.output.inversion_output_create", output_format=output_spec.output_format):
+        inv_out_for_outputs = _make_inversion_output(
+            prepared=prepared,
+            idata=idata,
+            run_spec=run_spec,
+            model_spec=model_spec,
+            output_spec=output_spec,
+        )
     inv_out = None
     with timed("rhime.output.multisector_diagnostics"):
-        diagnostics = _make_multisector_flux_diagnostics(
-            idata=idata,
-            prepared=prepared,
-            model_spec=model_spec,
-        )
+        diagnostics = _make_multisector_flux_diagnostics(inv_out_for_outputs)
     outputs: dict[str, Any] = {"sector_flux_diagnostics": diagnostics}
     output_metadata: dict[str, Any] = {}
     if output_spec.output_format != "none":
-        with timed("rhime.output.inversion_output_create", output_format=output_spec.output_format):
-            inv_out = _make_inversion_output(
-                prepared=prepared,
-                idata=idata,
-                run_spec=run_spec,
-                model_spec=model_spec,
-                output_spec=output_spec,
-            )
+        inv_out = inv_out_for_outputs
         outputs["inversion_output"] = inv_out
         output_metadata["inversion_output_contract"] = "modern"
 

--- a/openghg_inversions/rhime/outputs.py
+++ b/openghg_inversions/rhime/outputs.py
@@ -348,11 +348,24 @@ def make_multisector_output_bundle(
 
     if output_spec.output_format == "paris":
         paris_kwargs = dict(output_spec.paris_postprocessing_kwargs or {})
-        if paris_kwargs.get("template_version") == "latest":
+        template_version = paris_kwargs.pop("template_version", None)
+        if template_version == "latest":
             from openghg_inversions.postprocessing.make_paris_outputs import (
                 infer_flux_frequency,
                 paris_flux_output,
             )
+
+            flux_frequency = paris_kwargs.pop("flux_frequency", None)
+            if flux_frequency is None:
+                flux_frequency = infer_flux_frequency(inv_out_for_outputs.flux)
+            time_point = paris_kwargs.pop("time_point", "midpoint")
+            report_mode = paris_kwargs.pop("report_mode", False)
+            inversion_grid = paris_kwargs.pop("inversion_grid", True)
+            if paris_kwargs:
+                unexpected = ", ".join(sorted(paris_kwargs))
+                raise ValueError(
+                    f"Unsupported multi-sector latest PARIS postprocessing kwargs: {unexpected}."
+                )
 
             output_metadata["paris_note"] = (
                 "Multi-sector PARIS latest flux total output was generated; "
@@ -361,13 +374,10 @@ def make_multisector_output_bundle(
             flux_outs = paris_flux_output(
                 inv_out_for_outputs,
                 country_file=country_file,
-                time_point=paris_kwargs.pop("time_point", "midpoint"),
-                report_mode=paris_kwargs.pop("report_mode", False),
-                inversion_grid=paris_kwargs.pop("inversion_grid", True),
-                flux_frequency=paris_kwargs.pop(
-                    "flux_frequency",
-                    infer_flux_frequency(inv_out_for_outputs.flux),
-                ),
+                time_point=time_point,
+                report_mode=report_mode,
+                inversion_grid=inversion_grid,
+                flux_frequency=flux_frequency,
                 template_version="latest",
             )
             outputs["paris_flux"] = flux_outs

--- a/openghg_inversions/rhime/outputs.py
+++ b/openghg_inversions/rhime/outputs.py
@@ -314,6 +314,7 @@ def make_multisector_output_bundle(
     model_spec: RhimeModelSpec,
     idata: az.InferenceData,
     prepared: RhimePreparedInputs,
+    country_file: str | None,
 ) -> RhimeOutputBundle:
     """Create and optionally save transitional multi-sector RHIME outputs."""
     with timed("rhime.output.inversion_output_create", output_format=output_spec.output_format):
@@ -346,10 +347,53 @@ def make_multisector_output_bundle(
             output_metadata["inversion_output_path"] = str(inv_out_path)
 
     if output_spec.output_format == "paris":
-        output_metadata["paris_note"] = (
-            "Multi-sector PARIS schema support is not implemented in issue #398; "
-            "sector-aware modern diagnostics were generated instead."
-        )
+        paris_kwargs = dict(output_spec.paris_postprocessing_kwargs or {})
+        if paris_kwargs.get("template_version") == "latest":
+            from openghg_inversions.postprocessing.make_paris_outputs import (
+                infer_flux_frequency,
+                paris_flux_output,
+            )
+
+            output_metadata["paris_note"] = (
+                "Multi-sector PARIS latest flux total output was generated; "
+                "multi-sector PARIS concentration output is not implemented yet."
+            )
+            flux_outs = paris_flux_output(
+                inv_out_for_outputs,
+                country_file=country_file,
+                time_point=paris_kwargs.pop("time_point", "midpoint"),
+                report_mode=paris_kwargs.pop("report_mode", False),
+                inversion_grid=paris_kwargs.pop("inversion_grid", True),
+                flux_frequency=paris_kwargs.pop(
+                    "flux_frequency",
+                    infer_flux_frequency(inv_out_for_outputs.flux),
+                ),
+                template_version="latest",
+            )
+            outputs["paris_flux"] = flux_outs
+
+            if output_spec.output_path is not None:
+                Path(output_spec.output_path).mkdir(parents=True, exist_ok=True)
+                flux_file = _define_output_filename(
+                    output_spec.output_path,
+                    model_spec.species,
+                    model_spec.domain,
+                    output_spec.output_name + "_flux",
+                    run_spec.start_date,
+                    ext=".nc",
+                )
+                flux_outs.to_netcdf(
+                    flux_file,
+                    unlimited_dims=["time"],
+                    mode="w",
+                    encoding=ncdf_encoding(flux_outs),
+                )
+                output_metadata["paris_flux_path"] = str(flux_file)
+        else:
+            output_metadata["paris_note"] = (
+                "Multi-sector PARIS output requires paris_postprocessing_kwargs "
+                "with template_version='latest'; sector-aware diagnostics were generated instead."
+            )
     if output_spec.output_path is not None and output_spec.output_format != "none":
         Path(output_spec.output_path).mkdir(parents=True, exist_ok=True)
         diagnostics_path = (

--- a/openghg_inversions/rhime/runner.py
+++ b/openghg_inversions/rhime/runner.py
@@ -199,6 +199,7 @@ def _run_common(
             model_spec=run_spec.model,
             idata=idata,
             prepared=prepared,
+            country_file=run_spec.output.country_file,
         )
     else:
         output_bundle = make_standard_output_bundle(

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -21,8 +21,10 @@ from openghg_inversions.postprocessing.make_outputs import (
 )
 
 from openghg_inversions.postprocessing.make_paris_outputs import (
+    DEFAULT_PARIS_TEMPLATE_VERSION,
     _flux_interval_midpoints,
     make_paris_outputs,
+    paris_template_files,
     paris_flux_output,
 )
 
@@ -677,6 +679,22 @@ def test_make_paris_outputs(inv_out, europe_country_file, tmpdir, offset):
     # check we can write to netCDF
     flux_outs.to_netcdf(tmpdir / "flux.nc")
     conc_outs.to_netcdf(tmpdir / "conc.nc")
+
+
+def test_paris_template_registry_requires_explicit_latest():
+    """PARIS output keeps the legacy templates by default for the next release."""
+    legacy = paris_template_files(DEFAULT_PARIS_TEMPLATE_VERSION)
+    latest = paris_template_files("latest")
+
+    assert DEFAULT_PARIS_TEMPLATE_VERSION == "legacy"
+    assert legacy.concentration_version == "v03"
+    assert legacy.flux_version == "legacy"
+    assert latest.concentration_version == "v04"
+    assert latest.flux_version == "v03"
+    assert legacy.concentration.exists()
+    assert legacy.flux.exists()
+    assert latest.concentration.exists()
+    assert latest.flux.exists()
 
 
 def test_save_inversion_output(mcmc_args, tmpdir):

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -131,6 +131,31 @@ def _fake_multisector_basis_functions(*, artifact_source: str = "generated") -> 
     )
 
 
+def _fake_multisector_basis_functions_matching_country_grid(country_file: Path) -> BasisFunctions:
+    """Build a one-region multisector basis artifact on the grid of a test country file."""
+    country_grid = xr.open_dataset(country_file)
+    basis = xr.DataArray(
+        np.ones((country_grid.sizes["lat"], country_grid.sizes["lon"]), dtype=int),
+        dims=("lat", "lon"),
+        coords={"lat": country_grid.lat, "lon": country_grid.lon},
+        name="basis",
+    )
+    flux = xr.concat(
+        [
+            xr.ones_like(basis, dtype=float).expand_dims(source=["ff-inventory"]),
+            (3.0 * xr.ones_like(basis, dtype=float)).expand_dims(source=["ocean-inventory"]),
+        ],
+        dim="source",
+    ).rename("flux")
+    flux.attrs["units"] = "mol/m2/s"
+    return BasisFunctions.from_flat_basis(
+        basis_flat=basis,
+        flux=flux,
+        operator_kwargs={"state_dim": "region"},
+        metadata={BASIS_ARTIFACT_SOURCE_ATTR: "country-grid-multisector-test"},
+    )
+
+
 def _fake_source_specific_multisector_basis_functions(
     *,
     artifact_source: str = "generated",
@@ -2195,6 +2220,7 @@ def test_make_multisector_output_bundle_returns_modern_inv_out() -> None:
         model_spec=model_spec,
         idata=idata,
         prepared=prepared,
+        country_file=None,
     )
 
     assert isinstance(bundle.inv_out, InversionOutput)
@@ -2205,6 +2231,62 @@ def test_make_multisector_output_bundle_returns_modern_inv_out() -> None:
     assert "flux_ocean_posterior_mean" in bundle.outputs["sector_flux_diagnostics"]
     assert "flux_total_posterior_mean" in bundle.outputs["sector_flux_diagnostics"]
     assert bundle.outputs["inversion_output"] is bundle.inv_out
+
+
+def test_make_multisector_output_bundle_builds_latest_paris_flux(europe_country_file: Path) -> None:
+    """Multi-sector PARIS output builds explicit latest total flux output."""
+    sectors = (
+        SectorSpec(
+            name="FF",
+            flux_source="ff-inventory",
+            x_prior={"pdf": "normal", "mu": 1.0, "sigma": 0.2},
+            variable_suffix="ff",
+        ),
+        SectorSpec(
+            name="Ocean",
+            flux_source="ocean-inventory",
+            x_prior={"pdf": "normal", "mu": 1.0, "sigma": 0.2},
+            variable_suffix="ocean",
+        ),
+    )
+    model_spec = RhimeModelSpec(species="ch4", domain="EUROPE", sectors=sectors)
+    output_spec = RhimeOutputSpec(
+        output_format="paris",
+        output_name="test",
+        save_inversion_output=False,
+        paris_postprocessing_kwargs={"template_version": "latest", "inversion_grid": False},
+    )
+    run_spec = RhimeRunSpec(
+        "2019-01-01",
+        "2019-01-02",
+        ("TAC",),
+        ("1h",),
+        model_spec,
+        output_spec,
+        split_by_sectors=True,
+    )
+    prepared = RhimePreparedInputs(
+        inv_inputs=_minimal_output_inv_inputs(),
+        basis_functions=_fake_multisector_basis_functions_matching_country_grid(europe_country_file),
+        sites=("TAC",),
+        averaging_period=("1h",),
+        basis_artifact_source="generated",
+    )
+    idata = cast(Any, _multisector_postprocessing_inv_out().trace)
+
+    bundle = rhime_outputs.make_multisector_output_bundle(
+        output_spec=output_spec,
+        run_spec=run_spec,
+        model_spec=model_spec,
+        idata=idata,
+        prepared=prepared,
+        country_file=str(europe_country_file),
+    )
+
+    assert "paris_flux" in bundle.outputs
+    assert "paris_concentration" not in bundle.outputs
+    assert "not implemented yet" in bundle.output_metadata["paris_note"]
+    assert "flux_total_posterior" in bundle.outputs["paris_flux"]
 
 
 def test_modern_inversion_output_save_load_roundtrip(tmp_path: Path) -> None:
@@ -2714,6 +2796,57 @@ def test_latest_paris_output_processes_modern_output(europe_country_file: Path, 
 
     conc_outputs.to_netcdf(tmp_path / "latest_conc.nc")
     flux_outputs.to_netcdf(tmp_path / "latest_flux.nc")
+
+
+def test_latest_paris_flux_output_processes_multisector_total(
+    europe_country_file: Path,
+    tmp_path: Path,
+) -> None:
+    """Explicit latest PARIS flux output can use multisector reconstructed total flux."""
+    from openghg_inversions import convert
+    from openghg_inversions.postprocessing.countries import Countries
+    from openghg_inversions.postprocessing.make_paris_outputs import PARIS_LATEST_COUNTRIES, paris_flux_output
+
+    inv_out = _multisector_postprocessing_inv_out(
+        _fake_multisector_basis_functions_matching_country_grid(europe_country_file)
+    )
+
+    flux_outputs = paris_flux_output(
+        inv_out,
+        country_file=europe_country_file,
+        inversion_grid=False,
+        template_version="latest",
+    )
+
+    assert flux_outputs.attrs["paris_flux_template_version"] == "v03"
+    assert "flux_total_posterior" in flux_outputs
+    assert "stdev_flux_total_posterior" in flux_outputs
+    assert "flux_ff_posterior" not in flux_outputs
+    assert "flux_total_posterior_country" in flux_outputs
+    assert "covariance_flux_total_posterior_country" in flux_outputs
+    assert tuple(flux_outputs.country.values) == PARIS_LATEST_COUNTRIES
+    countries = Countries.from_file(
+        country_file=europe_country_file,
+        country_code="alpha3",
+        country_selections=list(PARIS_LATEST_COUNTRIES),
+        domain="EUROPE",
+    )
+    expected_country = (
+        2.0
+        * (countries.matrix * countries.area_grid).sum(("lat", "lon"))
+        * 365
+        * 24
+        * 3600
+        * convert.molar_mass("ch4")
+        * 1e-3
+    ).reindex(country=list(PARIS_LATEST_COUNTRIES))
+    np.testing.assert_allclose(
+        flux_outputs["flux_total_posterior_country"].isel(time=0).values,
+        expected_country.data.todense(),
+        rtol=1e-6,
+    )
+
+    flux_outputs.to_netcdf(tmp_path / "latest_multisector_flux.nc")
 
 
 def test_standard_basic_output_uses_modern_postprocessing_without_legacy_adapter(monkeypatch) -> None:

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -108,6 +108,55 @@ def _fake_basis_functions(*, artifact_source: str = "generated") -> BasisFunctio
     )
 
 
+def _fake_multisector_basis_functions(*, artifact_source: str = "generated") -> BasisFunctions:
+    """Build a one-cell basis artifact with source-specific prior flux."""
+    basis = xr.DataArray(
+        [[1]],
+        dims=("lat", "lon"),
+        coords={"lat": [0.0], "lon": [0.0]},
+        name="basis",
+    )
+    flux = xr.DataArray(
+        [[[1.0]], [[3.0]]],
+        dims=("source", "lat", "lon"),
+        coords={"source": ["ff-inventory", "ocean-inventory"], "lat": [0.0], "lon": [0.0]},
+        name="flux",
+    )
+    flux.attrs["units"] = "mol/m2/s"
+    return BasisFunctions.from_flat_basis(
+        basis_flat=basis,
+        flux=flux,
+        operator_kwargs={"state_dim": "region"},
+        metadata={BASIS_ARTIFACT_SOURCE_ATTR: artifact_source},
+    )
+
+
+def _fake_source_specific_multisector_basis_functions(
+    *,
+    artifact_source: str = "generated",
+) -> BasisFunctions:
+    """Build a one-cell source-specific basis artifact for multisector tests."""
+    basis = xr.DataArray(
+        [[1]],
+        dims=("lat", "lon"),
+        coords={"lat": [0.0], "lon": [0.0]},
+        name="basis",
+    )
+    flux = xr.DataArray(
+        [[[1.0]], [[3.0]]],
+        dims=("source", "lat", "lon"),
+        coords={"source": ["ff-inventory", "ocean-inventory"], "lat": [0.0], "lon": [0.0]},
+        name="flux",
+    )
+    flux.attrs["units"] = "mol/m2/s"
+    return BasisFunctions.from_multi_source_flat_basis(
+        basis_flat={"ff-inventory": basis, "ocean-inventory": basis},
+        flux=flux,
+        operator_kwargs={"state_dim": "region"},
+        metadata={BASIS_ARTIFACT_SOURCE_ATTR: artifact_source},
+    )
+
+
 def _fake_basis_functions_matching_country_grid(country_file: Path) -> BasisFunctions:
     """Build a one-region basis artifact on the grid of a test country file."""
     country_grid = xr.open_dataset(country_file)
@@ -403,6 +452,40 @@ def _modern_postprocessing_inv_out(
             "split_by_sectors": False,
         },
         model_metadata={"species": "ch4", "domain": "EUROPE"},
+    )
+
+
+def _multisector_postprocessing_inv_out(basis_functions: BasisFunctions | None = None) -> InversionOutput:
+    """Build a small multisector output for flux reconstruction tests."""
+    return InversionOutput(
+        trace=az.from_dict(
+            posterior={
+                "x_ff": np.array([[[0.0], [2.0]]]),
+                "x_ocean": np.array([[[2.0 / 3.0], [0.0]]]),
+            },
+            prior={
+                "x_ff": np.array([[[1.0], [1.0]]]),
+                "x_ocean": np.array([[[1.0], [1.0]]]),
+            },
+            coords={"region": [0]},
+            dims={"x_ff": ["region"], "x_ocean": ["region"]},
+        ),
+        inv_inputs=_minimal_output_inv_inputs(),
+        basis_functions=basis_functions or _fake_multisector_basis_functions(),
+        run_metadata={
+            "start_date": "2019-01-01",
+            "end_date": "2019-01-02",
+            "sites": ["TAC"],
+            "split_by_sectors": True,
+        },
+        model_metadata={
+            "species": "ch4",
+            "domain": "EUROPE",
+            "sectors": [
+                {"name": "FF", "flux_source": "ff-inventory", "variable_suffix": "ff"},
+                {"name": "Ocean", "flux_source": "ocean-inventory", "variable_suffix": "ocean"},
+            ],
+        },
     )
 
 
@@ -2118,6 +2201,9 @@ def test_make_multisector_output_bundle_returns_modern_inv_out() -> None:
     assert bundle.inv_out.run_metadata["split_by_sectors"] is True
     assert bundle.output_metadata["inversion_output_contract"] == "modern"
     assert "sector_flux_diagnostics" in bundle.outputs
+    assert "flux_ff_posterior_mean" in bundle.outputs["sector_flux_diagnostics"]
+    assert "flux_ocean_posterior_mean" in bundle.outputs["sector_flux_diagnostics"]
+    assert "flux_total_posterior_mean" in bundle.outputs["sector_flux_diagnostics"]
     assert bundle.outputs["inversion_output"] is bundle.inv_out
 
 
@@ -2312,6 +2398,45 @@ def test_modern_inversion_output_supports_flux_outputs() -> None:
     )
 
     assert "flux_posterior_mean" in modern_flux
+
+
+def test_multisector_flux_outputs_reconstruct_sector_and_total_flux() -> None:
+    """Multisector flux postprocessing reconstructs sector fluxes before total statistics."""
+    from openghg_inversions.postprocessing.make_outputs import make_flux_outputs
+
+    outputs = make_flux_outputs(
+        _multisector_postprocessing_inv_out(),
+        stats=["mean", "stdev"],
+        include_scale_factors=True,
+        report_flux_on_inversion_grid=False,
+    )
+
+    assert "flux_ff_posterior_mean" in outputs
+    assert "flux_ocean_posterior_mean" in outputs
+    assert "scaling_ff_posterior_mean" in outputs
+    assert "flux_total_posterior_mean" in outputs
+    assert "flux_total_posterior_stdev" in outputs
+    assert outputs["flux_ff_posterior_mean"].attrs["units"] == "mol/m2/s"
+    assert outputs["flux_total_posterior_mean"].attrs["units"] == "mol/m2/s"
+    assert float(outputs["flux_total_posterior_mean"].item()) == 2.0
+    assert float(outputs["flux_total_posterior_stdev"].item()) == 0.0
+    assert float(outputs["flux_ff_posterior_stdev"].item()) > 0.0
+
+
+def test_multisector_flux_outputs_support_source_specific_basis() -> None:
+    """Sector flux reconstruction handles source-specific retained basis artifacts."""
+    from openghg_inversions.postprocessing.make_outputs import make_flux_outputs
+
+    outputs = make_flux_outputs(
+        _multisector_postprocessing_inv_out(_fake_source_specific_multisector_basis_functions()),
+        stats=["mean", "mode_kde"],
+        include_scale_factors=False,
+        report_flux_on_inversion_grid=False,
+    )
+
+    assert "flux_total_posterior_mean" in outputs
+    assert "flux_total_posterior_mode" in outputs
+    assert float(outputs["flux_total_posterior_mean"].item()) == 2.0
 
 
 def test_modern_flux_outputs_use_retained_basis_operator(
@@ -2964,7 +3089,9 @@ def test_run_rhime_multisector_api_smoke(
     assert "x_ff" in posterior
     assert "x_ocean" in posterior
     assert "sector_flux_diagnostics" in result.outputs
-    assert list(result.outputs["sector_flux_diagnostics"].coords["sector"].values) == ["FF", "ocean"]
+    assert "flux_ff_posterior_mean" in result.outputs["sector_flux_diagnostics"]
+    assert "flux_ocean_posterior_mean" in result.outputs["sector_flux_diagnostics"]
+    assert "flux_total_posterior_mean" in result.outputs["sector_flux_diagnostics"]
 
 
 def test_cli_run_rhime_passes_config_and_overrides(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -131,13 +131,19 @@ def _fake_multisector_basis_functions(*, artifact_source: str = "generated") -> 
     )
 
 
-def _fake_multisector_basis_functions_matching_country_grid(country_file: Path) -> BasisFunctions:
+def _fake_multisector_basis_functions_matching_country_grid(
+    country_file: Path,
+    *,
+    coord_offset: float = 0.0,
+) -> BasisFunctions:
     """Build a one-region multisector basis artifact on the grid of a test country file."""
     country_grid = xr.open_dataset(country_file)
+    lat = country_grid.lat.values + coord_offset
+    lon = country_grid.lon.values + coord_offset
     basis = xr.DataArray(
         np.ones((country_grid.sizes["lat"], country_grid.sizes["lon"]), dtype=int),
         dims=("lat", "lon"),
-        coords={"lat": country_grid.lat, "lon": country_grid.lon},
+        coords={"lat": lat, "lon": lon},
         name="basis",
     )
     flux = xr.concat(
@@ -2254,7 +2260,11 @@ def test_make_multisector_output_bundle_builds_latest_paris_flux(europe_country_
         output_format="paris",
         output_name="test",
         save_inversion_output=False,
-        paris_postprocessing_kwargs={"template_version": "latest", "inversion_grid": False},
+        paris_postprocessing_kwargs={
+            "template_version": "latest",
+            "inversion_grid": False,
+            "flux_frequency": "yearly",
+        },
     )
     run_spec = RhimeRunSpec(
         "2019-01-01",
@@ -2265,9 +2275,11 @@ def test_make_multisector_output_bundle_builds_latest_paris_flux(europe_country_
         output_spec,
         split_by_sectors=True,
     )
+    basis_functions = _fake_multisector_basis_functions_matching_country_grid(europe_country_file)
+    basis_functions.flux.attrs["time_period"] = "not-a-parseable-period"
     prepared = RhimePreparedInputs(
         inv_inputs=_minimal_output_inv_inputs(),
-        basis_functions=_fake_multisector_basis_functions_matching_country_grid(europe_country_file),
+        basis_functions=basis_functions,
         sites=("TAC",),
         averaging_period=("1h",),
         basis_artifact_source="generated",
@@ -2777,6 +2789,11 @@ def test_latest_paris_output_processes_modern_output(europe_country_file: Path, 
     assert "mf_posterior" in conc_outputs
     assert "percentile_mf_posterior" in conc_outputs
     assert "Yobs" not in conc_outputs
+    assert conc_outputs["mf_posterior"].dtype == np.dtype("float32")
+    assert conc_outputs["mf_bc_prior"].dtype == np.dtype("float32")
+    assert conc_outputs["time_bnds"].dtype == np.dtype("float64")
+    assert conc_outputs["longitude"].dtype == np.dtype("float64")
+    assert conc_outputs["number_of_identifier"].dtype == np.dtype("int16")
 
     assert flux_outputs.attrs["paris_flux_template_version"] == "v03"
     assert "time_bnds" in flux_outputs
@@ -2793,9 +2810,55 @@ def test_latest_paris_output_processes_modern_output(europe_country_file: Path, 
         flux_outputs.sizes["country"],
     )
     assert "country_flux_total_posterior" not in flux_outputs
+    assert flux_outputs["flux_total_posterior"].dtype == np.dtype("float32")
+    assert flux_outputs["covariance_flux_total_posterior_country"].dtype == np.dtype("float32")
+    assert flux_outputs["time_bnds"].dtype == np.dtype("float64")
 
-    conc_outputs.to_netcdf(tmp_path / "latest_conc.nc")
-    flux_outputs.to_netcdf(tmp_path / "latest_flux.nc")
+    conc_file = tmp_path / "latest_conc.nc"
+    flux_file = tmp_path / "latest_flux.nc"
+    conc_outputs.to_netcdf(conc_file)
+    flux_outputs.to_netcdf(flux_file)
+    with xr.open_dataset(conc_file, decode_times=False) as reloaded_conc:
+        assert reloaded_conc["mf_posterior"].dtype == np.dtype("float32")
+        assert reloaded_conc["time_bnds"].dtype == np.dtype("float64")
+        assert reloaded_conc["longitude"].dtype == np.dtype("float64")
+    with xr.open_dataset(flux_file, decode_times=False) as reloaded_flux:
+        assert reloaded_flux["flux_total_posterior"].dtype == np.dtype("float32")
+        assert reloaded_flux["covariance_flux_total_posterior_country"].dtype == np.dtype("float32")
+        assert reloaded_flux["time_bnds"].dtype == np.dtype("float64")
+
+
+def test_latest_paris_concentration_fills_missing_bc_with_nan(europe_country_file: Path) -> None:
+    """Latest PARIS concentration keeps mandatory BC fields when no baseline trace exists."""
+    from openghg_inversions.postprocessing.make_paris_outputs import paris_concentration_outputs
+
+    base = _modern_postprocessing_inv_out(europe_country_file)
+    groups = {}
+    for group in base.trace.groups():
+        ds = base.trace[group]
+        groups[group] = ds.drop_vars([name for name in ("mu_bc", "hbc") if name in ds], errors="ignore")
+    trace = cast(Any, az.InferenceData)(**groups)
+    inv_out = InversionOutput(
+        trace=trace,
+        inv_inputs=base.inv_inputs,
+        basis_functions=base.basis_functions,
+        run_metadata=base.run_metadata,
+        model_metadata={**base.model_metadata, "use_bc": False},
+        output_metadata=base.output_metadata,
+        provenance=base.provenance,
+    )
+
+    conc_outputs = paris_concentration_outputs(
+        inv_out,
+        obs_avg_period="1h",
+        template_version="latest",
+    )
+
+    for name in ("mf_bc_prior", "mf_bc_posterior"):
+        assert name in conc_outputs
+        assert conc_outputs[name].dims == ("index",)
+        assert conc_outputs[name].dtype == np.dtype("float32")
+        assert np.isnan(conc_outputs[name].values).all()
 
 
 def test_latest_paris_flux_output_processes_multisector_total(
@@ -2808,7 +2871,7 @@ def test_latest_paris_flux_output_processes_multisector_total(
     from openghg_inversions.postprocessing.make_paris_outputs import PARIS_LATEST_COUNTRIES, paris_flux_output
 
     inv_out = _multisector_postprocessing_inv_out(
-        _fake_multisector_basis_functions_matching_country_grid(europe_country_file)
+        _fake_multisector_basis_functions_matching_country_grid(europe_country_file, coord_offset=1e-10)
     )
 
     flux_outputs = paris_flux_output(
@@ -2825,6 +2888,14 @@ def test_latest_paris_flux_output_processes_multisector_total(
     assert "flux_total_posterior_country" in flux_outputs
     assert "covariance_flux_total_posterior_country" in flux_outputs
     assert tuple(flux_outputs.country.values) == PARIS_LATEST_COUNTRIES
+    country_fraction_data = flux_outputs["country_fraction"].data
+    if hasattr(country_fraction_data, "todense"):
+        country_fraction_data = country_fraction_data.todense()
+    cell_area_data = flux_outputs["cell_area"].data
+    if hasattr(cell_area_data, "todense"):
+        cell_area_data = cell_area_data.todense()
+    assert not np.isnan(np.asarray(country_fraction_data)).any()
+    assert not np.isnan(np.asarray(cell_area_data)).any()
     countries = Countries.from_file(
         country_file=europe_country_file,
         country_code="alpha3",

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -2544,6 +2544,53 @@ def test_paris_output_processes_modern_output(europe_country_file: Path) -> None
         assert flux_outputs[name].dtype == np.dtype("float32")
 
 
+def test_latest_paris_output_processes_modern_output(europe_country_file: Path, tmp_path: Path) -> None:
+    """Explicit latest PARIS output uses the new concentration and flux templates."""
+    from openghg_inversions.postprocessing.make_paris_outputs import (
+        PARIS_LATEST_COUNTRIES,
+        make_paris_outputs,
+    )
+
+    flux_outputs, conc_outputs = make_paris_outputs(
+        _modern_postprocessing_inv_out(europe_country_file),
+        country_file=europe_country_file,
+        obs_avg_period="1h",
+        domain="europe",
+        inversion_grid=False,
+        template_version="latest",
+    )
+
+    assert conc_outputs.attrs["paris_concentration_template_version"] == "v04"
+    assert "index" in conc_outputs.dims
+    assert "platform" in conc_outputs.coords
+    assert "time_bnds" in conc_outputs
+    assert "number_of_identifier" in conc_outputs
+    assert "assimilation_flag" in conc_outputs
+    assert "mf_observed" in conc_outputs
+    assert "mf_posterior" in conc_outputs
+    assert "percentile_mf_posterior" in conc_outputs
+    assert "Yobs" not in conc_outputs
+
+    assert flux_outputs.attrs["paris_flux_template_version"] == "v03"
+    assert "time_bnds" in flux_outputs
+    assert "cell_area" in flux_outputs
+    assert "country_fraction" in flux_outputs
+    assert "flux_total_posterior" in flux_outputs
+    assert "flux_total_posterior_country" in flux_outputs
+    assert "stdev_flux_total_posterior" in flux_outputs
+    assert "covariance_flux_total_posterior_country" in flux_outputs
+    assert tuple(flux_outputs.country.values) == PARIS_LATEST_COUNTRIES
+    assert flux_outputs["covariance_flux_total_posterior_country"].shape == (
+        flux_outputs.sizes["time"],
+        flux_outputs.sizes["country"],
+        flux_outputs.sizes["country"],
+    )
+    assert "country_flux_total_posterior" not in flux_outputs
+
+    conc_outputs.to_netcdf(tmp_path / "latest_conc.nc")
+    flux_outputs.to_netcdf(tmp_path / "latest_flux.nc")
+
+
 def test_standard_basic_output_uses_modern_postprocessing_without_legacy_adapter(monkeypatch) -> None:
     """RHIME basic postprocessing consumes modern output without legacy adapters."""
     model_spec, output_spec, run_spec = _minimal_output_specs(output_format="basic")

--- a/tests/test_run_hbmcmc_shim.py
+++ b/tests/test_run_hbmcmc_shim.py
@@ -128,6 +128,23 @@ def test_fixedbasis_params_to_rhime_preserves_paris_compatibility_flag(tmp_path:
     assert "paris_postprocessing" not in translated
 
 
+def test_fixedbasis_params_to_rhime_preserves_latest_paris_kwargs(tmp_path: Path) -> None:
+    config_file = tmp_path / "hbmcmc.ini"
+    _fixedbasis_config(config_file)
+    params = run_hbmcmc.hbmcmc_extract_param(str(config_file), print_param=False)
+    params.pop("output_format")
+    params["paris_postprocessing"] = True
+    params["paris_postprocessing_kwargs"] = {"template_version": "latest", "inversion_grid": False}
+
+    translated = run_hbmcmc.fixedbasis_params_to_rhime(params)
+
+    assert translated["output_format"] == "paris"
+    assert translated["paris_postprocessing_kwargs"] == {
+        "template_version": "latest",
+        "inversion_grid": False,
+    }
+
+
 def test_fixedbasis_params_to_rhime_forces_legacy_filename_convention(tmp_path: Path) -> None:
     """run_hbmcmc keeps historical filenames even if a RHIME override is supplied."""
     config_file = tmp_path / "hbmcmc.ini"


### PR DESCRIPTION
## Summary

Refs #405.

This updates PARIS postprocessing in one branch stack:

- Adds an explicit PARIS template-version registry and copies the latest CDL templates into the postprocessing package:
  - concentration `v04`
  - flux `v03`
- Keeps the default PARIS template version as `legacy`; callers must pass `template_version="latest"` to opt into the new templates.
- Adds latest single-sector PARIS concentration and flux products, including `platform` metadata, latest flux/country variable names, `time_bnds`, `cell_area`, `country_fraction`, and country posterior covariance.
- Adds sector-aware flux reconstruction for multisector RHIME outputs, computing total flux statistics from reconstructed per-draw sector fluxes.
- Routes multisector `output_format="paris"` to latest total-flux PARIS output when `paris_postprocessing_kwargs={"template_version": "latest"}` is explicit.
- Adds `docs/plans/issue_405_paris_sector_outputs.md` to track decisions, progress, and remaining work.

## Compatibility

This should not change existing config-file behavior.

PR #448 now routes `run_hbmcmc.py` through `run_rhime(...)`, including old `paris_postprocessing=True` configs. This PR keeps `make_paris_outputs(...)` on the legacy PARIS templates by default, so existing configs that do not set `paris_postprocessing_kwargs={"template_version": "latest"}` should still use the legacy PARIS schema.

The latest schema is deliberately opt-in for now.

## Known Remaining Work

- Multisector PARIS concentration output is not implemented yet.
- Per-sector PARIS variables are not implemented yet; the multisector PARIS path currently emits total flux only.
- Full `tox -p` has not been run locally.

## Validation

- `HOME=/tmp MPLCONFIGDIR=/tmp .venv/bin/python -m pytest tests/test_run_hbmcmc_shim.py tests/test_rhime.py tests/test_postprocessing.py -k "fixedbasis_params_to_rhime_preserves_paris_compatibility_flag or fixedbasis_params_to_rhime_preserves_latest_paris_kwargs or run_hbmcmc_main_routes_to_run_rhime or latest_paris_output_processes_modern_output or latest_paris_concentration_fills_missing_bc_with_nan or latest_paris_flux_output_processes_multisector_total or make_multisector_output_bundle_builds_latest_paris_flux or multisector_flux_outputs_reconstruct_sector_and_total_flux or multisector_flux_outputs_support_source_specific_basis or make_multisector_output_bundle_returns_modern_inv_out or paris_output_processes_modern_output or paris_template_registry or fixedbasisMCMC_paris_postprocessing_receives_modern_output or paris_postprocessing_compatibility_matches_paris_output_format"`
- `uv run ruff check openghg_inversions/postprocessing/make_paris_outputs.py openghg_inversions/rhime/outputs.py tests/test_rhime.py tests/test_run_hbmcmc_shim.py`
- `uv run ruff format --check openghg_inversions/postprocessing/make_paris_outputs.py openghg_inversions/rhime/outputs.py tests/test_rhime.py tests/test_run_hbmcmc_shim.py`
- `uv run pyright openghg_inversions/postprocessing/make_paris_outputs.py openghg_inversions/rhime/outputs.py`
- `git diff --check`