### PR TITLE
Codex/405 paris sector vars

### DIFF
--- a/docs/plans/issue_405_paris_sector_outputs.md
+++ b/docs/plans/issue_405_paris_sector_outputs.md
@@ -16,7 +16,7 @@ Track implementation progress for GitHub issue #405: sector-aware RHIME outputs 
 2. Single-sector latest PARIS branch: implement explicit latest-template concentration and flux outputs, including `platform`, observation `index`, `time_bnds`, new `mf_*` names, flux `time_bnds`, `cell_area`, and latest country variable names.
 3. Sector reconstruction branch: reconstruct sector prior/posterior flux traces with each sector's own prior flux, sum reconstructed flux traces for total outputs, and move RHIME multisector diagnostics onto the postprocessing helper.
 4. Multisector total PARIS branch: route multisector `output_format="paris"` through total PARIS output creation.
-5. Per-sector PARIS branch: add sector-specific PARIS variables and a documented sector diagnostics dataset for variables that do not fit cleanly in the product files.
+5. Per-sector PARIS branch: add sector-specific PARIS flux variables and document any sector diagnostics that do not fit cleanly in the product files. Per-sector concentration remains a separate design item because multisector PARIS concentration output is not currently produced.
 
 ## Progress
 
@@ -25,7 +25,8 @@ Track implementation progress for GitHub issue #405: sector-aware RHIME outputs 
 - [x] Added explicit latest single-sector PARIS products.
 - [x] Added sector-aware flux reconstruction.
 - [x] Routed multisector PARIS outputs through total product creation.
-- [ ] Added per-sector PARIS variables and diagnostics.
+- [x] Added per-sector PARIS flux variables, sector coordinates, country totals, and covariance diagnostics.
+- [ ] Designed per-sector PARIS concentration variables for multisector concentration output.
 
 ## Test Plan
 

--- a/docs/plans/issue_405_paris_sector_outputs.md
+++ b/docs/plans/issue_405_paris_sector_outputs.md
@@ -9,6 +9,10 @@ Track implementation progress for GitHub issue #405: sector-aware RHIME outputs 
 - The next release should keep the current PARIS schema as the default. Users must pass an explicit latest-template option to produce the new PARIS concentration v04 and flux v03 outputs.
 - Site/platform metadata should be resolved from observation metadata first. Likely sources are `ObsData.metadata`, `ObsData.data.attrs`, and, as fallback, `openghg_defs` site definitions through the `openghg` dependency.
 - The preferred multisector output should include per-sector variables where the PARIS template supports them. Total PARIS outputs should still be generated from reconstructed sector flux fields, not from summed scale factors.
+- Latest-template country outputs use the canonical 22-country EUROPE v03 list by default so the ordinary output matches the supplied CDL. Pass `country_selections=None` to use every country from another domain file, or pass an explicit list of names or codes for a selected domain.
+- Multisector country traces should project each retained basis and prior flux to countries before applying posterior scaling traces. This keeps country-only statistics lazy without constructing a draw-wise latitude/longitude flux field.
+- Total country posterior covariance applies to both single-sector and multisector output. Multisector output additionally includes per-sector and cross-sector covariance variables.
+- NetCDF writing must preserve the explicit `units` and `calendar` attributes on time-bounds variables required by the supplied CDL templates, even though xarray's CF encoder normally removes duplicate bounds metadata.
 
 ## Branch Plan
 
@@ -26,12 +30,16 @@ Track implementation progress for GitHub issue #405: sector-aware RHIME outputs 
 - [x] Added sector-aware flux reconstruction.
 - [x] Routed multisector PARIS outputs through total product creation.
 - [x] Added per-sector PARIS flux variables, sector coordinates, country totals, and covariance diagnostics.
+- [x] Projected multisector country totals directly from basis regions and retained lazy Dask arrays until statistics require dense chunks.
+- [x] Kept the canonical EUROPE country list as the latest-template default while allowing explicit all-domain or selected-country output.
+- [x] Added a marked end-to-end multisector test covering local data preparation, sampling, postprocessing, NetCDF writing, and CDL-derived schema validation.
 - [ ] Designed per-sector PARIS concentration variables for multisector concentration output.
 
 ## Test Plan
 
 - Focused unit tests for template-version selection and legacy default behavior.
 - Single-sector latest-output tests for required v04/v03 variables and dimensions.
-- Synthetic multisector test where total posterior flux equals the sum of reconstructed sector posterior flux fields.
-- NetCDF write/read smoke tests for latest concentration and flux products.
-- Focused `uv run pytest` and `uv run ruff` checks on changed files, then full `tox -p` before review if time and resources allow.
+- Synthetic multisector tests where total prior/posterior flux and country traces equal the sum of reconstructed sector values.
+- NetCDF write/read smoke tests for latest concentration and flux products, including explicit time-bounds metadata.
+- A `slow` full-pipeline test using two distinct source labels for numerically identical fluxes, with output variables, dimensions, dtypes, and attributes checked against the flux v03 CDL.
+- Focused pytest, Ruff, and Pyright checks on changed files, then full `tox -p` before review.

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -38,7 +38,7 @@ import xarray as xr
 import openghg_inversions.hbmcmc.inversion_pymc as mcmc
 from openghg_inversions.basis.basis_functions import BasisFunctions
 from openghg_inversions.models.priors import lognormal_mu_sigma
-from openghg_inversions.utils import ncdf_encoding
+from openghg_inversions.utils import ncdf_encoding, write_netcdf_preserving_bounds_attrs
 from openghg_inversions.inversion_data import FixedBasisPreparedData, prepare_fixedbasis_inversion_data
 from openghg_inversions.postprocessing.inversion_output import (
     InversionOutput,
@@ -565,11 +565,15 @@ def _finalize_output(context: _OutputContext) -> xr.Dataset | dict | InversionOu
         )
         Path(context.outputpath).mkdir(parents=True, exist_ok=True)
 
-        conc_outs.to_netcdf(
-            conc_output_filename, unlimited_dims=["time"], mode="w", encoding=ncdf_encoding(conc_outs)
+        write_netcdf_preserving_bounds_attrs(
+            conc_outs,
+            conc_output_filename,
+            unlimited_dims=["time"],
         )
-        flux_outs.to_netcdf(
-            flux_output_filename, unlimited_dims=["time"], mode="w", encoding=ncdf_encoding(flux_outs)
+        write_netcdf_preserving_bounds_attrs(
+            flux_outs,
+            flux_output_filename,
+            unlimited_dims=["time"],
         )
 
         logging.info("PARIS concentration outputs saved to %s", conc_output_filename)

--- a/openghg_inversions/postprocessing/make_outputs.py
+++ b/openghg_inversions/postprocessing/make_outputs.py
@@ -383,13 +383,36 @@ def _multisector_flux_trace_parts(
 def make_multisector_flux_trace_outputs(
     inv_out: InversionOutput,
     report_flux_on_inversion_grid: bool = True,
+    *,
+    materialize: bool = True,
 ) -> xr.Dataset:
-    """Return per-draw reconstructed sector and total flux traces for multisector outputs."""
+    """Return per-draw reconstructed sector and total multisector flux traces.
+
+    Args:
+        inv_out: Inversion output containing multisector MCMC traces and retained
+            basis functions.
+        report_flux_on_inversion_grid: If true, reconstruct values on the reduced
+            inversion grid; otherwise include the sector prior flux on the
+            latitude/longitude grid.
+        materialize: If true, convert the completed trace to NumPy-backed arrays.
+            Set this to false when a downstream labelled reduction can preserve
+            lazy or sparse arrays. The default preserves the historical return
+            boundary.
+
+    Returns:
+        Per-draw total and sector flux traces with reconstruction metadata.
+
+    Raises:
+        ValueError: If ``inv_out`` is not multisector or lacks required sector
+            metadata or trace variables.
+    """
     _, sector_flux_traces, total_flux_trace = _multisector_flux_trace_parts(
         inv_out,
         report_flux_on_inversion_grid=report_flux_on_inversion_grid,
     )
-    result = xr.merge([total_flux_trace, *sector_flux_traces]).as_numpy()
+    result = xr.merge([total_flux_trace, *sector_flux_traces])
+    if materialize:
+        result = result.as_numpy()
     result = _copy_first_flux_nonfinite_metadata(result, [total_flux_trace, *sector_flux_traces])
     return add_basis_reconstruction_metadata(result, inv_out.basis_functions)
 

--- a/openghg_inversions/postprocessing/make_outputs.py
+++ b/openghg_inversions/postprocessing/make_outputs.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
+from openghg_inversions.array_ops import to_dense
 from openghg_inversions.basis.basis_functions import BasisFunctions
 from openghg_inversions.flux_sanitization import copy_flux_nonfinite_attrs
 from openghg_inversions.postprocessing.countries import Countries, paris_regions_dict
@@ -44,6 +45,7 @@ TRACE_GROUP_SUFFIXES = (
     "_posterior",
 )
 _PRODUCT_METADATA_FIELDS = Literal["species", "domain", "start_date", "end_date"]
+_DENSE_INVERSION_GRID_STATS = {"quantiles", "hdi", "median", "mode", "mode_kde"}
 
 
 class OutputSector(NamedTuple):
@@ -348,6 +350,21 @@ def _copy_first_flux_nonfinite_metadata(ds: xr.Dataset, sources: list[xr.Dataset
     return ds
 
 
+def _to_dense_dataset(ds: xr.Dataset) -> xr.Dataset:
+    """Convert sparse-backed data variables to dense arrays before unsupported reductions."""
+    return xr.Dataset(
+        {name: to_dense(data) for name, data in ds.data_vars.items()},
+        coords=ds.coords,
+        attrs=ds.attrs,
+    )
+
+
+def _multisector_inversion_grid_stats_need_dense(stats: list[str] | None) -> bool:
+    """Return whether selected inversion-grid stats need dense arrays for sparse inputs."""
+    selected_stats = stats or ["mean", "quantiles"]
+    return any(stat in _DENSE_INVERSION_GRID_STATS for stat in selected_stats)
+
+
 def _multisector_flux_trace_parts(
     inv_out: InversionOutput,
     report_flux_on_inversion_grid: bool = True,
@@ -414,9 +431,17 @@ def make_sector_flux_outputs(
     )
     flux_stats_args = _stats_args_with_defaults(stats, stats_args)
 
-    outputs = [calculate_stats(total_flux_trace, **flux_stats_args)]
+    should_densify = report_flux_on_inversion_grid and _multisector_inversion_grid_stats_need_dense(stats)
+
+    outputs = [
+        calculate_stats(
+            _to_dense_dataset(total_flux_trace) if should_densify else total_flux_trace,
+            **flux_stats_args,
+        )
+    ]
     for sector, flux_trace in zip(sectors, sector_flux_traces, strict=True):
-        outputs.append(calculate_stats(flux_trace, **flux_stats_args))
+        stats_input = _to_dense_dataset(flux_trace) if should_densify else flux_trace
+        outputs.append(calculate_stats(stats_input, **flux_stats_args))
         if include_scale_factors:
             outputs.append(_sector_scale_factor_stats(inv_out, sector, scale_stats_args))
 

--- a/openghg_inversions/postprocessing/make_outputs.py
+++ b/openghg_inversions/postprocessing/make_outputs.py
@@ -6,7 +6,6 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
-from openghg_inversions.array_ops import to_dense
 from openghg_inversions.basis.basis_functions import BasisFunctions
 from openghg_inversions.flux_sanitization import copy_flux_nonfinite_attrs
 from openghg_inversions.postprocessing.countries import Countries, paris_regions_dict
@@ -45,7 +44,6 @@ TRACE_GROUP_SUFFIXES = (
     "_posterior",
 )
 _PRODUCT_METADATA_FIELDS = Literal["species", "domain", "start_date", "end_date"]
-_DENSE_INVERSION_GRID_STATS = {"quantiles", "hdi", "median", "mode", "mode_kde"}
 
 
 class OutputSector(NamedTuple):
@@ -350,21 +348,6 @@ def _copy_first_flux_nonfinite_metadata(ds: xr.Dataset, sources: list[xr.Dataset
     return ds
 
 
-def _to_dense_dataset(ds: xr.Dataset) -> xr.Dataset:
-    """Convert sparse-backed data variables to dense arrays before unsupported reductions."""
-    return xr.Dataset(
-        {name: to_dense(data) for name, data in ds.data_vars.items()},
-        coords=ds.coords,
-        attrs=ds.attrs,
-    )
-
-
-def _multisector_inversion_grid_stats_need_dense(stats: list[str] | None) -> bool:
-    """Return whether selected inversion-grid stats need dense arrays for sparse inputs."""
-    selected_stats = stats or ["mean", "quantiles"]
-    return any(stat in _DENSE_INVERSION_GRID_STATS for stat in selected_stats)
-
-
 def _multisector_flux_trace_parts(
     inv_out: InversionOutput,
     report_flux_on_inversion_grid: bool = True,
@@ -431,17 +414,9 @@ def make_sector_flux_outputs(
     )
     flux_stats_args = _stats_args_with_defaults(stats, stats_args)
 
-    should_densify = report_flux_on_inversion_grid and _multisector_inversion_grid_stats_need_dense(stats)
-
-    outputs = [
-        calculate_stats(
-            _to_dense_dataset(total_flux_trace) if should_densify else total_flux_trace,
-            **flux_stats_args,
-        )
-    ]
+    outputs = [calculate_stats(total_flux_trace, **flux_stats_args)]
     for sector, flux_trace in zip(sectors, sector_flux_traces, strict=True):
-        stats_input = _to_dense_dataset(flux_trace) if should_densify else flux_trace
-        outputs.append(calculate_stats(stats_input, **flux_stats_args))
+        outputs.append(calculate_stats(flux_trace, **flux_stats_args))
         if include_scale_factors:
             outputs.append(_sector_scale_factor_stats(inv_out, sector, scale_stats_args))
 

--- a/openghg_inversions/postprocessing/make_outputs.py
+++ b/openghg_inversions/postprocessing/make_outputs.py
@@ -11,6 +11,7 @@ from openghg_inversions.flux_sanitization import copy_flux_nonfinite_attrs
 from openghg_inversions.postprocessing.countries import Countries, paris_regions_dict
 from openghg_inversions.postprocessing._basis_products import (
     add_basis_reconstruction_metadata,
+    make_x_to_country_matrix,
     reconstruct_flux_stats,
     reconstruct_scale_factor_stats,
 )
@@ -414,6 +415,82 @@ def make_multisector_flux_trace_outputs(
     if materialize:
         result = result.as_numpy()
     result = _copy_first_flux_nonfinite_metadata(result, [total_flux_trace, *sector_flux_traces])
+    return add_basis_reconstruction_metadata(result, inv_out.basis_functions)
+
+
+def make_multisector_country_trace_outputs(
+    inv_out: InversionOutput,
+    countries: Countries,
+) -> xr.Dataset:
+    """Map multisector scaling traces directly from basis regions to countries.
+
+    The country projection is formed independently for each sector using that
+    sector's retained basis operator and prior flux. Applying the projection to
+    the scaling traces avoids reconstructing draw-wise latitude/longitude flux
+    fields solely to calculate country totals.
+
+    Args:
+        inv_out: Multisector inversion output containing sector scaling traces,
+            retained basis functions, prior fluxes, and species metadata.
+        countries: Country masks and grid-cell areas aligned with the retained
+            flux grid.
+
+    Returns:
+        Lazy or sparse-compatible prior and posterior country traces in grams
+        per year. Variables are named ``country_<sector>_<when>`` plus summed
+        ``country_total_<when>`` variables.
+
+    Raises:
+        ValueError: If the inversion is not multisector or required sector or
+            species metadata is missing.
+    """
+    if not inv_out.is_multisector:
+        raise ValueError("Multisector country postprocessing requires a multisector inversion output.")
+
+    species = _require_output_metadata(inv_out, "species", "Country postprocessing")
+    sectors = _multisector_output_sectors(inv_out)
+    sector_country_traces = []
+    for sector in sectors:
+        scale_trace = _sector_scale_trace(inv_out, sector)
+        basis_functions = _sector_basis_functions(inv_out, sector, scale_trace)
+        x_to_country = make_x_to_country_matrix(
+            basis_functions,
+            _sector_flux(inv_out, sector),
+            scale_trace,
+            country_matrix=countries.matrix,
+            area_grid=countries.area_grid,
+            sparse=True,
+        )
+        country_trace = Countries._get_country_trace(species, scale_trace, x_to_country)
+        country_trace = country_trace.rename(
+            {
+                name: str(name).replace("x_", f"country_{sector.variable_suffix}_", 1)
+                for name in country_trace.data_vars
+            }
+        )
+        sector_country_traces.append(copy_flux_nonfinite_attrs(country_trace, x_to_country))
+
+    total_country_trace = xr.concat(
+        [
+            trace.rename(
+                {
+                    name: str(name).replace(
+                        f"country_{sector.variable_suffix}_",
+                        "country_total_",
+                        1,
+                    )
+                    for name in trace.data_vars
+                }
+            )
+            for sector, trace in zip(sectors, sector_country_traces, strict=True)
+        ],
+        dim="sector",
+    ).sum("sector")
+    result = xr.merge([total_country_trace, *sector_country_traces])
+    for name in result.data_vars:
+        result[name].attrs["units"] = "g/yr"
+
+    result = _copy_first_flux_nonfinite_metadata(result, [total_country_trace, *sector_country_traces])
     return add_basis_reconstruction_metadata(result, inv_out.basis_functions)
 
 

--- a/openghg_inversions/postprocessing/make_paris_outputs.py
+++ b/openghg_inversions/postprocessing/make_paris_outputs.py
@@ -866,52 +866,35 @@ def _latest_paris_countries(country_file: str | Path | None, domain: str) -> Cou
     return countries
 
 
-def _multisector_country_trace_kg(inv_out: InversionOutput, countries: Countries, species: str) -> xr.Dataset:
-    """Return multisector total country flux traces in kg/yr from reconstructed total flux."""
-    total_flux_trace = make_multisector_flux_trace_outputs(
-        inv_out,
-        report_flux_on_inversion_grid=False,
-    )[["flux_total_prior", "flux_total_posterior"]].rename(
-        {
-            "flux_total_prior": "country_prior",
-            "flux_total_posterior": "country_posterior",
-        }
-    )
-    country_weights = countries.matrix.as_numpy() * countries.area_grid.as_numpy()
-    country_weights = align_sparse_lat_lon(country_weights, total_flux_trace["country_posterior"])
-    country_trace = sparse_xr_dot(country_weights, total_flux_trace, dim=["lat", "lon"])
-    country_trace = country_trace * 365 * 24 * 3600 * convert.molar_mass(species) * 1e-3
-    return country_trace.reindex(country=list(PARIS_LATEST_COUNTRIES))
-
-
-def _multisector_sector_country_trace_kg(
+def _multisector_country_trace_kg(
     inv_out: InversionOutput,
     countries: Countries,
     species: str,
     sector_name_by_suffix: Mapping[str, str],
+    flux_trace: xr.Dataset | None = None,
 ) -> xr.Dataset:
-    """Return multisector per-sector country flux traces in kg/yr."""
-    flux_trace = make_multisector_flux_trace_outputs(
-        inv_out,
-        report_flux_on_inversion_grid=False,
-    )
-    rename: dict[str, str] = {}
-    keep_vars = []
+    """Reconstruct once and lazily reduce total and sector flux traces to countries."""
+    if flux_trace is None:
+        flux_trace = make_multisector_flux_trace_outputs(
+            inv_out,
+            report_flux_on_inversion_grid=False,
+            materialize=False,
+        )
+    rename = {
+        "flux_total_prior": "country_prior",
+        "flux_total_posterior": "country_posterior",
+    }
     for variable_suffix, sector_name in sector_name_by_suffix.items():
         for when in ("prior", "posterior"):
             source_name = f"flux_{variable_suffix}_{when}"
             if source_name in flux_trace:
-                keep_vars.append(source_name)
                 rename[source_name] = f"country_{sector_name}_{when}"
 
-    if not keep_vars:
-        return xr.Dataset()
-
-    sector_flux_trace = flux_trace[keep_vars].rename(rename)
-    country_weights = countries.matrix.as_numpy() * countries.area_grid.as_numpy()
-    reference_flux = next(iter(sector_flux_trace.data_vars.values()))
+    selected_flux_trace = flux_trace[list(rename)].rename(rename)
+    country_weights = countries.matrix * countries.area_grid
+    reference_flux = selected_flux_trace["country_posterior"]
     country_weights = align_sparse_lat_lon(country_weights, reference_flux)
-    country_trace = sparse_xr_dot(country_weights, sector_flux_trace, dim=["lat", "lon"])
+    country_trace = sparse_xr_dot(country_weights, selected_flux_trace, dim=["lat", "lon"])
     country_trace = country_trace * 365 * 24 * 3600 * convert.molar_mass(species) * 1e-3
     return country_trace.reindex(country=list(PARIS_LATEST_COUNTRIES))
 
@@ -924,19 +907,18 @@ def _latest_country_outputs(
     stats_args: dict[str, Any],
     country_file: str | Path | None,
     sector_name_by_suffix: Mapping[str, str] | None = None,
+    multisector_country_trace: xr.Dataset | None = None,
 ) -> xr.Dataset:
     """Return latest PARIS country statistics for single- or multisector outputs."""
     if inv_out.is_multisector:
-        country_traces = [_multisector_country_trace_kg(inv_out, countries, species)]
-        sector_trace = _multisector_sector_country_trace_kg(
-            inv_out,
-            countries,
-            species,
-            sector_name_by_suffix or _paris_sector_name_by_suffix(inv_out),
-        )
-        if sector_trace.data_vars:
-            country_traces.append(sector_trace)
-        country_trace = xr.merge(country_traces)
+        country_trace = multisector_country_trace
+        if country_trace is None:
+            country_trace = _multisector_country_trace_kg(
+                inv_out,
+                countries,
+                species,
+                sector_name_by_suffix or _paris_sector_name_by_suffix(inv_out),
+            )
         country_stats_args = dict(stats_args)
         country_stats_args["stats"] = stats
         return calculate_stats(country_trace, **country_stats_args)
@@ -957,10 +939,18 @@ def _country_posterior_covariance_kg(
     countries: Countries,
     species: str,
     flux_frequency: Literal["monthly", "yearly"] | str,
+    multisector_country_trace: xr.Dataset | None = None,
 ) -> np.ndarray:
     """Return posterior country-total covariance in kg2 yr-2."""
     if inv_out.is_multisector:
-        country_trace = _multisector_country_trace_kg(inv_out, countries, species)
+        country_trace = multisector_country_trace
+        if country_trace is None:
+            country_trace = _multisector_country_trace_kg(
+                inv_out,
+                countries,
+                species,
+                _paris_sector_name_by_suffix(inv_out),
+            )
         posterior = country_trace["country_posterior"]
     else:
         country_trace = countries.get_country_trace(inv_out=inv_out)
@@ -974,12 +964,13 @@ def _country_posterior_covariance_kg(
         inv_out.end_time,
     )
 
-    values = posterior.isel(flux_time=valid_indices).transpose("flux_time", "country", "draw").values
-    if values.shape[2] < 2:
+    posterior = posterior.isel(flux_time=valid_indices).dropna("draw", how="all")
+    values = posterior.transpose("flux_time", "country", "draw").values
+    if values.shape[2] == 0:
         return np.full((values.shape[0], values.shape[1], values.shape[1]), np.nan, dtype="float32")
 
     centered = values - values.mean(axis=2, keepdims=True)
-    return np.einsum("tcd,ted->tce", centered, centered) / (values.shape[2] - 1)
+    return np.einsum("tcd,ted->tce", centered, centered) / values.shape[2]
 
 
 def _sector_country_posterior_covariances_kg(
@@ -988,17 +979,20 @@ def _sector_country_posterior_covariances_kg(
     species: str,
     flux_frequency: Literal["monthly", "yearly"] | str,
     sector_name_by_suffix: Mapping[str, str],
+    multisector_country_trace: xr.Dataset | None = None,
 ) -> tuple[dict[str, np.ndarray], np.ndarray | None]:
     """Return within-sector and between-sector posterior country covariances."""
     if not sector_name_by_suffix:
         return {}, None
 
-    sector_trace = _multisector_sector_country_trace_kg(
-        inv_out,
-        countries,
-        species,
-        sector_name_by_suffix,
-    )
+    sector_trace = multisector_country_trace
+    if sector_trace is None:
+        sector_trace = _multisector_country_trace_kg(
+            inv_out,
+            countries,
+            species,
+            sector_name_by_suffix,
+        )
     sector_names = list(sector_name_by_suffix.values())
     first_posterior = sector_trace[f"country_{sector_names[0]}_posterior"]
     flux_period = _flux_frequency_to_offset(flux_frequency)
@@ -1013,17 +1007,18 @@ def _sector_country_posterior_covariances_kg(
     sector_posteriors = [
         sector_trace[f"country_{sector_name}_posterior"]
         .isel(flux_time=valid_indices)
+        .dropna("draw", how="all")
         .transpose("flux_time", "country", "draw")
         for sector_name in sector_names
     ]
     sector_covariances = {}
     for sector_name, posterior in zip(sector_names, sector_posteriors, strict=True):
         values = posterior.values
-        if values.shape[2] < 2:
+        if values.shape[2] == 0:
             covariance = np.full((values.shape[0], values.shape[1], values.shape[1]), np.nan, dtype="float32")
         else:
             centered = values - values.mean(axis=2, keepdims=True)
-            covariance = np.einsum("tcd,ted->tce", centered, centered) / (values.shape[2] - 1)
+            covariance = np.einsum("tcd,ted->tce", centered, centered) / values.shape[2]
         sector_covariances[sector_name] = covariance
 
     posterior_by_sector = xr.concat(
@@ -1034,7 +1029,7 @@ def _sector_country_posterior_covariances_kg(
         dim="sector",
     )
     values = posterior_by_sector.transpose("flux_time", "country", "sector", "draw").values
-    if values.shape[3] < 2:
+    if values.shape[3] == 0:
         sector_cross_covariance = np.full(
             (values.shape[0], values.shape[1], values.shape[2], values.shape[2]),
             np.nan,
@@ -1042,7 +1037,7 @@ def _sector_country_posterior_covariances_kg(
         )
     else:
         centered = values - values.mean(axis=3, keepdims=True)
-        sector_cross_covariance = np.einsum("tcsd,tced->tcse", centered, centered) / (values.shape[3] - 1)
+        sector_cross_covariance = np.einsum("tcsd,tced->tcse", centered, centered) / values.shape[3]
 
     return sector_covariances, sector_cross_covariance
 
@@ -1228,7 +1223,36 @@ def paris_flux_output_latest(
     inversion_grid: bool = True,
     flux_frequency: Literal["monthly", "yearly"] | str = "yearly",
 ) -> xr.Dataset:
-    """Create single-sector PARIS flux outputs for the latest CDL template."""
+    """Create single- or multisector flux output using the latest PARIS template.
+
+    Multisector output contains total and per-sector spatial and country
+    statistics. Sector fluxes are reconstructed with their own prior fluxes,
+    while total flux is calculated by summing those reconstructed traces.
+    Country covariance variables use the repeated country and sector dimensions
+    required verbatim by the supplied CDL schema.
+
+    Args:
+        inv_out: Inversion output with retained basis functions and flux traces.
+        country_file: Optional country-definition NetCDF file. If omitted, the
+            country helper resolves its configured default for the inversion
+            domain.
+        time_point: Flux timestamp convention. The latest template supports only
+            ``"midpoint"`` because it also reports interval bounds.
+        report_mode: If true, report KDE modes instead of means as central flux
+            estimates.
+        inversion_grid: If true, include the optional reduced inversion-grid
+            variables.
+        flux_frequency: Frequency used to construct output intervals. Supported
+            values are ``"monthly"`` and ``"yearly"``.
+
+    Returns:
+        Latest-template PARIS flux dataset with template dtypes and attributes.
+
+    Raises:
+        ValueError: If midpoint times are not requested, required inversion or
+            sector metadata is missing or invalid, the flux frequency is not
+            supported, or no valid flux interval falls within the inversion.
+    """
     if time_point != "midpoint":
         raise ValueError("Latest PARIS flux output requires midpoint time coordinates and time bounds.")
 
@@ -1238,14 +1262,38 @@ def paris_flux_output_latest(
     sector_name_by_suffix = _paris_sector_name_by_suffix(inv_out)
     sector_names = list(sector_name_by_suffix.values())
 
-    flux_outs = make_flux_outputs(
-        inv_out,
-        stats=stats,
-        stats_args=stats_args,
-        report_flux_on_inversion_grid=False,
-        include_scale_factors=False,
+    spatial_flux_trace = (
+        make_multisector_flux_trace_outputs(
+            inv_out,
+            report_flux_on_inversion_grid=False,
+            materialize=False,
+        )
+        if inv_out.is_multisector
+        else None
+    )
+    flux_outs = (
+        calculate_stats(spatial_flux_trace, stats=stats, **stats_args)
+        if spatial_flux_trace is not None
+        else make_flux_outputs(
+            inv_out,
+            stats=stats,
+            stats_args=stats_args,
+            report_flux_on_inversion_grid=False,
+            include_scale_factors=False,
+        )
     )
     countries = _latest_paris_countries(country_file=country_file, domain=domain)
+    multisector_country_trace = (
+        _multisector_country_trace_kg(
+            inv_out,
+            countries,
+            species,
+            sector_name_by_suffix,
+            flux_trace=spatial_flux_trace,
+        )
+        if inv_out.is_multisector
+        else None
+    )
     country_outs = _latest_country_outputs(
         inv_out,
         countries=countries,
@@ -1254,6 +1302,7 @@ def paris_flux_output_latest(
         stats_args=stats_args,
         country_file=country_file,
         sector_name_by_suffix=sector_name_by_suffix,
+        multisector_country_trace=multisector_country_trace,
     )
     country_fraction = countries.matrix.as_numpy().rename("country_fraction")
     cell_area = countries.area_grid.as_numpy().rename("cell_area")
@@ -1262,6 +1311,7 @@ def paris_flux_output_latest(
         countries=countries,
         species=species,
         flux_frequency=flux_frequency,
+        multisector_country_trace=multisector_country_trace,
     )
     sector_covariances, sector_cross_covariance = (
         _sector_country_posterior_covariances_kg(
@@ -1270,19 +1320,25 @@ def paris_flux_output_latest(
             species=species,
             flux_frequency=flux_frequency,
             sector_name_by_suffix=sector_name_by_suffix,
+            multisector_country_trace=multisector_country_trace,
         )
         if inv_out.is_multisector
         else ({}, None)
     )
 
     def flux_renamer(name: str) -> str:
-        if not name.startswith("flux_total_"):
-            for variable_suffix, sector_name in sector_name_by_suffix.items():
-                sector_prefix = f"flux_{variable_suffix}_"
-                if name.startswith(sector_prefix):
-                    name = name.replace(sector_prefix, f"flux_{sector_name}_", 1)
-                    break
-            else:
+        for variable_suffix, sector_name in sorted(
+            sector_name_by_suffix.items(),
+            key=lambda item: len(item[0]),
+            reverse=True,
+        ):
+            sector_prefix = f"flux_{variable_suffix}_"
+            remainder = name.removeprefix(sector_prefix)
+            if remainder != name and remainder.startswith(("prior_", "posterior_")):
+                name = f"flux_{sector_name}_{remainder}"
+                break
+        else:
+            if name.startswith("flux_") and not name.startswith("flux_total_"):
                 name = name.replace("flux_", "flux_total_", 1)
         if "quantile" in name:
             name = "percentile_" + name.replace("_quantile", "")
@@ -1296,11 +1352,12 @@ def paris_flux_output_latest(
     def country_renamer(name: str) -> str:
         suffix = name.removeprefix("country_")
         flux_label = "total"
-        for sector_name in sector_names:
+        for sector_name in sorted(sector_names, key=len, reverse=True):
             sector_prefix = f"{sector_name}_"
-            if suffix.startswith(sector_prefix):
+            remainder = suffix.removeprefix(sector_prefix)
+            if remainder != suffix and remainder.startswith(("prior_", "posterior_")):
                 flux_label = sector_name
-                suffix = suffix.removeprefix(sector_prefix)
+                suffix = remainder
                 break
 
         if "quantile" in suffix:
@@ -1362,8 +1419,8 @@ def paris_flux_output_latest(
             .pipe(_assign_flux_time_bounds, flux_frequency, inv_out.start_time, inv_out.end_time)
             .pipe(_convert_flux_time_and_bounds_to_epoch_days)
             .rename(flux_rename_dict)
-            .pipe(add_variable_attrs, emissions_attrs)
             .rename(inversion_grid_flux_rename_dict)
+            .pipe(add_variable_attrs, emissions_attrs)
         )
         result = result.merge(inversion_grid_flux_outs)
 
@@ -1390,7 +1447,10 @@ def paris_flux_output_latest(
     )
     result.attrs = make_global_attrs("flux", species=species, domain=domain)
     result.attrs["paris_flux_template_version"] = template_files.flux_version
-    result = copy_flux_nonfinite_attrs(result, flux_outs)
+    result = copy_flux_nonfinite_attrs(
+        result,
+        spatial_flux_trace if spatial_flux_trace is not None else flux_outs,
+    )
 
     result = _cast_data_vars_to_template_dtypes(result, template_files.flux, sector_names=sector_names)
     return add_basis_reconstruction_metadata(result, inv_out.basis_functions)

--- a/openghg_inversions/postprocessing/make_paris_outputs.py
+++ b/openghg_inversions/postprocessing/make_paris_outputs.py
@@ -3,7 +3,7 @@ import getpass
 import json
 import math
 import re
-from collections.abc import Hashable
+from collections.abc import Hashable, Iterable, Mapping
 import warnings
 from typing import Any, Literal, NamedTuple, cast
 
@@ -20,6 +20,7 @@ from openghg_inversions.postprocessing._basis_products import add_basis_reconstr
 from openghg_inversions.postprocessing.countries import Countries
 from openghg_inversions.postprocessing.inversion_output import InversionOutput
 from openghg_inversions.postprocessing.make_outputs import (
+    OutputSector,
     make_concentration_outputs,
     make_flux_outputs,
     make_country_outputs,
@@ -101,6 +102,7 @@ def paris_template_files(template_version: ParisTemplateVersion) -> ParisTemplat
 var_pat = re.compile(r"\s*[a-z]+ ([a-zA-Z_]+)\(.*\)")
 var_type_pat = re.compile(r"\s*([a-z]+) ([a-zA-Z_]+)\(.*\)")
 attr_pat = re.compile(r"\s+([a-zA-Z_]+):([a-zA-Z_]+)\s*=\s*([^;]+)")
+sector_name_pat = re.compile(r"[^a-z0-9]+")
 NETCDF_TO_NUMPY_DTYPE = {
     "byte": "int8",
     "short": "int16",
@@ -165,6 +167,81 @@ def get_data_var_dtypes(template_file: str | Path) -> dict[str, str]:
                 dtype_dict[var_name] = NETCDF_TO_NUMPY_DTYPE[netcdf_type]
 
     return dtype_dict
+
+
+def _replace_sector_placeholder(value: Any, sector_name: str) -> Any:
+    """Replace PARIS sector placeholders in string template values."""
+    if not isinstance(value, str):
+        return value
+    return value.replace("<sector_name>", sector_name).replace("sector_name", sector_name)
+
+
+def _expand_sector_template_mapping(
+    mapping: Mapping[str, Any],
+    sector_names: Iterable[str],
+) -> dict[str, Any]:
+    """Expand CDL ``sector_name`` placeholders for concrete sector variable names."""
+    expanded = dict(mapping)
+    for template_name, template_value in mapping.items():
+        if "sector_name" not in template_name:
+            continue
+        for sector_name in sector_names:
+            output_name = template_name.replace("sector_name", sector_name)
+            if isinstance(template_value, Mapping):
+                expanded[output_name] = {
+                    key: _replace_sector_placeholder(value, sector_name)
+                    for key, value in template_value.items()
+                }
+            else:
+                expanded[output_name] = _replace_sector_placeholder(template_value, sector_name)
+    return expanded
+
+
+def _paris_output_sectors(inv_out: InversionOutput) -> list[OutputSector]:
+    """Return multisector metadata in the local output-sector shape."""
+    raw_sectors = inv_out.model_metadata.get("sectors")
+    if not raw_sectors:
+        raise ValueError("Multisector PARIS output requires model_metadata['sectors'].")
+
+    sectors: list[OutputSector] = []
+    for raw_sector in raw_sectors:
+        if isinstance(raw_sector, Mapping):
+            name = raw_sector.get("name")
+            flux_source = raw_sector.get("flux_source")
+            variable_suffix = raw_sector.get("variable_suffix")
+        else:
+            name = getattr(raw_sector, "name", None)
+            flux_source = getattr(raw_sector, "flux_source", None)
+            variable_suffix = getattr(raw_sector, "variable_suffix", None)
+        if name is None or flux_source is None or variable_suffix is None:
+            raise ValueError("Sector metadata must include 'name', 'flux_source', and 'variable_suffix'.")
+        sectors.append(OutputSector(str(name), str(flux_source), str(variable_suffix)))
+
+    return sectors
+
+
+def _paris_sector_name_by_suffix(inv_out: InversionOutput) -> dict[str, str]:
+    """Return PARIS sector variable names keyed by RHIME variable suffix."""
+    if not inv_out.is_multisector:
+        return {}
+
+    sector_name_by_suffix = {}
+    used_names = set()
+    for sector in _paris_output_sectors(inv_out):
+        sector_name = sector_name_pat.sub("", sector.variable_suffix.lower())
+        if not sector_name:
+            raise ValueError(f"Could not derive a PARIS sector name from {sector.variable_suffix!r}.")
+        if sector_name == "total":
+            raise ValueError("PARIS sector name 'total' is reserved for summed flux variables.")
+        if sector_name in used_names:
+            raise ValueError(
+                "PARIS sector names must be unique after removing separator characters; "
+                f"duplicate sector name {sector_name!r}."
+            )
+        used_names.add(sector_name)
+        sector_name_by_suffix[sector.variable_suffix] = sector_name
+
+    return sector_name_by_suffix
 
 
 def _site_info_for_site(site: str) -> dict[str, Any]:
@@ -416,10 +493,19 @@ def _astype_data_array(da: xr.DataArray, dtype: str) -> xr.DataArray:
     return da.copy(data=da.data.astype(dtype))
 
 
-def _cast_data_vars_to_template_dtypes(ds: xr.Dataset, template_file: str | Path) -> xr.Dataset:
+def _cast_data_vars_to_template_dtypes(
+    ds: xr.Dataset,
+    template_file: str | Path,
+    *,
+    sector_names: Iterable[str] = (),
+) -> xr.Dataset:
     """Cast PARIS data variables to numeric dtypes declared by a CDL template."""
     updates: dict[Hashable, xr.DataArray] = {}
-    for name, dtype in get_data_var_dtypes(template_file).items():
+    dtype_mapping = cast(
+        dict[str, str],
+        _expand_sector_template_mapping(get_data_var_dtypes(template_file), sector_names),
+    )
+    for name, dtype in dtype_mapping.items():
         if name in ds.data_vars and ds[name].dtype != np.dtype(dtype):
             updates[name] = _astype_data_array(ds[name], dtype)
 
@@ -798,6 +884,38 @@ def _multisector_country_trace_kg(inv_out: InversionOutput, countries: Countries
     return country_trace.reindex(country=list(PARIS_LATEST_COUNTRIES))
 
 
+def _multisector_sector_country_trace_kg(
+    inv_out: InversionOutput,
+    countries: Countries,
+    species: str,
+    sector_name_by_suffix: Mapping[str, str],
+) -> xr.Dataset:
+    """Return multisector per-sector country flux traces in kg/yr."""
+    flux_trace = make_multisector_flux_trace_outputs(
+        inv_out,
+        report_flux_on_inversion_grid=False,
+    )
+    rename: dict[str, str] = {}
+    keep_vars = []
+    for variable_suffix, sector_name in sector_name_by_suffix.items():
+        for when in ("prior", "posterior"):
+            source_name = f"flux_{variable_suffix}_{when}"
+            if source_name in flux_trace:
+                keep_vars.append(source_name)
+                rename[source_name] = f"country_{sector_name}_{when}"
+
+    if not keep_vars:
+        return xr.Dataset()
+
+    sector_flux_trace = flux_trace[keep_vars].rename(rename)
+    country_weights = countries.matrix.as_numpy() * countries.area_grid.as_numpy()
+    reference_flux = next(iter(sector_flux_trace.data_vars.values()))
+    country_weights = align_sparse_lat_lon(country_weights, reference_flux)
+    country_trace = sparse_xr_dot(country_weights, sector_flux_trace, dim=["lat", "lon"])
+    country_trace = country_trace * 365 * 24 * 3600 * convert.molar_mass(species) * 1e-3
+    return country_trace.reindex(country=list(PARIS_LATEST_COUNTRIES))
+
+
 def _latest_country_outputs(
     inv_out: InversionOutput,
     countries: Countries,
@@ -805,10 +923,20 @@ def _latest_country_outputs(
     stats: list[str],
     stats_args: dict[str, Any],
     country_file: str | Path | None,
+    sector_name_by_suffix: Mapping[str, str] | None = None,
 ) -> xr.Dataset:
     """Return latest PARIS country statistics for single- or multisector outputs."""
     if inv_out.is_multisector:
-        country_trace = _multisector_country_trace_kg(inv_out, countries, species)
+        country_traces = [_multisector_country_trace_kg(inv_out, countries, species)]
+        sector_trace = _multisector_sector_country_trace_kg(
+            inv_out,
+            countries,
+            species,
+            sector_name_by_suffix or _paris_sector_name_by_suffix(inv_out),
+        )
+        if sector_trace.data_vars:
+            country_traces.append(sector_trace)
+        country_trace = xr.merge(country_traces)
         country_stats_args = dict(stats_args)
         country_stats_args["stats"] = stats
         return calculate_stats(country_trace, **country_stats_args)
@@ -854,6 +982,71 @@ def _country_posterior_covariance_kg(
     return np.einsum("tcd,ted->tce", centered, centered) / (values.shape[2] - 1)
 
 
+def _sector_country_posterior_covariances_kg(
+    inv_out: InversionOutput,
+    countries: Countries,
+    species: str,
+    flux_frequency: Literal["monthly", "yearly"] | str,
+    sector_name_by_suffix: Mapping[str, str],
+) -> tuple[dict[str, np.ndarray], np.ndarray | None]:
+    """Return within-sector and between-sector posterior country covariances."""
+    if not sector_name_by_suffix:
+        return {}, None
+
+    sector_trace = _multisector_sector_country_trace_kg(
+        inv_out,
+        countries,
+        species,
+        sector_name_by_suffix,
+    )
+    sector_names = list(sector_name_by_suffix.values())
+    first_posterior = sector_trace[f"country_{sector_names[0]}_posterior"]
+    flux_period = _flux_frequency_to_offset(flux_frequency)
+    flux_times = list(pd.to_datetime(first_posterior.flux_time.values))
+    _, _, valid_indices = _flux_interval_midpoints_and_bounds(
+        flux_times,
+        flux_period,
+        inv_out.start_time,
+        inv_out.end_time,
+    )
+
+    sector_posteriors = [
+        sector_trace[f"country_{sector_name}_posterior"]
+        .isel(flux_time=valid_indices)
+        .transpose("flux_time", "country", "draw")
+        for sector_name in sector_names
+    ]
+    sector_covariances = {}
+    for sector_name, posterior in zip(sector_names, sector_posteriors, strict=True):
+        values = posterior.values
+        if values.shape[2] < 2:
+            covariance = np.full((values.shape[0], values.shape[1], values.shape[1]), np.nan, dtype="float32")
+        else:
+            centered = values - values.mean(axis=2, keepdims=True)
+            covariance = np.einsum("tcd,ted->tce", centered, centered) / (values.shape[2] - 1)
+        sector_covariances[sector_name] = covariance
+
+    posterior_by_sector = xr.concat(
+        [
+            posterior.expand_dims(sector=[sector_name])
+            for sector_name, posterior in zip(sector_names, sector_posteriors, strict=True)
+        ],
+        dim="sector",
+    )
+    values = posterior_by_sector.transpose("flux_time", "country", "sector", "draw").values
+    if values.shape[3] < 2:
+        sector_cross_covariance = np.full(
+            (values.shape[0], values.shape[1], values.shape[2], values.shape[2]),
+            np.nan,
+            dtype="float32",
+        )
+    else:
+        centered = values - values.mean(axis=3, keepdims=True)
+        sector_cross_covariance = np.einsum("tcsd,tced->tcse", centered, centered) / (values.shape[3] - 1)
+
+    return sector_covariances, sector_cross_covariance
+
+
 def _add_country_covariance(result: xr.Dataset, covariance: np.ndarray, attrs: dict[str, Any]) -> xr.Dataset:
     """Add latest PARIS country covariance with the duplicate country dimension required by the template."""
     with warnings.catch_warnings():
@@ -863,6 +1056,35 @@ def _add_country_covariance(result: xr.Dataset, covariance: np.ndarray, attrs: d
             covariance,
         )
     result["covariance_flux_total_posterior_country"].attrs = attrs
+    return result
+
+
+def _add_sector_country_covariances(
+    result: xr.Dataset,
+    sector_covariances: Mapping[str, np.ndarray],
+    sector_cross_covariance: np.ndarray | None,
+    attrs: Mapping[str, dict[str, Any]],
+) -> xr.Dataset:
+    """Add latest PARIS sector covariance variables with template-required duplicate dimensions."""
+    for sector_name, covariance in sector_covariances.items():
+        variable_name = f"covariance_flux_{sector_name}_posterior_country"
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            result[variable_name] = (("time", "country", "country"), covariance)
+        result[variable_name].attrs = attrs.get(variable_name, {})
+
+    if sector_cross_covariance is not None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            result["covariance_flux_sectors_posterior_country"] = (
+                ("time", "country", "sector", "sector"),
+                sector_cross_covariance,
+            )
+        result["covariance_flux_sectors_posterior_country"].attrs = attrs.get(
+            "covariance_flux_sectors_posterior_country",
+            {},
+        )
+
     return result
 
 
@@ -1013,6 +1235,8 @@ def paris_flux_output_latest(
     species, domain = _require_paris_metadata(inv_out, allow_multisector=True)
     stats = ["kde_mode", "stdev", "quantiles"] if report_mode else ["mean", "stdev", "quantiles"]
     stats_args = {"quantiles__quantiles": [0.159, 0.841]}
+    sector_name_by_suffix = _paris_sector_name_by_suffix(inv_out)
+    sector_names = list(sector_name_by_suffix.values())
 
     flux_outs = make_flux_outputs(
         inv_out,
@@ -1022,10 +1246,6 @@ def paris_flux_output_latest(
         include_scale_factors=False,
     )
     countries = _latest_paris_countries(country_file=country_file, domain=domain)
-    if inv_out.is_multisector:
-        flux_outs = flux_outs[
-            [data_var for data_var in flux_outs.data_vars if str(data_var).startswith("flux_total_")]
-        ]
     country_outs = _latest_country_outputs(
         inv_out,
         countries=countries,
@@ -1033,6 +1253,7 @@ def paris_flux_output_latest(
         stats=stats,
         stats_args=stats_args,
         country_file=country_file,
+        sector_name_by_suffix=sector_name_by_suffix,
     )
     country_fraction = countries.matrix.as_numpy().rename("country_fraction")
     cell_area = countries.area_grid.as_numpy().rename("cell_area")
@@ -1042,10 +1263,27 @@ def paris_flux_output_latest(
         species=species,
         flux_frequency=flux_frequency,
     )
+    sector_covariances, sector_cross_covariance = (
+        _sector_country_posterior_covariances_kg(
+            inv_out,
+            countries=countries,
+            species=species,
+            flux_frequency=flux_frequency,
+            sector_name_by_suffix=sector_name_by_suffix,
+        )
+        if inv_out.is_multisector
+        else ({}, None)
+    )
 
     def flux_renamer(name: str) -> str:
         if not name.startswith("flux_total_"):
-            name = name.replace("flux_", "flux_total_", 1)
+            for variable_suffix, sector_name in sector_name_by_suffix.items():
+                sector_prefix = f"flux_{variable_suffix}_"
+                if name.startswith(sector_prefix):
+                    name = name.replace(sector_prefix, f"flux_{sector_name}_", 1)
+                    break
+            else:
+                name = name.replace("flux_", "flux_total_", 1)
         if "quantile" in name:
             name = "percentile_" + name.replace("_quantile", "")
         elif name.endswith("_stdev"):
@@ -1057,16 +1295,24 @@ def paris_flux_output_latest(
 
     def country_renamer(name: str) -> str:
         suffix = name.removeprefix("country_")
+        flux_label = "total"
+        for sector_name in sector_names:
+            sector_prefix = f"{sector_name}_"
+            if suffix.startswith(sector_prefix):
+                flux_label = sector_name
+                suffix = suffix.removeprefix(sector_prefix)
+                break
+
         if "quantile" in suffix:
             suffix = suffix.replace("_quantile", "")
-            return f"percentile_flux_total_{suffix}_country"
+            return f"percentile_flux_{flux_label}_{suffix}_country"
         if suffix.endswith("_stdev"):
             suffix = suffix.removesuffix("_stdev")
-            return f"stdev_flux_total_{suffix}_country"
+            return f"stdev_flux_{flux_label}_{suffix}_country"
         for stats_func_name in stats_functions:
             if suffix.endswith(f"_{stats_func_name}"):
                 suffix = suffix.removesuffix(f"_{stats_func_name}")
-        return f"flux_total_{suffix}_country"
+        return f"flux_{flux_label}_{suffix}_country"
 
     flux_rename_dict = {str(dv): flux_renamer(str(dv)) for dv in flux_outs.data_vars}
     country_rename_dict = {str(dv): country_renamer(str(dv)) for dv in country_outs.data_vars}
@@ -1078,7 +1324,10 @@ def paris_flux_output_latest(
         dim_rename_dict["lon"] = "longitude"
 
     template_files = paris_template_files("latest")
-    emissions_attrs = get_data_var_attrs(template_files.flux, species)
+    emissions_attrs = cast(
+        dict[str, dict[str, Any]],
+        _expand_sector_template_mapping(get_data_var_attrs(template_files.flux, species), sector_names),
+    )
 
     result = (
         xr.merge(
@@ -1094,8 +1343,10 @@ def paris_flux_output_latest(
         .pipe(_assign_flux_time_bounds, flux_frequency, inv_out.start_time, inv_out.end_time)
         .pipe(_convert_flux_time_and_bounds_to_epoch_days)
         .rename({**flux_rename_dict, **country_rename_dict})
-        .pipe(add_variable_attrs, emissions_attrs)
     )
+    if sector_names:
+        result = result.assign_coords(sector=("sector", np.asarray(sector_names, dtype=object)))
+    result = result.pipe(add_variable_attrs, emissions_attrs)
 
     if inversion_grid:
         inversion_grid_flux_rename_dict = {v: f"{v}_inversion_grid" for v in flux_rename_dict.values()}
@@ -1106,14 +1357,6 @@ def paris_flux_output_latest(
             report_flux_on_inversion_grid=True,
             include_scale_factors=False,
         )
-        if inv_out.is_multisector:
-            inversion_grid_flux_outs_raw = inversion_grid_flux_outs_raw[
-                [
-                    data_var
-                    for data_var in inversion_grid_flux_outs_raw.data_vars
-                    if str(data_var).startswith("flux_total_")
-                ]
-            ]
         inversion_grid_flux_outs = (
             inversion_grid_flux_outs_raw.rename(dim_rename_dict)
             .pipe(_assign_flux_time_bounds, flux_frequency, inv_out.start_time, inv_out.end_time)
@@ -1124,17 +1367,32 @@ def paris_flux_output_latest(
         )
         result = result.merge(inversion_grid_flux_outs)
 
-    result = result.transpose("time", "percentile", "country", "latitude", "longitude", "nbnds").as_numpy()
+    result = result.transpose(
+        "time",
+        "percentile",
+        "country",
+        "sector",
+        "latitude",
+        "longitude",
+        "nbnds",
+        missing_dims="ignore",
+    ).as_numpy()
     result = _add_country_covariance(
         result,
         country_covariance,
         emissions_attrs.get("covariance_flux_total_posterior_country", {}),
     )
+    result = _add_sector_country_covariances(
+        result,
+        sector_covariances,
+        sector_cross_covariance,
+        emissions_attrs,
+    )
     result.attrs = make_global_attrs("flux", species=species, domain=domain)
     result.attrs["paris_flux_template_version"] = template_files.flux_version
     result = copy_flux_nonfinite_attrs(result, flux_outs)
 
-    result = _cast_data_vars_to_template_dtypes(result, template_files.flux)
+    result = _cast_data_vars_to_template_dtypes(result, template_files.flux, sector_names=sector_names)
     return add_basis_reconstruction_metadata(result, inv_out.basis_functions)
 
 

--- a/openghg_inversions/postprocessing/make_paris_outputs.py
+++ b/openghg_inversions/postprocessing/make_paris_outputs.py
@@ -12,8 +12,7 @@ import pandas as pd
 import xarray as xr
 
 from openghg.util import timestamp_now  # pyright: ignore[reportPrivateImportUsage]
-from openghg_inversions import convert
-from openghg_inversions.array_ops import align_sparse_lat_lon, sparse_xr_dot
+from openghg_inversions.array_ops import align_sparse_lat_lon
 from openghg_inversions.config.version import code_version
 from openghg_inversions.flux_sanitization import copy_flux_nonfinite_attrs
 from openghg_inversions.postprocessing._basis_products import add_basis_reconstruction_metadata
@@ -24,6 +23,7 @@ from openghg_inversions.postprocessing.make_outputs import (
     make_concentration_outputs,
     make_flux_outputs,
     make_country_outputs,
+    make_multisector_country_trace_outputs,
     make_multisector_flux_trace_outputs,
     observation_and_error_outputs,
 )
@@ -854,101 +854,155 @@ def _convert_flux_time_and_bounds_to_epoch_days(ds: xr.Dataset) -> xr.Dataset:
     return result
 
 
-def _latest_paris_countries(country_file: str | Path | None, domain: str) -> Countries:
-    """Return country metadata for the latest PARIS CDL country list."""
+def _latest_paris_countries(
+    country_file: str | Path | None,
+    domain: str,
+    country_selections: Iterable[str] | None,
+) -> Countries:
+    """Return country metadata for a latest-template PARIS output.
+
+    Args:
+        country_file: Optional country-definition file for the inversion domain.
+        domain: Inversion domain used to resolve a default country file.
+        country_selections: Optional country names or codes to include. ``None``
+            preserves all countries and their order from the selected country
+            file, allowing the PARIS format to be used outside Europe.
+
+    Returns:
+        Country masks and area grid using alpha-3 labels. Explicit selections
+        are ordered as requested.
+    """
     countries = Countries.from_file(
         country_file=country_file,
         country_code="alpha3",
-        country_selections=list(PARIS_LATEST_COUNTRIES),
         domain=domain,
     )
-    countries.matrix = countries.matrix.reindex(country=list(PARIS_LATEST_COUNTRIES))
+    if country_selections is not None:
+        selections = countries.country_labels.select_by_country_info(country_selections)
+        countries.matrix = countries.matrix.sel(country=list(selections))
+        countries.country_selections = selections
     return countries
 
 
 def _multisector_country_trace_kg(
     inv_out: InversionOutput,
     countries: Countries,
-    species: str,
     sector_name_by_suffix: Mapping[str, str],
-    flux_trace: xr.Dataset | None = None,
 ) -> xr.Dataset:
-    """Reconstruct once and lazily reduce total and sector flux traces to countries."""
-    if flux_trace is None:
-        flux_trace = make_multisector_flux_trace_outputs(
-            inv_out,
-            report_flux_on_inversion_grid=False,
-            materialize=False,
-        )
+    """Return PARIS-labelled multisector country traces in kilograms per year.
+
+    Args:
+        inv_out: Multisector inversion output containing retained sector basis
+            functions and scaling traces.
+        countries: Country masks and cell areas used to project basis regions
+            directly to country totals.
+        sector_name_by_suffix: Mapping from each RHIME trace-variable suffix to
+            its normalized PARIS sector name. For example, ``{"total_ff":
+            "totalff"}`` maps ``country_total_ff_posterior`` to
+            ``country_totalff_posterior`` without confusing it with the summed
+            total variable.
+
+    Returns:
+        Lazy or sparse-compatible total and per-sector country traces with
+        dimensions ``(country, flux_time, draw)`` and units of kg yr-1. Summed
+        variables use ``country_prior`` and ``country_posterior``; sector
+        variables use ``country_<sector>_<when>``.
+
+    Raises:
+        ValueError: If required multisector metadata is missing or retained
+            basis, flux, and country grids cannot be aligned.
+    """
+    country_trace = make_multisector_country_trace_outputs(inv_out, countries) * 1e-3
     rename = {
-        "flux_total_prior": "country_prior",
-        "flux_total_posterior": "country_posterior",
+        "country_total_prior": "country_prior",
+        "country_total_posterior": "country_posterior",
     }
     for variable_suffix, sector_name in sector_name_by_suffix.items():
         for when in ("prior", "posterior"):
-            source_name = f"flux_{variable_suffix}_{when}"
-            if source_name in flux_trace:
+            source_name = f"country_{variable_suffix}_{when}"
+            if source_name in country_trace:
                 rename[source_name] = f"country_{sector_name}_{when}"
 
-    selected_flux_trace = flux_trace[list(rename)].rename(rename)
-    country_weights = countries.matrix * countries.area_grid
-    reference_flux = selected_flux_trace["country_posterior"]
-    country_weights = align_sparse_lat_lon(country_weights, reference_flux)
-    country_trace = sparse_xr_dot(country_weights, selected_flux_trace, dim=["lat", "lon"])
-    country_trace = country_trace * 365 * 24 * 3600 * convert.molar_mass(species) * 1e-3
-    return country_trace.reindex(country=list(PARIS_LATEST_COUNTRIES))
+    result = country_trace[list(rename)].rename(rename)
+    for name in result.data_vars:
+        result[name].attrs["units"] = "kg/yr"
+    return result
 
 
 def _latest_country_outputs(
     inv_out: InversionOutput,
     countries: Countries,
-    species: str,
     stats: list[str],
     stats_args: dict[str, Any],
-    country_file: str | Path | None,
     sector_name_by_suffix: Mapping[str, str] | None = None,
     multisector_country_trace: xr.Dataset | None = None,
 ) -> xr.Dataset:
-    """Return latest PARIS country statistics for single- or multisector outputs."""
+    """Return latest PARIS country statistics for single- or multisector outputs.
+
+    Args:
+        inv_out: Single- or multisector inversion output.
+        countries: Country masks and cell areas used for country projection.
+        stats: Statistics to calculate from the country traces.
+        stats_args: Additional arguments passed to ``calculate_stats``.
+        sector_name_by_suffix: Optional mapping from RHIME sector suffixes to
+            normalized PARIS sector names.
+        multisector_country_trace: Optional precomputed multisector country
+            trace in kilograms per year.
+
+    Returns:
+        Country statistics in kilograms per year, with ``country`` and
+        ``flux_time`` dimensions and total plus per-sector variables where
+        applicable.
+    """
     if inv_out.is_multisector:
         country_trace = multisector_country_trace
         if country_trace is None:
             country_trace = _multisector_country_trace_kg(
                 inv_out,
                 countries,
-                species,
                 sector_name_by_suffix or _paris_sector_name_by_suffix(inv_out),
             )
         country_stats_args = dict(stats_args)
         country_stats_args["stats"] = stats
         return calculate_stats(country_trace, **country_stats_args)
 
-    country_outs = make_country_outputs(
-        inv_out,
-        country_file=country_file,
-        country_selections=list(PARIS_LATEST_COUNTRIES),
-        stats=stats,
-        stats_args=stats_args,
-        country_code="alpha3",
-    )
-    return (country_outs * 1e-3).reindex(country=list(PARIS_LATEST_COUNTRIES))
+    country_trace = countries.get_country_trace(inv_out=inv_out) * 1e-3
+    country_stats_args = dict(stats_args)
+    country_stats_args["stats"] = stats
+    return calculate_stats(country_trace, **country_stats_args)
 
 
 def _country_posterior_covariance_kg(
     inv_out: InversionOutput,
     countries: Countries,
-    species: str,
     flux_frequency: Literal["monthly", "yearly"] | str,
     multisector_country_trace: xr.Dataset | None = None,
 ) -> np.ndarray:
-    """Return posterior country-total covariance in kg2 yr-2."""
+    """Calculate total posterior covariance between countries.
+
+    This calculation applies to both single-sector and multisector outputs. In
+    the single-sector case, country totals are mapped directly from basis-region
+    scaling traces by ``Countries.get_country_trace``. Multisector callers can
+    supply the already projected and summed country trace to avoid repeating
+    that work.
+
+    Args:
+        inv_out: Single- or multisector inversion output.
+        countries: Country masks and cell areas used for the country projection.
+        flux_frequency: Frequency used to select output flux intervals.
+        multisector_country_trace: Optional precomputed multisector country trace
+            in kilograms per year.
+
+    Returns:
+        Population covariance for each flux interval with dimensions ordered as
+        time, first country, and second country, in kg2 yr-2.
+    """
     if inv_out.is_multisector:
         country_trace = multisector_country_trace
         if country_trace is None:
             country_trace = _multisector_country_trace_kg(
                 inv_out,
                 countries,
-                species,
                 _paris_sector_name_by_suffix(inv_out),
             )
         posterior = country_trace["country_posterior"]
@@ -976,12 +1030,28 @@ def _country_posterior_covariance_kg(
 def _sector_country_posterior_covariances_kg(
     inv_out: InversionOutput,
     countries: Countries,
-    species: str,
     flux_frequency: Literal["monthly", "yearly"] | str,
     sector_name_by_suffix: Mapping[str, str],
     multisector_country_trace: xr.Dataset | None = None,
 ) -> tuple[dict[str, np.ndarray], np.ndarray | None]:
-    """Return within-sector and between-sector posterior country covariances."""
+    """Calculate within-sector and between-sector country covariances.
+
+    Args:
+        inv_out: Multisector inversion output.
+        countries: Country masks and cell areas used for country projection.
+        flux_frequency: Frequency used to select output flux intervals.
+        sector_name_by_suffix: Mapping from RHIME trace suffixes to normalized
+            PARIS sector names.
+        multisector_country_trace: Optional precomputed total and sector country
+            traces in kilograms per year.
+
+    Returns:
+        A mapping of sector name to population covariance arrays with shape
+        ``(flux_time, country, country)`` and an array of covariance between
+        sectors within each country with shape
+        ``(flux_time, country, sector, sector)``. Both are in kg2 yr-2. The
+        second result is ``None`` when no sectors are supplied.
+    """
     if not sector_name_by_suffix:
         return {}, None
 
@@ -990,7 +1060,6 @@ def _sector_country_posterior_covariances_kg(
         sector_trace = _multisector_country_trace_kg(
             inv_out,
             countries,
-            species,
             sector_name_by_suffix,
         )
     sector_names = list(sector_name_by_suffix.values())
@@ -1091,11 +1160,38 @@ def paris_flux_output(
     inversion_grid: bool = True,
     flux_frequency: Literal["monthly", "yearly"] | str = "yearly",
     template_version: ParisTemplateVersion = DEFAULT_PARIS_TEMPLATE_VERSION,
+    country_selections: Iterable[str] | None = PARIS_LATEST_COUNTRIES,
 ) -> xr.Dataset:
+    """Create a flux product using a selected PARIS template version.
+
+    Args:
+        inv_out: Inversion output with retained basis functions and flux traces.
+        country_file: Optional country-definition NetCDF file.
+        time_point: Flux timestamp convention.
+        report_mode: If true, report KDE modes instead of means as central
+            estimates.
+        inversion_grid: If true, include reduced inversion-grid variables.
+        flux_frequency: Frequency used to construct output flux intervals.
+        template_version: PARIS template version to emit. The default preserves
+            the legacy output contract; ``"latest"`` selects flux v03.
+        country_selections: Optional country names or codes for the latest
+            template. The default emits the canonical 22-country EUROPE v03
+            schema; pass ``None`` to include all countries from another domain
+            file. The legacy template ignores this option.
+
+    Returns:
+        PARIS flux dataset using the selected template's variable names,
+        dimensions, dtypes, units, and attributes.
+
+    Raises:
+        ValueError: If required inversion metadata is missing or a latest-only
+            time or frequency option is invalid.
+    """
     if template_version == "latest":
         return paris_flux_output_latest(
             inv_out,
             country_file=country_file,
+            country_selections=country_selections,
             time_point=time_point,
             report_mode=report_mode,
             inversion_grid=inversion_grid,
@@ -1222,6 +1318,7 @@ def paris_flux_output_latest(
     report_mode: bool = False,
     inversion_grid: bool = True,
     flux_frequency: Literal["monthly", "yearly"] | str = "yearly",
+    country_selections: Iterable[str] | None = PARIS_LATEST_COUNTRIES,
 ) -> xr.Dataset:
     """Create single- or multisector flux output using the latest PARIS template.
 
@@ -1244,6 +1341,9 @@ def paris_flux_output_latest(
             variables.
         flux_frequency: Frequency used to construct output intervals. Supported
             values are ``"monthly"`` and ``"yearly"``.
+        country_selections: Optional country names or codes to include. The
+            default emits the canonical 22-country EUROPE v03 product; pass
+            ``None`` to include every country from another domain file.
 
     Returns:
         Latest-template PARIS flux dataset with template dtypes and attributes.
@@ -1282,14 +1382,16 @@ def paris_flux_output_latest(
             include_scale_factors=False,
         )
     )
-    countries = _latest_paris_countries(country_file=country_file, domain=domain)
+    countries = _latest_paris_countries(
+        country_file=country_file,
+        domain=domain,
+        country_selections=country_selections,
+    )
     multisector_country_trace = (
         _multisector_country_trace_kg(
             inv_out,
             countries,
-            species,
             sector_name_by_suffix,
-            flux_trace=spatial_flux_trace,
         )
         if inv_out.is_multisector
         else None
@@ -1297,10 +1399,8 @@ def paris_flux_output_latest(
     country_outs = _latest_country_outputs(
         inv_out,
         countries=countries,
-        species=species,
         stats=stats,
         stats_args=stats_args,
-        country_file=country_file,
         sector_name_by_suffix=sector_name_by_suffix,
         multisector_country_trace=multisector_country_trace,
     )
@@ -1309,7 +1409,6 @@ def paris_flux_output_latest(
     country_covariance = _country_posterior_covariance_kg(
         inv_out,
         countries=countries,
-        species=species,
         flux_frequency=flux_frequency,
         multisector_country_trace=multisector_country_trace,
     )
@@ -1317,7 +1416,6 @@ def paris_flux_output_latest(
         _sector_country_posterior_covariances_kg(
             inv_out,
             countries=countries,
-            species=species,
             flux_frequency=flux_frequency,
             sector_name_by_suffix=sector_name_by_suffix,
             multisector_country_trace=multisector_country_trace,
@@ -1526,7 +1624,34 @@ def make_paris_outputs(
     obs_avg_period: str = "4h",
     domain: str | None = None,
     template_version: ParisTemplateVersion = DEFAULT_PARIS_TEMPLATE_VERSION,
+    country_selections: Iterable[str] | None = PARIS_LATEST_COUNTRIES,
 ) -> tuple[xr.Dataset, xr.Dataset]:
+    """Create matching PARIS flux and concentration products.
+
+    Args:
+        inv_out: Inversion output containing observations, model traces,
+            retained basis functions, and prior fluxes.
+        country_file: Optional country-definition NetCDF file.
+        time_point: Flux timestamp convention.
+        report_mode: If true, report KDE modes instead of means as central
+            estimates.
+        inversion_grid: If true, include reduced inversion-grid flux variables.
+        obs_avg_period: Averaging period recorded in concentration metadata.
+        domain: Optional domain override for concentration metadata.
+        template_version: PARIS template version to emit. ``"latest"`` selects
+            concentration v04 and flux v03.
+        country_selections: Optional latest-template country names or codes.
+            The default emits the canonical 22-country EUROPE v03 schema; pass
+            ``None`` to include all countries from another domain file.
+
+    Returns:
+        A tuple containing the flux dataset followed by the concentration
+        dataset.
+
+    Raises:
+        ValueError: If required inversion metadata is missing or template
+            constraints are not satisfied.
+    """
     # infer flux frequency
     flux_frequency = infer_flux_frequency(inv_out.flux)
     conc_outs = paris_concentration_outputs(
@@ -1539,6 +1664,7 @@ def make_paris_outputs(
         inv_out,
         report_mode=report_mode,
         country_file=country_file,
+        country_selections=country_selections,
         inversion_grid=inversion_grid,
         time_point=time_point,
         flux_frequency=flux_frequency,

--- a/openghg_inversions/postprocessing/stats.py
+++ b/openghg_inversions/postprocessing/stats.py
@@ -8,6 +8,7 @@ NetCDF serialisation.
 
 from collections import namedtuple
 from collections.abc import Callable, Iterable, Sequence
+from typing import cast
 
 import arviz as az
 import numpy as np
@@ -51,6 +52,13 @@ def _to_dense_dataset(ds: xr.Dataset) -> xr.Dataset:
     )
 
 
+def _consolidate_sample_dimension(ds: xr.Dataset, sample_dim: str) -> xr.Dataset:
+    """Rechunk a Dask-backed sample dimension into a single core chunk."""
+    if any(data.chunks is not None and sample_dim in data.dims for data in ds.data_vars.values()):
+        return ds.chunk({sample_dim: -1})
+    return ds
+
+
 @register_stat
 @add_suffix("quantile")
 @update_attrs("quantile_of")
@@ -73,7 +81,7 @@ def quantiles(
         xr.Dataset of specified quantiles, with a new `quantile` dimension.
 
     """
-    ds = _to_dense_dataset(ds)
+    ds = _consolidate_sample_dimension(_to_dense_dataset(ds), sample_dim)
     # cast to float32 since quantiles involve interpolation, and this always converts to
     # float64 in numpy and scipy interpolation routines
     return ds.quantile(q=quantiles, dim=sample_dim).astype("float32")
@@ -82,14 +90,22 @@ def quantiles(
 @register_stat
 @add_suffix("mode")
 @update_attrs("mode_of")
-def mode(ds: xr.Dataset, sample_dim="draw", thin: int = 1):
-    """Approximate the mode by the midpoint of the shorted interval containing k samples.
+def mode(ds: xr.Dataset, sample_dim: str = "draw", thin: int = 1) -> xr.Dataset:
+    """Approximate the mode using the shortest interval containing ``k`` samples.
 
     The slowest step is sorting. Still, this is over 30x faster than computing the KDE.
     (Unless you parallelise the KDE version by chunking the input.)
 
     Thinning by some integer factor will produce a corresponding speed up. For instance,
     if `thin = 2` is passed, then the running time will be roughly half.
+
+    Args:
+        ds: Dataset containing samples.
+        sample_dim: Dimension containing the samples.
+        thin: Integer stride used to thin samples before estimating the mode.
+
+    Returns:
+        Dataset containing the approximate mode for each input variable.
     """
 
     def mode_of_arr(arr, k):
@@ -104,8 +120,15 @@ def mode(ds: xr.Dataset, sample_dim="draw", thin: int = 1):
     else:
         k = int(ds.sizes[sample_dim] ** 0.8)  # k = (# draws)^{4/5}
 
-    ds = _to_dense_dataset(ds)
-    return xr.apply_ufunc(mode_of_arr, ds, input_core_dims=[[sample_dim]], kwargs={"k": k})
+    ds = _consolidate_sample_dimension(_to_dense_dataset(ds), sample_dim)
+    return xr.apply_ufunc(
+        mode_of_arr,
+        ds,
+        input_core_dims=[[sample_dim]],
+        kwargs={"k": k},
+        dask="parallelized",
+        output_dtypes=[float],
+    )
 
 
 @register_stat
@@ -113,7 +136,7 @@ def mode(ds: xr.Dataset, sample_dim="draw", thin: int = 1):
 @update_attrs("mode_of")
 def mode_kde(
     ds: xr.Dataset,
-    sample_dim="draw",
+    sample_dim: str = "draw",
     chunk_dim: str | None = None,
     chunk_size: int = 10,
 ) -> xr.Dataset:
@@ -121,6 +144,15 @@ def mode_kde(
 
     This can be parallelized if you chunk the DataArray first, e.g.
     >>> da_chunked = da.chunk({"basis_region": 10})
+
+    Args:
+        ds: Dataset containing samples.
+        sample_dim: Dimension containing the samples.
+        chunk_dim: Optional non-sample dimension to chunk for parallel execution.
+        chunk_size: Chunk size to use along ``chunk_dim``.
+
+    Returns:
+        Dataset containing the KDE-smoothed mode for each input variable.
     """
 
     def mode_of_row(row):
@@ -143,8 +175,8 @@ def mode_kde(
             return np.full(arr.shape[:-1], np.nan, dtype=float)
         return np.apply_along_axis(func1d=mode_of_row, axis=-1, arr=arr)
 
-    ds = _to_dense_dataset(ds)
-    if chunk_dim is not None:
+    ds = _consolidate_sample_dimension(_to_dense_dataset(ds), sample_dim)
+    if chunk_dim is not None and chunk_dim != sample_dim:
         return xr.apply_ufunc(
             func,
             ds.chunk({chunk_dim: chunk_size}),
@@ -166,9 +198,18 @@ def hdi(
     ds: xr.Dataset,
     hdi_prob: float | Iterable[float] = 0.68,
     sample_dim: str = "draw",
-):
-    """Compute highest density interval with the given probabilities."""
-    ds = _to_dense_dataset(ds)
+) -> xr.Dataset:
+    """Compute highest density intervals with the given probabilities.
+
+    Args:
+        ds: Dataset containing samples.
+        hdi_prob: Probability or probabilities contained by each interval.
+        sample_dim: Dimension containing the samples.
+
+    Returns:
+        Dataset containing the highest density interval bounds.
+    """
+    ds = _consolidate_sample_dimension(_to_dense_dataset(ds), sample_dim)
     # handle case of multiple hdi_probs
     if isinstance(hdi_prob, Iterable):
         return xr.merge([hdi(ds, hdi_prob=prob, sample_dim=sample_dim) for prob in hdi_prob])
@@ -176,14 +217,18 @@ def hdi(
     # wrap here to get hdi prob in suffix
     @add_suffix(f"hdi_{int(100 * hdi_prob)}")
     @update_attrs(f"hdi_{int(100 * hdi_prob)}_of")
-    def calc(data, hdi_prob):
-        return az.hdi(data, hdi_prob=hdi_prob)
+    def calc(data: xr.Dataset, probability: float) -> xr.Dataset:
+        """Call ArviZ and narrow its union return type for Dataset input."""
+        return cast(xr.Dataset, az.hdi(data, hdi_prob=probability))
 
     if "chain" not in ds.dims:
         ds = ds.expand_dims({"chain": [0]})
 
     if sample_dim != "draw":
         ds = ds.rename({sample_dim: "draw"})
+
+    if any(data.chunks is not None for data in ds.data_vars.values()):
+        ds = ds.compute()
 
     return calc(ds, hdi_prob)
 
@@ -207,9 +252,17 @@ def mean(ds: xr.Dataset, sample_dim="draw"):
 @register_stat
 @add_suffix("median")
 @update_attrs("median_of")
-def median(ds: xr.Dataset, sample_dim="draw"):
-    """Compute sample median."""
-    ds = _to_dense_dataset(ds)
+def median(ds: xr.Dataset, sample_dim: str = "draw") -> xr.Dataset:
+    """Compute the median along the sample dimension.
+
+    Args:
+        ds: Dataset containing samples.
+        sample_dim: Dimension containing the samples.
+
+    Returns:
+        Dataset containing the median for each input variable.
+    """
+    ds = _consolidate_sample_dimension(_to_dense_dataset(ds), sample_dim)
     return ds.median(dim=sample_dim)
 
 

--- a/openghg_inversions/postprocessing/stats.py
+++ b/openghg_inversions/postprocessing/stats.py
@@ -1,4 +1,10 @@
-"""Functions for computing statistics on datasets."""
+"""Functions for computing statistics on datasets.
+
+Statistics that call ``_to_dense_dataset`` need dense-compatible chunks for the
+operation itself. Statistics that can operate on sparse-backed arrays should not
+densify their inputs here; product code can still densify final outputs before
+NetCDF serialisation.
+"""
 
 from collections import namedtuple
 from collections.abc import Callable, Iterable, Sequence
@@ -8,6 +14,7 @@ import numpy as np
 import scipy
 import xarray as xr
 
+from openghg_inversions.array_ops import to_dense
 from openghg_inversions.postprocessing.utils import add_suffix, get_parameters, update_attrs
 
 StatsFunction = namedtuple("StatsFunction", ["name", "func", "params"])
@@ -35,11 +42,22 @@ def register_stat(stat: Callable) -> Callable:
     return stat
 
 
+def _to_dense_dataset(ds: xr.Dataset) -> xr.Dataset:
+    """Convert sparse-backed variables to dense chunks when a statistic cannot handle sparse arrays."""
+    return xr.Dataset(
+        {name: to_dense(data) for name, data in ds.data_vars.items()},
+        coords=ds.coords,
+        attrs=ds.attrs,
+    )
+
+
 @register_stat
 @add_suffix("quantile")
 @update_attrs("quantile_of")
 def quantiles(
-    ds: xr.Dataset, quantiles: Sequence[float] = [0.159, 0.841], sample_dim: str = "draw"
+    ds: xr.Dataset,
+    quantiles: Sequence[float] = [0.159, 0.841],
+    sample_dim: str = "draw",
 ) -> xr.Dataset:
     """Compute quantiles.
 
@@ -55,6 +73,7 @@ def quantiles(
         xr.Dataset of specified quantiles, with a new `quantile` dimension.
 
     """
+    ds = _to_dense_dataset(ds)
     # cast to float32 since quantiles involve interpolation, and this always converts to
     # float64 in numpy and scipy interpolation routines
     return ds.quantile(q=quantiles, dim=sample_dim).astype("float32")
@@ -85,6 +104,7 @@ def mode(ds: xr.Dataset, sample_dim="draw", thin: int = 1):
     else:
         k = int(ds.sizes[sample_dim] ** 0.8)  # k = (# draws)^{4/5}
 
+    ds = _to_dense_dataset(ds)
     return xr.apply_ufunc(mode_of_arr, ds, input_core_dims=[[sample_dim]], kwargs={"k": k})
 
 
@@ -92,7 +112,10 @@ def mode(ds: xr.Dataset, sample_dim="draw", thin: int = 1):
 @add_suffix("mode")
 @update_attrs("mode_of")
 def mode_kde(
-    ds: xr.Dataset, sample_dim="draw", chunk_dim: str | None = None, chunk_size: int = 10
+    ds: xr.Dataset,
+    sample_dim="draw",
+    chunk_dim: str | None = None,
+    chunk_size: int = 10,
 ) -> xr.Dataset:
     """Calculate the (KDE smoothed) mode of a data array containing MCMC samples.
 
@@ -120,6 +143,7 @@ def mode_kde(
             return np.full(arr.shape[:-1], np.nan, dtype=float)
         return np.apply_along_axis(func1d=mode_of_row, axis=-1, arr=arr)
 
+    ds = _to_dense_dataset(ds)
     if chunk_dim is not None:
         return xr.apply_ufunc(
             func,
@@ -138,8 +162,13 @@ def mode_kde(
 
 
 @register_stat
-def hdi(ds: xr.Dataset, hdi_prob: float | Iterable[float] = 0.68, sample_dim: str = "draw"):
+def hdi(
+    ds: xr.Dataset,
+    hdi_prob: float | Iterable[float] = 0.68,
+    sample_dim: str = "draw",
+):
     """Compute highest density interval with the given probabilities."""
+    ds = _to_dense_dataset(ds)
     # handle case of multiple hdi_probs
     if isinstance(hdi_prob, Iterable):
         return xr.merge([hdi(ds, hdi_prob=prob, sample_dim=sample_dim) for prob in hdi_prob])
@@ -180,6 +209,7 @@ def mean(ds: xr.Dataset, sample_dim="draw"):
 @update_attrs("median_of")
 def median(ds: xr.Dataset, sample_dim="draw"):
     """Compute sample median."""
+    ds = _to_dense_dataset(ds)
     return ds.median(dim=sample_dim)
 
 

--- a/openghg_inversions/rhime/outputs.py
+++ b/openghg_inversions/rhime/outputs.py
@@ -18,7 +18,7 @@ from openghg_inversions.postprocessing.inversion_output import (
 )
 from openghg_inversions.rhime.sampling import RhimeSampler
 from openghg_inversions.rhime.specs import OutputFilenameConvention, RhimeOutputSpec, RhimeRunSpec
-from openghg_inversions.utils import ncdf_encoding
+from openghg_inversions.utils import ncdf_encoding, write_netcdf_preserving_bounds_attrs
 
 
 @dataclass(frozen=True)
@@ -257,13 +257,9 @@ def make_standard_output_bundle(
                 ext=".nc",
             )
             with timed("rhime.output.paris_concentration_netcdf_write", path=conc_file):
-                conc_outs.to_netcdf(
-                    conc_file, unlimited_dims=["time"], mode="w", encoding=ncdf_encoding(conc_outs)
-                )
+                write_netcdf_preserving_bounds_attrs(conc_outs, conc_file, unlimited_dims=["time"])
             with timed("rhime.output.paris_flux_netcdf_write", path=flux_file):
-                flux_outs.to_netcdf(
-                    flux_file, unlimited_dims=["time"], mode="w", encoding=ncdf_encoding(flux_outs)
-                )
+                write_netcdf_preserving_bounds_attrs(flux_outs, flux_file, unlimited_dims=["time"])
             output_metadata["paris_concentration_path"] = str(conc_file)
             output_metadata["paris_flux_path"] = str(flux_file)
     elif output_spec.output_format == "legacy":
@@ -363,6 +359,9 @@ def make_multisector_output_bundle(
             time_point = paris_kwargs.pop("time_point", "midpoint")
             report_mode = paris_kwargs.pop("report_mode", False)
             inversion_grid = paris_kwargs.pop("inversion_grid", True)
+            country_selection_kwargs = {}
+            if "country_selections" in paris_kwargs:
+                country_selection_kwargs["country_selections"] = paris_kwargs.pop("country_selections")
             if paris_kwargs:
                 unexpected = ", ".join(sorted(paris_kwargs))
                 raise ValueError(
@@ -381,6 +380,7 @@ def make_multisector_output_bundle(
                 inversion_grid=inversion_grid,
                 flux_frequency=flux_frequency,
                 template_version="latest",
+                **country_selection_kwargs,
             )
             outputs["paris_flux"] = flux_outs
 
@@ -394,12 +394,7 @@ def make_multisector_output_bundle(
                     run_spec.start_date,
                     ext=".nc",
                 )
-                flux_outs.to_netcdf(
-                    flux_file,
-                    unlimited_dims=["time"],
-                    mode="w",
-                    encoding=ncdf_encoding(flux_outs),
-                )
+                write_netcdf_preserving_bounds_attrs(flux_outs, flux_file, unlimited_dims=["time"])
                 output_metadata["paris_flux_path"] = str(flux_file)
         else:
             output_metadata["paris_note"] = (

--- a/openghg_inversions/utils.py
+++ b/openghg_inversions/utils.py
@@ -11,7 +11,7 @@ Many functions in this submodule originated in the ACRG code base (in `acrg.name
 import re
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Literal
+from typing import Any, Literal
 
 import numpy as np
 import pandas as pd
@@ -160,6 +160,51 @@ def ncdf_encoding(ds_in: xr.Dataset) -> dict:
     }
 
     return encoding
+
+
+def write_netcdf_preserving_bounds_attrs(
+    ds: xr.Dataset,
+    path: str | Path,
+    *,
+    unlimited_dims: list[str] | None = None,
+) -> None:
+    """Write a compressed NetCDF while preserving explicit bounds metadata.
+
+    Xarray's CF encoder removes ``units`` and ``calendar`` from a bounds
+    variable when those attributes match its coordinate. Some external schemas,
+    including the latest PARIS CDL templates, require the attributes on both
+    variables, so they are appended after the normal write. The initial write
+    overwrites ``path``; backend and filesystem exceptions propagate.
+
+    Args:
+        ds: Dataset carrying the required bounds attributes.
+        path: Destination NetCDF path.
+        unlimited_dims: Optional dimensions to encode as unlimited.
+    """
+    ds.to_netcdf(
+        path,
+        unlimited_dims=unlimited_dims,
+        mode="w",
+        encoding=ncdf_encoding(ds),
+    )
+
+    bounds_attrs: dict[str, dict[str, Any]] = {}
+    for variable in ds.variables.values():
+        bounds_name = variable.attrs.get("bounds")
+        if not isinstance(bounds_name, str) or bounds_name not in ds:
+            continue
+        attrs = {
+            name: ds[bounds_name].attrs[name]
+            for name in ("units", "calendar")
+            if name in ds[bounds_name].attrs
+        }
+        if attrs:
+            bounds_attrs[bounds_name] = attrs
+
+    for bounds_name, attrs in bounds_attrs.items():
+        bounds = ds[bounds_name]
+        metadata_patch = xr.Dataset({bounds_name: (bounds.dims, bounds.data, attrs)})
+        metadata_patch.to_netcdf(path, mode="a")
 
 
 def get_country_file_path(country_file: str | Path | None = None, domain: str | None = None):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,10 +8,12 @@ import shutil
 import tempfile
 import time
 from importlib.metadata import version
-from typing import Iterator
+from typing import Callable, Iterator
 from types import MappingProxyType
 from unittest.mock import patch
 
+import arviz as az
+import numpy as np
 import pytest
 from openghg.standardise import (
     standardise_surface,
@@ -22,6 +24,9 @@ from openghg.standardise import (
 )
 import xarray as xr
 import zarr
+
+from openghg_inversions.basis.basis_functions import BASIS_ARTIFACT_SOURCE_ATTR, BasisFunctions
+from openghg_inversions.postprocessing.inversion_output import InversionOutput
 
 _raw_data_path = Path(".").resolve() / "tests/data/"
 _TEST_STORE_DIR_NAME = "openghg_inversions_testing_store"
@@ -84,6 +89,176 @@ def merged_data_file_name():
 def europe_country_file(raw_data_path):
     """Provides path to the EUROPE countryfile"""
     return raw_data_path / "country_EUROPE.nc"
+
+
+@pytest.fixture
+def fake_multisector_basis_functions() -> Callable[..., BasisFunctions]:
+    """Provide a builder for a one-cell basis artifact with sector prior fluxes."""
+
+    def _build(*, artifact_source: str = "generated") -> BasisFunctions:
+        """Build a one-cell basis artifact with source-specific prior flux."""
+        basis = xr.DataArray(
+            [[1]],
+            dims=("lat", "lon"),
+            coords={"lat": [0.0], "lon": [0.0]},
+            name="basis",
+        )
+        flux = xr.DataArray(
+            [[[1.0]], [[3.0]]],
+            dims=("source", "lat", "lon"),
+            coords={
+                "source": ["ff-inventory", "ocean-inventory"],
+                "lat": [0.0],
+                "lon": [0.0],
+            },
+            name="flux",
+        )
+        flux.attrs["units"] = "mol/m2/s"
+        return BasisFunctions.from_flat_basis(
+            basis_flat=basis,
+            flux=flux,
+            operator_kwargs={"state_dim": "region"},
+            metadata={BASIS_ARTIFACT_SOURCE_ATTR: artifact_source},
+        )
+
+    return _build
+
+
+@pytest.fixture
+def fake_multisector_basis_functions_matching_country_grid() -> Callable[..., BasisFunctions]:
+    """Provide a builder for a multisector basis artifact on a country grid."""
+
+    def _build(country_file: Path, *, coord_offset: float = 0.0) -> BasisFunctions:
+        """Build a one-region multisector basis artifact on a test country grid."""
+        country_grid = xr.open_dataset(country_file)
+        lat = country_grid.lat.values + coord_offset
+        lon = country_grid.lon.values + coord_offset
+        basis = xr.DataArray(
+            np.ones((country_grid.sizes["lat"], country_grid.sizes["lon"]), dtype=int),
+            dims=("lat", "lon"),
+            coords={"lat": lat, "lon": lon},
+            name="basis",
+        )
+        flux = xr.concat(
+            [
+                xr.ones_like(basis, dtype=float).expand_dims(source=["ff-inventory"]),
+                (3.0 * xr.ones_like(basis, dtype=float)).expand_dims(source=["ocean-inventory"]),
+            ],
+            dim="source",
+        ).rename("flux")
+        flux.attrs["units"] = "mol/m2/s"
+        return BasisFunctions.from_flat_basis(
+            basis_flat=basis,
+            flux=flux,
+            operator_kwargs={"state_dim": "region"},
+            metadata={BASIS_ARTIFACT_SOURCE_ATTR: "country-grid-multisector-test"},
+        )
+
+    return _build
+
+
+@pytest.fixture
+def fake_source_specific_multisector_basis_functions() -> Callable[..., BasisFunctions]:
+    """Provide a builder for source-specific multisector basis artifacts."""
+
+    def _build(*, artifact_source: str = "generated") -> BasisFunctions:
+        """Build a one-cell source-specific basis artifact for multisector tests."""
+        basis = xr.DataArray(
+            [[1]],
+            dims=("lat", "lon"),
+            coords={"lat": [0.0], "lon": [0.0]},
+            name="basis",
+        )
+        flux = xr.DataArray(
+            [[[1.0]], [[3.0]]],
+            dims=("source", "lat", "lon"),
+            coords={
+                "source": ["ff-inventory", "ocean-inventory"],
+                "lat": [0.0],
+                "lon": [0.0],
+            },
+            name="flux",
+        )
+        flux.attrs["units"] = "mol/m2/s"
+        return BasisFunctions.from_multi_source_flat_basis(
+            basis_flat={"ff-inventory": basis, "ocean-inventory": basis},
+            flux=flux,
+            operator_kwargs={"state_dim": "region"},
+            metadata={BASIS_ARTIFACT_SOURCE_ATTR: artifact_source},
+        )
+
+    return _build
+
+
+@pytest.fixture
+def multisector_postprocessing_inv_out(
+    fake_multisector_basis_functions: Callable[..., BasisFunctions],
+) -> Callable[[BasisFunctions | None], InversionOutput]:
+    """Provide a builder for small multisector postprocessing outputs."""
+
+    def _build(basis_functions: BasisFunctions | None = None) -> InversionOutput:
+        """Build a small multisector output for flux reconstruction tests."""
+        inv_inputs = xr.Dataset(
+            {
+                "H": (("region", "nmeasure"), [[1.0]]),
+                "mf": ("nmeasure", [10.0]),
+                "mf_error": ("nmeasure", [1.0]),
+                "mf_repeatability": ("nmeasure", [0.5]),
+                "mf_variability": ("nmeasure", [0.25]),
+                "site_indicator": ("nmeasure", [0]),
+            },
+            coords={
+                "region": [0],
+                "nmeasure": [0],
+                "site": ("nmeasure", ["TAC"]),
+                "time": (
+                    "nmeasure",
+                    np.array(["2019-01-01T00:00:00"], dtype="datetime64[ns]"),
+                ),
+            },
+        )
+        inv_inputs["mf"].attrs["units"] = "ppm"
+
+        return InversionOutput(
+            trace=az.from_dict(
+                posterior={
+                    "x_ff": np.array([[[0.0], [2.0]]]),
+                    "x_ocean": np.array([[[2.0 / 3.0], [0.0]]]),
+                },
+                prior={
+                    "x_ff": np.array([[[1.0], [1.0]]]),
+                    "x_ocean": np.array([[[1.0], [1.0]]]),
+                },
+                coords={"region": [0]},
+                dims={"x_ff": ["region"], "x_ocean": ["region"]},
+            ),
+            inv_inputs=inv_inputs.set_index(nmeasure=["site", "time"]),
+            basis_functions=basis_functions or fake_multisector_basis_functions(),
+            run_metadata={
+                "start_date": "2019-01-01",
+                "end_date": "2019-01-02",
+                "sites": ["TAC"],
+                "split_by_sectors": True,
+            },
+            model_metadata={
+                "species": "ch4",
+                "domain": "EUROPE",
+                "sectors": [
+                    {
+                        "name": "FF",
+                        "flux_source": "ff-inventory",
+                        "variable_suffix": "ff",
+                    },
+                    {
+                        "name": "Ocean",
+                        "flux_source": "ocean-inventory",
+                        "variable_suffix": "ocean",
+                    },
+                ],
+            },
+        )
+
+    return _build
 
 
 @pytest.fixture

--- a/tests/integration/test_multisector_paris_pipeline.py
+++ b/tests/integration/test_multisector_paris_pipeline.py
@@ -1,0 +1,265 @@
+"""Integration coverage for the multisector RHIME-to-PARIS pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from io import StringIO
+from pathlib import Path
+import re
+from typing import Any
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from openghg_inversions.postprocessing.make_paris_outputs import (
+    PARIS_LATEST_COUNTRIES,
+    paris_template_files,
+)
+from openghg_inversions.rhime import run_rhime_multisector
+
+
+_CDL_VARIABLE = re.compile(
+    r"^\s*(byte|short|int|float|double|string)\s+([A-Za-z_][A-Za-z0-9_]*)\(([^)]*)\)\s*;"
+)
+_CDL_ATTRIBUTE = re.compile(r"^\s+([A-Za-z_][A-Za-z0-9_]*):([A-Za-z_][A-Za-z0-9_]*)\s*=\s*([^;]+)")
+_NETCDF_DTYPES = {
+    "byte": np.dtype("int8"),
+    "short": np.dtype("int16"),
+    "int": np.dtype("int32"),
+    "float": np.dtype("float32"),
+    "double": np.dtype("float64"),
+}
+
+
+@dataclass(frozen=True)
+class _CdlVariable:
+    """Describe one numeric variable declared by the PARIS CDL template."""
+
+    dtype: np.dtype
+    dims: tuple[str, ...]
+    attrs: dict[str, str]
+
+
+def _expanded_numeric_flux_schema(
+    template: Path,
+    *,
+    species: str,
+    sectors: tuple[str, ...],
+) -> dict[str, _CdlVariable]:
+    """Parse and expand emitted numeric variables from the latest flux CDL.
+
+    Args:
+        template: Latest PARIS flux CDL path.
+        species: Species text substituted into template attributes.
+        sectors: Concrete sector names substituted for ``sector_name``.
+
+    Returns:
+        Numeric output schema keyed by expanded variable name, excluding the
+        optional inversion-grid variables disabled by this integration run.
+    """
+    parsed: dict[str, _CdlVariable] = {}
+    in_variables = False
+    for line in template.read_text(encoding="utf-8").splitlines():
+        if line.startswith("variables:"):
+            in_variables = True
+            continue
+        if not in_variables:
+            continue
+        variable_match = _CDL_VARIABLE.match(line)
+        if variable_match is not None:
+            netcdf_type, name, raw_dims = variable_match.groups()
+            if netcdf_type in _NETCDF_DTYPES:
+                parsed[name] = _CdlVariable(
+                    dtype=_NETCDF_DTYPES[netcdf_type],
+                    dims=tuple(dim.strip() for dim in raw_dims.split(",")),
+                    attrs={},
+                )
+            continue
+        attribute_match = _CDL_ATTRIBUTE.match(line)
+        if attribute_match is None:
+            continue
+        name, attribute, raw_value = attribute_match.groups()
+        if name in parsed and attribute != "_FillValue":
+            value = raw_value.strip().strip('"').replace("<species>", species)
+            parsed[name].attrs[attribute] = value
+
+    expanded: dict[str, _CdlVariable] = {}
+    for name, variable in parsed.items():
+        if "_inversion_grid" in name:
+            continue
+        concrete_sectors = sectors if "sector_name" in name else (None,)
+        for sector in concrete_sectors:
+            output_name = name if sector is None else name.replace("sector_name", sector)
+            attrs = {
+                key: (
+                    value
+                    if sector is None
+                    else value.replace("<sector_name>", sector).replace("sector_name", sector)
+                )
+                for key, value in variable.attrs.items()
+            }
+            expanded[output_name] = _CdlVariable(variable.dtype, variable.dims, attrs)
+    return expanded
+
+
+def _assert_raw_netcdf_matches_schema(
+    dataset: xr.Dataset,
+    expected: dict[str, _CdlVariable],
+) -> str:
+    """Validate raw NetCDF numeric variables and return Dataset.info output.
+
+    Args:
+        dataset: Runner output reopened with CF decoding disabled.
+        expected: Expanded numeric CDL schema.
+
+    Returns:
+        The ncdump-like ``Dataset.info`` text used as schema diagnostics.
+    """
+    info_buffer = StringIO()
+    dataset.info(buf=info_buffer)
+    schema_info = info_buffer.getvalue()
+
+    actual_numeric = {
+        name for name, variable in dataset.variables.items() if np.issubdtype(variable.dtype, np.number)
+    }
+    assert actual_numeric == set(expected), schema_info
+    for name, schema in expected.items():
+        variable = dataset[name]
+        assert variable.dims == schema.dims, schema_info
+        assert variable.dtype == schema.dtype, schema_info
+        if schema.dtype == np.dtype("float32"):
+            assert np.isnan(variable.attrs["_FillValue"]), schema_info
+        attrs_without_fill = {key: value for key, value in variable.attrs.items() if key != "_FillValue"}
+        assert attrs_without_fill == schema.attrs, schema_info
+
+    return schema_info
+
+
+@pytest.mark.slow
+def test_multisector_rhime_pipeline_writes_latest_paris_flux_schema(
+    tac_ch4_data_args: dict[str, Any],
+    default_bc_basis_directory: Path,
+    europe_country_file: Path,
+    tmp_path: Path,
+) -> None:
+    """Run real multisector RHIME sampling through latest PARIS NetCDF writes.
+
+    The two store-backed flux products are numerically equal but have distinct
+    source names and dimension order, exercising labelled alignment during
+    preparation as well as PyMC sampling, multisector postprocessing, and the
+    runner's on-disk NetCDF schema.
+    """
+    flux_sources = ("total-ukghg-edgar7", "total-ukghg-edgar7-shuffled")
+    args = tac_ch4_data_args.copy()
+    args.update(
+        {
+            "flux_sources": list(flux_sources),
+            "sector_sources": {"FF": flux_sources[0], "ocean": flux_sources[1]},
+            "output_name": "multisector_paris_pipeline",
+            "output_path": str(tmp_path),
+            "basis_algorithm": "quadtree",
+            "basis_output_path": str(tmp_path),
+            "bc_basis_directory": default_bc_basis_directory,
+            "nbasis": 4,
+            "draws": 2,
+            "burn": 0,
+            "tune": 0,
+            "chains": 1,
+            "reload_merged_data": False,
+            "output_format": "paris",
+            "save_inversion_output": False,
+            "country_file": europe_country_file,
+            "paris_postprocessing_kwargs": {
+                "template_version": "latest",
+                "inversion_grid": False,
+                "flux_frequency": "yearly",
+            },
+            "x_prior": {"pdf": "normal", "mu": 1.0, "sigma": 1.0},
+            "bc_prior": {"pdf": "normal", "mu": 1.0, "sigma": 1.0},
+            "sigma_prior": {"pdf": "uniform", "lower": 0.1, "upper": 10.0},
+            "sample_kwargs": {"random_seed": 405, "compute_convergence_checks": False},
+        }
+    )
+    args.pop("emissions_name")
+
+    result = run_rhime_multisector(**args)
+
+    assert result.basis_functions is not None
+    xr.testing.assert_allclose(
+        result.basis_functions.flux.sel(source=flux_sources[0], drop=True),
+        result.basis_functions.flux.sel(source=flux_sources[1], drop=True),
+    )
+    flux = result.outputs["paris_flux"]
+    for state in ("prior", "posterior"):
+        np.testing.assert_allclose(
+            flux[f"flux_total_{state}"],
+            flux[f"flux_ff_{state}"] + flux[f"flux_ocean_{state}"],
+            rtol=1e-6,
+        )
+
+    expected_flux_path = tmp_path / "multisector_paris_pipeline_flux_ch4_EUROPE_2019-01-01.nc"
+    expected_diagnostics_path = tmp_path / "multisector_paris_pipeline2019-01-01_sector_flux_diagnostics.nc"
+    assert result.output_metadata["paris_flux_path"] == str(expected_flux_path)
+    assert result.output_metadata["sector_flux_diagnostics_path"] == str(expected_diagnostics_path)
+    assert expected_flux_path.is_file()
+    assert expected_diagnostics_path.is_file()
+    assert "inversion_output_path" not in result.output_metadata
+    assert "paris_concentration" not in result.outputs
+    assert "paris_concentration_path" not in result.output_metadata
+    assert not list(tmp_path.glob("*concentration*.nc"))
+
+    expected_schema = _expanded_numeric_flux_schema(
+        paris_template_files("latest").flux,
+        species="ch4",
+        sectors=("ff", "ocean"),
+    )
+    with xr.open_dataset(expected_flux_path, decode_cf=False) as reloaded:
+        schema_info = _assert_raw_netcdf_matches_schema(reloaded, expected_schema)
+        assert reloaded.encoding["unlimited_dims"] == {"time"}
+        assert reloaded.sizes["country"] == len(PARIS_LATEST_COUNTRIES)
+        assert reloaded.sizes["sector"] == 2
+        assert reloaded.sizes["percentile"] == 2
+        assert reloaded.sizes["nbnds"] == 2
+        assert reloaded.sizes["longitude"] == 391
+        assert reloaded.sizes["latitude"] == 293
+        assert reloaded.sizes["time"] == 1
+        assert tuple(reloaded.country.values) == PARIS_LATEST_COUNTRIES
+        assert tuple(reloaded.sector.values) == ("ff", "ocean")
+        assert reloaded.country.attrs["long_name"] == "country_ISO_3166_1_alpha3"
+        assert reloaded.sector.attrs["long_name"] == "short name of flux sector"
+        assert reloaded.attrs["paris_flux_template_version"] == "v03"
+        assert {
+            "title",
+            "institution",
+            "inversion_system",
+            "inversion_system_version",
+            "apriori_description",
+            "transport_model",
+            "domain",
+            "species",
+            "project",
+            "references",
+            "history",
+            "conventions",
+            "license",
+        }.issubset(reloaded.attrs)
+        assert reloaded["covariance_flux_total_posterior_country"].dims == (
+            "time",
+            "country",
+            "country",
+        )
+        for sector in ("ff", "ocean"):
+            assert reloaded[f"covariance_flux_{sector}_posterior_country"].dims == (
+                "time",
+                "country",
+                "country",
+            )
+        assert reloaded["covariance_flux_sectors_posterior_country"].dims == (
+            "time",
+            "country",
+            "sector",
+            "sector",
+        )
+        assert "covariance_flux_total_posterior_country" in schema_info
+        assert "covariance_flux_sectors_posterior_country" in schema_info

--- a/tests/postprocessing/test_make_outputs.py
+++ b/tests/postprocessing/test_make_outputs.py
@@ -1,0 +1,111 @@
+"""Tests for multisector flux reconstruction in modern postprocessing outputs."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from openghg_inversions.basis.basis_functions import BasisFunctions
+from openghg_inversions.flux_sanitization import FluxNonFiniteMetadata, NONFINITE_POLICY_ZERO_FILL
+from openghg_inversions.postprocessing.inversion_output import InversionOutput
+from openghg_inversions.postprocessing.make_outputs import (
+    make_flux_outputs,
+    make_multisector_flux_trace_outputs,
+)
+
+
+def _flux_nonfinite_metadata(data: xr.DataArray | xr.Dataset) -> FluxNonFiniteMetadata:
+    """Return parsed non-finite flux metadata from an xarray object."""
+    metadata = FluxNonFiniteMetadata.from_attrs(data.attrs)
+    assert metadata is not None
+    return metadata
+
+
+def test_multisector_flux_outputs_reconstruct_sector_and_total_flux(
+    multisector_postprocessing_inv_out: Callable[..., InversionOutput],
+) -> None:
+    """Multisector flux postprocessing reconstructs sector fluxes before total statistics."""
+    outputs = make_flux_outputs(
+        multisector_postprocessing_inv_out(),
+        stats=["mean", "stdev"],
+        include_scale_factors=True,
+        report_flux_on_inversion_grid=False,
+    )
+
+    assert "flux_ff_posterior_mean" in outputs
+    assert "flux_ocean_posterior_mean" in outputs
+    assert "scaling_ff_posterior_mean" in outputs
+    assert "flux_total_posterior_mean" in outputs
+    assert "flux_total_posterior_stdev" in outputs
+    assert outputs["flux_ff_posterior_mean"].attrs["units"] == "mol/m2/s"
+    assert outputs["flux_total_posterior_mean"].attrs["units"] == "mol/m2/s"
+    assert float(outputs["flux_total_posterior_mean"].item()) == 2.0
+    assert float(outputs["flux_total_posterior_stdev"].item()) == 0.0
+    assert float(outputs["flux_ff_posterior_stdev"].item()) > 0.0
+    assert _flux_nonfinite_metadata(outputs).policy == NONFINITE_POLICY_ZERO_FILL
+
+
+def test_multisector_flux_outputs_support_inversion_grid_mean_stats(
+    multisector_postprocessing_inv_out: Callable[..., InversionOutput],
+) -> None:
+    """Multisector inversion-grid stats work when statistics do not need dense quantiles."""
+    outputs = make_flux_outputs(
+        multisector_postprocessing_inv_out(),
+        stats=["mean", "stdev"],
+        include_scale_factors=False,
+        report_flux_on_inversion_grid=True,
+    )
+
+    assert "flux_ff_posterior_mean" in outputs
+    assert "flux_ocean_posterior_mean" in outputs
+    assert "flux_total_posterior_mean" in outputs
+    assert float(outputs["flux_total_posterior_mean"].item()) == 2.0
+
+
+def test_multisector_flux_outputs_support_source_specific_basis(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_source_specific_multisector_basis_functions: Callable[..., BasisFunctions],
+    multisector_postprocessing_inv_out: Callable[..., InversionOutput],
+) -> None:
+    """Sector flux reconstruction handles source-specific retained basis artifacts."""
+    basis_functions = fake_source_specific_multisector_basis_functions()
+
+    def fail_flat_basis(self: BasisFunctions) -> xr.DataArray:
+        raise AssertionError("source-specific multisector outputs should not materialise flat basis")
+
+    monkeypatch.setattr(type(basis_functions), "flat_basis", fail_flat_basis)
+
+    outputs = make_flux_outputs(
+        multisector_postprocessing_inv_out(basis_functions),
+        stats=["mean", "mode_kde"],
+        include_scale_factors=False,
+        report_flux_on_inversion_grid=False,
+    )
+
+    assert "flux_total_posterior_mean" in outputs
+    assert "flux_total_posterior_mode" in outputs
+    assert float(outputs["flux_total_posterior_mean"].item()) == 2.0
+    assert _flux_nonfinite_metadata(outputs).policy == NONFINITE_POLICY_ZERO_FILL
+
+
+def test_multisector_flux_trace_materialization_is_optional(
+    multisector_postprocessing_inv_out: Callable[..., InversionOutput],
+) -> None:
+    """The trace API preserves its eager default and exposes a lazy internal boundary."""
+    inv_out = multisector_postprocessing_inv_out()
+
+    lazy_trace = make_multisector_flux_trace_outputs(
+        inv_out,
+        report_flux_on_inversion_grid=False,
+        materialize=False,
+    )
+    materialized_trace = make_multisector_flux_trace_outputs(
+        inv_out,
+        report_flux_on_inversion_grid=False,
+    )
+
+    assert not isinstance(lazy_trace["flux_total_posterior"].data, np.ndarray)
+    assert isinstance(materialized_trace["flux_total_posterior"].data, np.ndarray)

--- a/tests/postprocessing/test_make_outputs.py
+++ b/tests/postprocessing/test_make_outputs.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Callable
 
 import numpy as np
@@ -10,9 +11,12 @@ import xarray as xr
 
 from openghg_inversions.basis.basis_functions import BasisFunctions
 from openghg_inversions.flux_sanitization import FluxNonFiniteMetadata, NONFINITE_POLICY_ZERO_FILL
+from openghg_inversions.postprocessing import make_outputs
+from openghg_inversions.postprocessing.countries import Countries
 from openghg_inversions.postprocessing.inversion_output import InversionOutput
 from openghg_inversions.postprocessing.make_outputs import (
     make_flux_outputs,
+    make_multisector_country_trace_outputs,
     make_multisector_flux_trace_outputs,
 )
 
@@ -109,3 +113,47 @@ def test_multisector_flux_trace_materialization_is_optional(
 
     assert not isinstance(lazy_trace["flux_total_posterior"].data, np.ndarray)
     assert isinstance(materialized_trace["flux_total_posterior"].data, np.ndarray)
+
+
+def test_multisector_country_traces_project_basis_regions_before_scaling(
+    europe_country_file: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    fake_multisector_basis_functions_matching_country_grid: Callable[..., BasisFunctions],
+    multisector_postprocessing_inv_out: Callable[..., InversionOutput],
+) -> None:
+    """Country traces map basis regions without reconstructing draw-wise spatial flux."""
+    inv_out = multisector_postprocessing_inv_out(
+        fake_multisector_basis_functions_matching_country_grid(europe_country_file)
+    )
+    countries = Countries.from_file(
+        country_file=europe_country_file,
+        country_code="alpha3",
+        country_selections=["FRA", "GBR"],
+        domain="EUROPE",
+    )
+
+    def fail_spatial_reconstruction(*args: object, **kwargs: object) -> xr.Dataset:
+        """Fail if country totals reconstruct a latitude/longitude posterior trace."""
+        raise AssertionError("country projection must happen before spatial reconstruction")
+
+    monkeypatch.setattr(make_outputs, "_sector_flux_trace_dataset", fail_spatial_reconstruction)
+
+    country_trace = make_multisector_country_trace_outputs(inv_out, countries)
+
+    assert tuple(country_trace.country.values) == tuple(countries.matrix.country.values)
+    assert set(country_trace.country.values) == {"FRA", "GBR"}
+    assert "lat" not in country_trace.dims
+    assert "lon" not in country_trace.dims
+    assert {
+        "country_total_posterior",
+        "country_ff_posterior",
+        "country_ocean_posterior",
+    }.issubset(country_trace.data_vars)
+    assert country_trace["country_total_posterior"].chunks is not None
+    for when in ("prior", "posterior"):
+        np.testing.assert_allclose(
+            country_trace[f"country_total_{when}"].isel(draw=0),
+            country_trace[f"country_ff_{when}"].isel(draw=0)
+            + country_trace[f"country_ocean_{when}"].isel(draw=0),
+        )
+        assert country_trace[f"country_total_{when}"].attrs["units"] == "g/yr"

--- a/tests/postprocessing/test_make_paris_outputs.py
+++ b/tests/postprocessing/test_make_paris_outputs.py
@@ -1,0 +1,329 @@
+"""Tests for multisector products written with the latest PARIS flux template."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable, cast
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from openghg_inversions import convert
+from openghg_inversions.postprocessing import make_outputs, make_paris_outputs
+from openghg_inversions.basis.basis_functions import BasisFunctions
+from openghg_inversions.flux_sanitization import FluxNonFiniteMetadata, NONFINITE_POLICY_ZERO_FILL
+from openghg_inversions.postprocessing.countries import Countries
+from openghg_inversions.postprocessing.inversion_output import InversionOutput
+from openghg_inversions.postprocessing.make_paris_outputs import (
+    PARIS_LATEST_COUNTRIES,
+    _paris_sector_name_by_suffix,
+    paris_flux_output,
+)
+
+
+def _flux_nonfinite_metadata(data: xr.DataArray | xr.Dataset) -> FluxNonFiniteMetadata:
+    """Return parsed non-finite flux metadata from an xarray object."""
+    metadata = FluxNonFiniteMetadata.from_attrs(data.attrs)
+    assert metadata is not None
+    return metadata
+
+
+def test_latest_paris_sector_names_are_template_safe(
+    multisector_postprocessing_inv_out: Callable[..., InversionOutput],
+) -> None:
+    """PARIS sector names are lower-case variable-safe values derived from suffixes."""
+    inv_out = multisector_postprocessing_inv_out()
+    inv_out.model_metadata["sectors"] = [
+        {"name": "FF", "flux_source": "ff-inventory", "variable_suffix": "FF-sector"},
+        {"name": "Ocean", "flux_source": "ocean-inventory", "variable_suffix": "Ocean_sector"},
+    ]
+    assert _paris_sector_name_by_suffix(inv_out) == {
+        "FF-sector": "ffsector",
+        "Ocean_sector": "oceansector",
+    }
+
+    inv_out.model_metadata["sectors"] = [
+        {"name": "One", "flux_source": "ff-inventory", "variable_suffix": "sector-2"},
+        {"name": "Two", "flux_source": "ocean-inventory", "variable_suffix": "sector_2"},
+    ]
+    with pytest.raises(ValueError, match="duplicate sector name 'sector2'"):
+        _paris_sector_name_by_suffix(inv_out)
+
+    inv_out.model_metadata["sectors"] = [
+        {"name": "Total", "flux_source": "ff-inventory", "variable_suffix": "total"},
+    ]
+    with pytest.raises(ValueError, match="reserved"):
+        _paris_sector_name_by_suffix(inv_out)
+
+    inv_out.model_metadata["sectors"] = [
+        {"name": "Bad", "flux_source": "ff-inventory", "variable_suffix": "---"},
+    ]
+    with pytest.raises(ValueError, match="Could not derive"):
+        _paris_sector_name_by_suffix(inv_out)
+
+
+def test_latest_paris_flux_output_processes_multisector_sectors(
+    europe_country_file: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    fake_multisector_basis_functions_matching_country_grid: Callable[..., BasisFunctions],
+    multisector_postprocessing_inv_out: Callable[..., InversionOutput],
+) -> None:
+    """Latest multisector PARIS output reuses one lazy country trace with population covariance."""
+    inv_out = multisector_postprocessing_inv_out(
+        fake_multisector_basis_functions_matching_country_grid(
+            europe_country_file,
+            coord_offset=1e-10,
+        )
+    )
+    reconstruction_calls: list[tuple[bool, bool]] = []
+    sector_reconstruction_grids: list[bool] = []
+    original_reconstruct = make_paris_outputs.make_multisector_flux_trace_outputs
+    original_sector_reconstruct = make_outputs._sector_flux_trace_dataset
+
+    def record_reconstruction(
+        output: InversionOutput,
+        report_flux_on_inversion_grid: bool = True,
+        *,
+        materialize: bool = True,
+    ) -> xr.Dataset:
+        """Record whether PARIS crosses the eager trace boundary before aggregation."""
+        trace = original_reconstruct(
+            output,
+            report_flux_on_inversion_grid=report_flux_on_inversion_grid,
+            materialize=materialize,
+        )
+        is_lazy_or_sparse = not isinstance(trace["flux_total_posterior"].data, np.ndarray)
+        reconstruction_calls.append((materialize, is_lazy_or_sparse))
+        return trace
+
+    def record_sector_reconstruction(
+        output: InversionOutput,
+        sector: make_outputs.OutputSector,
+        *,
+        report_flux_on_inversion_grid: bool,
+    ) -> xr.Dataset:
+        """Record each sector reconstruction and the grid it targets."""
+        sector_reconstruction_grids.append(report_flux_on_inversion_grid)
+        return original_sector_reconstruct(
+            output,
+            sector,
+            report_flux_on_inversion_grid=report_flux_on_inversion_grid,
+        )
+
+    monkeypatch.setattr(
+        make_paris_outputs,
+        "make_multisector_flux_trace_outputs",
+        record_reconstruction,
+    )
+    monkeypatch.setattr(make_outputs, "_sector_flux_trace_dataset", record_sector_reconstruction)
+
+    flux_outputs = paris_flux_output(
+        inv_out,
+        country_file=europe_country_file,
+        inversion_grid=True,
+        template_version="latest",
+    )
+
+    assert flux_outputs.attrs["paris_flux_template_version"] == "v03"
+    assert reconstruction_calls == [(False, True)]
+    assert sector_reconstruction_grids.count(False) == 2
+    assert sector_reconstruction_grids.count(True) == 2
+    assert "flux_total_posterior" in flux_outputs
+    assert "stdev_flux_total_posterior" in flux_outputs
+    assert "flux_ff_posterior" in flux_outputs
+    assert "flux_ocean_posterior" in flux_outputs
+    assert "flux_ff_posterior_inversion_grid" in flux_outputs
+    assert "flux_ocean_posterior_inversion_grid" in flux_outputs
+    assert "flux_total_ff_posterior" not in flux_outputs
+    assert "flux_total_posterior_country" in flux_outputs
+    assert "flux_ff_posterior_country" in flux_outputs
+    assert "flux_ocean_posterior_country" in flux_outputs
+    assert "covariance_flux_total_posterior_country" in flux_outputs
+    assert "covariance_flux_ff_posterior_country" in flux_outputs
+    assert "covariance_flux_ocean_posterior_country" in flux_outputs
+    assert "covariance_flux_sectors_posterior_country" in flux_outputs
+    assert tuple(flux_outputs.sector.values) == ("ff", "ocean")
+    assert flux_outputs.sector.attrs["long_name"] == "short name of flux sector"
+    assert "ff" in flux_outputs["flux_ff_posterior"].attrs["long_name"]
+    assert "sector_name" not in flux_outputs["flux_ff_posterior"].attrs["long_name"]
+    assert flux_outputs["flux_ff_posterior_inversion_grid"].attrs == {
+        "units": "mol m-2 s-1",
+        "long_name": "posterior flux of  ch4 for ff on the inversion grid",
+        "cell_methods": "time:mean area:mean",
+    }
+    assert tuple(flux_outputs.country.values) == PARIS_LATEST_COUNTRIES
+    assert flux_outputs["flux_ff_posterior"].dtype == np.dtype("float32")
+    assert flux_outputs["covariance_flux_ff_posterior_country"].dtype == np.dtype("float32")
+    np.testing.assert_allclose(flux_outputs["flux_ff_posterior"].isel(time=0).values, 1.0)
+    np.testing.assert_allclose(flux_outputs["flux_ocean_posterior"].isel(time=0).values, 1.0)
+    country_fraction_data = flux_outputs["country_fraction"].data
+    if hasattr(country_fraction_data, "todense"):
+        country_fraction_data = country_fraction_data.todense()
+    cell_area_data = flux_outputs["cell_area"].data
+    if hasattr(cell_area_data, "todense"):
+        cell_area_data = cell_area_data.todense()
+    assert not np.isnan(np.asarray(country_fraction_data)).any()
+    assert not np.isnan(np.asarray(cell_area_data)).any()
+    countries = Countries.from_file(
+        country_file=europe_country_file,
+        country_code="alpha3",
+        country_selections=list(PARIS_LATEST_COUNTRIES),
+        domain="EUROPE",
+    )
+    expected_country = (
+        2.0
+        * (countries.matrix * countries.area_grid).sum(("lat", "lon"))
+        * 365
+        * 24
+        * 3600
+        * convert.molar_mass("ch4")
+        * 1e-3
+    ).reindex(country=list(PARIS_LATEST_COUNTRIES))
+    np.testing.assert_allclose(
+        flux_outputs["flux_total_posterior_country"].isel(time=0).values,
+        expected_country.data.todense(),
+        rtol=1e-6,
+    )
+    expected_sector_country = expected_country / 2.0
+    np.testing.assert_allclose(
+        flux_outputs["flux_ff_posterior_country"].isel(time=0).values,
+        expected_sector_country.data.todense(),
+        rtol=1e-6,
+    )
+    np.testing.assert_allclose(
+        flux_outputs["flux_ocean_posterior_country"].isel(time=0).values,
+        expected_sector_country.data.todense(),
+        rtol=1e-6,
+    )
+    largest_country = int(np.asarray(expected_sector_country.data.todense()).argmax())
+    expected_sector_variance = np.asarray(expected_sector_country.data.todense())[largest_country] ** 2
+    np.testing.assert_allclose(
+        flux_outputs["covariance_flux_ff_posterior_country"].values[
+            0,
+            largest_country,
+            largest_country,
+        ],
+        expected_sector_variance,
+        rtol=1e-6,
+    )
+    for flux_label in ("total", "ff", "ocean"):
+        covariance = flux_outputs[f"covariance_flux_{flux_label}_posterior_country"].values
+        stdev = flux_outputs[f"stdev_flux_{flux_label}_posterior_country"].values
+        np.testing.assert_allclose(
+            np.diagonal(covariance, axis1=1, axis2=2),
+            stdev**2,
+            rtol=1e-6,
+        )
+        assert np.isfinite(covariance).all()
+
+    sector_cross_covariance = flux_outputs["covariance_flux_sectors_posterior_country"].values
+    for sector_index, sector_name in enumerate(("ff", "ocean")):
+        np.testing.assert_allclose(
+            sector_cross_covariance[:, :, sector_index, sector_index],
+            flux_outputs[f"stdev_flux_{sector_name}_posterior_country"].values ** 2,
+            rtol=1e-6,
+        )
+    assert np.isfinite(sector_cross_covariance).all()
+    np.testing.assert_allclose(
+        flux_outputs["covariance_flux_sectors_posterior_country"].values[
+            0,
+            largest_country,
+            0,
+            1,
+        ],
+        -expected_sector_variance,
+        rtol=1e-6,
+    )
+    assert _flux_nonfinite_metadata(flux_outputs).policy == NONFINITE_POLICY_ZERO_FILL
+
+    flux_file = tmp_path / "latest_multisector_flux.nc"
+    flux_outputs.to_netcdf(flux_file)
+    with xr.open_dataset(flux_file) as reloaded_flux:
+        assert tuple(reloaded_flux.sector.values) == ("ff", "ocean")
+        assert tuple(reloaded_flux.country.values) == PARIS_LATEST_COUNTRIES
+        covariance_dims = {
+            "covariance_flux_total_posterior_country": ("time", "country", "country"),
+            "covariance_flux_ff_posterior_country": ("time", "country", "country"),
+            "covariance_flux_ocean_posterior_country": ("time", "country", "country"),
+            "covariance_flux_sectors_posterior_country": ("time", "country", "sector", "sector"),
+        }
+        for variable_name, expected_dims in covariance_dims.items():
+            expected = flux_outputs[variable_name]
+            actual = reloaded_flux[variable_name]
+            assert actual.dims == expected_dims
+            assert actual.shape == expected.shape
+            assert actual.dtype == np.dtype("float32")
+            assert actual.attrs == expected.attrs
+            np.testing.assert_allclose(actual.values, expected.values, rtol=1e-6)
+
+
+def test_latest_paris_flux_output_renames_overlapping_sector_suffixes_exactly(
+    europe_country_file: Path,
+    fake_multisector_basis_functions_matching_country_grid: Callable[..., BasisFunctions],
+    multisector_postprocessing_inv_out: Callable[..., InversionOutput],
+) -> None:
+    """Overlapping sector suffixes and a legitimate total prefix retain exact normalized names."""
+    basis_functions = fake_multisector_basis_functions_matching_country_grid(europe_country_file)
+    total_ff_flux = basis_functions.flux.sel(source="ff-inventory", drop=True).expand_dims(
+        source=["total-ff-inventory"]
+    )
+    basis_functions = basis_functions.with_flux(
+        xr.concat([basis_functions.flux, total_ff_flux], dim="source")
+    )
+    inv_out = multisector_postprocessing_inv_out(basis_functions)
+
+    for group_name in ("prior", "posterior"):
+        trace_group = getattr(inv_out.trace, group_name).rename(
+            {"x_ff": "x_energy", "x_ocean": "x_energy_waste"}
+        )
+        trace_group["x_total_ff"] = trace_group["x_energy"]
+        setattr(inv_out.trace, group_name, trace_group)
+    inference_data = cast(Any, inv_out.trace)
+    prior = inference_data.prior
+    extra_prior_draw = prior.isel(draw=[0]).assign_coords(draw=[prior.sizes["draw"]])
+    inference_data.prior = xr.concat([prior, extra_prior_draw], dim="draw")
+    inv_out.model_metadata["sectors"] = [
+        {"name": "Energy", "flux_source": "ff-inventory", "variable_suffix": "energy"},
+        {
+            "name": "Energy waste",
+            "flux_source": "ocean-inventory",
+            "variable_suffix": "energy_waste",
+        },
+        {
+            "name": "Total fossil fuel",
+            "flux_source": "total-ff-inventory",
+            "variable_suffix": "total_ff",
+        },
+    ]
+
+    flux_outputs = paris_flux_output(
+        inv_out,
+        country_file=europe_country_file,
+        inversion_grid=False,
+        template_version="latest",
+    )
+
+    expected_names = ("energy", "energywaste", "totalff")
+    assert tuple(flux_outputs.sector.values) == expected_names
+    for sector_name in expected_names:
+        variable_name = f"flux_{sector_name}_posterior"
+        assert variable_name in flux_outputs
+        assert f"flux_{sector_name}_posterior_country" in flux_outputs
+        assert flux_outputs[variable_name].dtype == np.dtype("float32")
+        assert flux_outputs[variable_name].attrs["long_name"] == (f"posterior ch4 fluxes from {sector_name}")
+        assert flux_outputs[variable_name].attrs["cell_methods"] == "time:mean area:mean"
+
+    assert "flux_energy_waste_posterior" not in flux_outputs
+    assert "flux_total_ff_posterior" not in flux_outputs
+    for flux_label in ("total", *expected_names):
+        covariance = flux_outputs[f"covariance_flux_{flux_label}_posterior_country"].values
+        stdev = flux_outputs[f"stdev_flux_{flux_label}_posterior_country"].values
+        assert np.isfinite(covariance).all()
+        np.testing.assert_allclose(
+            np.diagonal(covariance, axis1=1, axis2=2),
+            stdev**2,
+            rtol=1e-6,
+        )
+    assert np.isfinite(flux_outputs["covariance_flux_sectors_posterior_country"].values).all()

--- a/tests/postprocessing/test_make_paris_outputs.py
+++ b/tests/postprocessing/test_make_paris_outputs.py
@@ -17,6 +17,7 @@ from openghg_inversions.postprocessing.countries import Countries
 from openghg_inversions.postprocessing.inversion_output import InversionOutput
 from openghg_inversions.postprocessing.make_paris_outputs import (
     PARIS_LATEST_COUNTRIES,
+    _latest_paris_countries,
     _paris_sector_name_by_suffix,
     paris_flux_output,
 )
@@ -70,7 +71,7 @@ def test_latest_paris_flux_output_processes_multisector_sectors(
     fake_multisector_basis_functions_matching_country_grid: Callable[..., BasisFunctions],
     multisector_postprocessing_inv_out: Callable[..., InversionOutput],
 ) -> None:
-    """Latest multisector PARIS output reuses one lazy country trace with population covariance."""
+    """Latest multisector PARIS output projects countries before population covariance."""
     inv_out = multisector_postprocessing_inv_out(
         fake_multisector_basis_functions_matching_country_grid(
             europe_country_file,
@@ -122,6 +123,7 @@ def test_latest_paris_flux_output_processes_multisector_sectors(
     flux_outputs = paris_flux_output(
         inv_out,
         country_file=europe_country_file,
+        country_selections=PARIS_LATEST_COUNTRIES,
         inversion_grid=True,
         template_version="latest",
     )
@@ -301,6 +303,7 @@ def test_latest_paris_flux_output_renames_overlapping_sector_suffixes_exactly(
     flux_outputs = paris_flux_output(
         inv_out,
         country_file=europe_country_file,
+        country_selections=PARIS_LATEST_COUNTRIES,
         inversion_grid=False,
         template_version="latest",
     )
@@ -327,3 +330,41 @@ def test_latest_paris_flux_output_renames_overlapping_sector_suffixes_exactly(
             rtol=1e-6,
         )
     assert np.isfinite(flux_outputs["covariance_flux_sectors_posterior_country"].values).all()
+
+
+def test_latest_paris_country_selection_defaults_to_domain_file(
+    eastasia_country_file: Path,
+) -> None:
+    """Latest PARIS outputs do not inject the canonical European country list."""
+    countries = _latest_paris_countries(
+        country_file=eastasia_country_file,
+        domain="EASTASIA",
+        country_selections=None,
+    )
+    expected = Countries.from_file(
+        country_file=eastasia_country_file,
+        domain="EASTASIA",
+        country_code="alpha3",
+    )
+
+    assert tuple(countries.matrix.country.values) == tuple(expected.matrix.country.values)
+    assert set(countries.matrix.country.values) != set(PARIS_LATEST_COUNTRIES)
+
+
+def test_latest_paris_country_selection_normalizes_names_to_alpha3(
+    europe_country_file: Path,
+) -> None:
+    """Latest PARIS country names select finite masks with alpha-3 labels."""
+    countries = _latest_paris_countries(
+        country_file=europe_country_file,
+        domain="EUROPE",
+        country_selections=["France", "United Kingdom"],
+    )
+    expected = Countries.from_file(
+        country_file=europe_country_file,
+        domain="EUROPE",
+        country_code="alpha3",
+    ).matrix.sel(country=["FRA", "GBR"])
+
+    assert tuple(countries.matrix.country.values) == ("FRA", "GBR")
+    xr.testing.assert_identical(countries.matrix, expected)

--- a/tests/postprocessing/test_stats.py
+++ b/tests/postprocessing/test_stats.py
@@ -3,9 +3,75 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
+import sparse
 import xarray as xr
 
-from openghg_inversions.postprocessing.stats import mode_kde
+from openghg_inversions.postprocessing.stats import hdi, mean, median, mode, mode_kde, quantiles, stdev
+
+
+def _sparse_dataset(*, draw_chunk_size: int | None = None) -> xr.Dataset:
+    """Create a small dataset backed by a sparse array or sparse dask chunks."""
+    data = sparse.COO.from_numpy(np.tile([0.0, 3.0], (5, 1)))
+    result = xr.Dataset({"value": (("draw", "place"), data)})
+    if draw_chunk_size is not None:
+        return result.chunk({"draw": draw_chunk_size, "place": 1})
+    return result
+
+
+@pytest.mark.parametrize(
+    ("statistic", "kwargs", "result_name", "expected"),
+    [
+        pytest.param(quantiles, {"quantiles": [0.5]}, "value_quantile", [[0.0, 3.0]], id="quantiles"),
+        pytest.param(median, {}, "value_median", [0.0, 3.0], id="median"),
+        pytest.param(mode, {}, "value_mode", [0.0, 3.0], id="mode"),
+        pytest.param(mode_kde, {}, "value_mode", [0.0, 3.0], id="mode-kde"),
+        pytest.param(hdi, {"hdi_prob": 0.6}, "value_hdi_60", [[0.0, 0.0], [3.0, 3.0]], id="hdi"),
+    ],
+)
+@pytest.mark.parametrize(
+    "draw_chunk_size",
+    [
+        pytest.param(None, id="eager"),
+        pytest.param(5, id="one-draw-chunk"),
+        pytest.param(2, id="multiple-draw-chunks"),
+    ],
+)
+def test_dense_statistics_accept_sparse_data(
+    statistic, kwargs, result_name, expected, draw_chunk_size
+) -> None:
+    """Statistics requiring dense operations should own conversion of sparse inputs."""
+    result = statistic(_sparse_dataset(draw_chunk_size=draw_chunk_size), **kwargs)
+
+    if hasattr(result[result_name].data, "_meta"):
+        assert isinstance(result[result_name].data._meta, np.ndarray)
+    computed = result.compute()
+    assert isinstance(computed[result_name].data, np.ndarray)
+    np.testing.assert_allclose(computed[result_name], expected)
+
+
+@pytest.mark.parametrize(
+    ("statistic", "result_name", "expected"),
+    [
+        pytest.param(mean, "value_mean", [0.0, 3.0], id="mean"),
+        pytest.param(stdev, "value_stdev", [0.0, 0.0], id="stdev"),
+    ],
+)
+@pytest.mark.parametrize(
+    "draw_chunk_size",
+    [pytest.param(5, id="one-draw-chunk"), pytest.param(2, id="multiple-draw-chunks")],
+)
+def test_sparse_compatible_statistics_preserve_sparse_chunks(
+    statistic, result_name, expected, draw_chunk_size
+) -> None:
+    """Sparse-compatible statistics should not densify their dask chunks."""
+    result = statistic(_sparse_dataset(draw_chunk_size=draw_chunk_size))
+
+    assert isinstance(result[result_name].data._meta, sparse.COO)
+    assert result[result_name].chunks == ((1, 1),)
+    computed = result.compute()
+    assert isinstance(computed[result_name].data, sparse.COO)
+    np.testing.assert_allclose(computed[result_name].data.todense(), expected)
 
 
 def test_mode_kde_handles_nan_rows_with_dask_chunks() -> None:

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -393,9 +393,25 @@ def test_fixedbasisMCMC_paris_postprocessing_receives_modern_output(monkeypatch,
     def fake_make_paris_outputs(inv_out, **kwargs):
         captured["inv_out"] = inv_out
         captured["paris_kwargs"] = kwargs
+        concentration = xr.Dataset(
+            {
+                "Yobs": ("time", np.array([1900.0])),
+                "time_bnds": (("time", "nbnds"), np.array([[0.0, 1.0]])),
+            },
+            coords={"time": [0.5], "nbnds": [0, 1]},
+        )
+        concentration.time.attrs = {
+            "bounds": "time_bnds",
+            "units": "days since 1970-01-01 00:00:00",
+            "calendar": "proleptic_gregorian",
+        }
+        concentration.time_bnds.attrs = {
+            "units": "days since 1970-01-01 00:00:00",
+            "calendar": "proleptic_gregorian",
+        }
         return (
             xr.Dataset({"flux_total_posterior": ("time", np.array([1.0]))}, coords={"time": [0.0]}),
-            xr.Dataset({"Yobs": ("time", np.array([1900.0]))}, coords={"time": [0.0]}),
+            concentration,
         )
 
     monkeypatch.setattr(
@@ -424,6 +440,10 @@ def test_fixedbasisMCMC_paris_postprocessing_receives_modern_output(monkeypatch,
     assert captured["inv_out"].basis_functions is prepared.basis_objects["emissions"]
     assert isinstance(result, xr.Dataset)
     assert "Yobs" in result
+    concentration_path = next(tmp_path.glob("*_conc_*.nc"))
+    with xr.open_dataset(concentration_path, decode_cf=False) as saved_concentration:
+        assert saved_concentration.time_bnds.attrs["units"] == "days since 1970-01-01 00:00:00"
+        assert saved_concentration.time_bnds.attrs["calendar"] == "proleptic_gregorian"
 
 
 def test_fixedbasisMCMC_basic_postprocessing_receives_modern_output(monkeypatch, tmp_path):

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -52,6 +52,7 @@ from openghg_inversions.postprocessing._basis_products import (
     BASIS_RECONSTRUCTION_PATH_ATTR,
 )
 from openghg_inversions.postprocessing.make_outputs import observation_inputs_for_outputs
+from openghg_inversions.postprocessing.make_paris_outputs import PARIS_LATEST_COUNTRIES
 from openghg_inversions.rhime import (
     RhimeModelSpec,
     RhimeOutputSpec,
@@ -2220,6 +2221,7 @@ def test_make_multisector_output_bundle_builds_latest_paris_flux(
             "template_version": "latest",
             "inversion_grid": False,
             "flux_frequency": "yearly",
+            "country_selections": list(PARIS_LATEST_COUNTRIES),
         },
     )
     run_spec = RhimeRunSpec(
@@ -2755,7 +2757,6 @@ def test_paris_output_processes_modern_output(europe_country_file: Path) -> None
 def test_latest_paris_output_processes_modern_output(europe_country_file: Path, tmp_path: Path) -> None:
     """Explicit latest PARIS output uses the new concentration and flux templates."""
     from openghg_inversions.postprocessing.make_paris_outputs import (
-        PARIS_LATEST_COUNTRIES,
         make_paris_outputs,
     )
 
@@ -2797,6 +2798,15 @@ def test_latest_paris_output_processes_modern_output(europe_country_file: Path, 
         flux_outputs.sizes["time"],
         flux_outputs.sizes["country"],
         flux_outputs.sizes["country"],
+    )
+    np.testing.assert_allclose(
+        np.diagonal(
+            flux_outputs["covariance_flux_total_posterior_country"].values,
+            axis1=1,
+            axis2=2,
+        ),
+        flux_outputs["stdev_flux_total_posterior_country"].values ** 2,
+        rtol=1e-6,
     )
     assert "country_flux_total_posterior" not in flux_outputs
     assert flux_outputs["flux_total_posterior"].dtype == np.dtype("float32")

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import inspect
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Callable, cast
 
 import numpy as np
 import arviz as az
@@ -125,86 +125,6 @@ def _fake_basis_functions(*, artifact_source: str = "generated") -> BasisFunctio
     flux = xr.ones_like(basis, dtype=float).rename("flux")
     return BasisFunctions.from_flat_basis(
         basis_flat=basis,
-        flux=flux,
-        operator_kwargs={"state_dim": "region"},
-        metadata={BASIS_ARTIFACT_SOURCE_ATTR: artifact_source},
-    )
-
-
-def _fake_multisector_basis_functions(*, artifact_source: str = "generated") -> BasisFunctions:
-    """Build a one-cell basis artifact with source-specific prior flux."""
-    basis = xr.DataArray(
-        [[1]],
-        dims=("lat", "lon"),
-        coords={"lat": [0.0], "lon": [0.0]},
-        name="basis",
-    )
-    flux = xr.DataArray(
-        [[[1.0]], [[3.0]]],
-        dims=("source", "lat", "lon"),
-        coords={"source": ["ff-inventory", "ocean-inventory"], "lat": [0.0], "lon": [0.0]},
-        name="flux",
-    )
-    flux.attrs["units"] = "mol/m2/s"
-    return BasisFunctions.from_flat_basis(
-        basis_flat=basis,
-        flux=flux,
-        operator_kwargs={"state_dim": "region"},
-        metadata={BASIS_ARTIFACT_SOURCE_ATTR: artifact_source},
-    )
-
-
-def _fake_multisector_basis_functions_matching_country_grid(
-    country_file: Path,
-    *,
-    coord_offset: float = 0.0,
-) -> BasisFunctions:
-    """Build a one-region multisector basis artifact on the grid of a test country file."""
-    country_grid = xr.open_dataset(country_file)
-    lat = country_grid.lat.values + coord_offset
-    lon = country_grid.lon.values + coord_offset
-    basis = xr.DataArray(
-        np.ones((country_grid.sizes["lat"], country_grid.sizes["lon"]), dtype=int),
-        dims=("lat", "lon"),
-        coords={"lat": lat, "lon": lon},
-        name="basis",
-    )
-    flux = xr.concat(
-        [
-            xr.ones_like(basis, dtype=float).expand_dims(source=["ff-inventory"]),
-            (3.0 * xr.ones_like(basis, dtype=float)).expand_dims(source=["ocean-inventory"]),
-        ],
-        dim="source",
-    ).rename("flux")
-    flux.attrs["units"] = "mol/m2/s"
-    return BasisFunctions.from_flat_basis(
-        basis_flat=basis,
-        flux=flux,
-        operator_kwargs={"state_dim": "region"},
-        metadata={BASIS_ARTIFACT_SOURCE_ATTR: "country-grid-multisector-test"},
-    )
-
-
-def _fake_source_specific_multisector_basis_functions(
-    *,
-    artifact_source: str = "generated",
-) -> BasisFunctions:
-    """Build a one-cell source-specific basis artifact for multisector tests."""
-    basis = xr.DataArray(
-        [[1]],
-        dims=("lat", "lon"),
-        coords={"lat": [0.0], "lon": [0.0]},
-        name="basis",
-    )
-    flux = xr.DataArray(
-        [[[1.0]], [[3.0]]],
-        dims=("source", "lat", "lon"),
-        coords={"source": ["ff-inventory", "ocean-inventory"], "lat": [0.0], "lon": [0.0]},
-        name="flux",
-    )
-    flux.attrs["units"] = "mol/m2/s"
-    return BasisFunctions.from_multi_source_flat_basis(
-        basis_flat={"ff-inventory": basis, "ocean-inventory": basis},
         flux=flux,
         operator_kwargs={"state_dim": "region"},
         metadata={BASIS_ARTIFACT_SOURCE_ATTR: artifact_source},
@@ -520,40 +440,6 @@ def _modern_postprocessing_inv_out(
             "split_by_sectors": False,
         },
         model_metadata={"species": "ch4", "domain": "EUROPE"},
-    )
-
-
-def _multisector_postprocessing_inv_out(basis_functions: BasisFunctions | None = None) -> InversionOutput:
-    """Build a small multisector output for flux reconstruction tests."""
-    return InversionOutput(
-        trace=az.from_dict(
-            posterior={
-                "x_ff": np.array([[[0.0], [2.0]]]),
-                "x_ocean": np.array([[[2.0 / 3.0], [0.0]]]),
-            },
-            prior={
-                "x_ff": np.array([[[1.0], [1.0]]]),
-                "x_ocean": np.array([[[1.0], [1.0]]]),
-            },
-            coords={"region": [0]},
-            dims={"x_ff": ["region"], "x_ocean": ["region"]},
-        ),
-        inv_inputs=_minimal_output_inv_inputs(),
-        basis_functions=basis_functions or _fake_multisector_basis_functions(),
-        run_metadata={
-            "start_date": "2019-01-01",
-            "end_date": "2019-01-02",
-            "sites": ["TAC"],
-            "split_by_sectors": True,
-        },
-        model_metadata={
-            "species": "ch4",
-            "domain": "EUROPE",
-            "sectors": [
-                {"name": "FF", "flux_source": "ff-inventory", "variable_suffix": "ff"},
-                {"name": "Ocean", "flux_source": "ocean-inventory", "variable_suffix": "ocean"},
-            ],
-        },
     )
 
 
@@ -2305,7 +2191,11 @@ def test_make_multisector_output_bundle_returns_modern_inv_out() -> None:
     assert bundle.outputs["inversion_output"] is bundle.inv_out
 
 
-def test_make_multisector_output_bundle_builds_latest_paris_flux(europe_country_file: Path) -> None:
+def test_make_multisector_output_bundle_builds_latest_paris_flux(
+    europe_country_file: Path,
+    fake_multisector_basis_functions_matching_country_grid: Callable[..., BasisFunctions],
+    multisector_postprocessing_inv_out: Callable[..., InversionOutput],
+) -> None:
     """Multi-sector PARIS output builds explicit latest total and sector flux output."""
     sectors = (
         SectorSpec(
@@ -2341,7 +2231,7 @@ def test_make_multisector_output_bundle_builds_latest_paris_flux(europe_country_
         output_spec,
         split_by_sectors=True,
     )
-    basis_functions = _fake_multisector_basis_functions_matching_country_grid(europe_country_file)
+    basis_functions = fake_multisector_basis_functions_matching_country_grid(europe_country_file)
     basis_functions.flux.attrs["time_period"] = "not-a-parseable-period"
     prepared = RhimePreparedInputs(
         inv_inputs=_minimal_output_inv_inputs(),
@@ -2350,7 +2240,7 @@ def test_make_multisector_output_bundle_builds_latest_paris_flux(europe_country_
         averaging_period=("1h",),
         basis_artifact_source="generated",
     )
-    idata = cast(Any, _multisector_postprocessing_inv_out().trace)
+    idata = cast(Any, multisector_postprocessing_inv_out().trace)
 
     bundle = rhime_outputs.make_multisector_output_bundle(
         output_spec=output_spec,
@@ -2569,71 +2459,6 @@ def test_modern_inversion_output_supports_flux_outputs() -> None:
     )
 
     assert "flux_posterior_mean" in modern_flux
-
-
-def test_multisector_flux_outputs_reconstruct_sector_and_total_flux() -> None:
-    """Multisector flux postprocessing reconstructs sector fluxes before total statistics."""
-    from openghg_inversions.postprocessing.make_outputs import make_flux_outputs
-
-    outputs = make_flux_outputs(
-        _multisector_postprocessing_inv_out(),
-        stats=["mean", "stdev"],
-        include_scale_factors=True,
-        report_flux_on_inversion_grid=False,
-    )
-
-    assert "flux_ff_posterior_mean" in outputs
-    assert "flux_ocean_posterior_mean" in outputs
-    assert "scaling_ff_posterior_mean" in outputs
-    assert "flux_total_posterior_mean" in outputs
-    assert "flux_total_posterior_stdev" in outputs
-    assert outputs["flux_ff_posterior_mean"].attrs["units"] == "mol/m2/s"
-    assert outputs["flux_total_posterior_mean"].attrs["units"] == "mol/m2/s"
-    assert float(outputs["flux_total_posterior_mean"].item()) == 2.0
-    assert float(outputs["flux_total_posterior_stdev"].item()) == 0.0
-    assert float(outputs["flux_ff_posterior_stdev"].item()) > 0.0
-    assert _flux_nonfinite_metadata(outputs).policy == NONFINITE_POLICY_ZERO_FILL
-
-
-def test_multisector_flux_outputs_support_inversion_grid_mean_stats() -> None:
-    """Multisector inversion-grid stats work for statistics that do not need dense quantiles."""
-    from openghg_inversions.postprocessing.make_outputs import make_flux_outputs
-
-    outputs = make_flux_outputs(
-        _multisector_postprocessing_inv_out(),
-        stats=["mean", "stdev"],
-        include_scale_factors=False,
-        report_flux_on_inversion_grid=True,
-    )
-
-    assert "flux_ff_posterior_mean" in outputs
-    assert "flux_ocean_posterior_mean" in outputs
-    assert "flux_total_posterior_mean" in outputs
-    assert float(outputs["flux_total_posterior_mean"].item()) == 2.0
-
-
-def test_multisector_flux_outputs_support_source_specific_basis(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Sector flux reconstruction handles source-specific retained basis artifacts."""
-    from openghg_inversions.postprocessing.make_outputs import make_flux_outputs
-
-    basis_functions = _fake_source_specific_multisector_basis_functions()
-
-    def fail_flat_basis(self: BasisFunctions) -> xr.DataArray:
-        raise AssertionError("source-specific multisector outputs should not materialise flat basis")
-
-    monkeypatch.setattr(type(basis_functions), "flat_basis", fail_flat_basis)
-
-    outputs = make_flux_outputs(
-        _multisector_postprocessing_inv_out(basis_functions),
-        stats=["mean", "mode_kde"],
-        include_scale_factors=False,
-        report_flux_on_inversion_grid=False,
-    )
-
-    assert "flux_total_posterior_mean" in outputs
-    assert "flux_total_posterior_mode" in outputs
-    assert float(outputs["flux_total_posterior_mean"].item()) == 2.0
-    assert _flux_nonfinite_metadata(outputs).policy == NONFINITE_POLICY_ZERO_FILL
 
 
 def test_modern_flux_outputs_use_retained_basis_operator(
@@ -3023,149 +2848,6 @@ def test_latest_paris_concentration_fills_missing_bc_with_nan(europe_country_fil
         assert conc_outputs[name].dims == ("index",)
         assert conc_outputs[name].dtype == np.dtype("float32")
         assert np.isnan(conc_outputs[name].values).all()
-
-
-def test_latest_paris_sector_names_are_template_safe() -> None:
-    """PARIS sector names are lower-case variable-safe values derived from suffixes."""
-    from openghg_inversions.postprocessing.make_paris_outputs import _paris_sector_name_by_suffix
-
-    inv_out = _multisector_postprocessing_inv_out()
-    inv_out.model_metadata["sectors"] = [
-        {"name": "FF", "flux_source": "ff-inventory", "variable_suffix": "FF-sector"},
-        {"name": "Ocean", "flux_source": "ocean-inventory", "variable_suffix": "Ocean_sector"},
-    ]
-    assert _paris_sector_name_by_suffix(inv_out) == {
-        "FF-sector": "ffsector",
-        "Ocean_sector": "oceansector",
-    }
-
-    inv_out.model_metadata["sectors"] = [
-        {"name": "One", "flux_source": "ff-inventory", "variable_suffix": "sector-2"},
-        {"name": "Two", "flux_source": "ocean-inventory", "variable_suffix": "sector_2"},
-    ]
-    with pytest.raises(ValueError, match="duplicate sector name 'sector2'"):
-        _paris_sector_name_by_suffix(inv_out)
-
-    inv_out.model_metadata["sectors"] = [
-        {"name": "Total", "flux_source": "ff-inventory", "variable_suffix": "total"},
-    ]
-    with pytest.raises(ValueError, match="reserved"):
-        _paris_sector_name_by_suffix(inv_out)
-
-    inv_out.model_metadata["sectors"] = [
-        {"name": "Bad", "flux_source": "ff-inventory", "variable_suffix": "---"},
-    ]
-    with pytest.raises(ValueError, match="Could not derive"):
-        _paris_sector_name_by_suffix(inv_out)
-
-
-def test_latest_paris_flux_output_processes_multisector_sectors(
-    europe_country_file: Path,
-    tmp_path: Path,
-) -> None:
-    """Explicit latest PARIS flux output can use multisector reconstructed sector fluxes."""
-    from openghg_inversions import convert
-    from openghg_inversions.postprocessing.countries import Countries
-    from openghg_inversions.postprocessing.make_paris_outputs import PARIS_LATEST_COUNTRIES, paris_flux_output
-
-    inv_out = _multisector_postprocessing_inv_out(
-        _fake_multisector_basis_functions_matching_country_grid(europe_country_file, coord_offset=1e-10)
-    )
-
-    flux_outputs = paris_flux_output(
-        inv_out,
-        country_file=europe_country_file,
-        inversion_grid=True,
-        template_version="latest",
-    )
-
-    assert flux_outputs.attrs["paris_flux_template_version"] == "v03"
-    assert "flux_total_posterior" in flux_outputs
-    assert "stdev_flux_total_posterior" in flux_outputs
-    assert "flux_ff_posterior" in flux_outputs
-    assert "flux_ocean_posterior" in flux_outputs
-    assert "flux_ff_posterior_inversion_grid" in flux_outputs
-    assert "flux_ocean_posterior_inversion_grid" in flux_outputs
-    assert "flux_total_ff_posterior" not in flux_outputs
-    assert "flux_total_posterior_country" in flux_outputs
-    assert "flux_ff_posterior_country" in flux_outputs
-    assert "flux_ocean_posterior_country" in flux_outputs
-    assert "covariance_flux_total_posterior_country" in flux_outputs
-    assert "covariance_flux_ff_posterior_country" in flux_outputs
-    assert "covariance_flux_ocean_posterior_country" in flux_outputs
-    assert "covariance_flux_sectors_posterior_country" in flux_outputs
-    assert tuple(flux_outputs.sector.values) == ("ff", "ocean")
-    assert flux_outputs.sector.attrs["long_name"] == "short name of flux sector"
-    assert "ff" in flux_outputs["flux_ff_posterior"].attrs["long_name"]
-    assert "sector_name" not in flux_outputs["flux_ff_posterior"].attrs["long_name"]
-    assert tuple(flux_outputs.country.values) == PARIS_LATEST_COUNTRIES
-    assert flux_outputs["flux_ff_posterior"].dtype == np.dtype("float32")
-    assert flux_outputs["covariance_flux_ff_posterior_country"].dtype == np.dtype("float32")
-    np.testing.assert_allclose(flux_outputs["flux_ff_posterior"].isel(time=0).values, 1.0)
-    np.testing.assert_allclose(flux_outputs["flux_ocean_posterior"].isel(time=0).values, 1.0)
-    country_fraction_data = flux_outputs["country_fraction"].data
-    if hasattr(country_fraction_data, "todense"):
-        country_fraction_data = country_fraction_data.todense()
-    cell_area_data = flux_outputs["cell_area"].data
-    if hasattr(cell_area_data, "todense"):
-        cell_area_data = cell_area_data.todense()
-    assert not np.isnan(np.asarray(country_fraction_data)).any()
-    assert not np.isnan(np.asarray(cell_area_data)).any()
-    countries = Countries.from_file(
-        country_file=europe_country_file,
-        country_code="alpha3",
-        country_selections=list(PARIS_LATEST_COUNTRIES),
-        domain="EUROPE",
-    )
-    expected_country = (
-        2.0
-        * (countries.matrix * countries.area_grid).sum(("lat", "lon"))
-        * 365
-        * 24
-        * 3600
-        * convert.molar_mass("ch4")
-        * 1e-3
-    ).reindex(country=list(PARIS_LATEST_COUNTRIES))
-    np.testing.assert_allclose(
-        flux_outputs["flux_total_posterior_country"].isel(time=0).values,
-        expected_country.data.todense(),
-        rtol=1e-6,
-    )
-    expected_sector_country = expected_country / 2.0
-    np.testing.assert_allclose(
-        flux_outputs["flux_ff_posterior_country"].isel(time=0).values,
-        expected_sector_country.data.todense(),
-        rtol=1e-6,
-    )
-    np.testing.assert_allclose(
-        flux_outputs["flux_ocean_posterior_country"].isel(time=0).values,
-        expected_sector_country.data.todense(),
-        rtol=1e-6,
-    )
-    largest_country = int(np.asarray(expected_sector_country.data.todense()).argmax())
-    expected_sector_variance = 2.0 * np.asarray(expected_sector_country.data.todense())[largest_country] ** 2
-    np.testing.assert_allclose(
-        flux_outputs["covariance_flux_ff_posterior_country"].values[
-            0,
-            largest_country,
-            largest_country,
-        ],
-        expected_sector_variance,
-        rtol=1e-6,
-    )
-    np.testing.assert_allclose(
-        flux_outputs["covariance_flux_sectors_posterior_country"].values[
-            0,
-            largest_country,
-            0,
-            1,
-        ],
-        -expected_sector_variance,
-        rtol=1e-6,
-    )
-    assert _flux_nonfinite_metadata(flux_outputs).policy == NONFINITE_POLICY_ZERO_FILL
-
-    flux_outputs.to_netcdf(tmp_path / "latest_multisector_flux.nc")
 
 
 def test_standard_basic_output_uses_modern_postprocessing_without_legacy_adapter(monkeypatch) -> None:

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -2306,7 +2306,7 @@ def test_make_multisector_output_bundle_returns_modern_inv_out() -> None:
 
 
 def test_make_multisector_output_bundle_builds_latest_paris_flux(europe_country_file: Path) -> None:
-    """Multi-sector PARIS output builds explicit latest total flux output."""
+    """Multi-sector PARIS output builds explicit latest total and sector flux output."""
     sectors = (
         SectorSpec(
             name="FF",
@@ -2364,7 +2364,11 @@ def test_make_multisector_output_bundle_builds_latest_paris_flux(europe_country_
     assert "paris_flux" in bundle.outputs
     assert "paris_concentration" not in bundle.outputs
     assert "not implemented yet" in bundle.output_metadata["paris_note"]
-    assert "flux_total_posterior" in bundle.outputs["paris_flux"]
+    paris_flux = bundle.outputs["paris_flux"]
+    assert "flux_total_posterior" in paris_flux
+    assert "flux_ff_posterior" in paris_flux
+    assert "flux_ocean_posterior" in paris_flux
+    assert tuple(paris_flux.sector.values) == ("ff", "ocean")
 
 
 def test_modern_inversion_output_save_load_roundtrip(tmp_path: Path) -> None:
@@ -2589,6 +2593,23 @@ def test_multisector_flux_outputs_reconstruct_sector_and_total_flux() -> None:
     assert float(outputs["flux_total_posterior_stdev"].item()) == 0.0
     assert float(outputs["flux_ff_posterior_stdev"].item()) > 0.0
     assert _flux_nonfinite_metadata(outputs).policy == NONFINITE_POLICY_ZERO_FILL
+
+
+def test_multisector_flux_outputs_support_inversion_grid_mean_stats() -> None:
+    """Multisector inversion-grid stats work for statistics that do not need dense quantiles."""
+    from openghg_inversions.postprocessing.make_outputs import make_flux_outputs
+
+    outputs = make_flux_outputs(
+        _multisector_postprocessing_inv_out(),
+        stats=["mean", "stdev"],
+        include_scale_factors=False,
+        report_flux_on_inversion_grid=True,
+    )
+
+    assert "flux_ff_posterior_mean" in outputs
+    assert "flux_ocean_posterior_mean" in outputs
+    assert "flux_total_posterior_mean" in outputs
+    assert float(outputs["flux_total_posterior_mean"].item()) == 2.0
 
 
 def test_multisector_flux_outputs_support_source_specific_basis(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -3004,11 +3025,45 @@ def test_latest_paris_concentration_fills_missing_bc_with_nan(europe_country_fil
         assert np.isnan(conc_outputs[name].values).all()
 
 
-def test_latest_paris_flux_output_processes_multisector_total(
+def test_latest_paris_sector_names_are_template_safe() -> None:
+    """PARIS sector names are lower-case variable-safe values derived from suffixes."""
+    from openghg_inversions.postprocessing.make_paris_outputs import _paris_sector_name_by_suffix
+
+    inv_out = _multisector_postprocessing_inv_out()
+    inv_out.model_metadata["sectors"] = [
+        {"name": "FF", "flux_source": "ff-inventory", "variable_suffix": "FF-sector"},
+        {"name": "Ocean", "flux_source": "ocean-inventory", "variable_suffix": "Ocean_sector"},
+    ]
+    assert _paris_sector_name_by_suffix(inv_out) == {
+        "FF-sector": "ffsector",
+        "Ocean_sector": "oceansector",
+    }
+
+    inv_out.model_metadata["sectors"] = [
+        {"name": "One", "flux_source": "ff-inventory", "variable_suffix": "sector-2"},
+        {"name": "Two", "flux_source": "ocean-inventory", "variable_suffix": "sector_2"},
+    ]
+    with pytest.raises(ValueError, match="duplicate sector name 'sector2'"):
+        _paris_sector_name_by_suffix(inv_out)
+
+    inv_out.model_metadata["sectors"] = [
+        {"name": "Total", "flux_source": "ff-inventory", "variable_suffix": "total"},
+    ]
+    with pytest.raises(ValueError, match="reserved"):
+        _paris_sector_name_by_suffix(inv_out)
+
+    inv_out.model_metadata["sectors"] = [
+        {"name": "Bad", "flux_source": "ff-inventory", "variable_suffix": "---"},
+    ]
+    with pytest.raises(ValueError, match="Could not derive"):
+        _paris_sector_name_by_suffix(inv_out)
+
+
+def test_latest_paris_flux_output_processes_multisector_sectors(
     europe_country_file: Path,
     tmp_path: Path,
 ) -> None:
-    """Explicit latest PARIS flux output can use multisector reconstructed total flux."""
+    """Explicit latest PARIS flux output can use multisector reconstructed sector fluxes."""
     from openghg_inversions import convert
     from openghg_inversions.postprocessing.countries import Countries
     from openghg_inversions.postprocessing.make_paris_outputs import PARIS_LATEST_COUNTRIES, paris_flux_output
@@ -3020,17 +3075,34 @@ def test_latest_paris_flux_output_processes_multisector_total(
     flux_outputs = paris_flux_output(
         inv_out,
         country_file=europe_country_file,
-        inversion_grid=False,
+        inversion_grid=True,
         template_version="latest",
     )
 
     assert flux_outputs.attrs["paris_flux_template_version"] == "v03"
     assert "flux_total_posterior" in flux_outputs
     assert "stdev_flux_total_posterior" in flux_outputs
-    assert "flux_ff_posterior" not in flux_outputs
+    assert "flux_ff_posterior" in flux_outputs
+    assert "flux_ocean_posterior" in flux_outputs
+    assert "flux_ff_posterior_inversion_grid" in flux_outputs
+    assert "flux_ocean_posterior_inversion_grid" in flux_outputs
+    assert "flux_total_ff_posterior" not in flux_outputs
     assert "flux_total_posterior_country" in flux_outputs
+    assert "flux_ff_posterior_country" in flux_outputs
+    assert "flux_ocean_posterior_country" in flux_outputs
     assert "covariance_flux_total_posterior_country" in flux_outputs
+    assert "covariance_flux_ff_posterior_country" in flux_outputs
+    assert "covariance_flux_ocean_posterior_country" in flux_outputs
+    assert "covariance_flux_sectors_posterior_country" in flux_outputs
+    assert tuple(flux_outputs.sector.values) == ("ff", "ocean")
+    assert flux_outputs.sector.attrs["long_name"] == "short name of flux sector"
+    assert "ff" in flux_outputs["flux_ff_posterior"].attrs["long_name"]
+    assert "sector_name" not in flux_outputs["flux_ff_posterior"].attrs["long_name"]
     assert tuple(flux_outputs.country.values) == PARIS_LATEST_COUNTRIES
+    assert flux_outputs["flux_ff_posterior"].dtype == np.dtype("float32")
+    assert flux_outputs["covariance_flux_ff_posterior_country"].dtype == np.dtype("float32")
+    np.testing.assert_allclose(flux_outputs["flux_ff_posterior"].isel(time=0).values, 1.0)
+    np.testing.assert_allclose(flux_outputs["flux_ocean_posterior"].isel(time=0).values, 1.0)
     country_fraction_data = flux_outputs["country_fraction"].data
     if hasattr(country_fraction_data, "todense"):
         country_fraction_data = country_fraction_data.todense()
@@ -3057,6 +3129,38 @@ def test_latest_paris_flux_output_processes_multisector_total(
     np.testing.assert_allclose(
         flux_outputs["flux_total_posterior_country"].isel(time=0).values,
         expected_country.data.todense(),
+        rtol=1e-6,
+    )
+    expected_sector_country = expected_country / 2.0
+    np.testing.assert_allclose(
+        flux_outputs["flux_ff_posterior_country"].isel(time=0).values,
+        expected_sector_country.data.todense(),
+        rtol=1e-6,
+    )
+    np.testing.assert_allclose(
+        flux_outputs["flux_ocean_posterior_country"].isel(time=0).values,
+        expected_sector_country.data.todense(),
+        rtol=1e-6,
+    )
+    largest_country = int(np.asarray(expected_sector_country.data.todense()).argmax())
+    expected_sector_variance = 2.0 * np.asarray(expected_sector_country.data.todense())[largest_country] ** 2
+    np.testing.assert_allclose(
+        flux_outputs["covariance_flux_ff_posterior_country"].values[
+            0,
+            largest_country,
+            largest_country,
+        ],
+        expected_sector_variance,
+        rtol=1e-6,
+    )
+    np.testing.assert_allclose(
+        flux_outputs["covariance_flux_sectors_posterior_country"].values[
+            0,
+            largest_country,
+            0,
+            1,
+        ],
+        -expected_sector_variance,
         rtol=1e-6,
     )
     assert _flux_nonfinite_metadata(flux_outputs).policy == NONFINITE_POLICY_ZERO_FILL


### PR DESCRIPTION
## Summary

- Adds latest-PARIS multisector per-sector flux variables alongside the required total variables, including suffix-safe expansion of the CDL sector placeholders.
- Projects retained basis-region traces directly to country totals for each sector, preserving lazy Dask/sparse execution until statistics or NetCDF serialization require dense chunks.
- Adds total, within-sector, and between-sector posterior covariance diagnostics. The total covariance is emitted for both single-sector and multisector outputs and uses the same population estimator as the reported standard deviations.
- Keeps the latest EUROPE template's canonical 22-country list as the public default. Explicit `country_selections=None` opts into all countries in the domain file, and explicit names or codes are normalized to alpha-3 labels before projection.
- Preserves CF `units` and `calendar` attributes on bounds variables through a shared NetCDF writer used by RHIME and fixed-basis PARIS outputs.
- Adds a marked end-to-end integration test that runs two equal flux inputs through the real multisector data preparation, PyMC sampling, postprocessing, NetCDF write, and reopen path. It validates totals against sectors and compares dimensions, variables, dtypes, fill values, coordinates, and required attributes with the flux v03 CDL template.
- Keeps output-specific tests under `tests/postprocessing` and updates the issue #405 planning note with the implemented decisions and remaining concentration-output design work.

Closes #405.

## Checks

- [x] `tox -p` (OpenGHG current, previous minor, and `devel`, plus Ruff)
- [x] `.venv/bin/pytest tests/postprocessing/test_make_outputs.py tests/postprocessing/test_make_paris_outputs.py tests/test_rhime.py tests/test_postprocessing.py -q` (145 passed)
- [x] `.venv/bin/pytest -m slow tests/integration/test_multisector_paris_pipeline.py -q` (1 passed)
- [x] Ruff check and format check on all changed Python files
- [x] `git diff --check`

## Review

Subagent passes covered pipeline mapping, scientific-array correctness, test construction, docstrings, and final PR review. Their findings on country defaults and normalization, direct lazy country projection, single-sector covariance, bounds metadata, and fixed template dimensions are addressed in this branch. The final re-review found no remaining blockers.

## Notes

The PARIS CDL schema intentionally uses duplicate country and sector dimension names for covariance variables. Xarray warns when reopening those variables, so the integration test also validates their raw NetCDF dimensions directly.

## Template checklist

- [x] Closes #405
- [x] Tests added and passing
- [x] Documentation updated
- [x] Changelog entry not required for this unreleased feature branch
- [x] No new requirements
