### PR TITLE
Draft: HPC CI dummy trigger smoke

### DIFF
--- a/docs/hpc-ci-dummy-pr-trigger-20260610.md
+++ b/docs/hpc-ci-dummy-pr-trigger-20260610.md
@@ -1,0 +1,5 @@
+# HPC CI dummy trigger marker
+
+This file intentionally creates a harmless `openghg_inversions` pull request so the external HPC CI trigger can be exercised manually.
+
+Do not merge this PR unless a maintainer explicitly wants to keep the marker.


### PR DESCRIPTION
Manual opt-in HPC CI smoke PR.

This PR intentionally contains only a harmless docs marker so the external `hpc-ci openghg-pr-trigger` workflow can be exercised against an `openghg_inversions` PR SHA.

Do not merge without maintainer review. It can be closed after the smoke evidence is recorded.