### PR TITLE
Add inertial split step for constrained basis partitioning

### DIFF
--- a/openghg_inversions/basis/algorithms/_constrained.py
+++ b/openghg_inversions/basis/algorithms/_constrained.py
@@ -33,6 +33,7 @@ AllocationMode: TypeAlias = Literal["weight", "area"]
 NbasisAllocation: TypeAlias = int | Mapping[Hashable, int]
 GridNode: TypeAlias = tuple[int, int]
 GridPartition: TypeAlias = list[GridNode]
+_INERTIAL_TOLERANCE = 1.0e-12
 
 
 class SplitStrategy(Protocol):
@@ -106,6 +107,34 @@ class AxisParallelSplitStep:
             balanced=self.balanced,
             clean_splits=self.clean_splits,
         )
+        if not left or not right:
+            return [nodes]
+        return [left, right]
+
+
+@dataclass(frozen=True)
+class InertialSplitStep:
+    """Experimental split step using a weighted inertial regression axis.
+
+    This step uses grid-index coordinates only. Latitude, area, and physical
+    distance semantics are intentionally deferred to the OGI-048 design work.
+    """
+
+    balanced: bool = True
+
+    def __call__(self, nodes: GridPartition, weights: np.ndarray) -> list[GridPartition]:
+        """Return child partitions from one inertial-axis split.
+
+        Args:
+            nodes: Grid nodes in the partition being split.
+            weights: Non-negative weight field aligned to the source grid.
+
+        Returns:
+            Two child partitions when the inertial split succeeds, or the
+            original partition when neither inertial nor fallback splitting can
+            produce two non-empty sides.
+        """
+        left, right = _inertial_split_nodes(nodes, weights, balanced=self.balanced)
         if not left or not right:
             return [nodes]
         return [left, right]
@@ -748,6 +777,142 @@ def _axis_parallel_split_nodes(
         return left, right
 
     return ordered[:split_index], ordered[split_index:]
+
+
+def _inertial_split_nodes(
+    nodes: GridPartition,
+    weights: np.ndarray,
+    *,
+    balanced: bool,
+) -> tuple[GridPartition, GridPartition]:
+    """Split nodes along their weighted orthogonal-regression axis.
+
+    Degenerate or numerically unstable inertial fits fall back to an
+    axis-parallel split so callers always get deterministic behavior.
+    """
+    fallback = _axis_parallel_split_nodes(
+        nodes,
+        weights,
+        balanced=balanced,
+        clean_splits=False,
+    )
+    if len(nodes) < 3:
+        return fallback
+
+    inertial_order = _inertial_ordered_nodes(nodes, weights)
+    if inertial_order is None:
+        return fallback
+
+    ordered, projections = inertial_order
+    if balanced:
+        rows, cols = _node_indices(ordered)
+        split_index = _idx_of_half_cumsum(weights[rows, cols])
+    else:
+        split_index = len(ordered) // 2
+
+    split_index = min(max(split_index, 1), len(ordered) - 1)
+    if _projection_tie_at_split(projections, split_index):
+        return fallback
+
+    left = ordered[:split_index]
+    right = ordered[split_index:]
+    if not left or not right:
+        return fallback
+    return left, right
+
+
+def _inertial_ordered_nodes(
+    nodes: GridPartition,
+    weights: np.ndarray,
+) -> tuple[GridPartition, npt.NDArray[np.float64]] | None:
+    """Return nodes ordered by projection onto the weighted inertial axis."""
+    rows, cols = _node_indices(nodes)
+    node_weights = weights[rows, cols].astype(np.float64)
+    axis_and_centroid = _weighted_inertial_axis(nodes, node_weights)
+    if axis_and_centroid is None:
+        return None
+
+    axis, centroid = axis_and_centroid
+    coords = np.asarray(nodes, dtype=np.float64)
+    projections = (coords - centroid) @ axis
+    if not np.isfinite(projections).all() or float(np.ptp(projections)) <= _INERTIAL_TOLERANCE:
+        return None
+
+    order = sorted(
+        range(len(nodes)),
+        key=lambda index: (float(projections[index]), nodes[index][0], nodes[index][1]),
+    )
+    ordered_nodes = [nodes[index] for index in order]
+    ordered_projections = projections[order]
+    return ordered_nodes, ordered_projections
+
+
+def _weighted_inertial_axis(
+    nodes: GridPartition,
+    node_weights: npt.NDArray[np.float64],
+) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]] | None:
+    """Return the principal weighted orthogonal-regression axis and centroid."""
+    if not np.isfinite(node_weights).all():
+        return None
+
+    total_weight = float(node_weights.sum())
+    if total_weight <= 0.0 or not np.isfinite(total_weight):
+        return None
+
+    coords = np.asarray(nodes, dtype=np.float64)
+    weight_column = node_weights.reshape(-1, 1)
+    centroid = (coords * weight_column).sum(axis=0) / total_weight
+    centered = coords - centroid
+    mxy = float((node_weights * centered[:, 0] * centered[:, 1]).sum())
+    if np.isclose(mxy, 0.0, rtol=_INERTIAL_TOLERANCE, atol=_INERTIAL_TOLERANCE):
+        return None
+
+    covariance = centered.T @ (centered * weight_column) / total_weight
+    if not np.isfinite(covariance).all():
+        return None
+
+    try:
+        eigenvalues, eigenvectors = np.linalg.eigh(covariance)
+    except np.linalg.LinAlgError:
+        return None
+
+    if not np.isfinite(eigenvalues).all() or not np.isfinite(eigenvectors).all():
+        return None
+
+    axis_index = int(np.argmax(eigenvalues))
+    if float(eigenvalues[axis_index]) <= _INERTIAL_TOLERANCE:
+        return None
+    eigenvalue_gap = float(eigenvalues[axis_index] - eigenvalues[1 - axis_index])
+    if eigenvalue_gap <= _INERTIAL_TOLERANCE * max(1.0, abs(float(eigenvalues[axis_index]))):
+        return None
+
+    axis = eigenvectors[:, axis_index].astype(np.float64)
+    axis_norm = float(np.linalg.norm(axis))
+    if axis_norm <= _INERTIAL_TOLERANCE or not np.isfinite(axis_norm):
+        return None
+
+    axis = _canonical_inertial_axis(axis / axis_norm)
+    return axis, centroid
+
+
+def _canonical_inertial_axis(axis: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+    """Flip an eigenvector to a deterministic orientation for sorting."""
+    nonzero = np.flatnonzero(np.abs(axis) > _INERTIAL_TOLERANCE)
+    if len(nonzero) > 0 and axis[int(nonzero[0])] < 0.0:
+        return -axis
+    return axis
+
+
+def _projection_tie_at_split(projections: npt.NDArray[np.float64], split_index: int) -> bool:
+    """Return true when an inertial split would divide equal projections."""
+    return bool(
+        np.isclose(
+            projections[split_index - 1],
+            projections[split_index],
+            rtol=_INERTIAL_TOLERANCE,
+            atol=_INERTIAL_TOLERANCE,
+        )
+    )
 
 
 def _idx_of_half_cumsum(weights: npt.ArrayLike) -> int:

--- a/openghg_inversions/basis/algorithms/_constrained.py
+++ b/openghg_inversions/basis/algorithms/_constrained.py
@@ -114,10 +114,20 @@ class AxisParallelSplitStep:
 
 @dataclass(frozen=True)
 class InertialSplitStep:
-    """Experimental split step using a weighted inertial regression axis.
+    """Experimental split step using a weighted principal inertial axis.
 
-    This step uses grid-index coordinates only. Latitude, area, and physical
-    distance semantics are intentionally deferred to the OGI-048 design work.
+    The split projects partition cells onto the principal axis of their
+    weighted grid-index covariance, then cuts that one-dimensional ordering by
+    weight or by count. This lets diagonal, rotated, or strongly anisotropic
+    high-gradient structures split along their natural orientation instead of
+    being forced through row/column cuts. The greedy class-local orchestrator
+    still invokes this step independently inside each region class, so labels
+    keep the same region-constrained boundary guarantees as axis-parallel
+    splitting.
+
+    This step deliberately uses grid-index coordinates only. Latitude, area,
+    physical distance semantics, and possible lat/lon/time coordinates are
+    deferred to later design work.
     """
 
     balanced: bool = True
@@ -785,10 +795,18 @@ def _inertial_split_nodes(
     *,
     balanced: bool,
 ) -> tuple[GridPartition, GridPartition]:
-    """Split nodes along their weighted orthogonal-regression axis.
+    """Split nodes along their weighted principal inertial axis.
 
-    Degenerate or numerically unstable inertial fits fall back to an
-    axis-parallel split so callers always get deterministic behavior.
+    The implementation treats the row/column node coordinates as point masses,
+    orders cells by projection onto the dominant weighted covariance axis, and
+    splits that ordering near half total weight or half cell count. Compared
+    with row/column splits, this can preserve diagonal or rotated structures
+    while still returning ordinary node partitions to the greedy constrained
+    strategy.
+
+    Degenerate geometry, tied projections at the selected cut, or numerically
+    unstable inertial fits fall back to an axis-parallel split so callers always
+    get deterministic behavior.
     """
     fallback = _axis_parallel_split_nodes(
         nodes,
@@ -851,7 +869,15 @@ def _weighted_inertial_axis(
     nodes: GridPartition,
     node_weights: npt.NDArray[np.float64],
 ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]] | None:
-    """Return the principal weighted orthogonal-regression axis and centroid."""
+    """Return the principal weighted inertial axis and centroid.
+
+    The current problem is only a 2D row/column covariance, so a closed-form
+    axis formula would be possible. ``np.linalg.eigh`` is intentionally kept
+    here because the covariance is symmetric, the arrays are tiny, and the
+    symmetric eigensolver avoids slope/division edge cases while leaving a
+    straightforward path to future higher-dimensional coordinate spaces such as
+    lat/lon/time basis functions.
+    """
     if not np.isfinite(node_weights).all():
         return None
 
@@ -871,6 +897,8 @@ def _weighted_inertial_axis(
     if not np.isfinite(covariance).all():
         return None
 
+    # ``eigh`` is a stable symmetric eigensolver for this tiny covariance and
+    # keeps the implementation dimension-agnostic if coordinates grow past 2D.
     try:
         eigenvalues, eigenvectors = np.linalg.eigh(covariance)
     except np.linalg.LinAlgError:

--- a/tests/test_constrained_basis_algorithm.py
+++ b/tests/test_constrained_basis_algorithm.py
@@ -3,10 +3,12 @@ import pytest
 import xarray as xr
 
 from openghg_inversions.basis.algorithms import (
+    AxisParallelSplitStep,
     GreedyAxisParallelSplitStrategy,
     allocate_nbasis_by_class,
     region_constrained_basis,
 )
+from openghg_inversions.basis.algorithms._constrained import InertialSplitStep
 
 
 def _class_values_for_labels(labels: xr.DataArray, classes: xr.DataArray) -> dict[int, set]:
@@ -18,6 +20,14 @@ def _class_values_for_labels(labels: xr.DataArray, classes: xr.DataArray) -> dic
         class_values = classes.values[labels.values == label]
         result[int(label)] = {value for value in class_values if value == value}
     return result
+
+
+def _partition_weight(nodes: list[tuple[int, int]], weights: np.ndarray) -> float:
+    """Return total weight for a node partition."""
+    if not nodes:
+        return 0.0
+    rows, cols = zip(*nodes)
+    return float(weights[list(rows), list(cols)].sum())
 
 
 def test_region_constrained_basis_labels_do_not_cross_classes():
@@ -128,6 +138,113 @@ def test_greedy_axis_parallel_strategy_hits_target_region_count():
     labels = GreedyAxisParallelSplitStrategy()(weights, class_mask, target_regions=5)
 
     assert set(np.unique(labels)) == {1, 2, 3, 4, 5}
+
+
+def test_inertial_split_produces_two_non_empty_child_partitions():
+    """Non-degenerate inertial splits produce two child node partitions."""
+    nodes = [(0, 0), (1, 1), (2, 2), (3, 3), (4, 4)]
+    weights = np.zeros((5, 5))
+    for node in nodes:
+        weights[node] = 1.0
+
+    children = InertialSplitStep()(nodes, weights)
+
+    assert len(children) == 2
+    assert all(children)
+    assert sorted(children[0] + children[1]) == nodes
+
+
+def test_inertial_split_degenerate_geometry_falls_back_deterministically():
+    """Axis-aligned geometry with mxy=0 falls back to the axis-parallel step."""
+    nodes = [(0, 1), (1, 1), (2, 1), (3, 1)]
+    weights = np.ones((4, 3))
+
+    inertial_children = InertialSplitStep(balanced=False)(nodes, weights)
+    fallback_children = AxisParallelSplitStep(balanced=False)(nodes, weights)
+
+    assert inertial_children == fallback_children
+    assert len(inertial_children) == 2
+
+
+def test_inertial_split_projection_tie_falls_back_deterministically():
+    """A split boundary through equal projections uses the fallback splitter."""
+    nodes = [(0, 0), (0, 1), (1, 0), (1, 1)]
+    weights = np.array([[1.0, 100.0], [100.0, 1.0]])
+
+    inertial_children = InertialSplitStep(balanced=True)(nodes, weights)
+    fallback_children = AxisParallelSplitStep(balanced=True)(nodes, weights)
+
+    assert inertial_children == fallback_children
+    assert len(inertial_children) == 2
+
+
+def test_inertial_split_unsplittable_partition_returns_original_nodes():
+    """Unsplittable partitions return one non-empty child and no empty child."""
+    nodes = [(0, 0)]
+    weights = np.ones((1, 1))
+
+    children = InertialSplitStep()(nodes, weights)
+
+    assert children == [nodes]
+
+
+@pytest.mark.parametrize("fill_value", [0.0, 1.0])
+def test_inertial_split_handles_zero_and_equal_weights(fill_value: float):
+    """All-zero and equal weights do not crash or produce empty children."""
+    nodes = [(0, 0), (1, 1), (2, 2), (3, 3)]
+    weights = np.full((4, 4), fill_value)
+
+    children = InertialSplitStep()(nodes, weights)
+
+    assert len(children) == 2
+    assert all(children)
+    assert sorted(children[0] + children[1]) == nodes
+
+
+def test_inertial_split_balanced_approximates_half_weight_split():
+    """Balanced inertial splitting chooses the split nearest half total weight."""
+    nodes = [(0, 0), (1, 1), (2, 2), (3, 3)]
+    weights = np.zeros((4, 4))
+    for node, value in zip(nodes, [1.0, 1.0, 8.0, 10.0]):
+        weights[node] = value
+
+    children = InertialSplitStep(balanced=True)(nodes, weights)
+    child_weights = sorted(_partition_weight(child, weights) for child in children)
+
+    assert child_weights == [10.0, 10.0]
+
+
+def test_inertial_split_unbalanced_uses_count_based_split():
+    """Unbalanced inertial splitting divides ordered nodes by count."""
+    nodes = [(0, 0), (1, 1), (2, 2), (3, 3), (4, 4)]
+    weights = np.zeros((5, 5))
+    for node, value in zip(nodes, [100.0, 1.0, 1.0, 1.0, 1.0]):
+        weights[node] = value
+
+    children = InertialSplitStep(balanced=False)(nodes, weights)
+
+    assert sorted(len(child) for child in children) == [2, 3]
+    assert sorted(_partition_weight(child, weights) for child in children) == [3.0, 101.0]
+
+
+def test_region_constrained_basis_with_inertial_step_keeps_class_boundaries():
+    """Inertial split steps still run independently inside region classes."""
+    weights = xr.DataArray(np.ones((4, 4)), dims=("lat", "lon"))
+    class_values = np.full((4, 4), np.nan, dtype=object)
+    for index in range(4):
+        class_values[index, index] = "main"
+        class_values[index, 3 - index] = "anti"
+    classes = xr.DataArray(class_values, dims=weights.dims)
+
+    labels = region_constrained_basis(
+        weights,
+        classes,
+        nbasis=4,
+        split_strategy=GreedyAxisParallelSplitStrategy(split_step=InertialSplitStep()),
+    )
+
+    assert set(np.unique(labels.values)) == {0, 1, 2, 3, 4}
+    assert all(len(class_values) == 1 for class_values in _class_values_for_labels(labels, classes).values())
 
 
 def test_greedy_strategy_accepts_partition_step_returning_multiple_regions():

--- a/tests/test_constrained_basis_algorithm.py
+++ b/tests/test_constrained_basis_algorithm.py
@@ -227,6 +227,25 @@ def test_inertial_split_unbalanced_uses_count_based_split():
     assert sorted(_partition_weight(child, weights) for child in children) == [3.0, 101.0]
 
 
+def test_inertial_split_can_differ_from_axis_parallel_split():
+    """Inertial ordering can split anisotropic shapes away from row/column cuts."""
+    nodes = [(0, 0), (0, 1), (0, 2), (0, 3), (1, 0)]
+    weights = np.zeros((2, 4))
+    for node in nodes:
+        weights[node] = 1.0
+
+    inertial_children = InertialSplitStep(balanced=False)(nodes, weights)
+    axis_parallel_children = AxisParallelSplitStep(balanced=False)(nodes, weights)
+
+    inertial_sets = {frozenset(child) for child in inertial_children}
+    axis_parallel_sets = {frozenset(child) for child in axis_parallel_children}
+    assert inertial_sets != axis_parallel_sets
+    assert inertial_sets == {
+        frozenset({(0, 3), (0, 2)}),
+        frozenset({(0, 1), (0, 0), (1, 0)}),
+    }
+
+
 def test_region_constrained_basis_with_inertial_step_keeps_class_boundaries():
     """Inertial split steps still run independently inside region classes."""
     weights = xr.DataArray(np.ones((4, 4)), dims=("lat", "lon"))


### PR DESCRIPTION
## Summary
- Add an experimental `InertialSplitStep` that splits grid nodes along a weighted inertial axis.
- Fall back to the existing axis-parallel split when the inertial fit is degenerate, unstable, or would create an empty side.
- Extend constrained-basis tests to cover balanced and unbalanced behavior, fallback cases, and class-boundary preservation.

## Testing
- Not run (not requested)
- Added unit coverage for inertial splitting, fallback determinism, and integration with `region_constrained_basis`