### PR TITLE
Add grouped basis layout metadata core

### DIFF
--- a/openghg_inversions/basis/layout.py
+++ b/openghg_inversions/basis/layout.py
@@ -7,6 +7,10 @@ algorithms decide how to split cells inside a mask or region class, while
 ``BasisLayout`` records how those partition-local outputs are assembled into the
 single state axis consumed by ``BucketBasisOperator``.
 
+``BasisLayout`` does not infer a catch-all remainder region. Callers that need
+one should pass it as an explicit ``BasisPartition`` so the semantic group and
+local region label are visible in the resulting state metadata.
+
 The current implementation is eager and in-memory. It is intended for small
 metadata/layout assembly steps after region masks and basis labels have already
 been loaded or generated. File loading, lazy execution, large-grid chunking, and
@@ -26,6 +30,7 @@ BASIS_LABEL_DIM = "basis_label"
 BASIS_GROUP_COORD = "basis_group"
 BASIS_PARTITION_COORD = "basis_partition"
 REGION_IN_PARTITION_COORD = "region_in_partition"
+STATE_METADATA_COORDS = (BASIS_GROUP_COORD, BASIS_PARTITION_COORD, REGION_IN_PARTITION_COORD)
 
 
 @dataclass(frozen=True, slots=True)
@@ -65,6 +70,172 @@ class BasisLayoutResult:
 
 
 @dataclass(frozen=True, slots=True)
+class BasisStateMetadata:
+    """Semantic coordinates describing a basis operator state axis.
+
+    The metadata may start indexed by raw ``basis_label`` values from a flat
+    basis layout or by the final operator state dimension. This value object
+    owns validation and alignment so operator classes do not need to know the
+    dataset schema beyond their state coordinate and raw basis-label order.
+
+    Attributes:
+        dataset: Dataset containing ``basis_group``, ``basis_partition``, and
+            ``region_in_partition`` variables indexed by either ``basis_label``
+            or a final state dimension.
+    """
+
+    dataset: xr.Dataset
+
+    @classmethod
+    def from_dataset(cls, dataset: xr.Dataset | BasisStateMetadata) -> BasisStateMetadata:
+        """Return ``dataset`` as a ``BasisStateMetadata`` instance.
+
+        Args:
+            dataset: Metadata dataset or an existing ``BasisStateMetadata``.
+
+        Returns:
+            ``dataset`` wrapped as ``BasisStateMetadata``.
+        """
+        if isinstance(dataset, BasisStateMetadata):
+            return dataset
+        return cls(dataset=dataset)
+
+    @classmethod
+    def from_matrix(cls, mat: xr.DataArray, *, state_dim: str) -> BasisStateMetadata | None:
+        """Extract complete basis state metadata from matrix coordinates.
+
+        Args:
+            mat: Basis matrix that may carry grouped metadata coordinates on the
+                state dimension.
+            state_dim: Name of the state dimension on ``mat``.
+
+        Returns:
+            Metadata indexed by ``state_dim`` if all grouped metadata
+            coordinates are present, otherwise ``None``.
+        """
+        if not all(name in mat.coords for name in STATE_METADATA_COORDS):
+            return None
+        dataset = xr.Dataset(
+            data_vars={
+                name: (state_dim, np.asarray(mat.coords[name].values))
+                for name in STATE_METADATA_COORDS
+            },
+            coords={state_dim: np.asarray(mat[state_dim].values)},
+        )
+        return cls(dataset=dataset)
+
+    def to_dataset(self) -> xr.Dataset:
+        """Return the metadata as an xarray dataset."""
+        return self.dataset
+
+    def on_state_dim(
+        self,
+        *,
+        state_dim: str,
+        state_coord: xr.DataArray,
+        basis_value_labels: Sequence[int] | np.ndarray,
+    ) -> BasisStateMetadata:
+        """Return metadata indexed by the final operator state dimension.
+
+        Args:
+            state_dim: Final state dimension name.
+            state_coord: Final state coordinate after the operator label policy
+                has been applied.
+            basis_value_labels: Raw basis labels ordered to match the operator
+                state columns before final relabeling.
+
+        Returns:
+            Metadata aligned to ``state_coord`` and indexed by ``state_dim``.
+
+        Raises:
+            ValueError: If metadata labels do not match basis labels, if raw
+                labels are duplicated, if final-state metadata has the wrong
+                length, or if required variables are missing.
+        """
+        dataset = self.dataset
+        self._validate_required_variables(dataset)
+
+        if BASIS_LABEL_DIM in dataset.dims:
+            metadata_labels = _unique_integer_values(
+                dataset[BASIS_LABEL_DIM].values,
+                name=BASIS_LABEL_DIM,
+            )
+            expected_labels = _unique_integer_values(basis_value_labels, name="basis labels")
+            if set(metadata_labels.tolist()) != set(expected_labels.tolist()):
+                raise ValueError(
+                    "State metadata basis_label values must match the basis labels; "
+                    f"got {metadata_labels.tolist()} and expected {expected_labels.tolist()}."
+                )
+            metadata = dataset.sel({BASIS_LABEL_DIM: expected_labels})
+            metadata = metadata.rename({BASIS_LABEL_DIM: state_dim})
+        elif state_dim in dataset.dims:
+            metadata = dataset.copy()
+            if metadata.sizes[state_dim] != state_coord.sizes[state_dim]:
+                raise ValueError(
+                    f"State metadata has {metadata.sizes[state_dim]} entries on "
+                    f"{state_dim!r}; expected {state_coord.sizes[state_dim]}."
+                )
+            if state_dim in metadata.coords and not np.array_equal(
+                metadata[state_dim].values,
+                state_coord.values,
+            ):
+                raise ValueError(
+                    f"State metadata coordinate {state_dim!r} does not match "
+                    "the final operator state coordinate."
+                )
+        else:
+            raise ValueError(
+                f"State metadata must be indexed by {BASIS_LABEL_DIM!r} or {state_dim!r}."
+            )
+
+        metadata = metadata.assign_coords({state_dim: state_coord})
+        for name in STATE_METADATA_COORDS:
+            variable = metadata[name]
+            if variable.dims != (state_dim,):
+                raise ValueError(
+                    f"State metadata variable {name!r} must have only dimension "
+                    f"{state_dim!r}; got {variable.dims!r}."
+                )
+        return BasisStateMetadata(dataset=metadata)
+
+    def assign_to_matrix(self, mat: xr.DataArray, *, state_dim: str) -> xr.DataArray:
+        """Attach metadata variables as coordinates on a basis matrix.
+
+        Args:
+            mat: Basis matrix whose state coordinate matches this metadata.
+            state_dim: State dimension used by ``mat`` and this metadata.
+
+        Returns:
+            ``mat`` with grouped metadata coordinates attached.
+
+        Raises:
+            ValueError: If this metadata is not already indexed by
+                ``state_dim`` or required variables are malformed.
+        """
+        self._validate_required_variables(self.dataset)
+        if state_dim not in self.dataset.dims:
+            raise ValueError(f"State metadata must be indexed by {state_dim!r}.")
+
+        coords: dict[str, tuple[str, np.ndarray]] = {}
+        for name in STATE_METADATA_COORDS:
+            variable = self.dataset[name]
+            if variable.dims != (state_dim,):
+                raise ValueError(
+                    f"State metadata variable {name!r} must have only dimension "
+                    f"{state_dim!r}; got {variable.dims!r}."
+                )
+            coords[name] = (state_dim, np.asarray(variable.values))
+        return mat.assign_coords(coords)
+
+    @staticmethod
+    def _validate_required_variables(dataset: xr.Dataset) -> None:
+        """Raise if the standard grouped metadata variables are incomplete."""
+        for name in STATE_METADATA_COORDS:
+            if name not in dataset:
+                raise ValueError(f"State metadata is missing required variable {name!r}.")
+
+
+@dataclass(frozen=True, slots=True)
 class BasisLayout:
     """Combine disjoint basis partitions into one flat label map.
 
@@ -94,9 +265,9 @@ class BasisLayout:
             name: Name to assign to the returned flat-basis DataArray.
 
         Returns:
-            A combined basis map plus a metadata dataset indexed by
-            ``basis_label``. ``BucketBasisOperator`` maps that metadata onto the
-            final state coordinate after its configured label policy is applied.
+            A combined basis map plus metadata indexed by ``basis_label``.
+            ``BucketBasisOperator`` maps that metadata onto the final state
+            coordinate after its configured label policy is applied.
 
         Raises:
             ValueError: If partitions are empty, overlap, contain no mapped
@@ -218,3 +389,35 @@ def _positive_integer_labels(values: np.ndarray, partition_name: str) -> np.ndar
     if not np.all(values == np.floor(values)):
         raise ValueError(f"Basis partition {partition_name!r} labels must be integer-valued.")
     return np.unique(values.astype(int))
+
+
+def _unique_integer_values(values: Sequence[int] | np.ndarray, *, name: str) -> np.ndarray:
+    """Return integer values after checking uniqueness.
+
+    Args:
+        values: Values expected to be integer-valued.
+        name: Name used in validation error messages.
+
+    Returns:
+        Integer values in their original order.
+
+    Raises:
+        ValueError: If values are not finite integers or contain duplicates.
+    """
+    raw_values = np.asarray(values)
+    if not np.issubdtype(raw_values.dtype, np.number):
+        raise ValueError(f"{name} values must be numeric integer values.")
+    try:
+        numeric_values = raw_values.astype(float)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} values must be integer-valued.") from exc
+
+    if not np.all(np.isfinite(numeric_values)) or not np.all(
+        numeric_values == np.floor(numeric_values)
+    ):
+        raise ValueError(f"{name} values must be integer-valued.")
+
+    integer_values = numeric_values.astype(int)
+    if len(np.unique(integer_values)) != len(integer_values):
+        raise ValueError(f"{name} values must be unique; got {integer_values.tolist()}.")
+    return integer_values

--- a/openghg_inversions/basis/layout.py
+++ b/openghg_inversions/basis/layout.py
@@ -1,4 +1,17 @@
-"""Helpers for combining partition-local basis labels into one state axis."""
+"""Grouped basis layout helpers.
+
+This module contains the small internal representation used to combine
+partition-local basis labels into one flat basis map while preserving semantic
+state metadata. It is intentionally separate from basis-generation algorithms:
+algorithms decide how to split cells inside a mask or region class, while
+``BasisLayout`` records how those partition-local outputs are assembled into the
+single state axis consumed by ``BucketBasisOperator``.
+
+The current implementation is eager and in-memory. It is intended for small
+metadata/layout assembly steps after region masks and basis labels have already
+been loaded or generated. File loading, lazy execution, large-grid chunking, and
+public RHIME configuration are handled outside this module.
+"""
 
 from __future__ import annotations
 
@@ -21,6 +34,14 @@ class BasisPartition:
 
     Positive integer values in ``labels`` are treated as local region labels.
     Non-positive values and NaNs are treated as cells outside this partition.
+
+    Attributes:
+        name: Stable partition name used in ``basis_partition`` metadata.
+        labels: Partition-local label array. Positive integer values identify
+            regions inside this partition.
+        group: Semantic group name used in ``basis_group`` metadata.
+        attrs: Optional partition metadata reserved for future callers. These
+            attrs are not currently serialized into the layout result.
     """
 
     name: str
@@ -31,7 +52,13 @@ class BasisPartition:
 
 @dataclass(frozen=True, slots=True)
 class BasisLayoutResult:
-    """Combined flat basis labels plus raw-label keyed state metadata."""
+    """Combined flat basis labels plus raw-label keyed state metadata.
+
+    Attributes:
+        basis_flat: Positive integer flat basis map covering every grid cell.
+        state_metadata: Dataset indexed by ``basis_label`` with
+            ``basis_group``, ``basis_partition``, and ``region_in_partition``.
+    """
 
     basis_flat: xr.DataArray
     state_metadata: xr.Dataset
@@ -45,6 +72,13 @@ class BasisLayout:
     label arrays are materialized as NumPy arrays while building the combined
     map. File loading, lazy execution, and large-grid chunking policy remain
     outside this small metadata/layout boundary.
+
+    Attributes:
+        partitions: Ordered partition definitions to combine. Partitions must
+            cover disjoint grid cells and the combined layout must cover the
+            full grid.
+        state_dim: Name of the downstream state dimension that will eventually
+            receive the metadata coordinates.
     """
 
     partitions: Sequence[BasisPartition]
@@ -55,6 +89,9 @@ class BasisLayout:
 
         This method materializes partition labels and the combined map in
         memory.
+
+        Args:
+            name: Name to assign to the returned flat-basis DataArray.
 
         Returns:
             A combined basis map plus a metadata dataset indexed by
@@ -124,7 +161,19 @@ class BasisLayout:
 
 
 def _align_partition_labels(labels: xr.DataArray, template: xr.DataArray) -> xr.DataArray:
-    """Return labels transposed to the template grid after exact coordinate checks."""
+    """Return labels transposed to the template grid.
+
+    Args:
+        labels: Partition label array to validate and transpose.
+        template: First partition label array whose dimensions and coordinates
+            define the layout grid.
+
+    Returns:
+        ``labels`` transposed into ``template`` dimension order.
+
+    Raises:
+        ValueError: If dimensions differ or coordinates are not exactly aligned.
+    """
     if set(labels.dims) != set(template.dims):
         raise ValueError(
             f"Basis partition dims {labels.dims!r} do not match template dims {template.dims!r}."
@@ -135,7 +184,18 @@ def _align_partition_labels(labels: xr.DataArray, template: xr.DataArray) -> xr.
 
 
 def _numeric_label_values(labels: xr.DataArray, partition_name: str) -> np.ndarray:
-    """Return label values as float for NaN-aware validation."""
+    """Return numeric label values as floats for NaN-aware validation.
+
+    Args:
+        labels: Partition label array to materialize.
+        partition_name: Partition name used in validation error messages.
+
+    Returns:
+        Label values as a floating-point NumPy array.
+
+    Raises:
+        TypeError: If ``labels`` is not numeric.
+    """
     values = np.asarray(labels.values)
     if not np.issubdtype(values.dtype, np.number):
         raise TypeError(f"Basis partition {partition_name!r} labels must be numeric.")
@@ -143,7 +203,18 @@ def _numeric_label_values(labels: xr.DataArray, partition_name: str) -> np.ndarr
 
 
 def _positive_integer_labels(values: np.ndarray, partition_name: str) -> np.ndarray:
-    """Return sorted unique positive integer labels, validating integrality."""
+    """Return sorted unique positive integer labels.
+
+    Args:
+        values: Positive mapped label values for one partition.
+        partition_name: Partition name used in validation error messages.
+
+    Returns:
+        Sorted unique integer label values.
+
+    Raises:
+        ValueError: If any mapped label value is not integer-valued.
+    """
     if not np.all(values == np.floor(values)):
         raise ValueError(f"Basis partition {partition_name!r} labels must be integer-valued.")
     return np.unique(values.astype(int))

--- a/openghg_inversions/basis/layout.py
+++ b/openghg_inversions/basis/layout.py
@@ -1,0 +1,149 @@
+"""Helpers for combining partition-local basis labels into one state axis."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+import xarray as xr
+
+BASIS_LABEL_DIM = "basis_label"
+BASIS_GROUP_COORD = "basis_group"
+BASIS_PARTITION_COORD = "basis_partition"
+REGION_IN_PARTITION_COORD = "region_in_partition"
+
+
+@dataclass(frozen=True, slots=True)
+class BasisPartition:
+    """Partition-local basis labels and their semantic group name.
+
+    Positive integer values in ``labels`` are treated as local region labels.
+    Non-positive values and NaNs are treated as cells outside this partition.
+    """
+
+    name: str
+    labels: xr.DataArray
+    group: str
+    attrs: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class BasisLayoutResult:
+    """Combined flat basis labels plus raw-label keyed state metadata."""
+
+    basis_flat: xr.DataArray
+    state_metadata: xr.Dataset
+
+
+@dataclass(frozen=True, slots=True)
+class BasisLayout:
+    """Combine disjoint basis partitions into one flat label map.
+
+    This first implementation is intentionally eager and in-memory: partition
+    label arrays are materialized as NumPy arrays while building the combined
+    map. File loading, lazy execution, and large-grid chunking policy remain
+    outside this small metadata/layout boundary.
+    """
+
+    partitions: Sequence[BasisPartition]
+    state_dim: str = "state"
+
+    def to_flat_basis(self, *, name: str = "basis") -> BasisLayoutResult:
+        """Return a positive-label flat basis and metadata keyed by raw labels.
+
+        This method materializes partition labels and the combined map in
+        memory.
+
+        Returns:
+            A combined basis map plus a metadata dataset indexed by
+            ``basis_label``. ``BucketBasisOperator`` maps that metadata onto the
+            final state coordinate after its configured label policy is applied.
+
+        Raises:
+            ValueError: If partitions are empty, overlap, contain no mapped
+                cells, or leave grid cells unmapped.
+            TypeError: If partition labels are not numeric.
+        """
+        partitions = tuple(self.partitions)
+        if not partitions:
+            raise ValueError("BasisLayout requires at least one partition.")
+
+        template = partitions[0].labels
+        combined = np.zeros(template.shape, dtype=int)
+        covered = np.zeros(template.shape, dtype=bool)
+        basis_labels: list[int] = []
+        groups: list[str] = []
+        partition_names: list[str] = []
+        region_in_partition: list[int] = []
+        next_label = 1
+
+        for partition in partitions:
+            labels = _align_partition_labels(partition.labels, template)
+            values = _numeric_label_values(labels, partition.name)
+            mapped = np.isfinite(values) & (values > 0)
+
+            if not mapped.any():
+                raise ValueError(f"Basis partition {partition.name!r} has no positive labels.")
+            if np.any(covered & mapped):
+                raise ValueError(f"Basis partition {partition.name!r} overlaps an earlier partition.")
+
+            local_labels = _positive_integer_labels(values[mapped], partition.name)
+            for local_label in local_labels:
+                combined[mapped & (values == local_label)] = next_label
+                basis_labels.append(next_label)
+                groups.append(partition.group)
+                partition_names.append(partition.name)
+                region_in_partition.append(int(local_label))
+                next_label += 1
+
+            covered |= mapped
+
+        if not covered.all():
+            missing = int(np.size(covered) - np.count_nonzero(covered))
+            raise ValueError(f"BasisLayout partitions leave {missing} grid cells unmapped.")
+
+        basis_flat = xr.DataArray(
+            combined,
+            dims=template.dims,
+            coords=template.coords,
+            name=name,
+            attrs=dict(template.attrs),
+        )
+        state_metadata = xr.Dataset(
+            data_vars={
+                BASIS_GROUP_COORD: (BASIS_LABEL_DIM, np.asarray(groups, dtype=object)),
+                BASIS_PARTITION_COORD: (BASIS_LABEL_DIM, np.asarray(partition_names, dtype=object)),
+                REGION_IN_PARTITION_COORD: (BASIS_LABEL_DIM, np.asarray(region_in_partition, dtype=int)),
+            },
+            coords={BASIS_LABEL_DIM: np.asarray(basis_labels, dtype=int)},
+            attrs={"state_dim": self.state_dim},
+        )
+        return BasisLayoutResult(basis_flat=basis_flat, state_metadata=state_metadata)
+
+
+def _align_partition_labels(labels: xr.DataArray, template: xr.DataArray) -> xr.DataArray:
+    """Return labels transposed to the template grid after exact coordinate checks."""
+    if set(labels.dims) != set(template.dims):
+        raise ValueError(
+            f"Basis partition dims {labels.dims!r} do not match template dims {template.dims!r}."
+        )
+    labels = labels.transpose(*template.dims)
+    xr.align(template, labels, join="exact")
+    return labels
+
+
+def _numeric_label_values(labels: xr.DataArray, partition_name: str) -> np.ndarray:
+    """Return label values as float for NaN-aware validation."""
+    values = np.asarray(labels.values)
+    if not np.issubdtype(values.dtype, np.number):
+        raise TypeError(f"Basis partition {partition_name!r} labels must be numeric.")
+    return values.astype(float)
+
+
+def _positive_integer_labels(values: np.ndarray, partition_name: str) -> np.ndarray:
+    """Return sorted unique positive integer labels, validating integrality."""
+    if not np.all(values == np.floor(values)):
+        raise ValueError(f"Basis partition {partition_name!r} labels must be integer-valued.")
+    return np.unique(values.astype(int))

--- a/openghg_inversions/basis/operators.py
+++ b/openghg_inversions/basis/operators.py
@@ -443,11 +443,30 @@ class BucketBasisOperator(BasisOperator):
 
     @property
     def state_metadata(self) -> xr.Dataset | None:
-        """Semantic metadata coordinates carried on the state dimension."""
+        """Semantic metadata coordinates carried on the state dimension.
+
+        Returns:
+            Dataset containing ``basis_group``, ``basis_partition``, and
+            ``region_in_partition`` indexed by ``meta.state_dim``, or ``None``
+            when no grouped metadata was supplied.
+        """
         return self._state_metadata
 
     def _basis_value_labels(self, mat: xr.DataArray) -> np.ndarray:
-        """Return raw basis labels in the dummy-column order."""
+        """Return raw basis labels in the dummy-column order.
+
+        Args:
+            mat: Dummy matrix returned by ``get_xr_dummies`` before or after
+                state-coordinate relabeling.
+
+        Returns:
+            Raw non-negative or positive basis labels ordered to match the dummy
+            matrix state columns.
+
+        Raises:
+            ValueError: If the flat basis labels do not form a supported
+                zero-based or one-based label set.
+        """
         labels = np.unique(self.basis_flat.values.astype(int))
         positive_labels = labels[labels > 0]
         non_negative_labels = labels[labels >= 0]
@@ -472,9 +491,16 @@ class BucketBasisOperator(BasisOperator):
 
         Args:
             mat: Dummy matrix returned by `get_xr_dummies`.
+            basis_value_labels: Optional raw basis labels ordered to match the
+                dummy matrix columns. If omitted, they are computed from
+                ``basis_flat``.
 
         Returns:
             `mat` with an updated state coordinate.
+
+        Raises:
+            ValueError: If ``region_labels`` is unknown or the flat basis labels
+                do not form a supported label set.
 
         Notes:
             This assumes `get_xr_dummies` orders categories in ascending order
@@ -506,7 +532,24 @@ class BucketBasisOperator(BasisOperator):
         *,
         basis_value_labels: np.ndarray,
     ) -> xr.DataArray:
-        """Attach metadata coordinates after final state labels are known."""
+        """Attach grouped metadata coordinates to the basis matrix.
+
+        Args:
+            mat: Basis matrix whose state coordinate already reflects the
+                configured ``region_labels`` policy.
+            state_metadata: Metadata dataset indexed either by raw
+                ``basis_label`` values or by the final state dimension.
+            basis_value_labels: Raw basis labels ordered to match ``mat`` state
+                columns before final state-coordinate relabeling.
+
+        Returns:
+            ``mat`` with grouped metadata attached as coordinates on
+            ``meta.state_dim``.
+
+        Raises:
+            ValueError: If required metadata variables are missing or not
+                one-dimensional on the state dimension.
+        """
         metadata = self._metadata_on_state_dim(
             state_metadata,
             mat=mat,
@@ -532,7 +575,24 @@ class BucketBasisOperator(BasisOperator):
         mat: xr.DataArray,
         basis_value_labels: np.ndarray,
     ) -> xr.Dataset:
-        """Return metadata indexed in final state-coordinate order."""
+        """Return metadata indexed in final state-coordinate order.
+
+        Args:
+            state_metadata: Metadata indexed by ``basis_label`` or by
+                ``meta.state_dim``.
+            mat: Basis matrix carrying the final operator state coordinate.
+            basis_value_labels: Raw basis labels ordered to match ``mat`` state
+                columns before final state-coordinate relabeling.
+
+        Returns:
+            Metadata dataset indexed by ``meta.state_dim`` and aligned to
+            ``mat``.
+
+        Raises:
+            ValueError: If metadata labels do not match basis labels, if
+                final-state metadata has the wrong length, or if the metadata
+                coordinate does not match the final operator state coordinate.
+        """
         state_coord = mat[self.meta.state_dim]
         if BASIS_LABEL_DIM in state_metadata.dims:
             metadata_labels = np.asarray(state_metadata[BASIS_LABEL_DIM].values).astype(int)
@@ -567,7 +627,17 @@ class BucketBasisOperator(BasisOperator):
         return metadata.assign_coords({self.meta.state_dim: state_coord})
 
     def _state_metadata_from_matrix(self, mat: xr.DataArray) -> xr.Dataset | None:
-        """Extract serialisable state metadata from basis-matrix coordinates."""
+        """Extract serialisable state metadata from basis-matrix coordinates.
+
+        Args:
+            mat: Basis matrix that may carry grouped metadata coordinates on
+                ``meta.state_dim``.
+
+        Returns:
+            Dataset containing grouped metadata coordinates indexed by
+            ``meta.state_dim``, or ``None`` when the matrix does not carry the
+            complete grouped metadata coordinate set.
+        """
         if not all(name in mat.coords for name in STATE_METADATA_COORDS):
             return None
         return xr.Dataset(

--- a/openghg_inversions/basis/operators.py
+++ b/openghg_inversions/basis/operators.py
@@ -64,6 +64,12 @@ from openghg_inversions.array_ops import (
     force_align,
     get_xr_dummies,
 )
+from openghg_inversions.basis.layout import (
+    BASIS_GROUP_COORD,
+    BASIS_LABEL_DIM,
+    BASIS_PARTITION_COORD,
+    REGION_IN_PARTITION_COORD,
+)
 
 # ----------------------------
 # Registry
@@ -358,6 +364,7 @@ def drop_singleton_time(da: xr.DataArray, *, name: str = "basis_flat") -> xr.Dat
 # at 0 (i.e. 0, 1, ..., N-1) or at 1 (i.e. 1, 2, ..., N), or "basis_values"
 # which will use whatever values are in the flat basis array values.
 RegionLabels = Literal["range0", "range1", "basis_values"]
+STATE_METADATA_COORDS = (BASIS_GROUP_COORD, BASIS_PARTITION_COORD, REGION_IN_PARTITION_COORD)
 
 
 @register_basis_operator("bucket")
@@ -374,6 +381,7 @@ class BucketBasisOperator(BasisOperator):
         meta: BasisMeta | None = None,
         state_dim: str | None = None,
         region_labels: RegionLabels = "range0",
+        state_metadata: xr.Dataset | None = None,
         chunks: dict[str, int] | None = None,
     ) -> None:
         """Creates a single-source bucket basis operator.
@@ -387,6 +395,8 @@ class BucketBasisOperator(BasisOperator):
                 - `"range0"`: `0..N-1` (legacy-friendly)
                 - `"range1"`: `1..N`
                 - `"basis_values"`: use the ordered non-negative labels found in `basis_flat`.
+            state_metadata: Optional metadata for the state axis. Metadata may be
+                indexed by raw ``basis_label`` values or by the final state dimension.
             chunks: Optional chunking to apply to the basis matrix.
         """
         meta = meta or BasisMeta()
@@ -403,14 +413,23 @@ class BucketBasisOperator(BasisOperator):
         # create dummy matrix (grid -> state)
         # cat_dim name must match meta.state_dim
         mat = get_xr_dummies(self.basis_flat, cat_dim=self.meta.state_dim)
+        basis_value_labels = self._basis_value_labels(mat)
 
         # optionally override state coordinate policy
-        mat = self._apply_region_labels_policy(mat)
+        mat = self._apply_region_labels_policy(mat, basis_value_labels=basis_value_labels)
+
+        if state_metadata is not None:
+            mat = self._assign_state_metadata(
+                mat,
+                state_metadata,
+                basis_value_labels=basis_value_labels,
+            )
 
         # chunking
         mat = mat.chunk(chunks) if chunks is not None else mat.chunk()
 
         self._basis_matrix = mat
+        self._state_metadata = self._state_metadata_from_matrix(mat)
 
     @property
     def meta(self) -> BasisMeta:
@@ -422,7 +441,33 @@ class BucketBasisOperator(BasisOperator):
         """Basis matrix."""
         return self._basis_matrix
 
-    def _apply_region_labels_policy(self, mat: xr.DataArray) -> xr.DataArray:
+    @property
+    def state_metadata(self) -> xr.Dataset | None:
+        """Semantic metadata coordinates carried on the state dimension."""
+        return self._state_metadata
+
+    def _basis_value_labels(self, mat: xr.DataArray) -> np.ndarray:
+        """Return raw basis labels in the dummy-column order."""
+        labels = np.unique(self.basis_flat.values.astype(int))
+        positive_labels = labels[labels > 0]
+        non_negative_labels = labels[labels >= 0]
+        n = mat.sizes[self.meta.state_dim]
+
+        if len(positive_labels) == n:
+            return positive_labels.astype(int)
+        if len(non_negative_labels) == n:
+            return non_negative_labels.astype(int)
+        raise ValueError(
+            "Basis labels must be one-based positive values or zero-based non-negative values; "
+            f"got labels {labels.tolist()} for {n} dummy columns."
+        )
+
+    def _apply_region_labels_policy(
+        self,
+        mat: xr.DataArray,
+        *,
+        basis_value_labels: np.ndarray | None = None,
+    ) -> xr.DataArray:
         """Applies the configured `region_labels` policy to the state coordinate.
 
         Args:
@@ -437,20 +482,9 @@ class BucketBasisOperator(BasisOperator):
             (`1..N`) and zero-based legacy output labels (`0..N-1`) are
             accepted.
         """
-        labels = np.unique(self.basis_flat.values.astype(int))
-        positive_labels = labels[labels > 0]
-        non_negative_labels = labels[labels >= 0]
+        if basis_value_labels is None:
+            basis_value_labels = self._basis_value_labels(mat)
         n = mat.sizes[self.meta.state_dim]
-
-        if len(positive_labels) == n:
-            basis_value_labels = positive_labels
-        elif len(non_negative_labels) == n:
-            basis_value_labels = non_negative_labels
-        else:
-            raise ValueError(
-                "Basis labels must be one-based positive values or zero-based non-negative values; "
-                f"got labels {labels.tolist()} for {n} dummy columns."
-            )
 
         if self.region_labels == "range0":
             coord = np.arange(n, dtype=int)
@@ -464,6 +498,85 @@ class BucketBasisOperator(BasisOperator):
         # Assign coordinate. Important: this assumes get_xr_dummies created state columns
         # ordered by sorted unique labels. If that assumption changes, we must reindex.
         return mat.assign_coords({self.meta.state_dim: coord})
+
+    def _assign_state_metadata(
+        self,
+        mat: xr.DataArray,
+        state_metadata: xr.Dataset,
+        *,
+        basis_value_labels: np.ndarray,
+    ) -> xr.DataArray:
+        """Attach metadata coordinates after final state labels are known."""
+        metadata = self._metadata_on_state_dim(
+            state_metadata,
+            mat=mat,
+            basis_value_labels=basis_value_labels,
+        )
+        coords: dict[str, tuple[str, np.ndarray]] = {}
+        for name in STATE_METADATA_COORDS:
+            if name not in metadata:
+                raise ValueError(f"State metadata is missing required variable {name!r}.")
+            variable = metadata[name]
+            if variable.dims != (self.meta.state_dim,):
+                raise ValueError(
+                    f"State metadata variable {name!r} must have only dimension "
+                    f"{self.meta.state_dim!r}; got {variable.dims!r}."
+                )
+            coords[name] = (self.meta.state_dim, np.asarray(variable.values))
+        return mat.assign_coords(coords)
+
+    def _metadata_on_state_dim(
+        self,
+        state_metadata: xr.Dataset,
+        *,
+        mat: xr.DataArray,
+        basis_value_labels: np.ndarray,
+    ) -> xr.Dataset:
+        """Return metadata indexed in final state-coordinate order."""
+        state_coord = mat[self.meta.state_dim]
+        if BASIS_LABEL_DIM in state_metadata.dims:
+            metadata_labels = np.asarray(state_metadata[BASIS_LABEL_DIM].values).astype(int)
+            expected_labels = np.asarray(basis_value_labels).astype(int)
+            if set(metadata_labels.tolist()) != set(expected_labels.tolist()):
+                raise ValueError(
+                    "State metadata basis_label values must match the basis labels; "
+                    f"got {metadata_labels.tolist()} and expected {expected_labels.tolist()}."
+                )
+            metadata = state_metadata.sel({BASIS_LABEL_DIM: expected_labels})
+            metadata = metadata.rename({BASIS_LABEL_DIM: self.meta.state_dim})
+        elif self.meta.state_dim in state_metadata.dims:
+            metadata = state_metadata.copy()
+            if metadata.sizes[self.meta.state_dim] != mat.sizes[self.meta.state_dim]:
+                raise ValueError(
+                    f"State metadata has {metadata.sizes[self.meta.state_dim]} entries on "
+                    f"{self.meta.state_dim!r}; expected {mat.sizes[self.meta.state_dim]}."
+                )
+            if self.meta.state_dim in metadata.coords and not np.array_equal(
+                metadata[self.meta.state_dim].values,
+                state_coord.values,
+            ):
+                raise ValueError(
+                    f"State metadata coordinate {self.meta.state_dim!r} does not match "
+                    "the final operator state coordinate."
+                )
+        else:
+            raise ValueError(
+                f"State metadata must be indexed by {BASIS_LABEL_DIM!r} or "
+                f"{self.meta.state_dim!r}."
+            )
+        return metadata.assign_coords({self.meta.state_dim: state_coord})
+
+    def _state_metadata_from_matrix(self, mat: xr.DataArray) -> xr.Dataset | None:
+        """Extract serialisable state metadata from basis-matrix coordinates."""
+        if not all(name in mat.coords for name in STATE_METADATA_COORDS):
+            return None
+        return xr.Dataset(
+            data_vars={
+                name: (self.meta.state_dim, np.asarray(mat.coords[name].values))
+                for name in STATE_METADATA_COORDS
+            },
+            coords={self.meta.state_dim: np.asarray(mat[self.meta.state_dim].values)},
+        )
 
     # ---- DataTree IO ----
 
@@ -486,6 +599,8 @@ class BucketBasisOperator(BasisOperator):
                 "region_labels": self.region_labels,
             }
         )
+        if self.state_metadata is not None:
+            dt["state_metadata"] = xr.DataTree(self.state_metadata)
         return dt
 
     @classmethod
@@ -501,6 +616,7 @@ class BucketBasisOperator(BasisOperator):
         ds = dt.to_dataset()
 
         basis_flat = ds["basis_flat"]
+        state_metadata = dt["state_metadata"].to_dataset() if "state_metadata" in dt else None
         meta = BasisMeta(
             grid_dims=tuple(dt.attrs.get("grid_dims", ("lat", "lon"))),
             state_dim=str(dt.attrs.get("state_dim", "state")),
@@ -511,6 +627,7 @@ class BucketBasisOperator(BasisOperator):
             basis_flat=basis_flat,
             meta=meta,
             region_labels=region_labels,  # type: ignore[arg-type]
+            state_metadata=state_metadata,
         )
 
 

--- a/openghg_inversions/basis/operators.py
+++ b/openghg_inversions/basis/operators.py
@@ -51,8 +51,9 @@ Notes
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, ClassVar, Literal, cast
+from typing import Any, ClassVar, Literal, TypeVar, cast
 from typing_extensions import Self
 
 import numpy as np
@@ -65,10 +66,7 @@ from openghg_inversions.array_ops import (
     get_xr_dummies,
 )
 from openghg_inversions.basis.layout import (
-    BASIS_GROUP_COORD,
-    BASIS_LABEL_DIM,
-    BASIS_PARTITION_COORD,
-    REGION_IN_PARTITION_COORD,
+    BasisStateMetadata,
 )
 
 # ----------------------------
@@ -76,9 +74,10 @@ from openghg_inversions.basis.layout import (
 # ----------------------------
 
 _BASIS_OPERATOR_REGISTRY: dict[str, type[BasisOperator]] = {}
+BasisOperatorT = TypeVar("BasisOperatorT", bound="BasisOperator")
 
 
-def register_basis_operator(kind: str):
+def register_basis_operator(kind: str) -> Callable[[type[BasisOperatorT]], type[BasisOperatorT]]:
     """Registers a `BasisOperator` subclass for DataTree deserialisation.
 
     This decorator builds a small module-level registry mapping a stable `kind`
@@ -96,7 +95,7 @@ def register_basis_operator(kind: str):
         ValueError: If `kind` is already registered to a different class.
     """
 
-    def _decorator(cls: type[BasisOperator]) -> type[BasisOperator]:
+    def _decorator(cls: type[BasisOperatorT]) -> type[BasisOperatorT]:
         if kind in _BASIS_OPERATOR_REGISTRY and _BASIS_OPERATOR_REGISTRY[kind] is not cls:
             raise ValueError(
                 f"BasisOperator kind '{kind}' already registered with {_BASIS_OPERATOR_REGISTRY[kind]}"
@@ -364,7 +363,6 @@ def drop_singleton_time(da: xr.DataArray, *, name: str = "basis_flat") -> xr.Dat
 # at 0 (i.e. 0, 1, ..., N-1) or at 1 (i.e. 1, 2, ..., N), or "basis_values"
 # which will use whatever values are in the flat basis array values.
 RegionLabels = Literal["range0", "range1", "basis_values"]
-STATE_METADATA_COORDS = (BASIS_GROUP_COORD, BASIS_PARTITION_COORD, REGION_IN_PARTITION_COORD)
 
 
 @register_basis_operator("bucket")
@@ -381,7 +379,7 @@ class BucketBasisOperator(BasisOperator):
         meta: BasisMeta | None = None,
         state_dim: str | None = None,
         region_labels: RegionLabels = "range0",
-        state_metadata: xr.Dataset | None = None,
+        state_metadata: xr.Dataset | BasisStateMetadata | None = None,
         chunks: dict[str, int] | None = None,
     ) -> None:
         """Creates a single-source bucket basis operator.
@@ -419,17 +417,20 @@ class BucketBasisOperator(BasisOperator):
         mat = self._apply_region_labels_policy(mat, basis_value_labels=basis_value_labels)
 
         if state_metadata is not None:
-            mat = self._assign_state_metadata(
-                mat,
-                state_metadata,
+            state_metadata_on_state_dim = BasisStateMetadata.from_dataset(
+                state_metadata
+            ).on_state_dim(
+                state_dim=self.meta.state_dim,
+                state_coord=mat[self.meta.state_dim],
                 basis_value_labels=basis_value_labels,
             )
+            mat = state_metadata_on_state_dim.assign_to_matrix(mat, state_dim=self.meta.state_dim)
 
         # chunking
         mat = mat.chunk(chunks) if chunks is not None else mat.chunk()
 
         self._basis_matrix = mat
-        self._state_metadata = self._state_metadata_from_matrix(mat)
+        self._state_metadata = BasisStateMetadata.from_matrix(mat, state_dim=self.meta.state_dim)
 
     @property
     def meta(self) -> BasisMeta:
@@ -450,7 +451,9 @@ class BucketBasisOperator(BasisOperator):
             ``region_in_partition`` indexed by ``meta.state_dim``, or ``None``
             when no grouped metadata was supplied.
         """
-        return self._state_metadata
+        if self._state_metadata is None:
+            return None
+        return self._state_metadata.to_dataset()
 
     def _basis_value_labels(self, mat: xr.DataArray) -> np.ndarray:
         """Return raw basis labels in the dummy-column order.
@@ -525,129 +528,6 @@ class BucketBasisOperator(BasisOperator):
         # ordered by sorted unique labels. If that assumption changes, we must reindex.
         return mat.assign_coords({self.meta.state_dim: coord})
 
-    def _assign_state_metadata(
-        self,
-        mat: xr.DataArray,
-        state_metadata: xr.Dataset,
-        *,
-        basis_value_labels: np.ndarray,
-    ) -> xr.DataArray:
-        """Attach grouped metadata coordinates to the basis matrix.
-
-        Args:
-            mat: Basis matrix whose state coordinate already reflects the
-                configured ``region_labels`` policy.
-            state_metadata: Metadata dataset indexed either by raw
-                ``basis_label`` values or by the final state dimension.
-            basis_value_labels: Raw basis labels ordered to match ``mat`` state
-                columns before final state-coordinate relabeling.
-
-        Returns:
-            ``mat`` with grouped metadata attached as coordinates on
-            ``meta.state_dim``.
-
-        Raises:
-            ValueError: If required metadata variables are missing or not
-                one-dimensional on the state dimension.
-        """
-        metadata = self._metadata_on_state_dim(
-            state_metadata,
-            mat=mat,
-            basis_value_labels=basis_value_labels,
-        )
-        coords: dict[str, tuple[str, np.ndarray]] = {}
-        for name in STATE_METADATA_COORDS:
-            if name not in metadata:
-                raise ValueError(f"State metadata is missing required variable {name!r}.")
-            variable = metadata[name]
-            if variable.dims != (self.meta.state_dim,):
-                raise ValueError(
-                    f"State metadata variable {name!r} must have only dimension "
-                    f"{self.meta.state_dim!r}; got {variable.dims!r}."
-                )
-            coords[name] = (self.meta.state_dim, np.asarray(variable.values))
-        return mat.assign_coords(coords)
-
-    def _metadata_on_state_dim(
-        self,
-        state_metadata: xr.Dataset,
-        *,
-        mat: xr.DataArray,
-        basis_value_labels: np.ndarray,
-    ) -> xr.Dataset:
-        """Return metadata indexed in final state-coordinate order.
-
-        Args:
-            state_metadata: Metadata indexed by ``basis_label`` or by
-                ``meta.state_dim``.
-            mat: Basis matrix carrying the final operator state coordinate.
-            basis_value_labels: Raw basis labels ordered to match ``mat`` state
-                columns before final state-coordinate relabeling.
-
-        Returns:
-            Metadata dataset indexed by ``meta.state_dim`` and aligned to
-            ``mat``.
-
-        Raises:
-            ValueError: If metadata labels do not match basis labels, if
-                final-state metadata has the wrong length, or if the metadata
-                coordinate does not match the final operator state coordinate.
-        """
-        state_coord = mat[self.meta.state_dim]
-        if BASIS_LABEL_DIM in state_metadata.dims:
-            metadata_labels = np.asarray(state_metadata[BASIS_LABEL_DIM].values).astype(int)
-            expected_labels = np.asarray(basis_value_labels).astype(int)
-            if set(metadata_labels.tolist()) != set(expected_labels.tolist()):
-                raise ValueError(
-                    "State metadata basis_label values must match the basis labels; "
-                    f"got {metadata_labels.tolist()} and expected {expected_labels.tolist()}."
-                )
-            metadata = state_metadata.sel({BASIS_LABEL_DIM: expected_labels})
-            metadata = metadata.rename({BASIS_LABEL_DIM: self.meta.state_dim})
-        elif self.meta.state_dim in state_metadata.dims:
-            metadata = state_metadata.copy()
-            if metadata.sizes[self.meta.state_dim] != mat.sizes[self.meta.state_dim]:
-                raise ValueError(
-                    f"State metadata has {metadata.sizes[self.meta.state_dim]} entries on "
-                    f"{self.meta.state_dim!r}; expected {mat.sizes[self.meta.state_dim]}."
-                )
-            if self.meta.state_dim in metadata.coords and not np.array_equal(
-                metadata[self.meta.state_dim].values,
-                state_coord.values,
-            ):
-                raise ValueError(
-                    f"State metadata coordinate {self.meta.state_dim!r} does not match "
-                    "the final operator state coordinate."
-                )
-        else:
-            raise ValueError(
-                f"State metadata must be indexed by {BASIS_LABEL_DIM!r} or "
-                f"{self.meta.state_dim!r}."
-            )
-        return metadata.assign_coords({self.meta.state_dim: state_coord})
-
-    def _state_metadata_from_matrix(self, mat: xr.DataArray) -> xr.Dataset | None:
-        """Extract serialisable state metadata from basis-matrix coordinates.
-
-        Args:
-            mat: Basis matrix that may carry grouped metadata coordinates on
-                ``meta.state_dim``.
-
-        Returns:
-            Dataset containing grouped metadata coordinates indexed by
-            ``meta.state_dim``, or ``None`` when the matrix does not carry the
-            complete grouped metadata coordinate set.
-        """
-        if not all(name in mat.coords for name in STATE_METADATA_COORDS):
-            return None
-        return xr.Dataset(
-            data_vars={
-                name: (self.meta.state_dim, np.asarray(mat.coords[name].values))
-                for name in STATE_METADATA_COORDS
-            },
-            coords={self.meta.state_dim: np.asarray(mat[self.meta.state_dim].values)},
-        )
-
     # ---- DataTree IO ----
 
     def to_datatree(self) -> xr.DataTree:
@@ -669,8 +549,8 @@ class BucketBasisOperator(BasisOperator):
                 "region_labels": self.region_labels,
             }
         )
-        if self.state_metadata is not None:
-            dt["state_metadata"] = xr.DataTree(self.state_metadata)
+        if self._state_metadata is not None:
+            dt["state_metadata"] = xr.DataTree(self._state_metadata.to_dataset())
         return dt
 
     @classmethod

--- a/tests/test_basis_layout.py
+++ b/tests/test_basis_layout.py
@@ -1,0 +1,253 @@
+import numpy as np
+import pytest
+import xarray as xr
+
+from openghg_inversions.basis.basis_functions import BasisFunctions
+from openghg_inversions.basis.layout import (
+    BASIS_GROUP_COORD,
+    BASIS_LABEL_DIM,
+    BASIS_PARTITION_COORD,
+    REGION_IN_PARTITION_COORD,
+    BasisLayout,
+    BasisPartition,
+)
+from openghg_inversions.basis.operators import BucketBasisOperator
+
+
+def _basis_grid(values: list[list[int]], *, name: str = "basis") -> xr.DataArray:
+    return xr.DataArray(
+        np.asarray(values, dtype=int),
+        dims=("lat", "lon"),
+        coords={"lat": [0.0, 1.0], "lon": [10.0, 20.0]},
+        name=name,
+    )
+
+
+def _state_metadata(raw_labels: list[int]) -> xr.Dataset:
+    return xr.Dataset(
+        data_vars={
+            BASIS_GROUP_COORD: (BASIS_LABEL_DIM, ["outer", "inner"]),
+            BASIS_PARTITION_COORD: (BASIS_LABEL_DIM, ["fixed_outer_10", "generated_inner"]),
+            REGION_IN_PARTITION_COORD: (BASIS_LABEL_DIM, [10, 1]),
+        },
+        coords={BASIS_LABEL_DIM: raw_labels},
+    )
+
+
+def test_basis_layout_combines_disjoint_partitions_with_metadata():
+    """A layout offsets partition-local labels and records raw-label metadata."""
+    inner = _basis_grid([[1, 2], [0, 0]], name="inner")
+    outer = _basis_grid([[0, 0], [1, 1]], name="outer")
+
+    result = BasisLayout(
+        partitions=(
+            BasisPartition(name="inner", labels=inner, group="inner"),
+            BasisPartition(name="outer", labels=outer, group="outer"),
+        ),
+        state_dim="region",
+    ).to_flat_basis()
+
+    expected_basis = _basis_grid([[1, 2], [3, 3]])
+    expected_metadata = xr.Dataset(
+        data_vars={
+            BASIS_GROUP_COORD: (BASIS_LABEL_DIM, ["inner", "inner", "outer"]),
+            BASIS_PARTITION_COORD: (BASIS_LABEL_DIM, ["inner", "inner", "outer"]),
+            REGION_IN_PARTITION_COORD: (BASIS_LABEL_DIM, [1, 2, 1]),
+        },
+        coords={BASIS_LABEL_DIM: [1, 2, 3]},
+        attrs={"state_dim": "region"},
+    )
+
+    xr.testing.assert_identical(result.basis_flat, expected_basis)
+    xr.testing.assert_identical(result.state_metadata, expected_metadata)
+
+
+def test_basis_layout_rejects_overlapping_partitions():
+    """Partitions must cover disjoint grid cells."""
+    first = _basis_grid([[1, 0], [0, 0]], name="first")
+    second = _basis_grid([[1, 1], [1, 1]], name="second")
+
+    layout = BasisLayout(
+        partitions=(
+            BasisPartition(name="first", labels=first, group="first"),
+            BasisPartition(name="second", labels=second, group="second"),
+        )
+    )
+
+    with pytest.raises(ValueError, match="overlaps"):
+        layout.to_flat_basis()
+
+
+def test_basis_layout_rejects_unmapped_grid_cells():
+    """Every grid cell must belong to exactly one partition in this core helper."""
+    first = _basis_grid([[1, 1], [0, 0]], name="first")
+    second = _basis_grid([[0, 0], [1, 0]], name="second")
+
+    layout = BasisLayout(
+        partitions=(
+            BasisPartition(name="first", labels=first, group="first"),
+            BasisPartition(name="second", labels=second, group="second"),
+        )
+    )
+
+    with pytest.raises(ValueError, match="unmapped"):
+        layout.to_flat_basis()
+
+
+def test_basis_layout_rejects_non_integer_labels():
+    """Partition labels must be integer-valued before global relabeling."""
+    labels = _basis_grid([[1, 1], [0, 0]], name="labels").astype(float)
+    labels.values[0, 0] = 1.5
+    other = _basis_grid([[0, 0], [1, 1]], name="other")
+
+    layout = BasisLayout(
+        partitions=(
+            BasisPartition(name="labels", labels=labels, group="labels"),
+            BasisPartition(name="other", labels=other, group="other"),
+        )
+    )
+
+    with pytest.raises(ValueError, match="integer-valued"):
+        layout.to_flat_basis()
+
+
+def test_basis_layout_rejects_coordinate_mismatch():
+    """Partition grids must align exactly before labels can be combined."""
+    first = _basis_grid([[1, 1], [0, 0]], name="first")
+    second = _basis_grid([[0, 0], [1, 1]], name="second").assign_coords(lat=[0.0, 2.0])
+
+    layout = BasisLayout(
+        partitions=(
+            BasisPartition(name="first", labels=first, group="first"),
+            BasisPartition(name="second", labels=second, group="second"),
+        )
+    )
+
+    with pytest.raises(ValueError):
+        layout.to_flat_basis()
+
+
+def test_bucket_operator_attaches_metadata_after_region_label_policy():
+    """Raw basis labels can differ from final state coordinates."""
+    basis = _basis_grid([[10, 20], [10, 20]])
+    operator = BucketBasisOperator(
+        basis_flat=basis,
+        state_dim="region",
+        region_labels="range0",
+        state_metadata=_state_metadata([10, 20]),
+    )
+
+    assert operator.basis_matrix.region.values.tolist() == [0, 1]
+    assert operator.basis_matrix[BASIS_GROUP_COORD].values.tolist() == ["outer", "inner"]
+    assert operator.basis_matrix[BASIS_PARTITION_COORD].values.tolist() == [
+        "fixed_outer_10",
+        "generated_inner",
+    ]
+    assert operator.basis_matrix[REGION_IN_PARTITION_COORD].values.tolist() == [10, 1]
+
+
+def test_bucket_operator_reorders_raw_label_metadata():
+    """Metadata keyed by raw basis labels need not arrive in sorted label order."""
+    basis = _basis_grid([[10, 20], [10, 20]])
+    metadata = xr.Dataset(
+        data_vars={
+            BASIS_GROUP_COORD: (BASIS_LABEL_DIM, ["inner", "outer"]),
+            BASIS_PARTITION_COORD: (BASIS_LABEL_DIM, ["generated_inner", "fixed_outer_10"]),
+            REGION_IN_PARTITION_COORD: (BASIS_LABEL_DIM, [1, 10]),
+        },
+        coords={BASIS_LABEL_DIM: [20, 10]},
+    )
+    operator = BucketBasisOperator(
+        basis_flat=basis,
+        state_dim="region",
+        region_labels="range0",
+        state_metadata=metadata,
+    )
+
+    assert operator.basis_matrix[BASIS_GROUP_COORD].values.tolist() == ["outer", "inner"]
+    assert operator.basis_matrix[REGION_IN_PARTITION_COORD].values.tolist() == [10, 1]
+
+
+def test_bucket_operator_rejects_missing_state_metadata_variable():
+    """State metadata must include the standard grouped-layout coordinates."""
+    basis = _basis_grid([[10, 20], [10, 20]])
+    metadata = _state_metadata([10, 20]).drop_vars(BASIS_GROUP_COORD)
+
+    with pytest.raises(ValueError, match=BASIS_GROUP_COORD):
+        BucketBasisOperator(
+            basis_flat=basis,
+            state_dim="region",
+            region_labels="range0",
+            state_metadata=metadata,
+        )
+
+
+def test_bucket_operator_rejects_mismatched_raw_label_metadata():
+    """Raw-label metadata must cover exactly the basis labels."""
+    basis = _basis_grid([[10, 20], [10, 20]])
+
+    with pytest.raises(ValueError, match="basis_label values"):
+        BucketBasisOperator(
+            basis_flat=basis,
+            state_dim="region",
+            region_labels="range0",
+            state_metadata=_state_metadata([10, 30]),
+        )
+
+
+def test_bucket_operator_rejects_mismatched_final_state_metadata():
+    """Metadata already indexed by final state must match the final state coordinate."""
+    basis = _basis_grid([[10, 20], [10, 20]])
+    metadata = xr.Dataset(
+        data_vars={
+            BASIS_GROUP_COORD: ("region", ["outer", "inner"]),
+            BASIS_PARTITION_COORD: ("region", ["fixed_outer_10", "generated_inner"]),
+            REGION_IN_PARTITION_COORD: ("region", [10, 1]),
+        },
+        coords={"region": [1, 0]},
+    )
+
+    with pytest.raises(ValueError, match="does not match"):
+        BucketBasisOperator(
+            basis_flat=basis,
+            state_dim="region",
+            region_labels="range0",
+            state_metadata=metadata,
+        )
+
+
+def test_bucket_operator_datatree_roundtrip_preserves_state_metadata():
+    """Operator DataTree serialization keeps grouped state coordinates."""
+    basis = _basis_grid([[10, 20], [10, 20]])
+    operator = BucketBasisOperator(
+        basis_flat=basis,
+        state_dim="region",
+        region_labels="range0",
+        state_metadata=_state_metadata([10, 20]),
+    )
+
+    restored = BucketBasisOperator.from_datatree(operator.to_datatree())
+
+    xr.testing.assert_identical(restored.basis_matrix, operator.basis_matrix)
+    xr.testing.assert_identical(restored.state_metadata, operator.state_metadata)
+
+
+def test_basis_functions_save_load_preserves_state_metadata(tmp_path):
+    """BasisFunctions artifacts retain state metadata coordinates on load."""
+    basis = _basis_grid([[10, 20], [10, 20]])
+    flux = xr.ones_like(basis, dtype=float).rename("flux")
+    basis_functions = BasisFunctions.from_flat_basis(
+        basis_flat=basis,
+        flux=flux,
+        operator_kwargs={
+            "state_dim": "region",
+            "region_labels": "range0",
+            "state_metadata": _state_metadata([10, 20]),
+        },
+    )
+
+    output_file = tmp_path / "basis.nc"
+    basis_functions.save(output_file)
+    restored = BasisFunctions.load(output_file)
+
+    xr.testing.assert_identical(restored.operator.basis_matrix, basis_functions.operator.basis_matrix)

--- a/tests/test_basis_layout.py
+++ b/tests/test_basis_layout.py
@@ -11,7 +11,7 @@ from openghg_inversions.basis.layout import (
     BasisLayout,
     BasisPartition,
 )
-from openghg_inversions.basis.operators import BucketBasisOperator
+from openghg_inversions.basis.operators import BasisOperator, BucketBasisOperator
 
 
 def _basis_grid(values: list[list[int]], *, name: str = "basis") -> xr.DataArray:
@@ -60,6 +60,43 @@ def test_basis_layout_combines_disjoint_partitions_with_metadata():
 
     xr.testing.assert_identical(result.basis_flat, expected_basis)
     xr.testing.assert_identical(result.state_metadata, expected_metadata)
+
+
+def test_basis_layout_requires_explicit_remainder_partition():
+    """Layouts do not synthesize an implicit remainder partition."""
+    inner = _basis_grid([[1, 2], [0, 0]], name="inner")
+    layout = BasisLayout(
+        partitions=(BasisPartition(name="generated_inner", labels=inner, group="inner"),),
+        state_dim="region",
+    )
+
+    with pytest.raises(ValueError, match="unmapped"):
+        layout.to_flat_basis()
+
+
+def test_basis_layout_preserves_explicit_remainder_partition_metadata():
+    """A caller-provided remainder partition is recorded like any partition."""
+    inner = _basis_grid([[1, 2], [0, 0]], name="inner")
+    remainder = _basis_grid([[0, 0], [1, 1]], name="remainder")
+
+    result = BasisLayout(
+        partitions=(
+            BasisPartition(name="generated_inner", labels=inner, group="inner"),
+            BasisPartition(name="explicit_remainder", labels=remainder, group="remainder"),
+        ),
+        state_dim="region",
+    ).to_flat_basis()
+    metadata = result.state_metadata
+
+    xr.testing.assert_identical(result.basis_flat, _basis_grid([[1, 2], [3, 3]]))
+    assert metadata[BASIS_GROUP_COORD].values.tolist() == ["inner", "inner", "remainder"]
+    assert metadata[BASIS_PARTITION_COORD].values.tolist() == [
+        "generated_inner",
+        "generated_inner",
+        "explicit_remainder",
+    ]
+    assert metadata[REGION_IN_PARTITION_COORD].values.tolist() == [1, 2, 1]
+    assert metadata[BASIS_LABEL_DIM].values.tolist() == [1, 2, 3]
 
 
 def test_basis_layout_rejects_overlapping_partitions():
@@ -195,6 +232,51 @@ def test_bucket_operator_rejects_mismatched_raw_label_metadata():
         )
 
 
+def test_bucket_operator_rejects_duplicate_raw_label_metadata():
+    """Raw-label metadata must identify each basis label exactly once."""
+    basis = _basis_grid([[10, 20], [10, 20]])
+    metadata = xr.Dataset(
+        data_vars={
+            BASIS_GROUP_COORD: (BASIS_LABEL_DIM, ["outer-a", "outer-b", "inner"]),
+            BASIS_PARTITION_COORD: (
+                BASIS_LABEL_DIM,
+                ["fixed_outer_a", "fixed_outer_b", "generated_inner"],
+            ),
+            REGION_IN_PARTITION_COORD: (BASIS_LABEL_DIM, [10, 10, 1]),
+        },
+        coords={BASIS_LABEL_DIM: [10, 10, 20]},
+    )
+
+    with pytest.raises(ValueError, match="basis_label.*unique"):
+        BucketBasisOperator(
+            basis_flat=basis,
+            state_dim="region",
+            region_labels="range0",
+            state_metadata=metadata,
+        )
+
+
+def test_bucket_operator_rejects_non_numeric_raw_label_metadata():
+    """Raw basis-label coordinates must be numeric before state alignment."""
+    basis = _basis_grid([[10, 20], [10, 20]])
+    metadata = xr.Dataset(
+        data_vars={
+            BASIS_GROUP_COORD: (BASIS_LABEL_DIM, ["outer", "inner"]),
+            BASIS_PARTITION_COORD: (BASIS_LABEL_DIM, ["fixed_outer_10", "generated_inner"]),
+            REGION_IN_PARTITION_COORD: (BASIS_LABEL_DIM, [10, 1]),
+        },
+        coords={BASIS_LABEL_DIM: ["10", "20"]},
+    )
+
+    with pytest.raises(ValueError, match="basis_label.*numeric"):
+        BucketBasisOperator(
+            basis_flat=basis,
+            state_dim="region",
+            region_labels="range0",
+            state_metadata=metadata,
+        )
+
+
 def test_bucket_operator_rejects_mismatched_final_state_metadata():
     """Metadata already indexed by final state must match the final state coordinate."""
     basis = _basis_grid([[10, 20], [10, 20]])
@@ -227,9 +309,16 @@ def test_bucket_operator_datatree_roundtrip_preserves_state_metadata():
     )
 
     restored = BucketBasisOperator.from_datatree(operator.to_datatree())
+    decoded = BasisOperator.decode_datatree(operator.to_datatree())
 
     xr.testing.assert_identical(restored.basis_matrix, operator.basis_matrix)
+    assert restored.state_metadata is not None
+    assert operator.state_metadata is not None
     xr.testing.assert_identical(restored.state_metadata, operator.state_metadata)
+    assert isinstance(decoded, BucketBasisOperator)
+    assert decoded.state_metadata is not None
+    xr.testing.assert_identical(decoded.basis_matrix, operator.basis_matrix)
+    xr.testing.assert_identical(decoded.state_metadata, operator.state_metadata)
 
 
 def test_basis_functions_save_load_preserves_state_metadata(tmp_path):
@@ -249,5 +338,20 @@ def test_basis_functions_save_load_preserves_state_metadata(tmp_path):
     output_file = tmp_path / "basis.nc"
     basis_functions.save(output_file)
     restored = BasisFunctions.load(output_file)
+    restored_operator = restored.operator
+    original_operator = basis_functions.operator
 
-    xr.testing.assert_identical(restored.operator.basis_matrix, basis_functions.operator.basis_matrix)
+    xr.testing.assert_identical(restored_operator.basis_matrix, original_operator.basis_matrix)
+    assert isinstance(restored_operator, BucketBasisOperator)
+    assert isinstance(original_operator, BucketBasisOperator)
+    assert restored_operator.state_metadata is not None
+    assert original_operator.state_metadata is not None
+    xr.testing.assert_identical(
+        restored_operator.state_metadata,
+        original_operator.state_metadata,
+    )
+    for coord_name in (BASIS_GROUP_COORD, BASIS_PARTITION_COORD, REGION_IN_PARTITION_COORD):
+        xr.testing.assert_identical(
+            restored_operator.basis_matrix[coord_name],
+            original_operator.basis_matrix[coord_name],
+        )


### PR DESCRIPTION
* **Summary of changes**

Adds the first grouped basis layout implementation slice for OGI-023:
- adds an internal `BasisLayout` / `BasisPartition` helper that combines disjoint partition-local labels into one flat positive-label map plus raw-label keyed metadata;
- teaches `BucketBasisOperator` to attach `basis_group`, `basis_partition`, and `region_in_partition` after its final state-coordinate label policy is applied;
- persists that optional state metadata through operator DataTree and `BasisFunctions.save/load` roundtrips;
- keeps legacy `fixed_outer_regions_basis`, `run_hbmcmc.py`, and the existing `quadtree` / `weighted` option surface unchanged.

This tracks #457 / #449 as a focused OGI-023 implementation slice. It intentionally does not close #457; disconnected-part reporting, geography-aware cleanup, and RHIME/config routing remain follow-up work.

* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx (not closing #457; partial OGI-023 implementation slice)
- [x] Tests added and passing
- [ ] Documentation and tutorials updated/added (internal docstrings only; no user-facing option added)
- [ ] Added an entry to the `CHANGELOG.md` file
- [ ] Added any new requirements to `requirements.txt`

Validation:
- `uv run pytest tests/test_basis_layout.py`
- `uv run pytest tests/test_basis_functions.py -k "datatree or fixed_outer"`
- `uv run pytest tests/test_constrained_basis_algorithm.py -k "intersect or tuple or constrained"`
- `uv run ruff check openghg_inversions/basis/layout.py openghg_inversions/basis/operators.py tests/test_basis_layout.py`
- `tox -p`
