### PR TITLE
Document split-stopping basis semantics

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -74,6 +74,7 @@ NOTE: flux and boundary conditions data usually has a specific *domain*, but it 
     -   basis functions for fluxes can be created on the fly with the `quadtree` or `weighted` algorithms. You can also read in pre-defined basis functions. Default location: `openghg_inversions/basis_functions`
     -   region-constrained basis generation is available through the Python basis API when the caller supplies an already loaded `region_classes` `DataArray`. This is intended for land/sea, country, or other region-class masks, and keeps labels from crossing those classes. The current `.ini`/`run_hbmcmc.py` route does not yet load `region_classes` from a file, so use a saved basis file or the Python wrapper for this case.
     -   region-constrained splitting can optionally use `split_acceptance="contrast_score"` with a design contribution array. This uses a fixed design covariance `S` and a prior split-contrast standard deviation `tau`; the default `tau=1`, `S=I` is only an uncalibrated ranking/debugging score, not calibrated expected information gain. Do not build this score from observed mole fractions or residuals.
+    -   lower-level region-constrained algorithms also support split-stopping policies. `MinChildWeightShare` is a parent-relative balance guard, while `MinChildTargetWeightShare` rejects children below a share of the class-local equal-target region weight, `weights.sum() / target_regions`. Their thresholds are not interchangeable; with stopping enabled, `nbasis` is an upper target. These child-share policies are not yet routed through `.ini`, `run_hbmcmc.py`, or RHIME config options.
     -   basis functions for the boundary conditions have a similar format. Default location `openghg_inversions/bc_basis_functions`
 
 Summary
@@ -259,7 +260,7 @@ met_model = 'UKV'  ; or None if not specified, check the metadata for your footp
 ;   - nbasis - Number of basis functions to use for quadtree derived basis function (rounded to %4)
 ; Region-constrained basis functions are available through the Python basis API
 ; when a caller supplies region_classes. This .ini route does not currently load
-; region_classes from file.
+; region_classes from file or route child-share split-stopping policies.
 
 bc_basis_case  = "NESW"
 bc_basis_directory = "/group/chemistry/acrg/LPDM/bc_basis_functions/"  ; LPDM/bc_basis_functions is default

--- a/docs/plans/mask_constrained_basis.md
+++ b/docs/plans/mask_constrained_basis.md
@@ -32,11 +32,10 @@ part of #340.
 - Partition each mapped class independently, then offset labels globally so
   region labels never collide across classes.
 - Preserve unmapped cells consistently with label `0`.
-- Start with a prototype-inspired greedy axis-parallel repeated-bisection split
-  strategy rather than the current recursive weighted bucket splitter. Do not
-  implement inertial partitions yet, but keep the strategy boundary explicit so
-  an inertial split, quadtree-style split, recursive weighted split, or other
-  partitioning step can be substituted.
+- Keep greedy axis-parallel repeated-bisection as the default split strategy
+  rather than the legacy recursive weighted bucket splitter. Keep the strategy
+  boundary explicit so inertial, quadtree-style, recursive weighted, or other
+  partitioning steps can be substituted when they have tests and routing.
 - Document `nbasis` allocation. Initial target: support explicit per-class
   allocation plus automatic allocation proportional to class total weight, with a
   minimum for non-empty mapped classes.
@@ -141,10 +140,16 @@ be tested without committing to config syntax.
   explicit loop prevention and a reason that a later attempt could succeed.
   Fallback to a different split step or a more permissive split is also deferred
   until there is evidence that the extra behavior is needed.
-- Defer config-file routing, `basis_functions_wrapper` exposure, and RHIME
-  runner options for split stopping. The core policy is useful and testable at
-  the lower-level greedy strategy boundary, while public routing should wait for
-  the surrounding basis option schema to settle.
+- Current public routing is intentionally narrower than the algorithm layer.
+  Lower-level Python calls can pass split-stopping policies such as
+  `MinChildWeightShare`, `MinChildTargetWeightShare`,
+  `MaxChildPCAEccentricity`, or `AllSplitAcceptancePolicies` through
+  `GreedyAxisParallelSplitStrategy`. The higher-level basis wrappers currently
+  route only `split_acceptance="none"` and `split_acceptance="contrast_score"`.
+  `.ini`, `run_hbmcmc.py`, `run_rhime`, and `run-rhime` do not yet expose
+  parent-share or equal-target child-share thresholds as config options. Public
+  config routing for those policies should wait for the surrounding basis option
+  schema to settle.
 - Treat simulated annealing, precomputed multiscale weights, and observation-
   weighted definitions as future optimizer/weight-builder work. They are useful
   sources from `~/Documents/basis_functions`, but they should not block the
@@ -281,3 +286,8 @@ be tested without committing to config syntax.
   geometry. The narrow API adds `LatLonGridGeometry` as an opt-in geometry
   object for axis-parallel and inertial split steps, while keeping weights,
   split stopping, allocation, and public config routing unchanged.
+- 2026-07-05: Documented OGI-060 split-stopping semantics in the user-facing
+  basis notes. The docs now state that parent-relative and equal-target
+  thresholds are not interchangeable, that requested region counts become upper
+  targets when stopping is enabled, and that only `"none"` and
+  `"contrast_score"` are currently routed through the higher-level wrappers.

--- a/docs/plans/ogi_048_basis_algorithm_options.md
+++ b/docs/plans/ogi_048_basis_algorithm_options.md
@@ -24,6 +24,14 @@ Axis-parallel contrast rows append `/contrast` to the candidate label. They use 
 
 For the no-mask score rows below, allocation is reported as `single_class` because there is only one class. The generator uses the normal weight-allocation API internally, but no inter-class allocation decision is being tested in that case.
 
+Current API routing is narrower than this option matrix. The core constrained
+algorithm can compose split-stopping policies such as `MinChildWeightShare`,
+`MinChildTargetWeightShare`, and `MaxChildPCAEccentricity`, and those policies
+can return fewer regions than the requested target. Higher-level basis wrappers
+currently expose only `split_acceptance="none"` and
+`split_acceptance="contrast_score"`; child-share stopping thresholds are not
+available through `.ini`, `run_hbmcmc.py`, or RHIME config options.
+
 ## Option Shorthand
 
 Candidate labels use the format `allocation/split_step/split_mode/geometry`. The objective group is shown separately because no mask, land/sea mask, and selected-country mask answer different scientific basis-design questions.

--- a/docs/usage/getting_started.rst
+++ b/docs/usage/getting_started.rst
@@ -90,6 +90,19 @@ Data not stored in OpenGHG
     current ``.ini``/``run_hbmcmc.py`` route does not yet load
     ``region_classes`` from a file, so use a saved basis file or the Python
     wrapper for this case.
+  - region-constrained splitting can optionally use
+    ``split_acceptance="contrast_score"`` with a design contribution array.
+    This uses a fixed design covariance ``S`` and a prior split-contrast
+    standard deviation ``tau``; the default ``tau=1``, ``S=I`` is only an
+    uncalibrated ranking/debugging score, not calibrated expected information
+    gain. Do not build this score from observed mole fractions or residuals.
+  - lower-level region-constrained algorithms also support split-stopping
+    policies. ``MinChildWeightShare`` is a parent-relative balance guard,
+    while ``MinChildTargetWeightShare`` rejects children below a share of the
+    class-local equal-target region weight, ``weights.sum() / target_regions``.
+    Their thresholds are not interchangeable; with stopping enabled,
+    ``nbasis`` is an upper target. These child-share policies are not yet
+    routed through ``.ini``, ``run_hbmcmc.py``, or RHIME config options.
   - basis functions for the boundary conditions have a similar format.
     Default location ``openghg_inversions/bc_basis_functions``
 
@@ -319,7 +332,7 @@ The following file, ``my_hbmcmc_inputs.ini`` can be used to run an
    ; Input values to extract the basis cases to use within the inversion for boundary conditions and emissions
    ; basis_algorithm (str): Choice of basis function algorithm to use. One of "quadtree" or "weighted".
    ; The Python basis API also supports "region_constrained" when the caller supplies a region_classes DataArray;
-   ; this .ini route does not currently load region_classes from file.
+   ; this .ini route does not currently load region_classes from file or route child-share split-stopping policies.
    ; bc_basis_case (str): Boundary conditions basis, defaults to "NESW" (looks for file format {bc_basis_case}_{domain}_*.nc)
    ; bc_basis_directory (str/None): Directory for bc_basis functions. If None provided, creates new folder in openghg_inversions expecting to find bc_basis_function files there.
    ; fp_basis_case (str/None): Emissions bases:

--- a/docs/usage/rhime.rst
+++ b/docs/usage/rhime.rst
@@ -124,6 +124,32 @@ are not the same strings as the OpenGHG source values.
        "ocean": {"pdf": "lognormal", "mean": 1.0, "stdev": 1.0}
    }
 
+Generated Basis Functions
+-------------------------
+
+RHIME can load saved flux basis functions with ``fp_basis_case`` or generate a
+basis with ``basis_algorithm`` and ``nbasis``. The legacy generated-basis
+choices exposed through RHIME config are still ``"quadtree"`` and
+``"weighted"``.
+
+The lower-level Python basis API also supports ``"region_constrained"`` when a
+caller supplies an already loaded ``region_classes`` ``DataArray``. That path
+keeps generated labels from crossing land/sea, country, inner/outer, or other
+class boundaries, but RHIME config and ``run_hbmcmc.py`` do not yet load
+``region_classes`` from files. For RHIME runs that need these masks today,
+build and save the basis through the Python basis API, then load it as a saved
+basis case.
+
+Region-constrained algorithms have split-stopping policies at the lower-level
+strategy boundary. ``MinChildWeightShare`` is a parent-relative balance guard:
+it compares the lightest proposed child with the current parent partition.
+``MinChildTargetWeightShare`` is an equal-target low-weight guard: it compares
+the lightest proposed child with ``weights.sum() / target_regions`` for the
+class/source-local field being partitioned. Thresholds such as ``0.1`` mean
+different things for those policies, and generated region counts become upper
+targets when split stopping rejects remaining candidates. These child-share
+policies are not currently routed through RHIME config options.
+
 Output Formats
 --------------
 

--- a/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template.ini
+++ b/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template.ini
@@ -79,7 +79,7 @@ bc_input = None
 ; Input values to extract the basis cases to use within the inversion for boundary conditions and emissions
 ; basis_algorithm (str): Choice of basis function algorithm to use. One of "quadtree" or "weighted".
 ; The Python basis API also supports "region_constrained" when the caller supplies a region_classes DataArray;
-; this .ini route does not currently load region_classes from file.
+; this .ini route does not currently load region_classes from file or route child-share split-stopping policies.
 ; bc_basis_case (str): Boundary conditions basis, defaults to "NESW" (looks for file format {bc_basis_case}_{domain}_*.nc)
 ; bc_basis_directory (str/None): Directory for bc_basis functions. If None provided, creates new folder in openghg_inversions
 ;                                expecting to find bc_basis_function files there.


### PR DESCRIPTION
* **Summary of changes**

- Document the difference between parent-relative `MinChildWeightShare` and equal-target `MinChildTargetWeightShare` split-stopping policies.
- Clarify that split-stopping can make `nbasis` an upper target, and that child-share policies are currently lower-level Python strategy options rather than `.ini`, `run_hbmcmc.py`, or RHIME config options.
- Sync basis option wording across the getting-started docs, RHIME usage docs, planning notes, and the packaged hbmcmc input template.

* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx (tracker task: OGI-060)
- [x] Tests added and passing (docs-only; `git diff --check` and Sphinx docs build passed)
- [x] Documentation and tutorials updated/added
- [ ] Added an entry to the `CHANGELOG.md` file (docs clarification only)
- [ ] Added any new requirements to `requirements.txt` (not needed)