### PR TITLE
Make retained basis metadata primary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 ## Code changes
 
 
+- Made retained `BasisFunctions` / `BasisOperator` metadata the primary basis
+  contract for RHIME preparation and modern postprocessing outputs. Derived
+  flux, country, PARIS, and legacy-format products now record stable basis
+  reconstruction metadata, retained basis artifacts record loaded/saved paths,
+  and source-specific multisector flux reconstruction no longer reaches through
+  the legacy flat-basis view. Legacy flat basis artifacts remain readable as an
+  explicit compatibility fallback but are deprecated for new workflows.
+  [#429](https://github.com/openghg/openghg_inversions/issues/429)
 - Added a modern `output_format="legacy"` compatibility product, routed deprecated
   `hbmcmc` / `hbmcmc_postprocessing` output requests to it, and made
   `run_hbmcmc.py` translate fixedbasis-style configs into `run_rhime` calls while

--- a/README.md
+++ b/README.md
@@ -230,6 +230,14 @@ old fixedbasis implementation.
 Direct `fixedbasisMCMC(...)` calls are a temporary legacy Python path, not a
 wrapper around `run_rhime(...)`. New work should not target that API.
 
+Modern RHIME preparation, `InversionOutput`, and postprocessing use retained
+`BasisFunctions` / `BasisOperator` objects as the primary basis representation.
+Derived flux, country, PARIS, and legacy-format products record the
+operator-backed reconstruction path and retained basis artifact source/path when
+known. Legacy flat basis NetCDF artifacts remain readable as an explicit
+compatibility fallback, but new workflows should save and load DataTree
+`BasisFunctions` artifacts.
+
 The old output names `hbmcmc` and `hbmcmc_postprocessing` are deprecated
 aliases for the modern `legacy` output format. The compatibility wrapper keeps
 the old HBMCMC filename convention for these outputs; direct `run_rhime` calls

--- a/docs/plans/clean_up_inversions_refactor.md
+++ b/docs/plans/clean_up_inversions_refactor.md
@@ -546,14 +546,26 @@ review.
 
 ## Follow-up operator work for #429
 
+- Done in #429 first slice: modern RHIME preparation and postprocessing treat
+  retained `BasisFunctions` / `BasisOperator` objects as the primary basis
+  representation, and derived flux, country, PARIS, and legacy-format products
+  record stable operator-backed reconstruction metadata.
+- Done in #429 first slice: retained basis artifacts record loaded/saved file
+  paths when known, and source-specific multisector flux reconstruction moved
+  source selection to the `BasisFunctions` / operator boundary rather than
+  reaching through the legacy flat-basis view.
+- Legacy flat basis artifacts remain readable only as an explicit
+  compatibility fallback. Compatibility output formats may still emit flat
+  basis maps, but new workflows should prefer DataTree `BasisFunctions`
+  artifacts.
 - Consider adding a `BasisOperator.project(...)` or similar reduction API for
   grid-to-state products, based on the prototype
   `~/Documents/inversions/src/inversions/basis_functions.py`. The prototype's
   `project()` method covers weighted and normalised reductions that would make
   postprocessing country totals, region means, and uncertainty reductions less
   dependent on ad hoc `sparse_xr_dot` calls.
-- Keep this as #429 operator cleanup unless it is needed to remove fixedbasis
-  legacy carriers in #416.
+- Track any future `BasisOperator.project(...)` work separately from #429 unless
+  it is needed to remove a concrete legacy compatibility boundary.
 
 # Deferred 
 
@@ -610,8 +622,6 @@ model components that consume them.
 ## Deferred Issue #383 / Issue #429 output boundary
 
 - #383 landed the first modern postprocessing slice that consumes retained
-  `BasisFunctions` for standard flux/country products while preserving flat
-  legacy fallback.
-- #429 remains the boundary for operator-backed output and postprocessing.
-  It should make the operator-backed path primary, add durable reconstruction
-  metadata, and define the deprecation policy for legacy basis reconstruction.
+  `BasisFunctions` for standard flux/country products.
+- #429 made operator-backed postprocessing primary, added durable reconstruction
+  metadata, and defined the deprecation policy for legacy basis reconstruction.

--- a/docs/usage/rhime.rst
+++ b/docs/usage/rhime.rst
@@ -132,6 +132,15 @@ Standard single-sector RHIME supports ``inv_out``, ``basic``, ``paris``, and
 product from the modern ``InversionOutput``. The deprecated names ``hbmcmc``
 and ``hbmcmc_postprocessing`` are accepted as aliases for ``legacy``.
 
+Modern RHIME preparation, ``InversionOutput`` artifacts, and postprocessing use
+retained ``BasisFunctions`` / ``BasisOperator`` objects as the primary basis
+representation. Derived flux, country, PARIS, and legacy-format products record
+``basis_reconstruction_path="operator-backed"`` plus the retained basis artifact
+source/path when known. Legacy flat basis NetCDF files remain readable as an
+explicit compatibility fallback, and flat basis maps may still be emitted by
+compatibility output formats, but new workflows should save and load DataTree
+``BasisFunctions`` artifacts instead of relying on flat-basis reconstruction.
+
 ``run_hbmcmc.py`` is now a compatibility wrapper for old fixedbasis-style INI
 files. It translates legacy option names to the modern ``run_rhime`` API and
 uses the legacy filename convention. New scripts and new configs should use

--- a/openghg_inversions/basis/_wrapper.py
+++ b/openghg_inversions/basis/_wrapper.py
@@ -8,6 +8,7 @@ from typing import Any, Literal, cast
 import xarray as xr
 
 from .basis_functions import (
+    BASIS_ARTIFACT_PATH_ATTR,
     BASIS_ARTIFACT_SOURCE_ATTR,
     BasisFunctions,
     basis_functions_from_fp_all_flat_basis,
@@ -188,7 +189,7 @@ def make_basis_functions(
         if not isinstance(basis_data_array, xr.DataArray):
             raise TypeError("Saving generated basis output currently requires a single flat basis DataArray.")
         if basis_output_format == "legacy":
-            _save_basis(
+            basis_artifact_path = _save_basis(
                 basis=basis_data_array,
                 basis_algorithm=basis_algorithm,
                 output_dir=output_path,
@@ -197,7 +198,7 @@ def make_basis_functions(
                 output_name=outputname,
             )
         elif basis_output_format == "datatree":
-            _save_basis_datatree(
+            basis_artifact_path = _save_basis_datatree(
                 basis_functions=basis_functions_object,
                 basis=basis_data_array,
                 basis_algorithm=basis_algorithm,
@@ -206,6 +207,11 @@ def make_basis_functions(
                 species=species,
                 output_name=outputname,
             )
+        else:
+            raise ValueError(f"Unknown basis_output_format '{basis_output_format}'.")
+        basis_functions_object = basis_functions_object.with_metadata(
+            {BASIS_ARTIFACT_PATH_ATTR: str(basis_artifact_path)}
+        )
 
     return basis_functions_object
 
@@ -382,7 +388,10 @@ def load_basis_functions(
         print(f"Loaded DataTree basis artifact: {datatree_files[0]}")
         current_flux = flux_from_fp_all(fp_all)
         basis_functions = basis_functions.with_flux(current_flux).with_metadata(
-            {BASIS_ARTIFACT_SOURCE_ATTR: "datatree"}
+            {
+                BASIS_ARTIFACT_SOURCE_ATTR: "datatree",
+                BASIS_ARTIFACT_PATH_ATTR: str(datatree_files[0]),
+            }
         )
         if "source" in current_flux.dims:
             basis_functions = basis_functions.select_sources(
@@ -399,7 +408,10 @@ def load_basis_functions(
     return basis_functions_from_fp_all_flat_basis(
         fp_all=fp_all,
         basis_flat=basis_data_array,
-        metadata={BASIS_ARTIFACT_SOURCE_ATTR: "legacy_flat"},
+        metadata={
+            BASIS_ARTIFACT_SOURCE_ATTR: "legacy_flat",
+            BASIS_ARTIFACT_PATH_ATTR: _basis_artifact_path_metadata(files),
+        },
     )
 
 
@@ -419,6 +431,11 @@ def _basis_artifact_files(
     return files
 
 
+def _basis_artifact_path_metadata(files: list[Path]) -> str:
+    """Return deterministic artifact path metadata for one or more matched files."""
+    return ";".join(str(file) for file in files)
+
+
 def _is_basis_datatree_artifact(path: Path) -> bool:
     """Return true when a file contains the BasisFunctions DataTree schema."""
     try:
@@ -435,7 +452,7 @@ def _save_basis(
     domain: str,
     species: str,
     output_name: str | None = None,
-) -> None:
+) -> Path:
     """Save basis functions to netCDF.
 
     Args:
@@ -454,7 +471,7 @@ def _save_basis(
         Default None
 
     Returns:
-        None. Saves basis dataset to netCDF.
+        Path to the written basis artifact.
     """
     basis_out_path = Path(output_dir, domain.upper())
 
@@ -468,7 +485,9 @@ def _save_basis(
     else:
         output_name = f"{basis_algorithm}_{species}-{output_name}_{domain}_{start_date}.nc"
 
-    basis.to_netcdf(basis_out_path / output_name, mode="w")
+    output_path = basis_out_path / output_name
+    basis.to_netcdf(output_path, mode="w")
+    return output_path
 
 
 def _save_basis_datatree(
@@ -479,7 +498,7 @@ def _save_basis_datatree(
     domain: str,
     species: str,
     output_name: str | None = None,
-) -> None:
+) -> Path:
     """Save ``BasisFunctions`` using the wrapper's DataTree file convention.
 
     This is an opt-in serialization path around ``BasisFunctions.save``. The
@@ -498,4 +517,6 @@ def _save_basis_datatree(
     else:
         output_name = f"{basis_algorithm}_{species}-{output_name}_{domain}_{start_date}_basis_datatree.nc"
 
-    basis_functions.save(basis_out_path / output_name)
+    output_path = basis_out_path / output_name
+    basis_functions.save(output_path)
+    return output_path

--- a/openghg_inversions/basis/basis_functions.py
+++ b/openghg_inversions/basis/basis_functions.py
@@ -35,6 +35,9 @@ from openghg_inversions.basis.operators import (
 
 BASIS_METADATA_ATTR_PREFIX = "openghg_inversions:"
 BASIS_ARTIFACT_SOURCE_ATTR = f"{BASIS_METADATA_ATTR_PREFIX}basis_artifact_source"
+BASIS_ARTIFACT_PATH_ATTR = f"{BASIS_METADATA_ATTR_PREFIX}basis_artifact_path"
+_BASIS_ARTIFACT_SOURCE_FALLBACK_ATTR = "basis_artifact_source"
+_BASIS_ARTIFACT_PATH_FALLBACK_ATTR = "basis_artifact_path"
 
 
 @dataclass(frozen=True, slots=True)
@@ -189,8 +192,47 @@ class FluxWeightedBasis:
     @property
     def basis_artifact_source(self) -> str | None:
         """Return the source used to create/load this basis, when recorded."""
-        source = self.metadata.get(BASIS_ARTIFACT_SOURCE_ATTR)
+        source = self.metadata.get(
+            BASIS_ARTIFACT_SOURCE_ATTR, self.metadata.get(_BASIS_ARTIFACT_SOURCE_FALLBACK_ATTR)
+        )
         return str(source) if source is not None else None
+
+    @property
+    def basis_artifact_path(self) -> str | None:
+        """Return the basis artifact path used to create/load this basis, when recorded."""
+        path = self.metadata.get(
+            BASIS_ARTIFACT_PATH_ATTR, self.metadata.get(_BASIS_ARTIFACT_PATH_FALLBACK_ATTR)
+        )
+        return str(path) if path is not None else None
+
+    def for_source(self, source: str, *, state_dim: str | None = None) -> Self:
+        """Return a source-specific basis object for postprocessing.
+
+        Shared-basis operators are reused with the selected source flux. Operators
+        that own source-specific basis maps can expose an ``operator_for_source``
+        method to return a single-source operator without going through the
+        legacy flat-basis view.
+
+        Args:
+            source: Flux source label to select from source-specific flux and
+                basis operators.
+            state_dim: Optional state dimension for the selected source
+                operator. When omitted, the operator chooses its default.
+
+        Returns:
+            A basis object with the selected source flux and a compatible
+            operator.
+
+        Raises:
+            ValueError: If the underlying source-specific operator does not
+                contain ``source``.
+        """
+        flux = self.flux.sel(source=source, drop=True) if "source" in self.flux.dims else self.flux
+        operator_for_source = getattr(self.operator, "operator_for_source", None)
+        if callable(operator_for_source):
+            operator = cast(BasisOperator, operator_for_source(source, state_dim=state_dim))
+            return type(self)(operator=operator, flux=flux, metadata=dict(self.metadata))
+        return type(self)(operator=self.operator, flux=flux, metadata=dict(self.metadata))
 
     def flat_basis(self) -> xr.DataArray | dict[str, xr.DataArray]:
         """Return the legacy flattened basis view used by ``fp_sensitivity``."""
@@ -395,11 +437,11 @@ def basis_functions_from_fp_all_flat_basis(
     basis_flat: xr.DataArray | Mapping[str, xr.DataArray],
     metadata: Mapping[str, Any] | None = None,
 ) -> FluxWeightedBasis:
-    """Legacy adapter that constructs a basis object from wrapper inputs.
+    """Compatibility adapter that constructs a basis object from flat basis data.
 
-    This is a temporary compatibility helper for the current ``fp_sensitivity``
-    path. Remove it when issue #429 makes ``BasisFunctions.sensitivity`` the
-    source of prepared sensitivities.
+    Legacy flat basis artifacts remain readable for a transition period, but
+    modern preparation and postprocessing should consume the returned
+    ``BasisFunctions`` object rather than the flat representation directly.
 
     Args:
         fp_all: Legacy merged-data dictionary containing a ``".flux"`` side

--- a/openghg_inversions/basis/operators.py
+++ b/openghg_inversions/basis/operators.py
@@ -52,7 +52,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import ClassVar, Literal
+from typing import Any, ClassVar, Literal, cast
 from typing_extensions import Self
 
 import numpy as np
@@ -594,6 +594,36 @@ class MultiSourceBucketBasisOperator(BasisOperator):
     def basis_matrix(self) -> xr.DataArray:
         """Basis matrix."""
         return self._basis_matrix
+
+    def operator_for_source(self, source: str, *, state_dim: str | None = None) -> BucketBasisOperator:
+        """Return a single-source bucket operator for one source.
+
+        This keeps source-specific basis selection at the operator boundary,
+        avoiding direct use of the legacy flat-basis compatibility view in
+        modern postprocessing code.
+
+        Args:
+            source: Source label to select from the source-specific basis
+                mapping.
+            state_dim: Optional state dimension for the returned single-source
+                operator. If omitted, the per-source region dimension is used.
+
+        Returns:
+            A single-source bucket operator for ``source``.
+
+        Raises:
+            ValueError: If ``source`` is not present in this operator.
+        """
+        try:
+            basis_flat = self.basis_flat[source]
+        except KeyError as exc:
+            raise ValueError(f"Basis operator is missing basis for source {source!r}.") from exc
+
+        meta = BasisMeta(grid_dims=self.meta.grid_dims, state_dim=state_dim or self.region_in_source_dim)
+        operator_cls = cast(Any, BucketBasisOperator)
+        return cast(
+            BucketBasisOperator, operator_cls(basis_flat=basis_flat, meta=meta, region_labels="range0")
+        )
 
     def _align_source_like_state(self, other: xr.DataArray) -> xr.DataArray:
         """Broadcast `other(source, ...)` onto `state` using the state MultiIndex level `source`.

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -416,6 +416,7 @@ def _build_inversion_output_args(
             "averaging_period": list(averaging_period),
             "split_by_sectors": False,
             "basis_artifact_source": prepared.basis_artifact_source,
+            "basis_artifact_path": prepared.basis_artifact_path,
         },
         "model_metadata": {"species": species, "domain": domain},
         "output_metadata": {
@@ -429,6 +430,7 @@ def _build_inversion_output_args(
         "provenance": {
             "contract": "modern_fixedbasis_inversion_output",
             "compatibility_issue": "416",
+            "basis_representation": "operator-backed",
             "legacy_postprocessing_fields": sorted(str(key) for key in legacy_postprocess_args),
         },
     }

--- a/openghg_inversions/inversion_data/preparation.py
+++ b/openghg_inversions/inversion_data/preparation.py
@@ -46,6 +46,7 @@ class FixedBasisPreparedData:
         averaging_period: Averaging periods aligned to retained sites.
         basis_objects: Basis objects returned by ``basis_functions_wrapper``.
         basis_artifact_source: Source of the flux basis artifact.
+        basis_artifact_path: Path to the flux basis artifact, when loaded or saved.
     """
 
     fp_all: dict
@@ -55,6 +56,7 @@ class FixedBasisPreparedData:
     averaging_period: list[str | None] = field(default_factory=list)
     basis_objects: dict[str, BasisFunctions] = field(default_factory=dict)
     basis_artifact_source: str = "generated"
+    basis_artifact_path: str | None = None
 
 
 @dataclass(frozen=True)
@@ -70,6 +72,7 @@ class RhimePreparedInputs:
         averaging_period: Averaging periods aligned to retained sites.
         basis_artifact_source: Description of whether the basis was generated
             or loaded from an artifact.
+        basis_artifact_path: Path to the basis artifact, when loaded or saved.
         site_lats: Release latitudes aligned to ``sites``, when available.
         site_lons: Release longitudes aligned to ``sites``, when available.
     """
@@ -79,6 +82,7 @@ class RhimePreparedInputs:
     sites: tuple[str, ...]
     averaging_period: tuple[str | None, ...]
     basis_artifact_source: str
+    basis_artifact_path: str | None = None
     site_lats: tuple[float, ...] | None = None
     site_lons: tuple[float, ...] | None = None
 
@@ -584,7 +588,9 @@ def prepare_fixedbasis_inversion_data(
         return_basis_objects=True,
     )
     fp_data, fixedbasis_basis_objects = cast(tuple[dict, dict[str, BasisFunctions]], basis_result)
-    basis_source = fixedbasis_basis_objects["emissions"].basis_artifact_source or "generated"
+    emissions_basis = fixedbasis_basis_objects["emissions"]
+    basis_source = emissions_basis.basis_artifact_source or "generated"
+    basis_path = getattr(emissions_basis, "basis_artifact_path", None)
     basis_objects = fixedbasis_basis_objects if return_basis_objects else {}
 
     fp_data, prepared_sites, prepared_averaging_period = _apply_filters_and_drop_empty_sites(
@@ -613,6 +619,7 @@ def prepare_fixedbasis_inversion_data(
         inv_inputs=inv_inputs,
         basis_objects=basis_objects,
         basis_artifact_source=basis_source,
+        basis_artifact_path=basis_path,
         sites=prepared_sites,
         averaging_period=prepared_averaging_period,
     )
@@ -746,6 +753,7 @@ def prepare_rhime_inputs(
             output_path=basis_output_path,
         )
     basis_source = basis_functions.basis_artifact_source or "generated"
+    basis_path = getattr(basis_functions, "basis_artifact_path", None)
 
     with timed("rhime.prepare_inputs.footprint_sensitivity_total", sites=len(merged.sites)):
         fp_data = _rhime_site_data_from_basis_functions(
@@ -795,6 +803,7 @@ def prepare_rhime_inputs(
         inv_inputs=inv_inputs,
         basis_functions=basis_functions,
         basis_artifact_source=basis_source,
+        basis_artifact_path=basis_path,
         sites=tuple(prepared_sites),
         averaging_period=tuple(prepared_averaging_period),
         site_lats=site_lats,

--- a/openghg_inversions/postprocessing/_basis_products.py
+++ b/openghg_inversions/postprocessing/_basis_products.py
@@ -7,7 +7,46 @@ import xarray as xr
 from openghg_inversions.array_ops import align_sparse_lat_lon, sparse_xr_dot
 from openghg_inversions.basis.basis_functions import BasisFunctions
 
+BASIS_RECONSTRUCTION_PATH_ATTR = "basis_reconstruction_path"
+BASIS_ARTIFACT_SOURCE_OUTPUT_ATTR = "basis_artifact_source"
+BASIS_ARTIFACT_PATH_OUTPUT_ATTR = "basis_artifact_path"
+
+BASIS_RECONSTRUCTION_OPERATOR_BACKED = "operator-backed"
+
+BASIS_ARTIFACT_SOURCE_GENERATED = "generated"
+BASIS_ARTIFACT_SOURCE_LOADED_DATATREE = "loaded-datatree"
+BASIS_ARTIFACT_SOURCE_LOADED_LEGACY_FLAT = "loaded-legacy-flat"
+
+_OUTPUT_BASIS_ARTIFACT_SOURCE_LABELS = {
+    "generated": BASIS_ARTIFACT_SOURCE_GENERATED,
+    "datatree": BASIS_ARTIFACT_SOURCE_LOADED_DATATREE,
+    "legacy_flat": BASIS_ARTIFACT_SOURCE_LOADED_LEGACY_FLAT,
+}
+
 _TRACE_STATE_DIMS = ("region", "nx")
+
+
+def basis_artifact_output_label(basis_functions: BasisFunctions) -> str:
+    """Return the stable output label for a retained basis artifact source."""
+    source = getattr(basis_functions, "basis_artifact_source", None) or BASIS_ARTIFACT_SOURCE_GENERATED
+    return _OUTPUT_BASIS_ARTIFACT_SOURCE_LABELS.get(source, source)
+
+
+def add_basis_reconstruction_metadata(
+    ds: xr.Dataset,
+    basis_functions: BasisFunctions,
+    *,
+    reconstruction_path: str = BASIS_RECONSTRUCTION_OPERATOR_BACKED,
+) -> xr.Dataset:
+    """Attach stable basis provenance metadata to a derived output dataset."""
+    result = ds.copy(deep=False)
+    result.attrs = dict(result.attrs)
+    result.attrs[BASIS_RECONSTRUCTION_PATH_ATTR] = reconstruction_path
+    result.attrs[BASIS_ARTIFACT_SOURCE_OUTPUT_ATTR] = basis_artifact_output_label(basis_functions)
+    basis_artifact_path = getattr(basis_functions, "basis_artifact_path", None)
+    if basis_artifact_path is not None:
+        result.attrs[BASIS_ARTIFACT_PATH_OUTPUT_ATTR] = basis_artifact_path
+    return result
 
 
 def _trace_state_dim(ds: xr.Dataset, basis_functions: BasisFunctions | None = None) -> str:

--- a/openghg_inversions/postprocessing/legacy_outputs.py
+++ b/openghg_inversions/postprocessing/legacy_outputs.py
@@ -13,6 +13,7 @@ import xarray as xr
 
 from openghg_inversions import utils
 from openghg_inversions._country_file import load_country_dataset
+from openghg_inversions.postprocessing._basis_products import add_basis_reconstruction_metadata
 from openghg_inversions.postprocessing.inversion_output import InversionOutput
 from openghg_inversions.postprocessing.make_outputs import (
     flat_basis_for_output,
@@ -600,7 +601,9 @@ def _legacy_flat_basis(inv_out: InversionOutput) -> xr.DataArray:
     values = _as_array(basis)
     if values.size and np.nanmin(values) >= 1:
         values = values - 1
-    return xr.DataArray(values, dims=basis.dims, coords=basis.coords, attrs=basis.attrs, name="basisfunctions")
+    return xr.DataArray(
+        values, dims=basis.dims, coords=basis.coords, attrs=basis.attrs, name="basisfunctions"
+    )
 
 
 def _format_legacy_attr_prior(prior: object) -> str | None:
@@ -828,4 +831,4 @@ def make_legacy_hbmcmc_output(
     out.attrs["Convergence"] = _legacy_convergence(inv_out)
     out.attrs.update(_legacy_hbmcmc_attrs(inv_out))
 
-    return out
+    return add_basis_reconstruction_metadata(out, inv_out.basis_functions)

--- a/openghg_inversions/postprocessing/make_outputs.py
+++ b/openghg_inversions/postprocessing/make_outputs.py
@@ -9,6 +9,7 @@ import xarray as xr
 from openghg_inversions.basis.basis_functions import BasisFunctions
 from openghg_inversions.postprocessing.countries import Countries, paris_regions_dict
 from openghg_inversions.postprocessing._basis_products import (
+    add_basis_reconstruction_metadata,
     reconstruct_flux_stats,
     reconstruct_scale_factor_stats,
 )
@@ -111,23 +112,9 @@ def _sector_basis_functions(
     trace: xr.Dataset,
 ) -> BasisFunctions:
     """Return a basis object whose state dimension matches one sector trace."""
-    sector_flux = _sector_flux(inv_out, sector)
-    flat_basis = inv_out.basis_functions.flat_basis()
-    if not isinstance(flat_basis, dict):
-        return inv_out.basis_functions.with_flux(sector_flux)
-
-    try:
-        sector_basis = flat_basis[sector.flux_source]
-    except KeyError as exc:
-        raise ValueError(
-            f"BasisFunctions object is missing basis for sector flux source {sector.flux_source!r}."
-        ) from exc
-
-    return BasisFunctions.from_flat_basis(
-        basis_flat=sector_basis,
-        flux=sector_flux,
-        operator_kwargs={"state_dim": _state_chunk_dim(trace, inv_out)},
-        metadata=inv_out.basis_functions.metadata,
+    return inv_out.basis_functions.for_source(
+        sector.flux_source,
+        state_dim=_state_chunk_dim(trace, inv_out),
     )
 
 
@@ -393,7 +380,8 @@ def make_multisector_flux_trace_outputs(
         inv_out,
         report_flux_on_inversion_grid=report_flux_on_inversion_grid,
     )
-    return xr.merge([total_flux_trace, *sector_flux_traces]).as_numpy()
+    result = xr.merge([total_flux_trace, *sector_flux_traces]).as_numpy()
+    return add_basis_reconstruction_metadata(result, inv_out.basis_functions)
 
 
 def make_sector_flux_outputs(
@@ -422,7 +410,8 @@ def make_sector_flux_outputs(
         if include_scale_factors:
             outputs.append(_sector_scale_factor_stats(inv_out, sector, scale_stats_args))
 
-    return _set_multisector_flux_attrs(xr.merge(outputs), inv_out, sectors).as_numpy()
+    result = _set_multisector_flux_attrs(xr.merge(outputs), inv_out, sectors).as_numpy()
+    return add_basis_reconstruction_metadata(result, inv_out.basis_functions)
 
 
 def make_flux_outputs(
@@ -507,7 +496,7 @@ def make_flux_outputs(
 
         flux_stats = xr.merge([flux_stats, scale_factor_stats])
 
-    return flux_stats.as_numpy()
+    return add_basis_reconstruction_metadata(flux_stats.as_numpy(), inv_out.basis_functions)
 
 
 def flatten_post_prior(ds: xr.Dataset) -> xr.Dataset:
@@ -708,7 +697,7 @@ def make_country_outputs(
 
     country_stats = calculate_stats(country_traces, **stats_args)
 
-    return country_stats.as_numpy()
+    return add_basis_reconstruction_metadata(country_stats.as_numpy(), inv_out.basis_functions)
 
 
 def basic_output(
@@ -778,4 +767,4 @@ def basic_output(
 
     result.attrs["description"] = "RHIME inversion outputs."
 
-    return result
+    return add_basis_reconstruction_metadata(result, inv_out.basis_functions)

--- a/openghg_inversions/postprocessing/make_paris_outputs.py
+++ b/openghg_inversions/postprocessing/make_paris_outputs.py
@@ -15,6 +15,7 @@ from openghg.util import timestamp_now  # pyright: ignore[reportPrivateImportUsa
 from openghg_inversions import convert
 from openghg_inversions.array_ops import align_sparse_lat_lon, sparse_xr_dot
 from openghg_inversions.config.version import code_version
+from openghg_inversions.postprocessing._basis_products import add_basis_reconstruction_metadata
 from openghg_inversions.postprocessing.countries import Countries
 from openghg_inversions.postprocessing.inversion_output import InversionOutput
 from openghg_inversions.postprocessing.make_outputs import (
@@ -991,7 +992,8 @@ def paris_flux_output(
     result.attrs = make_global_attrs("flux")
     result.attrs["paris_flux_template_version"] = template_files.flux_version
 
-    return _cast_float_data_vars_to_float32(result).as_numpy()
+    result = _cast_float_data_vars_to_float32(result).as_numpy()
+    return add_basis_reconstruction_metadata(result, inv_out.basis_functions)
 
 
 def paris_flux_output_latest(
@@ -1129,7 +1131,8 @@ def paris_flux_output_latest(
     result.attrs = make_global_attrs("flux", species=species, domain=domain)
     result.attrs["paris_flux_template_version"] = template_files.flux_version
 
-    return _cast_data_vars_to_template_dtypes(result, template_files.flux)
+    result = _cast_data_vars_to_template_dtypes(result, template_files.flux)
+    return add_basis_reconstruction_metadata(result, inv_out.basis_functions)
 
 
 def infer_flux_frequency(flux: xr.DataArray) -> str:

--- a/openghg_inversions/rhime/outputs.py
+++ b/openghg_inversions/rhime/outputs.py
@@ -131,6 +131,7 @@ def _make_inversion_output(
             "averaging_period": list(run_spec.averaging_period),
             "split_by_sectors": run_spec.split_by_sectors,
             "basis_artifact_source": prepared.basis_artifact_source,
+            "basis_artifact_path": prepared.basis_artifact_path,
             "site_lats": list(prepared.site_lats) if prepared.site_lats is not None else None,
             "site_lons": list(prepared.site_lons) if prepared.site_lons is not None else None,
         },
@@ -146,6 +147,7 @@ def _make_inversion_output(
         provenance={
             "contract": "modern_rhime_inversion_output",
             "compatibility_issue": "401",
+            "basis_representation": "operator-backed",
         },
     )
 

--- a/tests/test_basis_functions.py
+++ b/tests/test_basis_functions.py
@@ -1,8 +1,10 @@
+from pathlib import Path
+from types import SimpleNamespace
+
 import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
-from types import SimpleNamespace
 
 import openghg_inversions.basis as basis_package
 import openghg_inversions.basis._functions as basis_module
@@ -26,6 +28,7 @@ from openghg_inversions.basis._wrapper import (
     make_basis_functions,
 )
 from openghg_inversions.basis.basis_functions import (
+    BASIS_ARTIFACT_PATH_ATTR,
     BASIS_ARTIFACT_SOURCE_ATTR,
     BasisFunctions,
     basis_functions_from_fp_all_flat_basis,
@@ -1143,7 +1146,7 @@ def test_load_basis_functions_prefers_datatree_schema(tmp_path):
     )
     fp_all = {".flux": {"emissions": current_flux}, ".split_by_sectors": False}
 
-    _save_basis_datatree(
+    saved_path = _save_basis_datatree(
         basis_functions=bf,
         basis=basis_flat,
         basis_algorithm="weighted",
@@ -1161,6 +1164,7 @@ def test_load_basis_functions_prefers_datatree_schema(tmp_path):
     )
 
     assert loaded.basis_artifact_source == "datatree"
+    assert loaded.basis_artifact_path == str(saved_path)
     assert isinstance(loaded, BasisFunctions)
     xr.testing.assert_identical(loaded.flat_basis(), bf.operator.basis_flat.rename("basis"))
     xr.testing.assert_identical(loaded.operator.basis_matrix, bf.operator.basis_matrix)
@@ -1296,7 +1300,7 @@ def test_load_basis_functions_falls_back_to_legacy_flat(tmp_path):
     flux = xr.ones_like(basis_flat.isel(time=0, drop=True), dtype=float).rename("flux")
     fp_all = {".flux": {"emissions": flux}, ".split_by_sectors": False}
 
-    _save_basis(
+    saved_path = _save_basis(
         basis=basis_flat,
         basis_algorithm="weighted",
         output_dir=str(tmp_path),
@@ -1318,6 +1322,63 @@ def test_load_basis_functions_falls_back_to_legacy_flat(tmp_path):
         operator_kwargs={"state_dim": "region"},
     )
     assert loaded.basis_artifact_source == "legacy_flat"
+    assert loaded.basis_artifact_path == str(saved_path)
     assert isinstance(loaded, BasisFunctions)
     xr.testing.assert_identical(loaded.operator.basis_matrix, expected.operator.basis_matrix)
     xr.testing.assert_identical(loaded.flux, expected.flux)
+
+
+def test_basis_artifact_metadata_properties_accept_plain_keys():
+    """Basis artifact metadata properties accept pre-namespaced metadata keys."""
+    basis_flat = make_basis_flat_from_blocks([[1]])
+    flux = xr.ones_like(basis_flat, dtype=float).rename("flux")
+    basis_functions = BasisFunctions.from_flat_basis(
+        basis_flat=basis_flat,
+        flux=flux,
+        operator_kwargs={"state_dim": "region"},
+        metadata={"basis_artifact_source": "datatree", "basis_artifact_path": "/tmp/plain-basis.nc"},
+    )
+
+    assert basis_functions.basis_artifact_source == "datatree"
+    assert basis_functions.basis_artifact_path == "/tmp/plain-basis.nc"
+
+
+def test_make_basis_functions_records_saved_generated_basis_path(tmp_path):
+    """Generated basis saves record the written artifact path on the retained object."""
+    basis_flat = make_basis_flat_from_blocks([[1, 1], [2, 2]]).expand_dims(time=[np.datetime64("2019-01-01")])
+    flux = xr.ones_like(basis_flat.isel(time=0, drop=True), dtype=float).rename("flux")
+    fp_all = {".flux": {"emissions": flux}, ".split_by_sectors": False}
+
+    class StaticBasisAlgorithm:
+        description = "static test basis"
+
+        @staticmethod
+        def algorithm(*args: object, **kwargs: object) -> xr.DataArray:
+            return basis_flat
+
+    old_algorithm = basis_module.basis_functions.get("static_path_test")
+    basis_module.basis_functions["static_path_test"] = StaticBasisAlgorithm
+    try:
+        basis_object = make_basis_functions(
+            fp_all=fp_all,
+            species="ch4",
+            domain="EUROPE",
+            start_date="2019-01-01",
+            emissions_name=["emissions"],
+            nbasis=2,
+            basis_algorithm="static_path_test",
+            outputname="path-check",
+            output_path=str(tmp_path),
+            basis_output_format="datatree",
+        )
+    finally:
+        if old_algorithm is None:
+            del basis_module.basis_functions["static_path_test"]
+        else:
+            basis_module.basis_functions["static_path_test"] = old_algorithm
+
+    assert basis_object.basis_artifact_source == "generated"
+    assert basis_object.basis_artifact_path is not None
+    assert basis_object.basis_artifact_path.endswith("_basis_datatree.nc")
+    assert Path(basis_object.basis_artifact_path).exists()
+    assert basis_object.metadata[BASIS_ARTIFACT_PATH_ATTR] == basis_object.basis_artifact_path

--- a/tests/test_basis_operators.py
+++ b/tests/test_basis_operators.py
@@ -82,7 +82,10 @@ def test_bucket_basis_operator_accepts_zero_based_flat_basis():
 # Test interpolation for MultiSourceBucketBasisOperator
 # --------------------------------------------------------------------------------------
 
-def _make_multisource_operator_for_broadcast_tests(state_dim: str = "state") -> MultiSourceBucketBasisOperator:
+
+def _make_multisource_operator_for_broadcast_tests(
+    state_dim: str = "state",
+) -> MultiSourceBucketBasisOperator:
     """Create a tiny multisource operator with ragged per-source region counts.
 
     Source A has 2 regions; source B has 1 region.
@@ -102,7 +105,9 @@ def _make_multisource_operator_for_broadcast_tests(state_dim: str = "state") -> 
     return MultiSourceBucketBasisOperator({"A": basis_a, "B": basis_b}, state_dim=state_dim)
 
 
-def _state_for_operator(op: MultiSourceBucketBasisOperator, values: list[float], name: str = "state") -> xr.DataArray:
+def _state_for_operator(
+    op: MultiSourceBucketBasisOperator, values: list[float], name: str = "state"
+) -> xr.DataArray:
     """Create a state(state) vector matching the operator's gathered MultiIndex order."""
     state_index = op.basis_matrix[op.meta.state_dim]
     if len(values) != state_index.size:
@@ -137,8 +142,13 @@ def test_multisource_interpolate_broadcasts_weights_source_to_state():
     assert set(out.dims) == {"lat", "lon"}
 
     expected = xr.DataArray(
-        np.array([[10.0 * 2.0 + 1000.0 * 3.0, 100.0 * 2.0 + 1000.0 * 3.0],
-                  [10.0 * 2.0 + 1000.0 * 3.0, 100.0 * 2.0 + 1000.0 * 3.0]], dtype=float),
+        np.array(
+            [
+                [10.0 * 2.0 + 1000.0 * 3.0, 100.0 * 2.0 + 1000.0 * 3.0],
+                [10.0 * 2.0 + 1000.0 * 3.0, 100.0 * 2.0 + 1000.0 * 3.0],
+            ],
+            dtype=float,
+        ),
         dims=("lat", "lon"),
         coords={"lat": [0, 1], "lon": [0, 1]},
         name=out.name,
@@ -178,3 +188,37 @@ def test_multisource_interpolate_broadcasts_weights_source_with_nontrivial_value
     )
 
     xr.testing.assert_allclose(out, expected)
+
+
+def test_multisource_operator_for_source_matches_source_slice_interpolation():
+    """Selected source operators reproduce the corresponding multisource interpolation slice."""
+    op = _make_multisource_operator_for_broadcast_tests(state_dim="state")
+
+    # Select the two-region source A from the gathered multisource operator.
+    selected = op.operator_for_source("A", state_dim="region")
+    source_state = xr.DataArray(
+        [2.0, 5.0],
+        dims=("region",),
+        coords={"region": [0, 1]},
+        name="x",
+    )
+    source_weights = xr.DataArray(
+        np.array([[3.0, 7.0], [11.0, 13.0]], dtype=float),
+        dims=("lat", "lon"),
+        coords={"lat": [0, 1], "lon": [0, 1]},
+        name="weights",
+    )
+
+    selected_out = selected.interpolate(source_state, weights=source_weights)
+
+    multisource_state = _state_for_operator(op, [2.0, 5.0, 0.0], name="x")
+    multisource_weights = xr.concat(
+        [
+            source_weights.expand_dims(source=["A"]),
+            xr.zeros_like(source_weights).expand_dims(source=["B"]),
+        ],
+        dim="source",
+    )
+    multisource_out = op.interpolate(multisource_state, weights=multisource_weights)
+
+    xr.testing.assert_allclose(selected_out, multisource_out)

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -22,7 +22,11 @@ import openghg_inversions.rhime.sampling as rhime_sampling
 import openghg_inversions.rhime.specs as rhime_specs
 import openghg_inversions.inversion_data.preparation as prep_module
 import openghg_inversions.rhime.runner as rhime_module
-from openghg_inversions.basis.basis_functions import BASIS_ARTIFACT_SOURCE_ATTR, BasisFunctions
+from openghg_inversions.basis.basis_functions import (
+    BASIS_ARTIFACT_PATH_ATTR,
+    BASIS_ARTIFACT_SOURCE_ATTR,
+    BasisFunctions,
+)
 from openghg_inversions.cli import main
 from openghg_inversions.inversion_data import RhimePreparedInputs, prepare_rhime_inputs
 from openghg_inversions.inversion_inputs import make_inv_inputs
@@ -35,6 +39,13 @@ from openghg_inversions.models import (
     safe_pymc_name,
 )
 from openghg_inversions.postprocessing.inversion_output import InversionOutput
+from openghg_inversions.postprocessing._basis_products import (
+    BASIS_ARTIFACT_PATH_OUTPUT_ATTR,
+    BASIS_ARTIFACT_SOURCE_LOADED_DATATREE,
+    BASIS_ARTIFACT_SOURCE_OUTPUT_ATTR,
+    BASIS_RECONSTRUCTION_OPERATOR_BACKED,
+    BASIS_RECONSTRUCTION_PATH_ATTR,
+)
 from openghg_inversions.postprocessing.make_outputs import observation_inputs_for_outputs
 from openghg_inversions.rhime import (
     RhimeModelSpec,
@@ -2333,12 +2344,16 @@ def test_make_multisector_output_bundle_builds_latest_paris_flux(europe_country_
 def test_modern_inversion_output_save_load_roundtrip(tmp_path: Path) -> None:
     """Modern RHIME InversionOutput preserves retained inputs, basis, and metadata."""
     model_spec, output_spec, run_spec = _minimal_output_specs()
+    basis_artifact_path = str(tmp_path / "unit-basis.nc")
     prepared = RhimePreparedInputs(
         inv_inputs=_minimal_output_inv_inputs(),
-        basis_functions=_fake_basis_functions(artifact_source="unit-test"),
+        basis_functions=_fake_basis_functions(artifact_source="unit-test").with_metadata(
+            {BASIS_ARTIFACT_PATH_ATTR: basis_artifact_path}
+        ),
         sites=("TAC",),
         averaging_period=("1h",),
         basis_artifact_source="unit-test",
+        basis_artifact_path=basis_artifact_path,
     )
     bundle = rhime_outputs.make_standard_output_bundle(
         output_spec=output_spec,
@@ -2358,6 +2373,9 @@ def test_modern_inversion_output_save_load_roundtrip(tmp_path: Path) -> None:
     assert reloaded.domain == "EUROPE"
     assert reloaded.start_date == "2019-01-01"
     assert reloaded.run_metadata["basis_artifact_source"] == "unit-test"
+    assert reloaded.run_metadata["basis_artifact_path"] == basis_artifact_path
+    assert reloaded.basis_functions.basis_artifact_path == basis_artifact_path
+    assert reloaded.provenance["basis_representation"] == "operator-backed"
     assert reloaded.output_metadata["output_format"] == "inv_out"
     xr.testing.assert_identical(reloaded.inv_inputs, prepared.inv_inputs)
     xr.testing.assert_identical(reloaded.basis_functions.flux, prepared.basis_functions.flux)
@@ -2546,12 +2564,19 @@ def test_multisector_flux_outputs_reconstruct_sector_and_total_flux() -> None:
     assert float(outputs["flux_ff_posterior_stdev"].item()) > 0.0
 
 
-def test_multisector_flux_outputs_support_source_specific_basis() -> None:
+def test_multisector_flux_outputs_support_source_specific_basis(monkeypatch: pytest.MonkeyPatch) -> None:
     """Sector flux reconstruction handles source-specific retained basis artifacts."""
     from openghg_inversions.postprocessing.make_outputs import make_flux_outputs
 
+    basis_functions = _fake_source_specific_multisector_basis_functions()
+
+    def fail_flat_basis(self: BasisFunctions) -> xr.DataArray:
+        raise AssertionError("source-specific multisector outputs should not materialise flat basis")
+
+    monkeypatch.setattr(type(basis_functions), "flat_basis", fail_flat_basis)
+
     outputs = make_flux_outputs(
-        _multisector_postprocessing_inv_out(_fake_source_specific_multisector_basis_functions()),
+        _multisector_postprocessing_inv_out(basis_functions),
         stats=["mean", "mode_kde"],
         include_scale_factors=False,
         report_flux_on_inversion_grid=False,
@@ -2586,6 +2611,28 @@ def test_modern_flux_outputs_use_retained_basis_operator(
     assert "flux_posterior_mean" in flux_outputs
     assert "scaling_posterior_mean" in flux_outputs
     assert operator.interpolate_calls
+
+
+def test_modern_outputs_record_basis_reconstruction_metadata(europe_country_file: Path) -> None:
+    """Modern derived outputs record stable basis reconstruction metadata."""
+    from openghg_inversions.postprocessing.make_outputs import make_country_outputs, make_flux_outputs
+
+    basis_artifact_path = "/tmp/example-basis.nc"
+    basis_functions = _fake_basis_functions_matching_country_grid(europe_country_file).with_metadata(
+        {
+            BASIS_ARTIFACT_SOURCE_ATTR: "datatree",
+            "basis_artifact_path": basis_artifact_path,
+        }
+    )
+    inv_out = _modern_postprocessing_inv_out(europe_country_file, basis_functions=basis_functions)
+
+    flux_outputs = make_flux_outputs(inv_out, include_scale_factors=False)
+    country_outputs = make_country_outputs(inv_out, country_file=europe_country_file)
+
+    for outputs in (flux_outputs, country_outputs):
+        assert outputs.attrs[BASIS_RECONSTRUCTION_PATH_ATTR] == BASIS_RECONSTRUCTION_OPERATOR_BACKED
+        assert outputs.attrs[BASIS_ARTIFACT_SOURCE_OUTPUT_ATTR] == BASIS_ARTIFACT_SOURCE_LOADED_DATATREE
+        assert outputs.attrs[BASIS_ARTIFACT_PATH_OUTPUT_ATTR] == basis_artifact_path
 
 
 def test_modern_operator_flux_and_country_outputs_run_on_nonuniform_basis(
@@ -2629,6 +2676,7 @@ def test_modern_paris_flux_outputs_use_retained_basis_operator(
     assert "flux_total_posterior" in flux_outputs
     assert "country_flux_total_posterior" in flux_outputs
     assert "flux_total_posterior_inversion_grid" in flux_outputs
+    assert flux_outputs.attrs[BASIS_RECONSTRUCTION_PATH_ATTR] == BASIS_RECONSTRUCTION_OPERATOR_BACKED
     for name in (
         "flux_total_posterior",
         "country_flux_total_posterior",


### PR DESCRIPTION
* **Summary of changes**

- Make retained `BasisFunctions` / `BasisOperator` metadata the primary basis contract for RHIME preparation and modern postprocessing.
- Record basis artifact source/path metadata for generated, DataTree-loaded, and legacy-flat-loaded basis artifacts, and preserve it through modern `InversionOutput` metadata.
- Move source-specific multisector flux reconstruction through `BasisFunctions.for_source()` / operator selection instead of materialising the legacy flat-basis view.
- Add stable `basis_reconstruction_path="operator-backed"` and basis artifact attrs to derived flux, country, PARIS, basic, and legacy-format outputs.
- Update README, RHIME usage docs, refactor plan notes, and CHANGELOG guidance for DataTree `BasisFunctions` artifacts and legacy flat-basis deprecation.

* **Please check if the PR fulfills these requirements**

- [x] Closes #429
- [x] Tests added and passing
- [x] Documentation and tutorials updated/added
- [x] Added an entry to the `CHANGELOG.md` file
- [x] No new requirements added

Closes #429.
Part of #360.

Tests:
- `tox -p`
- `uv run ruff format --check openghg_inversions/basis/_wrapper.py openghg_inversions/basis/basis_functions.py openghg_inversions/basis/operators.py openghg_inversions/hbmcmc/hbmcmc.py openghg_inversions/inversion_data/preparation.py openghg_inversions/postprocessing/_basis_products.py openghg_inversions/postprocessing/legacy_outputs.py openghg_inversions/postprocessing/make_outputs.py openghg_inversions/postprocessing/make_paris_outputs.py openghg_inversions/rhime/outputs.py tests/test_basis_functions.py tests/test_basis_operators.py tests/test_rhime.py`
- `uv run ruff check openghg_inversions/basis/_wrapper.py openghg_inversions/basis/basis_functions.py openghg_inversions/basis/operators.py openghg_inversions/hbmcmc/hbmcmc.py openghg_inversions/inversion_data/preparation.py openghg_inversions/postprocessing/_basis_products.py openghg_inversions/postprocessing/legacy_outputs.py openghg_inversions/postprocessing/make_outputs.py openghg_inversions/postprocessing/make_paris_outputs.py openghg_inversions/rhime/outputs.py tests/test_basis_functions.py tests/test_basis_operators.py tests/test_rhime.py`
- `uv run pyright openghg_inversions/basis/basis_functions.py openghg_inversions/basis/operators.py openghg_inversions/basis/_wrapper.py openghg_inversions/inversion_data/preparation.py openghg_inversions/postprocessing/_basis_products.py openghg_inversions/postprocessing/make_outputs.py openghg_inversions/postprocessing/make_paris_outputs.py openghg_inversions/postprocessing/legacy_outputs.py openghg_inversions/rhime/outputs.py openghg_inversions/hbmcmc/hbmcmc.py`
- Focused pytest selections for basis load/save metadata, `operator_for_source`, legacy output fixtures, RHIME preparation, modern/PARIS output metadata, and source-specific multisector reconstruction.