### PR TITLE
[codex] Reject multisector source-keyed xprior

### DIFF
--- a/openghg_inversions/rhime/params.py
+++ b/openghg_inversions/rhime/params.py
@@ -265,6 +265,17 @@ def normalise_sector_priors(
     return {str(sector): dict(prior) for sector, prior in sector_priors.items()}
 
 
+def validate_multisector_x_prior(x_prior: Mapping[str, Any] | None) -> None:
+    """Raise if multi-sector ``x_prior`` is not a shared prior spec."""
+    if x_prior is None or "pdf" in x_prior:
+        return
+    raise ValueError(
+        "Invalid RHIME config value for `x_prior`: multi-sector source-keyed priors are not "
+        "supported via `xprior`/`x_prior`; use `sector_priors` keyed by sector name, or provide "
+        "a single shared prior dict with top-level `pdf`."
+    )
+
+
 def normalise_sector_sources(
     sector_sources: Mapping[str, Any] | None,
 ) -> dict[str, str] | None:
@@ -470,6 +481,8 @@ def make_rhime_runner_setup(
     sigma_prior = normalise_optional_mapping(remaining.pop("sigma_prior", None))
     offset_prior = normalise_optional_mapping(remaining.pop("offset_prior", None))
     sector_priors = normalise_sector_priors(remaining.pop("sector_priors", None))
+    if multisector:
+        validate_multisector_x_prior(x_prior)
     offset_args = normalise_optional_mapping(remaining.get("offset_args"))
 
     use_bc = remaining.get("use_bc", True)

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -1153,6 +1153,35 @@ def test_run_rhime_multisector_rejects_non_mapping_sector_prior_values(
         )
 
 
+def test_run_rhime_multisector_rejects_source_keyed_xprior_before_data_preparation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Legacy source-keyed ``xprior`` fails before RHIME data preparation."""
+
+    def fail_prepare(**kwargs):
+        raise AssertionError("prepare_rhime_inputs should not be called")
+
+    setattr(fail_prepare, "__signature__", inspect.signature(prepare_rhime_inputs))
+    monkeypatch.setattr(rhime_module, "prepare_rhime_inputs", fail_prepare)
+
+    with pytest.raises(ValueError, match="source-keyed priors"):
+        run_rhime_multisector(
+            species="ch4",
+            sites=["TAC"],
+            averaging_period=["1h"],
+            domain="EUROPE",
+            start_date="2019-01-01",
+            end_date="2019-01-02",
+            output_name="test",
+            output_format="none",
+            emissions_name=["sector-a", "sector-b"],
+            xprior={
+                "sector-a": {"pdf": "normal", "mu": 1.0, "sigma": 0.2},
+                "sector-b": {"pdf": "normal", "mu": 1.0, "sigma": 0.3},
+            },
+        )
+
+
 def test_run_rhime_multisector_rejects_non_mapping_sector_sources(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- Reject multi-sector RHIME `x_prior` mappings that do not define a top-level `pdf` before data preparation starts.
- Keep shared `x_prior` semantics explicit and route per-sector prior dictionaries through `sector_priors`.
- Add a regression test for legacy `emissions_name` plus source-keyed `xprior` so the original crash path now raises a clear `ValueError`.

Closes #469.

## Validation

- `uv run pytest tests/test_rhime.py -k "source_keyed_xprior or runner_setup_builds_specs or non_mapping_sector_prior"`
- `uv run ruff check openghg_inversions/rhime/params.py tests/test_rhime.py`
- `uv run ruff format --check openghg_inversions/rhime/params.py tests/test_rhime.py`
- `tox -p`