### PR TITLE
[codex] Fix generated basis NaN weights

### DIFF
--- a/openghg_inversions/basis/_functions.py
+++ b/openghg_inversions/basis/_functions.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Literal, cast
 
 import pandas as pd
+import numpy as np
 import xarray as xr
 import logging
 
@@ -244,12 +245,43 @@ def basis_weights_from_fp_all(
     return _mean_fp_times_mean_flux(flux, footprints, abs_flux=abs_flux, mask=mask).as_numpy()
 
 
+def _sanitize_generated_basis_weights(
+    weights: xr.DataArray,
+    *,
+    algorithm: str,
+    require_nonzero: bool = False,
+) -> xr.DataArray:
+    """Replace non-finite generated-basis weights and reject empty weight fields."""
+    weights = weights.as_numpy()
+    finite = xr.apply_ufunc(np.isfinite, weights)
+    if not bool(finite.any().item()):
+        raise ValueError(f"{algorithm} generated-basis weights contain no finite values.")
+
+    sanitized = weights.where(finite, 0.0)
+
+    if require_nonzero and not bool((sanitized != 0.0).any().item()):
+        raise ValueError(
+            f"{algorithm} generated-basis weights contain no non-zero finite values "
+            "after replacing non-finite values with zero."
+        )
+
+    return sanitized
+
+
 def _normalise_weights_by_max(weights: xr.DataArray) -> xr.DataArray:
     """Return weights scaled by their maximum when the maximum is positive."""
     max_weight = float(weights.max())
     if max_weight > 0:
         return weights / max_weight
     return weights
+
+
+def _normalise_weights_by_nonzero_max(weights: xr.DataArray) -> xr.DataArray:
+    """Return weights scaled by their finite non-zero maximum."""
+    max_weight = float(weights.max())
+    if not np.isfinite(max_weight) or max_weight == 0.0:
+        raise ValueError("generated-basis weights have no finite non-zero maximum.")
+    return weights / max_weight
 
 
 def _finalise_generated_basis(
@@ -288,8 +320,9 @@ def quadtree_basis_from_weights(
         Basis field with ``lat``/``lon`` dimensions, a singleton ``time``
         dimension, and integer region labels.
     """
+    weights = _sanitize_generated_basis_weights(weights, algorithm="quadtree", require_nonzero=True)
     func = partial(quadtree_algorithm, nbasis=nbasis, seed=seed)
-    quad_basis = xr.apply_ufunc(func, weights.as_numpy())
+    quad_basis = xr.apply_ufunc(func, weights)
     return _finalise_generated_basis(quad_basis, start_date=start_date, domain=domain)
 
 
@@ -318,8 +351,8 @@ def bucket_basis_from_weights(
         Basis field with ``lat``/``lon`` dimensions, a singleton ``time``
         dimension, and integer region labels.
     """
-    weights = weights.as_numpy()
-    weights = weights / weights.max()
+    weights = _sanitize_generated_basis_weights(weights, algorithm="weighted bucket", require_nonzero=True)
+    weights = _normalise_weights_by_nonzero_max(weights)
     func = partial(
         weighted_algorithm,
         nregion=nbasis,
@@ -388,7 +421,7 @@ def region_constrained_basis_from_weights(
         Basis field with globally unique integer labels that do not cross
         ``region_classes`` values.
     """
-    raw_weights = weights.as_numpy()
+    raw_weights = _sanitize_generated_basis_weights(weights, algorithm="region-constrained")
     weights = _normalise_weights_by_max(raw_weights)
     region_classes = region_classes.transpose(*weights.dims)
     region_classes = region_classes.sel({dim: weights.coords[dim] for dim in weights.dims})

--- a/tests/test_basis_functions.py
+++ b/tests/test_basis_functions.py
@@ -141,6 +141,218 @@ def test_basis_weights_from_fp_all_applies_abs_flux_and_mask():
     xr.testing.assert_allclose(weights, expected)
 
 
+def _basis_weights_with_nonfinite_cells() -> xr.DataArray:
+    """Build generated-basis weights with NaN and infinite cells."""
+    return xr.DataArray(
+        np.array([[np.nan, np.inf], [-np.inf, 4.0]]),
+        dims=("lat", "lon"),
+        coords={"lat": [10.0, 20.0], "lon": [1.0, 2.0]},
+        name="basis_weight",
+    )
+
+
+def test_quadtree_basis_from_weights_sanitizes_nonfinite_before_dispatch(monkeypatch):
+    """Quadtree adapter sends finite weights to the lower-level algorithm."""
+    weights = _basis_weights_with_nonfinite_cells()
+
+    def fake_quadtree_algorithm(grid: np.ndarray, nbasis: int, seed: int | None = None) -> np.ndarray:
+        """Assert non-finite cells were replaced with zero before dispatch."""
+        assert nbasis == 3
+        assert seed == 7
+        np.testing.assert_allclose(grid, np.array([[0.0, 0.0], [0.0, 4.0]]))
+        return np.arange(1, grid.size + 1).reshape(grid.shape)
+
+    monkeypatch.setattr(basis_module, "quadtree_algorithm", fake_quadtree_algorithm)
+
+    basis_func = quadtree_basis_from_weights(weights, "2019-01-01", "TEST", nbasis=3, seed=7)
+
+    assert basis_func.dims == ("lat", "lon", "time")
+    xr.testing.assert_equal(basis_func.lat, weights.lat)
+    xr.testing.assert_equal(basis_func.lon, weights.lon)
+    assert basis_func.attrs["domain"] == "TEST"
+
+
+def test_bucket_basis_from_weights_sanitizes_nonfinite_before_dispatch(monkeypatch):
+    """Weighted bucket adapter normalizes finite sanitized weights."""
+    weights = _basis_weights_with_nonfinite_cells()
+
+    def fake_weighted_algorithm(
+        grid: np.ndarray,
+        nregion: int,
+        bucket: float,
+        domain: str,
+        country_directory: str | None = None,
+    ) -> np.ndarray:
+        """Assert non-finite cells were replaced and normalized before dispatch."""
+        assert nregion == 4
+        assert bucket == 1
+        assert domain == "TEST"
+        assert country_directory == "/tmp/countries"
+        np.testing.assert_allclose(grid, np.array([[0.0, 0.0], [0.0, 1.0]]))
+        return np.arange(1, grid.size + 1).reshape(grid.shape)
+
+    monkeypatch.setattr(basis_module, "weighted_algorithm", fake_weighted_algorithm)
+
+    basis_func = bucket_basis_from_weights(
+        weights,
+        "2019-01-01",
+        "TEST",
+        nbasis=4,
+        country_directory="/tmp/countries",
+    )
+
+    assert basis_func.dims == ("lat", "lon", "time")
+    xr.testing.assert_equal(basis_func.lat, weights.lat)
+    xr.testing.assert_equal(basis_func.lon, weights.lon)
+    assert basis_func.attrs["domain"] == "TEST"
+
+
+def test_bucket_basis_from_weights_preserves_all_negative_normalization(monkeypatch):
+    """Weighted bucket adapter keeps legacy normalization by a negative maximum."""
+    weights = xr.DataArray(
+        np.array([[-4.0, -2.0], [-1.0, -3.0]]),
+        dims=("lat", "lon"),
+        coords={"lat": [10.0, 20.0], "lon": [1.0, 2.0]},
+    )
+
+    def fake_weighted_algorithm(
+        grid: np.ndarray,
+        nregion: int,
+        bucket: float,
+        domain: str,
+        country_directory: str | None = None,
+    ) -> np.ndarray:
+        """Assert all-negative weights are still divided by their maximum."""
+        del nregion, bucket, domain, country_directory
+        np.testing.assert_allclose(grid, np.array([[4.0, 2.0], [1.0, 3.0]]))
+        return np.arange(1, grid.size + 1).reshape(grid.shape)
+
+    monkeypatch.setattr(basis_module, "weighted_algorithm", fake_weighted_algorithm)
+
+    basis_func = bucket_basis_from_weights(weights, "2019-01-01", "TEST")
+
+    assert basis_func.dims == ("lat", "lon", "time")
+    assert basis_func.attrs["domain"] == "TEST"
+
+
+def test_region_constrained_basis_from_weights_sanitizes_nonfinite_before_dispatch(monkeypatch):
+    """Region-constrained adapter sends finite normalized weights to the algorithm."""
+    weights = _basis_weights_with_nonfinite_cells()
+    region_classes = xr.DataArray(
+        np.array([["west", "west"], ["east", "east"]], dtype=object),
+        dims=weights.dims,
+        coords=weights.coords,
+        name="region_class",
+    )
+
+    def fake_region_constrained_basis(
+        weights_arg: xr.DataArray,
+        region_classes_arg: xr.DataArray,
+        nbasis: int,
+        **kwargs,
+    ) -> xr.DataArray:
+        """Assert non-finite cells were replaced and normalized before dispatch."""
+        del kwargs
+        assert nbasis == 2
+        np.testing.assert_allclose(weights_arg.values, np.array([[0.0, 0.0], [0.0, 1.0]]))
+        xr.testing.assert_equal(region_classes_arg, region_classes)
+        return xr.ones_like(weights_arg, dtype=int)
+
+    monkeypatch.setattr(basis_module, "region_constrained_basis", fake_region_constrained_basis)
+
+    basis_func = region_constrained_basis_from_weights(
+        weights,
+        "2019-01-01",
+        "TEST",
+        region_classes=region_classes,
+        nbasis=2,
+    )
+
+    assert basis_func.dims == ("lat", "lon", "time")
+    xr.testing.assert_equal(basis_func.lat, weights.lat)
+    xr.testing.assert_equal(basis_func.lon, weights.lon)
+    assert basis_func.attrs["domain"] == "TEST"
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        quadtree_basis_from_weights,
+        bucket_basis_from_weights,
+    ],
+)
+@pytest.mark.parametrize(
+    ("values", "message"),
+    [
+        (np.zeros((2, 2)), "no non-zero finite values"),
+        (np.full((2, 2), np.nan), "no finite values"),
+    ],
+)
+def test_quadtree_and_bucket_basis_from_weights_reject_empty_sanitized_weights(factory, values, message):
+    """Quadtree and weighted bucket adapters reject empty sanitized weights."""
+    weights = xr.DataArray(
+        values,
+        dims=("lat", "lon"),
+        coords={"lat": [10.0, 20.0], "lon": [1.0, 2.0]},
+    )
+
+    with pytest.raises(ValueError, match=message):
+        factory(weights, "2019-01-01", "TEST")
+
+
+def test_region_constrained_basis_from_weights_all_zero_falls_back_to_area():
+    """Region-constrained all-zero finite weights keep the existing area fallback."""
+    _fp_all, region_classes = _tiny_region_constrained_fp_all()
+    weights = xr.zeros_like(region_classes, dtype=float)
+
+    basis_func = region_constrained_basis_from_weights(
+        weights,
+        "2020-01-01",
+        "TEST",
+        region_classes=region_classes,
+        nbasis=4,
+    )
+
+    assert basis_func.dims == ("lat", "lon", "time")
+    xr.testing.assert_equal(basis_func.lat, weights.lat)
+    xr.testing.assert_equal(basis_func.lon, weights.lon)
+    assert np.isfinite(basis_func.values).all()
+    labels = basis_func.squeeze("time", drop=True)
+    assert set(np.unique(labels.values)) == {1, 2, 3, 4}
+    _assert_basis_labels_do_not_cross_classes(labels, region_classes)
+
+
+@pytest.mark.parametrize(
+    ("values", "message"),
+    [
+        (np.full((2, 2), np.nan), "no finite values"),
+        (np.full((2, 2), np.inf), "no finite values"),
+        (np.empty((0, 2)), "no finite values"),
+    ],
+)
+def test_region_constrained_basis_from_weights_rejects_no_finite_cells(values, message):
+    """Region-constrained rejects all-invalid weights instead of area-fallback labels."""
+    weights = xr.DataArray(
+        values,
+        dims=("lat", "lon"),
+        coords={"lat": np.arange(values.shape[0], dtype=float), "lon": [1.0, 2.0]},
+    )
+    region_classes = xr.DataArray(
+        np.full(values.shape, "class", dtype=object),
+        dims=weights.dims,
+        coords=weights.coords,
+    )
+
+    with pytest.raises(ValueError, match=message):
+        region_constrained_basis_from_weights(
+            weights,
+            "2020-01-01",
+            "TEST",
+            region_classes=region_classes,
+            nbasis=2,
+        )
+
+
 def test_quadtree_basis_from_weights_matches_fp_all_adapter(monkeypatch):
     """Quadtree ``fp_all`` wrapper delegates to the weight-first helper."""
     fp_all = _simple_fp_all_for_basis_weights()


### PR DESCRIPTION
* **Summary of changes**

- Zero-fill non-finite generated-basis weight cells before dispatching to quadtree, weighted/bucket, and region-constrained basis algorithms.
- Reject generated-basis weight fields with no finite cells, and reject empty/all-zero quadtree or weighted/bucket fields before lower-level normalization/optimization.
- Preserve the region-constrained finite all-zero weight area fallback.
- Preserve legacy weighted/bucket normalization for all-negative finite weights.
- Add focused regression tests for mixed NaN/Inf cells, all-invalid cells, all-zero handling, and the all-negative weighted/bucket compatibility case.

* **Overlap / PR handling**

- This intentionally updates the existing draft PR #474 for issue #473 instead of opening a duplicate OGI-028 PR.
- The previous PR #474 branch was stale against current `devel`; this update replaces it with a current `devel`-based commit while preserving newer region-constrained options.

* **Please check if the PR fulfills these requirements**

- [x] Closes #473
- [x] Tests added and passing
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry to the `CHANGELOG.md` file
- [x] No new requirements added

Closes #473.

Review:
- Subagent code mapping identified the shared generated-basis adapter boundary and edge cases.
- Subagent testing review requested all-invalid and finite all-zero region-constrained coverage.
- Final subagent review found no blockers after preserving all-negative weighted/bucket normalization.

Tests:
- `uv run pytest tests/test_basis_functions.py -k "sanitizes_nonfinite or empty_sanitized or no_finite_cells or all_zero_falls_back or all_negative_normalization or quadtree_basis_from_weights or bucket_basis_from_weights or region_constrained_basis_from_weights"`
- `uv run pytest tests/test_basis_functions.py tests/test_constrained_basis_algorithm.py tests/test_weighted_basis_algorithm.py`
- `uv run ruff check openghg_inversions/basis/_functions.py tests/test_basis_functions.py`
- `uv run pyright openghg_inversions/basis/_functions.py`
- `git diff --check`

Not run:
- `tox -p`
