### PR TITLE
Filter RHIME data before generated basis construction

### DIFF
--- a/docs/plans/mask_constrained_basis.md
+++ b/docs/plans/mask_constrained_basis.md
@@ -26,6 +26,9 @@ part of #340.
   as adapters.
 - `codex/ogi-043-fixed-outer-layout`: design note for preserving legacy InTEM
   fixed outer regions while exposing them as grouped constrained partitions.
+- `codex/ogi-041-filter-before-basis`: RHIME-only bugfix branch with one
+  observation-filter stage before basis loading or generation and sensitivity
+  construction.
 
 ## Design Notes
 
@@ -281,6 +284,12 @@ be tested without committing to config syntax.
   route while defining the grouped RHIME path as a constrained allocation:
   fixed outer classes get one basis region each and the inner class receives the
   requested generated regions.
+- 2026-07-05: Started OGI-041 on `codex/ogi-041-filter-before-basis`.
+  Modern RHIME preparation now applies observation filters once, before either
+  loading or generating the basis and before sensitivity construction. The same
+  filtered merged data, sites, and averaging metadata flow through both stages.
+  The legacy fixedbasis preparation path remains unchanged and should be handled
+  by a separate task if that behavior needs to move.
 - 2026-06-21: Added greedy split stopping through a lower-level
   `SplitAcceptancePolicy` hook and `MinChildWeightShare` policy. Rejected
   splits freeze the selected parent partition, so the requested class-local

--- a/openghg_inversions/inversion_data/preparation.py
+++ b/openghg_inversions/inversion_data/preparation.py
@@ -428,9 +428,8 @@ def _bc_basis_directory_arg(bc_basis_directory: str | Path | None) -> str | None
 
 def _rhime_site_data_from_basis_functions(
     *,
-    fp_all: dict,
+    merged: _MergedInversionData,
     basis_functions: BasisFunctions,
-    sites: list[str],
     domain: str,
     split_by_sectors: bool,
     flux_sources: list[str],
@@ -438,11 +437,11 @@ def _rhime_site_data_from_basis_functions(
     bc_basis_case: str,
     bc_basis_directory: str | None,
 ) -> dict:
-    """Build RHIME site datasets using retained basis functions only."""
-    fp_data = {site: fp_all[site].copy() for site in sites}
+    """Apply retained basis functions to one prepared merged-data stage."""
+    fp_data = {site: merged.fp_all[site].copy() for site in merged.sites}
     fp_x_flux_name = "fp_x_flux_sectoral" if split_by_sectors else "fp_x_flux"
 
-    for site in sites:
+    for site in merged.sites:
         if fp_data[site].sizes.get("time", 0) == 0:
             continue
         fp_x_flux = fp_data[site][fp_x_flux_name]
@@ -478,7 +477,7 @@ def _rhime_site_data_from_basis_functions(
         )
 
     if use_bc:
-        with timed("rhime.prepare_inputs.bc_sensitivity", sites=len(sites)):
+        with timed("rhime.prepare_inputs.bc_sensitivity", sites=len(merged.sites)):
             fp_data = bc_sensitivity(
                 fp_data,
                 domain=domain,
@@ -487,6 +486,42 @@ def _rhime_site_data_from_basis_functions(
             )
 
     return fp_data
+
+
+def _filter_merged_inversion_data(
+    *,
+    merged: _MergedInversionData,
+    filters: Any,
+) -> _MergedInversionData:
+    """Filter merged RHIME data as a separate pre-basis preparation stage.
+
+    Args:
+        merged: Merged site data and site-aligned metadata from data gathering
+            or reload.
+        filters: Filter configuration accepted by
+            :func:`openghg_inversions.filters.filtering`.
+
+    Returns:
+        Merged data containing filtered site datasets, with empty sites and
+        their aligned averaging periods removed. If no filters are configured
+        and all sites contain data, the original merged data are returned.
+
+    Raises:
+        ValueError: If every requested site is removed by filtering.
+    """
+    if filters is None and all(merged.fp_all[site].time.values.shape[0] > 0 for site in merged.sites):
+        return merged
+
+    fp_data = {site: merged.fp_all[site].copy() for site in merged.sites}
+    fp_data, sites, averaging_period = _apply_filters_and_drop_empty_sites(
+        fp_data=fp_data,
+        sites=merged.sites,
+        averaging_period=merged.averaging_period,
+        filters=filters,
+    )
+    fp_all = {key: value for key, value in merged.fp_all.items() if key.startswith(".")}
+    fp_all.update(fp_data)
+    return _MergedInversionData(fp_all=fp_all, sites=sites, averaging_period=averaging_period)
 
 
 def prepare_fixedbasis_inversion_data(
@@ -694,6 +729,10 @@ def prepare_rhime_inputs(
 ) -> RhimePreparedInputs:
     """Prepare modern RHIME inputs without exposing legacy fixedbasis containers.
 
+    Observation filters are applied once to merged data before basis loading or
+    generation. The same filtered site datasets and aligned metadata are then
+    used for sensitivity construction.
+
     Args:
         species: Primary gas or tracer name used for object-store lookup and
             output naming.
@@ -754,6 +793,9 @@ def prepare_rhime_inputs(
             flux_non_finite_check=flux_non_finite_check,
         )
 
+    with timed("rhime.prepare_inputs.obs_filtering", sites=len(merged.sites), filters=filters is not None):
+        filtered_merged = _filter_merged_inversion_data(merged=merged, filters=filters)
+
     with timed(
         "rhime.prepare_inputs.basis_build",
         basis_algorithm=basis_algorithm,
@@ -766,7 +808,7 @@ def prepare_rhime_inputs(
             fp_basis_case=fp_basis_case,
             basis_directory=basis_directory,
             country_directory=country_directory,
-            fp_all=merged.fp_all,
+            fp_all=filtered_merged.fp_all,
             species=species,
             domain=domain,
             start_date=start_date,
@@ -775,14 +817,11 @@ def prepare_rhime_inputs(
             outputname=output_name,
             output_path=basis_output_path,
         )
-    basis_source = basis_functions.basis_artifact_source or "generated"
-    basis_path = getattr(basis_functions, "basis_artifact_path", None)
 
-    with timed("rhime.prepare_inputs.footprint_sensitivity_total", sites=len(merged.sites)):
+    with timed("rhime.prepare_inputs.footprint_sensitivity_total", sites=len(filtered_merged.sites)):
         fp_data = _rhime_site_data_from_basis_functions(
-            fp_all=merged.fp_all,
+            merged=filtered_merged,
             basis_functions=basis_functions,
-            sites=merged.sites,
             domain=domain,
             split_by_sectors=split_by_sectors,
             flux_sources=flux_sources,
@@ -790,19 +829,14 @@ def prepare_rhime_inputs(
             bc_basis_case=bc_basis_case,
             bc_basis_directory=_bc_basis_directory_arg(bc_basis_directory),
         )
-    with timed("rhime.prepare_inputs.obs_filtering", sites=len(merged.sites), filters=filters is not None):
-        fp_data, prepared_sites, prepared_averaging_period = _apply_filters_and_drop_empty_sites(
-            fp_data=fp_data,
-            sites=merged.sites,
-            averaging_period=merged.averaging_period,
-            filters=filters,
-        )
-    _set_domain_attrs(fp_data, prepared_sites, domain)
+    basis_source = basis_functions.basis_artifact_source or "generated"
+    basis_path = getattr(basis_functions, "basis_artifact_path", None)
+    _set_domain_attrs(fp_data, filtered_merged.sites, domain)
 
-    with timed("rhime.prepare_inputs.make_inv_inputs", sites=len(prepared_sites)):
+    with timed("rhime.prepare_inputs.make_inv_inputs", sites=len(filtered_merged.sites)):
         inv_inputs = _make_inv_inputs(
             fp_data=fp_data,
-            sites=prepared_sites,
+            sites=filtered_merged.sites,
             start_date=start_date,
             bc_freq=bc_freq,
             sigma_freq=sigma_freq,
@@ -811,12 +845,12 @@ def prepare_rhime_inputs(
             min_error_options=min_error_options,
         )
     _warn_for_nan_inputs(inv_inputs, use_bc=use_bc)
-    site_lats, site_lons = _site_release_coordinates(fp_data, prepared_sites)
+    site_lats, site_lons = _site_release_coordinates(fp_data, filtered_merged.sites)
     log_timing(
         "rhime.prepare_inputs.prepared_dims",
         0.0,
         nmeasure=inv_inputs.sizes.get("nmeasure"),
-        sites=len(prepared_sites),
+        sites=len(filtered_merged.sites),
         regions=inv_inputs.sizes.get("region"),
         sources=inv_inputs.sizes.get("source"),
         basis_source=basis_source,
@@ -827,8 +861,8 @@ def prepare_rhime_inputs(
         basis_functions=basis_functions,
         basis_artifact_source=basis_source,
         basis_artifact_path=basis_path,
-        sites=tuple(prepared_sites),
-        averaging_period=tuple(prepared_averaging_period),
+        sites=tuple(filtered_merged.sites),
+        averaging_period=tuple(filtered_merged.averaging_period),
         site_lats=site_lats,
         site_lons=site_lons,
     )

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -486,6 +486,22 @@ class _DynamicSpyBasisFunctions(_SpyBasisFunctions):
         )
 
 
+class _DynamicSectorSpyBasisFunctions(_SpyBasisFunctions):
+    """BasisFunctions test double that derives source-resolved sensitivity."""
+
+    def __init__(self) -> None:
+        super().__init__(xr.DataArray())
+
+    def sensitivity(self, fp_x_flux: xr.DataArray, fillna: bool = True) -> xr.DataArray:
+        self.sensitivity_calls.append(fp_x_flux)
+        return xr.DataArray(
+            np.ones((1, fp_x_flux.sizes["time"], fp_x_flux.sizes["source"])),
+            dims=("region", "time", "source"),
+            coords={"region": [0], "time": fp_x_flux.time, "source": fp_x_flux.source},
+            name="H",
+        )
+
+
 def test_build_rhime_model_contains_expected_variables(
     rhime_inv_inputs: xr.Dataset, builder_args: dict
 ) -> None:
@@ -2187,10 +2203,327 @@ def test_prepare_rhime_inputs_treats_min_error_none_as_default(
     assert captured_min_error == 0.0
 
 
+def test_prepare_rhime_inputs_filters_sites_before_basis_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One filter pass should feed basis, flux, and BC sensitivity construction."""
+    site_data = {"TAC": _site_dataset([2.0, 3.0, 4.0])}
+    basis_functions = _DynamicSpyBasisFunctions()
+    filtering_calls = 0
+    captured_basis_times: tuple[np.datetime64, ...] | None = None
+    captured_bc_times: tuple[np.datetime64, ...] | None = None
+    retained_times = tuple(site_data["TAC"].time.isel(time=[1]).values)
+
+    def fake_data_processing_surface_notracer(
+        **kwargs: object,
+    ) -> tuple[dict, list[str], list[str], list[str], list[str], list[str]]:
+        return (
+            {**site_data, ".species": "CH4"},
+            ["TAC"],
+            ["185m"],
+            ["185m"],
+            ["instrument-1"],
+            ["1H"],
+        )
+
+    def fake_filtering(fp_data: dict, filters: object) -> dict:
+        nonlocal filtering_calls
+        filtering_calls += 1
+        assert filters == ["keep-middle"]
+        assert "H" not in fp_data["TAC"]
+        return {"TAC": fp_data["TAC"].isel(time=[1])}
+
+    def fake_make_basis_functions(**kwargs: object) -> _DynamicSpyBasisFunctions:
+        nonlocal captured_basis_times
+        fp_all = kwargs["fp_all"]
+        assert isinstance(fp_all, dict)
+        captured_basis_times = tuple(fp_all["TAC"].time.values)
+        return basis_functions
+
+    def fake_bc_sensitivity(fp_data: dict, **kwargs: object) -> dict:
+        """Record filtered times and add matching boundary-condition sensitivity."""
+        nonlocal captured_bc_times
+        captured_bc_times = tuple(fp_data["TAC"].time.values)
+        fp_data["TAC"]["H_bc"] = xr.DataArray(
+            np.ones((1, len(retained_times))),
+            dims=("bc_region", "time"),
+            coords={"bc_region": [0], "time": fp_data["TAC"].time},
+        )
+        return fp_data
+
+    def fake_make_inv_inputs(fp_data: dict, sites: list[str], **kwargs: object) -> xr.Dataset:
+        assert sites == ["TAC"]
+        assert tuple(fp_data["TAC"].time.values) == retained_times
+        assert tuple(fp_data["TAC"]["H"].time.values) == retained_times
+        assert tuple(fp_data["TAC"]["H_bc"].time.values) == retained_times
+        return _minimal_inv_inputs()
+
+    monkeypatch.setattr(
+        prep_module,
+        "data_processing_surface_notracer",
+        fake_data_processing_surface_notracer,
+    )
+    monkeypatch.setattr(prep_module, "filtering", fake_filtering)
+    monkeypatch.setattr(prep_module, "make_basis_functions", fake_make_basis_functions)
+    monkeypatch.setattr(prep_module, "bc_sensitivity", fake_bc_sensitivity)
+    monkeypatch.setattr(prep_module, "make_inv_inputs", fake_make_inv_inputs)
+
+    prepared = prepare_rhime_inputs(
+        species="ch4",
+        sites=["TAC"],
+        domain="EUROPE",
+        averaging_period=["1H"],
+        start_date="2019-01-01",
+        end_date="2019-02-01",
+        output_name="filter_before_basis",
+        flux_sources=["total-ukghg-edgar7"],
+        use_bc=True,
+        filters=["keep-middle"],
+    )
+
+    assert prepared.sites == ("TAC",)
+    assert prepared.averaging_period == ("1H",)
+    assert captured_basis_times == retained_times
+    assert tuple(basis_functions.sensitivity_calls[0].time.values) == retained_times
+    assert captured_bc_times == retained_times
+    assert filtering_calls == 1
+
+
+def test_prepare_rhime_inputs_applies_daily_median_before_sensitivity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Daily-median filtering should aggregate times before basis projection."""
+    site_dataset = _site_dataset([2.0, 3.0, 4.0]).drop_vars(["fp_x_flux", "lat", "lon"])
+    site_dataset["fp_x_flux"] = xr.DataArray(
+        [[[0.0, 100.0]], [[0.0, 0.0]], [[100.0, 0.0]]],
+        dims=("time", "lat", "lon"),
+        coords={"time": site_dataset.time, "lat": [0.0], "lon": [0.0, 1.0]},
+    )
+    basis_input: xr.DataArray | None = None
+    final_sensitivity: xr.DataArray | None = None
+
+    def fake_data_processing_surface_notracer(
+        **kwargs: object,
+    ) -> tuple[dict, list[str], list[str], list[str], list[str], list[str]]:
+        return (
+            {"TAC": site_dataset, ".species": "CH4"},
+            ["TAC"],
+            ["185m"],
+            ["185m"],
+            ["instrument-1"],
+            ["1H"],
+        )
+
+    def fake_make_basis_functions(**kwargs: object) -> BasisFunctions:
+        nonlocal basis_input
+        fp_all = kwargs["fp_all"]
+        assert isinstance(fp_all, dict)
+        basis_input = fp_all["TAC"]["fp_x_flux"].copy()
+        basis = xr.DataArray(
+            [[1, 1]],
+            dims=("lat", "lon"),
+            coords={"lat": [0.0], "lon": [0.0, 1.0]},
+        )
+        return BasisFunctions.from_flat_basis(basis_flat=basis, flux=xr.ones_like(basis))
+
+    def fake_make_inv_inputs(fp_data: dict, sites: list[str], **kwargs: object) -> xr.Dataset:
+        nonlocal final_sensitivity
+        final_sensitivity = fp_data["TAC"]["H"].copy()
+        return _minimal_inv_inputs()
+
+    monkeypatch.setattr(
+        prep_module,
+        "data_processing_surface_notracer",
+        fake_data_processing_surface_notracer,
+    )
+    monkeypatch.setattr(prep_module, "make_basis_functions", fake_make_basis_functions)
+    monkeypatch.setattr(prep_module, "make_inv_inputs", fake_make_inv_inputs)
+
+    prepare_rhime_inputs(
+        species="ch4",
+        sites=["TAC"],
+        domain="EUROPE",
+        averaging_period=["1H"],
+        start_date="2019-01-01",
+        end_date="2019-02-01",
+        output_name="daily_median_filter_order",
+        flux_sources=["total-ukghg-edgar7"],
+        use_bc=False,
+        filters=["daily_median"],
+    )
+
+    assert basis_input is not None
+    assert basis_input.sizes["time"] == 1
+    xr.testing.assert_allclose(basis_input, xr.zeros_like(basis_input))
+    assert final_sensitivity is not None
+    xr.testing.assert_identical(final_sensitivity.time, basis_input.time)
+    xr.testing.assert_allclose(final_sensitivity, xr.zeros_like(final_sensitivity))
+
+
+def test_prepare_rhime_inputs_filters_multisector_sites_before_basis_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Multisector filtering should preserve source dimensions on retained times."""
+    site_dataset = _site_dataset([2.0, 3.0, 4.0])
+    flux_sources = ["total-ukghg-edgar7", "sector-2"]
+    site_dataset["fp_x_flux_sectoral"] = xr.concat(
+        [
+            site_dataset["fp_x_flux"],
+            2.0 * site_dataset["fp_x_flux"],
+        ],
+        dim=xr.DataArray(flux_sources, dims="source", name="source"),
+    )
+    site_data = {"TAC": site_dataset}
+    basis_functions = _DynamicSectorSpyBasisFunctions()
+    captured_split_by_sectors: object = None
+    retained_times = tuple(site_dataset.time.isel(time=[2]).values)
+
+    def fake_data_processing_surface_notracer(
+        **kwargs: object,
+    ) -> tuple[dict, list[str], list[str], list[str], list[str], list[str]]:
+        return (
+            {
+                **site_data,
+                ".flux": {source: object() for source in flux_sources},
+                ".species": "CH4",
+                ".split_by_sectors": True,
+            },
+            ["TAC"],
+            ["185m"],
+            ["185m"],
+            ["instrument-1"],
+            ["1H"],
+        )
+
+    def fake_filtering(fp_data: dict, filters: object) -> dict:
+        assert filters == {"TAC": ["keep-last"]}
+        assert "H" not in fp_data["TAC"]
+        return {"TAC": fp_data["TAC"].isel(time=[2])}
+
+    def fake_make_basis_functions(**kwargs: object) -> _DynamicSectorSpyBasisFunctions:
+        nonlocal captured_split_by_sectors
+        fp_all = kwargs["fp_all"]
+        assert isinstance(fp_all, dict)
+        captured_split_by_sectors = fp_all[".split_by_sectors"]
+        assert tuple(fp_all["TAC"].time.values) == retained_times
+        return basis_functions
+
+    def fake_make_inv_inputs(fp_data: dict, sites: list[str], **kwargs: object) -> xr.Dataset:
+        assert sites == ["TAC"]
+        assert tuple(fp_data["TAC"].time.values) == retained_times
+        assert tuple(fp_data["TAC"]["H"].time.values) == retained_times
+        assert fp_data["TAC"]["H"].dims == ("region", "time", "source")
+        assert tuple(fp_data["TAC"]["H"].source.values) == tuple(flux_sources)
+        return _minimal_inv_inputs()
+
+    monkeypatch.setattr(
+        prep_module,
+        "data_processing_surface_notracer",
+        fake_data_processing_surface_notracer,
+    )
+    monkeypatch.setattr(prep_module, "filtering", fake_filtering)
+    monkeypatch.setattr(prep_module, "make_basis_functions", fake_make_basis_functions)
+    monkeypatch.setattr(prep_module, "make_inv_inputs", fake_make_inv_inputs)
+
+    prepared = prepare_rhime_inputs(
+        species="ch4",
+        sites=["TAC"],
+        domain="EUROPE",
+        averaging_period=["1H"],
+        start_date="2019-01-01",
+        end_date="2019-02-01",
+        output_name="filter_before_sector_basis",
+        flux_sources=flux_sources,
+        split_by_sectors=True,
+        use_bc=False,
+        filters={"TAC": ["keep-last"]},
+    )
+
+    assert prepared.sites == ("TAC",)
+    assert captured_split_by_sectors is True
+    assert tuple(basis_functions.sensitivity_calls[0].time.values) == retained_times
+    assert tuple(basis_functions.sensitivity_calls[0].source.values) == tuple(flux_sources)
+    assert basis_functions.sensitivity_calls[0].name == "fp_x_flux_sectoral"
+
+
+def test_prepare_rhime_inputs_filters_loaded_basis_before_sensitivity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Loaded-basis runs should filter observations once before sensitivity construction."""
+    site_data = {"TAC": _site_dataset([2.0, 3.0, 4.0])}
+    basis_functions = _DynamicSpyBasisFunctions()
+    captured_basis_times: tuple[np.datetime64, ...] | None = None
+    filtering_calls = 0
+    retained_times = tuple(site_data["TAC"].time.isel(time=[1]).values)
+
+    def fake_data_processing_surface_notracer(
+        **kwargs: object,
+    ) -> tuple[dict, list[str], list[str], list[str], list[str], list[str]]:
+        return (
+            {**site_data, ".species": "CH4"},
+            ["TAC"],
+            ["185m"],
+            ["185m"],
+            ["instrument-1"],
+            ["1H"],
+        )
+
+    def fake_make_basis_functions(**kwargs: object) -> _DynamicSpyBasisFunctions:
+        nonlocal captured_basis_times
+        assert kwargs["fp_basis_case"] == "saved_case"
+        fp_all = kwargs["fp_all"]
+        assert isinstance(fp_all, dict)
+        captured_basis_times = tuple(fp_all["TAC"].time.values)
+        return basis_functions
+
+    def fake_filtering(fp_data: dict, filters: object) -> dict:
+        nonlocal filtering_calls
+        filtering_calls += 1
+        assert filters == ["keep-middle"]
+        assert "H" not in fp_data["TAC"]
+        return {"TAC": fp_data["TAC"].isel(time=[1])}
+
+    def fake_make_inv_inputs(fp_data: dict, sites: list[str], **kwargs: object) -> xr.Dataset:
+        assert sites == ["TAC"]
+        assert tuple(fp_data["TAC"].time.values) == retained_times
+        assert tuple(fp_data["TAC"]["H"].time.values) == retained_times
+        return _minimal_inv_inputs()
+
+    monkeypatch.setattr(
+        prep_module,
+        "data_processing_surface_notracer",
+        fake_data_processing_surface_notracer,
+    )
+    monkeypatch.setattr(prep_module, "make_basis_functions", fake_make_basis_functions)
+    monkeypatch.setattr(prep_module, "filtering", fake_filtering)
+    monkeypatch.setattr(prep_module, "make_inv_inputs", fake_make_inv_inputs)
+
+    prepared = prepare_rhime_inputs(
+        species="ch4",
+        sites=["TAC"],
+        domain="EUROPE",
+        averaging_period=["1H"],
+        start_date="2019-01-01",
+        end_date="2019-02-01",
+        output_name="filter_loaded_basis",
+        flux_sources=["total-ukghg-edgar7"],
+        fp_basis_case="saved_case",
+        use_bc=False,
+        filters=["keep-middle"],
+    )
+
+    assert prepared.sites == ("TAC",)
+    assert captured_basis_times == retained_times
+    assert tuple(basis_functions.sensitivity_calls[0].time.values) == retained_times
+    assert filtering_calls == 1
+
+
 def test_prepare_rhime_inputs_aligns_averaging_period_after_empty_site_drop(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Filtering should keep site metadata aligned after dropping an empty site."""
     site_data = {"TAC": _site_dataset([2.0]), "MHD": _site_dataset([])}
+    captured_basis_sites: list[str] | None = None
 
     def fake_data_processing_surface_notracer(
         **kwargs: object,
@@ -2205,6 +2538,10 @@ def test_prepare_rhime_inputs_aligns_averaging_period_after_empty_site_drop(
         )
 
     def fake_make_basis_functions(**kwargs: object) -> BasisFunctions:
+        nonlocal captured_basis_sites
+        fp_all = kwargs["fp_all"]
+        assert isinstance(fp_all, dict)
+        captured_basis_sites = [key for key in fp_all if not key.startswith(".")]
         return _fake_basis_functions()
 
     def fake_make_inv_inputs(fp_data: dict, sites: list[str], **kwargs: object) -> xr.Dataset:
@@ -2233,11 +2570,13 @@ def test_prepare_rhime_inputs_aligns_averaging_period_after_empty_site_drop(
 
     assert prepared.sites == ("TAC",)
     assert prepared.averaging_period == ("1H",)
+    assert captured_basis_sites == ["TAC"]
 
 
-def test_prepare_rhime_inputs_rejects_all_sites_dropped_after_sensitivity(
+def test_prepare_rhime_inputs_rejects_all_sites_dropped_before_basis_generation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Filtering should fail before basis construction when every site is empty."""
     site_data = {"TAC": _site_dataset([]), "MHD": _site_dataset([])}
 
     def fake_data_processing_surface_notracer(
@@ -2253,7 +2592,7 @@ def test_prepare_rhime_inputs_rejects_all_sites_dropped_after_sensitivity(
         )
 
     def fake_make_basis_functions(**kwargs: object) -> BasisFunctions:
-        return _fake_basis_functions()
+        raise AssertionError("Basis generation should not run when all sites are dropped.")
 
     monkeypatch.setattr(
         prep_module,


### PR DESCRIPTION
* **Summary of changes**

- Apply modern RHIME observation filters and resampling once, before either loading or generating basis functions and before sensitivity construction.
- Pass the same filtered site datasets and aligned metadata through basis fit/load, emissions sensitivity, and boundary-condition sensitivity.
- Keep filtering and basis application as separate reusable preparation steps while retaining adjacent fit/load-and-apply orchestration.
- Preserve the legacy Python `fixedbasisMCMC` preparation path unchanged.
- Add single-sector, multisector, loaded-basis, boundary-condition, daily-median, empty-site, and all-sites-dropped regression coverage.

Related: #449, #460

* **Validation**

- `tox -p`
- `uv run pytest tests/test_rhime.py -k 'filters_sites_before_basis_generation or applies_daily_median_before_sensitivity or filters_multisector_sites_before_basis_generation or filters_loaded_basis_before_sensitivity or aligns_averaging_period_after_empty_site_drop or rejects_all_sites_dropped_before_basis_generation or direct_sensitivity'`
- `uv run pytest tests/test_rhime.py`
- `uv run ruff check openghg_inversions/inversion_data/preparation.py tests/test_rhime.py`
- `uv run ruff format --check openghg_inversions/inversion_data/preparation.py tests/test_rhime.py`
- `uv run pyright openghg_inversions/inversion_data/preparation.py`

* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [x] Tests added and passing
- [x] Documentation and tutorials updated/added
- [ ] Added an entry to the `CHANGELOG.md` file
- [x] Added any new requirements to `requirements.txt` (none needed)
