### PR TITLE
Sanitize non-finite flux before retained output reconstruction

### DIFF
--- a/openghg_inversions/basis/basis_functions.py
+++ b/openghg_inversions/basis/basis_functions.py
@@ -96,7 +96,7 @@ class FluxWeightedBasis:
 
         operator_cls = cast(Any, BucketBasisOperator)
         operator = operator_cls(basis_flat=basis_flat, **kwargs)
-        flux = sanitize_flux_nonfinite(flux, context="retained basis construction")
+        flux = sanitize_flux_nonfinite(flux, context="retained basis construction", trust_attrs=False)
         return cls(operator=operator, flux=flux, metadata=dict(metadata or {}))
 
     @classmethod
@@ -129,12 +129,16 @@ class FluxWeightedBasis:
         if not isinstance(flux, xr.DataArray):
             flux = concat_data_arrays(flux, key_dim="source")
 
-        flux = sanitize_flux_nonfinite(flux, context="retained multisource basis construction")
+        flux = sanitize_flux_nonfinite(
+            flux,
+            context="retained multisource basis construction",
+            trust_attrs=False,
+        )
         return cls(operator=operator, flux=flux, metadata=dict(metadata or {}))
 
     def with_flux(self, flux: xr.DataArray) -> Self:
         """Return a copy with the same operator and metadata but a different flux."""
-        flux = sanitize_flux_nonfinite(flux, context="retained basis flux replacement")
+        flux = sanitize_flux_nonfinite(flux, context="retained basis flux replacement", trust_attrs=False)
         return type(self)(operator=self.operator, flux=flux, metadata=dict(self.metadata))
 
     def with_metadata(self, metadata: Mapping[str, Any]) -> Self:
@@ -508,7 +512,7 @@ def flux_from_fp_all(fp_all: dict) -> xr.DataArray:
     else:
         flux = _combine_flux_sources_like_modelscenario(flux_arrays)
 
-    return sanitize_flux_nonfinite(flux, context="retained basis flux from fp_all")
+    return sanitize_flux_nonfinite(flux, context="retained basis flux from fp_all", trust_attrs=False)
 
 
 def _serialisable_basis_metadata(metadata: Mapping[str, Any]) -> dict[str, Any]:

--- a/openghg_inversions/basis/basis_functions.py
+++ b/openghg_inversions/basis/basis_functions.py
@@ -32,6 +32,7 @@ from openghg_inversions.basis.operators import (
     MultiSourceBucketBasisOperator,
     RegionLabels,
 )
+from openghg_inversions.flux_sanitization import sanitize_flux_nonfinite
 
 BASIS_METADATA_ATTR_PREFIX = "openghg_inversions:"
 BASIS_ARTIFACT_SOURCE_ATTR = f"{BASIS_METADATA_ATTR_PREFIX}basis_artifact_source"
@@ -95,6 +96,7 @@ class FluxWeightedBasis:
 
         operator_cls = cast(Any, BucketBasisOperator)
         operator = operator_cls(basis_flat=basis_flat, **kwargs)
+        flux = sanitize_flux_nonfinite(flux, context="retained basis construction")
         return cls(operator=operator, flux=flux, metadata=dict(metadata or {}))
 
     @classmethod
@@ -127,10 +129,12 @@ class FluxWeightedBasis:
         if not isinstance(flux, xr.DataArray):
             flux = concat_data_arrays(flux, key_dim="source")
 
+        flux = sanitize_flux_nonfinite(flux, context="retained multisource basis construction")
         return cls(operator=operator, flux=flux, metadata=dict(metadata or {}))
 
     def with_flux(self, flux: xr.DataArray) -> Self:
         """Return a copy with the same operator and metadata but a different flux."""
+        flux = sanitize_flux_nonfinite(flux, context="retained basis flux replacement")
         return type(self)(operator=self.operator, flux=flux, metadata=dict(self.metadata))
 
     def with_metadata(self, metadata: Mapping[str, Any]) -> Self:
@@ -504,7 +508,7 @@ def flux_from_fp_all(fp_all: dict) -> xr.DataArray:
     else:
         flux = _combine_flux_sources_like_modelscenario(flux_arrays)
 
-    return flux
+    return sanitize_flux_nonfinite(flux, context="retained basis flux from fp_all")
 
 
 def _serialisable_basis_metadata(metadata: Mapping[str, Any]) -> dict[str, Any]:

--- a/openghg_inversions/basis/basis_functions.py
+++ b/openghg_inversions/basis/basis_functions.py
@@ -96,7 +96,7 @@ class FluxWeightedBasis:
 
         operator_cls = cast(Any, BucketBasisOperator)
         operator = operator_cls(basis_flat=basis_flat, **kwargs)
-        flux = sanitize_flux_nonfinite(flux, context="retained basis construction", trust_attrs=False)
+        flux = sanitize_flux_nonfinite(flux, context="retained basis construction")
         return cls(operator=operator, flux=flux, metadata=dict(metadata or {}))
 
     @classmethod
@@ -126,19 +126,22 @@ class FluxWeightedBasis:
         operator_cls = cast(Any, MultiSourceBucketBasisOperator)
         operator = operator_cls(basis_flat=dict(basis_flat), **kwargs)
 
-        if not isinstance(flux, xr.DataArray):
+        if isinstance(flux, xr.DataArray):
+            trust_attrs = True
+        else:
             flux = concat_data_arrays(flux, key_dim="source")
+            trust_attrs = False
 
         flux = sanitize_flux_nonfinite(
             flux,
             context="retained multisource basis construction",
-            trust_attrs=False,
+            trust_attrs=trust_attrs,
         )
         return cls(operator=operator, flux=flux, metadata=dict(metadata or {}))
 
     def with_flux(self, flux: xr.DataArray) -> Self:
         """Return a copy with the same operator and metadata but a different flux."""
-        flux = sanitize_flux_nonfinite(flux, context="retained basis flux replacement", trust_attrs=False)
+        flux = sanitize_flux_nonfinite(flux, context="retained basis flux replacement")
         return type(self)(operator=self.operator, flux=flux, metadata=dict(self.metadata))
 
     def with_metadata(self, metadata: Mapping[str, Any]) -> Self:
@@ -512,7 +515,11 @@ def flux_from_fp_all(fp_all: dict) -> xr.DataArray:
     else:
         flux = _combine_flux_sources_like_modelscenario(flux_arrays)
 
-    return sanitize_flux_nonfinite(flux, context="retained basis flux from fp_all", trust_attrs=False)
+    return sanitize_flux_nonfinite(
+        flux,
+        context="retained basis flux from fp_all",
+        trust_attrs=len(flux_arrays) == 1,
+    )
 
 
 def _serialisable_basis_metadata(metadata: Mapping[str, Any]) -> dict[str, Any]:

--- a/openghg_inversions/config/templates/rhime_template.ini
+++ b/openghg_inversions/config/templates/rhime_template.ini
@@ -68,6 +68,8 @@ chains = 4
 averaging_error = True
 min_error = 0.0
 fix_basis_outer_regions = False
+; "lazy" records and applies zero-fill lazily; "count" computes exact non-finite flux counts once.
+flux_non_finite_check = "lazy"
 use_bc = True
 nuts_sampler = "pymc"
 save_trace = False

--- a/openghg_inversions/flux_sanitization.py
+++ b/openghg_inversions/flux_sanitization.py
@@ -1,9 +1,23 @@
-"""Helpers for applying a consistent non-finite flux policy."""
+"""Helpers for applying a consistent non-finite flux policy.
+
+OpenGHG flux data can contain ``NaN`` or infinite values even though those
+values do not have a scientific interpretation for flux weighting. This module
+normalises those values to zero early enough to protect generated and retained
+basis workflows.
+
+The sanitation policy is stored in one namespaced xarray attribute as compact
+JSON. xarray attrs are the metadata channel that survives NetCDF-like
+serialisation, but they should contain simple serialisable values rather than
+Python objects. Keeping the metadata behind a small dataclass gives callers a
+typed interface without spreading many string attribute names through the code.
+"""
 
 from __future__ import annotations
 
 from collections.abc import Mapping
+from dataclasses import dataclass
 from datetime import datetime, timezone
+import json
 from typing import Any, Literal
 import warnings
 
@@ -12,14 +26,9 @@ import xarray as xr
 
 FluxNonFiniteCheck = Literal["lazy", "count"]
 
-NONFINITE_POLICY_ATTR = "openghg_inversions:non_finite_policy"
-NONFINITE_FILL_VALUE_ATTR = "openghg_inversions:non_finite_fill_value"
-NONFINITE_CHECKED_ATTR = "openghg_inversions:non_finite_checked"
-NONFINITE_COUNT_ATTR = "openghg_inversions:non_finite_count"
-NONFINITE_TOTAL_ATTR = "openghg_inversions:non_finite_total"
-NONFINITE_FRACTION_ATTR = "openghg_inversions:non_finite_fraction"
-NONFINITE_CONTEXT_ATTR = "openghg_inversions:non_finite_context"
-NONFINITE_SOURCE_ATTR = "openghg_inversions:non_finite_source"
+# xarray persists attrs to NetCDF/Zarr metadata, so this key is namespaced to
+# avoid collisions with CF/OpenGHG attrs while keeping the value JSON-serialisable.
+NONFINITE_METADATA_ATTR = "openghg_inversions:non_finite_flux"
 
 NONFINITE_POLICY_ZERO_FILL = "zero_fill"
 NONFINITE_CHECKED_NOT_COUNTED = "not_counted"
@@ -30,20 +39,181 @@ _UPSTREAM_POLICY_ATTRS = (
     "openghg:missing_value_policy",
     "openghg:non_finite_policy",
 )
-_LOCAL_ATTRS = (
-    NONFINITE_POLICY_ATTR,
-    NONFINITE_FILL_VALUE_ATTR,
-    NONFINITE_CHECKED_ATTR,
-    NONFINITE_COUNT_ATTR,
-    NONFINITE_TOTAL_ATTR,
-    NONFINITE_FRACTION_ATTR,
-    NONFINITE_CONTEXT_ATTR,
-    NONFINITE_SOURCE_ATTR,
+_LEGACY_NONFINITE_POLICY_ATTR = "openghg_inversions:non_finite_policy"
+_LEGACY_NONFINITE_FILL_VALUE_ATTR = "openghg_inversions:non_finite_fill_value"
+_LEGACY_NONFINITE_CHECKED_ATTR = "openghg_inversions:non_finite_checked"
+_LEGACY_NONFINITE_COUNT_ATTR = "openghg_inversions:non_finite_count"
+_LEGACY_NONFINITE_TOTAL_ATTR = "openghg_inversions:non_finite_total"
+_LEGACY_NONFINITE_FRACTION_ATTR = "openghg_inversions:non_finite_fraction"
+_LEGACY_NONFINITE_CONTEXT_ATTR = "openghg_inversions:non_finite_context"
+_LEGACY_NONFINITE_SOURCE_ATTR = "openghg_inversions:non_finite_source"
+_LEGACY_LOCAL_ATTRS = (
+    _LEGACY_NONFINITE_POLICY_ATTR,
+    _LEGACY_NONFINITE_FILL_VALUE_ATTR,
+    _LEGACY_NONFINITE_CHECKED_ATTR,
+    _LEGACY_NONFINITE_COUNT_ATTR,
+    _LEGACY_NONFINITE_TOTAL_ATTR,
+    _LEGACY_NONFINITE_FRACTION_ATTR,
+    _LEGACY_NONFINITE_CONTEXT_ATTR,
+    _LEGACY_NONFINITE_SOURCE_ATTR,
 )
 
 
 class NonFiniteFluxWarning(UserWarning):
     """Warning emitted when non-finite flux values are replaced."""
+
+
+@dataclass(frozen=True, slots=True)
+class FluxNonFiniteMetadata:
+    """Machine-readable metadata describing non-finite flux handling.
+
+    The dataclass is the in-memory representation used by this module. Its
+    serialised form is a JSON object stored under ``NONFINITE_METADATA_ATTR`` so
+    the metadata can survive NetCDF/Zarr roundtrips without placing a Python
+    object in ``DataArray.attrs``.
+
+    Attributes:
+        schema_version: JSON metadata schema version.
+        policy: Non-finite handling policy. Currently only ``"zero_fill"`` is
+            written locally.
+        fill_value: Value used to replace non-finite cells.
+        checked: Whether the array was lazily sanitised without counting values
+            or audited with an exact count.
+        context: Human-readable processing context where the policy was
+            applied.
+        source: Optional flux source label.
+        count: Exact non-finite count when ``checked`` is ``"computed"``.
+        total: Exact total cell count when ``checked`` is ``"computed"``.
+        fraction: Exact non-finite fraction when ``checked`` is ``"computed"``.
+    """
+
+    schema_version: int = 1
+    policy: str = NONFINITE_POLICY_ZERO_FILL
+    fill_value: float = 0.0
+    checked: str = NONFINITE_CHECKED_NOT_COUNTED
+    context: str | None = None
+    source: str | None = None
+    count: int | None = None
+    total: int | None = None
+    fraction: float | None = None
+
+    @classmethod
+    def from_attrs(cls, attrs: Mapping[Any, Any]) -> "FluxNonFiniteMetadata | None":
+        """Parse local non-finite metadata from xarray attrs.
+
+        Args:
+            attrs: Attribute mapping from a DataArray or Dataset.
+
+        Returns:
+            Parsed metadata when local JSON metadata or legacy per-field
+            metadata is present, otherwise ``None``.
+        """
+        raw_metadata = attrs.get(NONFINITE_METADATA_ATTR)
+        if raw_metadata is not None:
+            return cls.from_json(raw_metadata)
+
+        legacy_policy = attrs.get(_LEGACY_NONFINITE_POLICY_ATTR)
+        if legacy_policy is None:
+            return None
+
+        return cls(
+            schema_version=1,
+            policy=str(legacy_policy),
+            fill_value=float(attrs.get(_LEGACY_NONFINITE_FILL_VALUE_ATTR, 0.0)),
+            checked=str(attrs.get(_LEGACY_NONFINITE_CHECKED_ATTR, NONFINITE_CHECKED_NOT_COUNTED)),
+            context=_optional_str(attrs.get(_LEGACY_NONFINITE_CONTEXT_ATTR)),
+            source=_optional_str(attrs.get(_LEGACY_NONFINITE_SOURCE_ATTR)),
+            count=_optional_int(attrs.get(_LEGACY_NONFINITE_COUNT_ATTR)),
+            total=_optional_int(attrs.get(_LEGACY_NONFINITE_TOTAL_ATTR)),
+            fraction=_optional_float(attrs.get(_LEGACY_NONFINITE_FRACTION_ATTR)),
+        )
+
+    @classmethod
+    def from_json(cls, value: object) -> "FluxNonFiniteMetadata":
+        """Parse metadata from a JSON string or mapping.
+
+        Args:
+            value: JSON string, bytes, or mapping stored in xarray attrs.
+
+        Returns:
+            Parsed metadata.
+
+        Raises:
+            ValueError: If the stored value is not valid metadata.
+        """
+        if isinstance(value, bytes):
+            value = value.decode()
+        if isinstance(value, str):
+            try:
+                data = json.loads(value)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"Invalid non-finite flux metadata JSON: {value!r}") from exc
+        elif isinstance(value, Mapping):
+            data = dict(value)
+        else:
+            raise ValueError(f"Unsupported non-finite flux metadata value: {value!r}")
+
+        if not isinstance(data, Mapping):
+            raise ValueError(f"Non-finite flux metadata must be a JSON object: {value!r}")
+
+        return cls(
+            schema_version=int(data.get("schema_version", 1)),
+            policy=str(data.get("policy", NONFINITE_POLICY_ZERO_FILL)),
+            fill_value=float(data.get("fill_value", 0.0)),
+            checked=str(data.get("checked", NONFINITE_CHECKED_NOT_COUNTED)),
+            context=_optional_str(data.get("context")),
+            source=_optional_str(data.get("source")),
+            count=_optional_int(data.get("count")),
+            total=_optional_int(data.get("total")),
+            fraction=_optional_float(data.get("fraction")),
+        )
+
+    def declares_zero_fill(self) -> bool:
+        """Return whether this metadata declares a zero-fill policy."""
+        return _normalise_policy(self.policy) in _ZERO_FILL_POLICY_VALUES and float(self.fill_value) == 0.0
+
+    def to_json_dict(self) -> dict[str, str | int | float | None]:
+        """Return a JSON-serialisable dictionary.
+
+        Returns:
+            Dictionary containing only primitive or null values suitable for
+            JSON encoding in xarray attrs.
+        """
+        data: dict[str, str | int | float | None] = {
+            "schema_version": int(self.schema_version),
+            "policy": self.policy,
+            "fill_value": float(self.fill_value),
+            "checked": self.checked,
+            "context": self.context,
+            "source": self.source,
+            "count": None,
+            "total": None,
+            "fraction": None,
+        }
+        if self.checked == NONFINITE_CHECKED_COMPUTED:
+            data["count"] = int(self.count or 0)
+            data["total"] = int(self.total or 0)
+            data["fraction"] = float(self.fraction or 0.0)
+        return data
+
+    def to_json(self) -> str:
+        """Return compact JSON suitable for storing in xarray attrs."""
+        return json.dumps(self.to_json_dict(), sort_keys=True, separators=(",", ":"))
+
+
+def _optional_str(value: object) -> str | None:
+    """Coerce optional attr values to strings."""
+    return None if value is None else str(value)
+
+
+def _optional_int(value: object) -> int | None:
+    """Coerce optional attr values to integers."""
+    return None if value is None else int(str(value))
+
+
+def _optional_float(value: object) -> float | None:
+    """Coerce optional attr values to floats."""
+    return None if value is None else float(str(value))
 
 
 def _normalise_policy(value: object) -> str:
@@ -52,9 +222,18 @@ def _normalise_policy(value: object) -> str:
 
 
 def attrs_declare_zero_filled_nonfinite(attrs: Mapping[Any, Any]) -> bool:
-    """Return true if attrs declare a trusted zero-fill non-finite policy."""
-    local_policy = attrs.get(NONFINITE_POLICY_ATTR)
-    if local_policy is not None and _normalise_policy(local_policy) in _ZERO_FILL_POLICY_VALUES:
+    """Return true if attrs declare a trusted zero-fill non-finite policy.
+
+    Args:
+        attrs: Attribute mapping from a DataArray or Dataset.
+
+    Returns:
+        ``True`` when local metadata, legacy local metadata, or recognised
+        upstream OpenGHG metadata declares that non-finite flux values have
+        already been zero-filled.
+    """
+    local_metadata = FluxNonFiniteMetadata.from_attrs(attrs)
+    if local_metadata is not None and local_metadata.declares_zero_fill():
         return True
 
     for attr in _UPSTREAM_POLICY_ATTRS:
@@ -73,7 +252,19 @@ def _history_entry(
     count: int | None,
     total: int | None,
 ) -> str:
-    """Build a compact CF-style history entry for flux sanitation."""
+    """Build a compact CF-style history entry for flux sanitation.
+
+    Args:
+        context: Processing context where sanitation was applied.
+        source: Optional flux source label.
+        checked: Check mode recorded in metadata.
+        count: Exact non-finite count when ``checked`` is ``"computed"``.
+        total: Exact total cell count when ``checked`` is ``"computed"``.
+
+    Returns:
+        A UTC timestamped history line describing either lazy replacement or
+        exact counted replacement.
+    """
     timestamp = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
     source_part = f" source={source}" if source is not None else ""
     if checked == NONFINITE_CHECKED_COMPUTED and count is not None and total is not None:
@@ -93,7 +284,19 @@ def _append_history(attrs: dict[Any, Any], entry: str) -> None:
 
 
 def _nonfinite_count(finite: xr.DataArray, total: int) -> tuple[int, int, float]:
-    """Compute non-finite count metadata from a Boolean finite mask."""
+    """Compute non-finite count metadata from a Boolean finite mask.
+
+    Args:
+        finite: Boolean mask with ``True`` where flux values are finite.
+        total: Total number of cells represented by ``finite``.
+
+    Returns:
+        Tuple of ``(count, total, fraction)`` for non-finite cells.
+
+    Notes:
+        This function calls ``compute()`` on the mask reduction, so callers
+        should only use it for explicit audit/count mode.
+    """
     count_value = (~finite).sum().compute()
     count = int(count_value.item())
     fraction = float(count / total) if total else 0.0
@@ -110,22 +313,36 @@ def _with_nonfinite_attrs(
     total: int | None = None,
     fraction: float | None = None,
 ) -> xr.DataArray:
-    """Return a shallow copy with non-finite policy attrs attached."""
+    """Return a shallow copy with non-finite policy attrs attached.
+
+    Args:
+        flux: Flux DataArray receiving metadata. Data values are not changed by
+            this helper.
+        context: Processing context where sanitation was applied.
+        source: Optional flux source label.
+        checked: Check mode recorded in metadata.
+        count: Exact non-finite count when ``checked`` is ``"computed"``.
+        total: Exact total cell count when ``checked`` is ``"computed"``.
+        fraction: Exact non-finite fraction when ``checked`` is ``"computed"``.
+
+    Returns:
+        A shallow copy of ``flux`` with JSON metadata attached under
+        ``NONFINITE_METADATA_ATTR``, stale legacy per-field attrs removed, and a
+        new CF-style ``history`` entry appended.
+    """
     result = flux.copy(deep=False)
     attrs = dict(flux.attrs)
-    attrs[NONFINITE_POLICY_ATTR] = NONFINITE_POLICY_ZERO_FILL
-    attrs[NONFINITE_FILL_VALUE_ATTR] = 0.0
-    attrs[NONFINITE_CHECKED_ATTR] = checked
-    attrs[NONFINITE_CONTEXT_ATTR] = context
-    if source is not None:
-        attrs[NONFINITE_SOURCE_ATTR] = source
-    if checked == NONFINITE_CHECKED_COMPUTED:
-        attrs[NONFINITE_COUNT_ATTR] = int(count or 0)
-        attrs[NONFINITE_TOTAL_ATTR] = int(total or 0)
-        attrs[NONFINITE_FRACTION_ATTR] = float(fraction or 0.0)
-    else:
-        for attr in (NONFINITE_COUNT_ATTR, NONFINITE_TOTAL_ATTR, NONFINITE_FRACTION_ATTR):
-            attrs.pop(attr, None)
+    metadata = FluxNonFiniteMetadata(
+        checked=checked,
+        context=context,
+        source=source,
+        count=count,
+        total=total,
+        fraction=fraction,
+    )
+    attrs[NONFINITE_METADATA_ATTR] = metadata.to_json()
+    for attr in _LEGACY_LOCAL_ATTRS:
+        attrs.pop(attr, None)
 
     _append_history(
         attrs,
@@ -155,14 +372,39 @@ def sanitize_flux_nonfinite(
     The default ``check="lazy"`` creates a lazy xarray/dask graph and does not
     compute a count. Use ``check="count"`` when exact non-finite counts are
     needed for audit logs, accepting that this computes the finite mask.
+
+    Args:
+        flux: Flux field to sanitize.
+        context: Human-readable processing context used in metadata and
+            warnings.
+        source: Optional flux source label to record in metadata.
+        check: ``"lazy"`` to avoid computing counts, or ``"count"`` to compute
+            exact count/total/fraction metadata.
+        trust_attrs: If ``True``, return flux unchanged when attrs already
+            declare a zero-fill policy. ``check="count"`` still audits local
+            metadata that has not already recorded computed counts.
+        warn: Emit a warning when values are replaced or a lazy fallback is
+            applied.
+
+    Returns:
+        Sanitized flux with non-finite values replaced by ``0.0`` and local
+        JSON policy metadata attached.
+
+    Raises:
+        ValueError: If ``check`` is not ``"lazy"`` or ``"count"``.
+
+    Warns:
+        NonFiniteFluxWarning: If ``warn`` is ``True`` and values are counted as
+        non-finite in count mode, or when lazy fallback sanitation is applied.
     """
     if check not in ("lazy", "count"):
         raise ValueError("`check` must be either 'lazy' or 'count'.")
 
+    metadata = FluxNonFiniteMetadata.from_attrs(flux.attrs)
     if (
         trust_attrs
         and attrs_declare_zero_filled_nonfinite(flux.attrs)
-        and (check == "lazy" or flux.attrs.get(NONFINITE_CHECKED_ATTR) == NONFINITE_CHECKED_COMPUTED)
+        and (check == "lazy" or (metadata is not None and metadata.checked == NONFINITE_CHECKED_COMPUTED))
     ):
         return flux
 
@@ -220,7 +462,23 @@ def sanitize_fp_all_fluxes(
     trust_attrs: bool = True,
     warn: bool = False,
 ) -> dict:
-    """Sanitize every ``fp_all['.flux']`` entry in place and return ``fp_all``."""
+    """Sanitize all flux entries in an ``fp_all`` mapping.
+
+    Args:
+        fp_all: Legacy footprint/flux mapping. Flux entries are expected under
+            ``fp_all[".flux"]`` as objects with a ``data`` dataset containing a
+            ``"flux"`` variable.
+        context: Human-readable processing context used in metadata and
+            warnings.
+        check: ``"lazy"`` to avoid computing counts, or ``"count"`` to compute
+            exact count/total/fraction metadata.
+        trust_attrs: If ``True``, skip entries that already declare a zero-fill
+            policy.
+        warn: Emit warnings for replacements or lazy fallbacks.
+
+    Returns:
+        The input mapping, modified in place where flux entries are found.
+    """
     flux_entries = fp_all.get(".flux")
     if not isinstance(flux_entries, Mapping):
         return fp_all
@@ -244,10 +502,21 @@ def sanitize_fp_all_fluxes(
 def copy_flux_nonfinite_attrs(
     target: xr.Dataset | xr.DataArray, flux: xr.Dataset | xr.DataArray
 ) -> xr.Dataset | xr.DataArray:
-    """Copy machine-readable non-finite flux attrs onto an output object."""
+    """Copy machine-readable non-finite flux metadata onto an output object.
+
+    Args:
+        target: Dataset or DataArray receiving metadata.
+        flux: Dataset or DataArray whose attrs may contain local non-finite flux
+            metadata.
+
+    Returns:
+        A shallow copy of ``target`` with local JSON non-finite metadata copied
+        from ``flux`` when present. Legacy local attrs are normalised to the
+        current JSON attr.
+    """
     result = target.copy(deep=False)
     result.attrs = dict(target.attrs)
-    for attr in _LOCAL_ATTRS:
-        if attr in flux.attrs:
-            result.attrs[attr] = flux.attrs[attr]
+    metadata = FluxNonFiniteMetadata.from_attrs(flux.attrs)
+    if metadata is not None:
+        result.attrs[NONFINITE_METADATA_ATTR] = metadata.to_json()
     return result

--- a/openghg_inversions/flux_sanitization.py
+++ b/openghg_inversions/flux_sanitization.py
@@ -1,0 +1,253 @@
+"""Helpers for applying a consistent non-finite flux policy."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from typing import Any, Literal
+import warnings
+
+import numpy as np
+import xarray as xr
+
+FluxNonFiniteCheck = Literal["lazy", "count"]
+
+NONFINITE_POLICY_ATTR = "openghg_inversions:non_finite_policy"
+NONFINITE_FILL_VALUE_ATTR = "openghg_inversions:non_finite_fill_value"
+NONFINITE_CHECKED_ATTR = "openghg_inversions:non_finite_checked"
+NONFINITE_COUNT_ATTR = "openghg_inversions:non_finite_count"
+NONFINITE_TOTAL_ATTR = "openghg_inversions:non_finite_total"
+NONFINITE_FRACTION_ATTR = "openghg_inversions:non_finite_fraction"
+NONFINITE_CONTEXT_ATTR = "openghg_inversions:non_finite_context"
+NONFINITE_SOURCE_ATTR = "openghg_inversions:non_finite_source"
+
+NONFINITE_POLICY_ZERO_FILL = "zero_fill"
+NONFINITE_CHECKED_NOT_COUNTED = "not_counted"
+NONFINITE_CHECKED_COMPUTED = "computed"
+
+_ZERO_FILL_POLICY_VALUES = {"zero_fill", "fill_zero", "replace_with_zero"}
+_UPSTREAM_POLICY_ATTRS = (
+    "openghg:missing_value_policy",
+    "openghg:non_finite_policy",
+)
+_LOCAL_ATTRS = (
+    NONFINITE_POLICY_ATTR,
+    NONFINITE_FILL_VALUE_ATTR,
+    NONFINITE_CHECKED_ATTR,
+    NONFINITE_COUNT_ATTR,
+    NONFINITE_TOTAL_ATTR,
+    NONFINITE_FRACTION_ATTR,
+    NONFINITE_CONTEXT_ATTR,
+    NONFINITE_SOURCE_ATTR,
+)
+
+
+class NonFiniteFluxWarning(UserWarning):
+    """Warning emitted when non-finite flux values are replaced."""
+
+
+def _normalise_policy(value: object) -> str:
+    """Normalize policy text for attribute comparisons."""
+    return str(value).strip().lower().replace("-", "_")
+
+
+def attrs_declare_zero_filled_nonfinite(attrs: Mapping[Any, Any]) -> bool:
+    """Return true if attrs declare a trusted zero-fill non-finite policy."""
+    local_policy = attrs.get(NONFINITE_POLICY_ATTR)
+    if local_policy is not None and _normalise_policy(local_policy) in _ZERO_FILL_POLICY_VALUES:
+        return True
+
+    for attr in _UPSTREAM_POLICY_ATTRS:
+        upstream_policy = attrs.get(attr)
+        if upstream_policy is not None and _normalise_policy(upstream_policy) in _ZERO_FILL_POLICY_VALUES:
+            return True
+
+    return False
+
+
+def _history_entry(
+    *,
+    context: str,
+    source: str | None,
+    checked: str,
+    count: int | None,
+    total: int | None,
+) -> str:
+    """Build a compact CF-style history entry for flux sanitation."""
+    timestamp = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    source_part = f" source={source}" if source is not None else ""
+    if checked == NONFINITE_CHECKED_COMPUTED and count is not None and total is not None:
+        count_part = f" replaced {count}/{total} non-finite values"
+    else:
+        count_part = " applied lazy non-finite replacement without counting values"
+    return (
+        f"{timestamp} OpenGHG Inversions:{source_part}{count_part}; "
+        f"policy={NONFINITE_POLICY_ZERO_FILL}; fill_value=0.0; context={context}."
+    )
+
+
+def _append_history(attrs: dict[Any, Any], entry: str) -> None:
+    """Append a history entry while preserving any existing value."""
+    existing = attrs.get("history")
+    attrs["history"] = f"{existing}\n{entry}" if existing else entry
+
+
+def _nonfinite_count(finite: xr.DataArray, total: int) -> tuple[int, int, float]:
+    """Compute non-finite count metadata from a Boolean finite mask."""
+    count_value = (~finite).sum().compute()
+    count = int(count_value.item())
+    fraction = float(count / total) if total else 0.0
+    return count, total, fraction
+
+
+def _with_nonfinite_attrs(
+    flux: xr.DataArray,
+    *,
+    context: str,
+    source: str | None,
+    checked: str,
+    count: int | None = None,
+    total: int | None = None,
+    fraction: float | None = None,
+) -> xr.DataArray:
+    """Return a shallow copy with non-finite policy attrs attached."""
+    result = flux.copy(deep=False)
+    attrs = dict(flux.attrs)
+    attrs[NONFINITE_POLICY_ATTR] = NONFINITE_POLICY_ZERO_FILL
+    attrs[NONFINITE_FILL_VALUE_ATTR] = 0.0
+    attrs[NONFINITE_CHECKED_ATTR] = checked
+    attrs[NONFINITE_CONTEXT_ATTR] = context
+    if source is not None:
+        attrs[NONFINITE_SOURCE_ATTR] = source
+    if checked == NONFINITE_CHECKED_COMPUTED:
+        attrs[NONFINITE_COUNT_ATTR] = int(count or 0)
+        attrs[NONFINITE_TOTAL_ATTR] = int(total or 0)
+        attrs[NONFINITE_FRACTION_ATTR] = float(fraction or 0.0)
+    else:
+        for attr in (NONFINITE_COUNT_ATTR, NONFINITE_TOTAL_ATTR, NONFINITE_FRACTION_ATTR):
+            attrs.pop(attr, None)
+
+    _append_history(
+        attrs,
+        _history_entry(
+            context=context,
+            source=source,
+            checked=checked,
+            count=count,
+            total=total,
+        ),
+    )
+    result.attrs = attrs
+    return result
+
+
+def sanitize_flux_nonfinite(
+    flux: xr.DataArray,
+    *,
+    context: str,
+    source: str | None = None,
+    check: FluxNonFiniteCheck = "lazy",
+    trust_attrs: bool = True,
+    warn: bool = False,
+) -> xr.DataArray:
+    """Replace non-finite flux values with zero and record the policy.
+
+    The default ``check="lazy"`` creates a lazy xarray/dask graph and does not
+    compute a count. Use ``check="count"`` when exact non-finite counts are
+    needed for audit logs, accepting that this computes the finite mask.
+    """
+    if check not in ("lazy", "count"):
+        raise ValueError("`check` must be either 'lazy' or 'count'.")
+
+    if (
+        trust_attrs
+        and attrs_declare_zero_filled_nonfinite(flux.attrs)
+        and (check == "lazy" or flux.attrs.get(NONFINITE_CHECKED_ATTR) == NONFINITE_CHECKED_COMPUTED)
+    ):
+        return flux
+
+    finite = xr.apply_ufunc(np.isfinite, flux, dask="allowed")
+    count: int | None = None
+    total: int | None = None
+    fraction: float | None = None
+    checked = NONFINITE_CHECKED_NOT_COUNTED
+    if check == "count":
+        total = int(flux.size)
+        count, total, fraction = _nonfinite_count(finite, total)
+        checked = NONFINITE_CHECKED_COMPUTED
+
+    sanitized = flux.where(finite, 0.0)
+    if np.issubdtype(flux.dtype, np.floating):
+        sanitized = sanitized.astype(flux.dtype)
+    sanitized = _with_nonfinite_attrs(
+        sanitized,
+        context=context,
+        source=source,
+        checked=checked,
+        count=count,
+        total=total,
+        fraction=fraction,
+    )
+
+    if warn:
+        if check == "count" and count:
+            warnings.warn(
+                (
+                    f"Flux {source or '<unknown>'} contains {count} non-finite values "
+                    f"out of {total}; replacing them with 0.0 for {context}."
+                ),
+                NonFiniteFluxWarning,
+                stacklevel=2,
+            )
+        elif check == "lazy":
+            warnings.warn(
+                (
+                    f"Flux {source or '<unknown>'} has not declared a non-finite policy; "
+                    f"lazily replacing any non-finite values with 0.0 for {context}."
+                ),
+                NonFiniteFluxWarning,
+                stacklevel=2,
+            )
+
+    return sanitized
+
+
+def sanitize_fp_all_fluxes(
+    fp_all: dict,
+    *,
+    context: str,
+    check: FluxNonFiniteCheck = "lazy",
+    trust_attrs: bool = True,
+    warn: bool = False,
+) -> dict:
+    """Sanitize every ``fp_all['.flux']`` entry in place and return ``fp_all``."""
+    flux_entries = fp_all.get(".flux")
+    if not isinstance(flux_entries, Mapping):
+        return fp_all
+
+    for source, flux_data in flux_entries.items():
+        data = getattr(flux_data, "data", None)
+        if not isinstance(data, xr.Dataset) or "flux" not in data:
+            continue
+        data["flux"] = sanitize_flux_nonfinite(
+            data["flux"],
+            context=context,
+            source=str(source),
+            check=check,
+            trust_attrs=trust_attrs,
+            warn=warn,
+        )
+
+    return fp_all
+
+
+def copy_flux_nonfinite_attrs(
+    target: xr.Dataset | xr.DataArray, flux: xr.Dataset | xr.DataArray
+) -> xr.Dataset | xr.DataArray:
+    """Copy machine-readable non-finite flux attrs onto an output object."""
+    result = target.copy(deep=False)
+    result.attrs = dict(target.attrs)
+    for attr in _LOCAL_ATTRS:
+        if attr in flux.attrs:
+            result.attrs[attr] = flux.attrs[attr]
+    return result

--- a/openghg_inversions/flux_sanitization.py
+++ b/openghg_inversions/flux_sanitization.py
@@ -15,16 +15,17 @@ typed interface without spreading many string attribute names through the code.
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 import json
-from typing import Any, Literal
+from typing import Any, Literal, TypeVar
 import warnings
 
 import numpy as np
 import xarray as xr
 
 FluxNonFiniteCheck = Literal["lazy", "count"]
+_XarrayObjectT = TypeVar("_XarrayObjectT", xr.DataArray, xr.Dataset)
 
 # xarray persists attrs to NetCDF/Zarr metadata, so this key is namespaced to
 # avoid collisions with CF/OpenGHG attrs while keeping the value JSON-serialisable.
@@ -33,12 +34,6 @@ NONFINITE_METADATA_ATTR = "openghg_inversions:non_finite_flux"
 NONFINITE_POLICY_ZERO_FILL = "zero_fill"
 NONFINITE_CHECKED_NOT_COUNTED = "not_counted"
 NONFINITE_CHECKED_COMPUTED = "computed"
-
-_ZERO_FILL_POLICY_VALUES = {"zero_fill", "fill_zero", "replace_with_zero"}
-_UPSTREAM_POLICY_ATTRS = (
-    "openghg:missing_value_policy",
-    "openghg:non_finite_policy",
-)
 
 
 class NonFiniteFluxWarning(UserWarning):
@@ -123,21 +118,31 @@ class FluxNonFiniteMetadata:
         if not isinstance(data, Mapping):
             raise ValueError(f"Non-finite flux metadata must be a JSON object: {value!r}")
 
+        context = data.get("context")
+        source = data.get("source")
+        count = data.get("count")
+        total = data.get("total")
+        fraction = data.get("fraction")
         return cls(
             schema_version=int(data.get("schema_version", 1)),
             policy=str(data.get("policy", NONFINITE_POLICY_ZERO_FILL)),
             fill_value=float(data.get("fill_value", 0.0)),
             checked=str(data.get("checked", NONFINITE_CHECKED_NOT_COUNTED)),
-            context=_optional_str(data.get("context")),
-            source=_optional_str(data.get("source")),
-            count=_optional_int(data.get("count")),
-            total=_optional_int(data.get("total")),
-            fraction=_optional_float(data.get("fraction")),
+            context=None if context is None else str(context),
+            source=None if source is None else str(source),
+            count=None if count is None else int(str(count)),
+            total=None if total is None else int(str(total)),
+            fraction=None if fraction is None else float(str(fraction)),
         )
 
     def declares_zero_fill(self) -> bool:
-        """Return whether this metadata declares a zero-fill policy."""
-        return _normalise_policy(self.policy) in _ZERO_FILL_POLICY_VALUES and float(self.fill_value) == 0.0
+        """Return whether this metadata declares a zero-fill policy.
+
+        Returns:
+            ``True`` when the policy and fill value describe replacement with
+            zero.
+        """
+        return self.policy == NONFINITE_POLICY_ZERO_FILL and float(self.fill_value) == 0.0
 
     def to_json_dict(self) -> dict[str, str | int | float | None]:
         """Return a JSON-serialisable dictionary.
@@ -146,69 +151,15 @@ class FluxNonFiniteMetadata:
             Dictionary containing only primitive or null values suitable for
             JSON encoding in xarray attrs.
         """
-        data: dict[str, str | int | float | None] = {
-            "schema_version": int(self.schema_version),
-            "policy": self.policy,
-            "fill_value": float(self.fill_value),
-            "checked": self.checked,
-            "context": self.context,
-            "source": self.source,
-            "count": None,
-            "total": None,
-            "fraction": None,
-        }
-        if self.checked == NONFINITE_CHECKED_COMPUTED:
-            data["count"] = int(self.count or 0)
-            data["total"] = int(self.total or 0)
-            data["fraction"] = float(self.fraction or 0.0)
-        return data
+        return asdict(self)
 
     def to_json(self) -> str:
-        """Return compact JSON suitable for storing in xarray attrs."""
+        """Return compact JSON suitable for storing in xarray attrs.
+
+        Returns:
+            JSON object encoded as a compact string.
+        """
         return json.dumps(self.to_json_dict(), sort_keys=True, separators=(",", ":"))
-
-
-def _optional_str(value: object) -> str | None:
-    """Coerce optional attr values to strings."""
-    return None if value is None else str(value)
-
-
-def _optional_int(value: object) -> int | None:
-    """Coerce optional attr values to integers."""
-    return None if value is None else int(str(value))
-
-
-def _optional_float(value: object) -> float | None:
-    """Coerce optional attr values to floats."""
-    return None if value is None else float(str(value))
-
-
-def _normalise_policy(value: object) -> str:
-    """Normalize policy text for attribute comparisons."""
-    return str(value).strip().lower().replace("-", "_")
-
-
-def attrs_declare_zero_filled_nonfinite(attrs: Mapping[Any, Any]) -> bool:
-    """Return true if attrs declare a trusted zero-fill non-finite policy.
-
-    Args:
-        attrs: Attribute mapping from a DataArray or Dataset.
-
-    Returns:
-        ``True`` when local JSON metadata or recognised upstream OpenGHG
-        metadata declares that non-finite flux values have already been
-        zero-filled.
-    """
-    local_metadata = FluxNonFiniteMetadata.from_attrs(attrs)
-    if local_metadata is not None and local_metadata.declares_zero_fill():
-        return True
-
-    for attr in _UPSTREAM_POLICY_ATTRS:
-        upstream_policy = attrs.get(attr)
-        if upstream_policy is not None and _normalise_policy(upstream_policy) in _ZERO_FILL_POLICY_VALUES:
-            return True
-
-    return False
 
 
 def _history_entry(
@@ -242,12 +193,6 @@ def _history_entry(
         f"{timestamp} OpenGHG Inversions:{source_part}{count_part}; "
         f"policy={NONFINITE_POLICY_ZERO_FILL}; fill_value=0.0; context={context}."
     )
-
-
-def _append_history(attrs: dict[Any, Any], entry: str) -> None:
-    """Append a history entry while preserving any existing value."""
-    existing = attrs.get("history")
-    attrs["history"] = f"{existing}\n{entry}" if existing else entry
 
 
 def _nonfinite_count(finite: xr.DataArray, total: int) -> tuple[int, int, float]:
@@ -309,16 +254,15 @@ def _with_nonfinite_attrs(
     )
     attrs[NONFINITE_METADATA_ATTR] = metadata.to_json()
 
-    _append_history(
-        attrs,
-        _history_entry(
-            context=context,
-            source=source,
-            checked=checked,
-            count=count,
-            total=total,
-        ),
+    history_entry = _history_entry(
+        context=context,
+        source=source,
+        checked=checked,
+        count=count,
+        total=total,
     )
+    existing_history = attrs.get("history")
+    attrs["history"] = f"{existing_history}\n{history_entry}" if existing_history else history_entry
     result.attrs = attrs
     return result
 
@@ -345,9 +289,9 @@ def sanitize_flux_nonfinite(
         source: Optional flux source label to record in metadata.
         check: ``"lazy"`` to avoid computing counts, or ``"count"`` to compute
             exact count/total/fraction metadata.
-        trust_attrs: If ``True``, return flux unchanged when attrs already
-            declare a zero-fill policy. ``check="count"`` still audits local
-            metadata that has not already recorded computed counts.
+        trust_attrs: If ``True``, return flux unchanged when local attrs already
+            declare a zero-fill policy. A previous lazy replacement cannot be
+            upgraded to an exact count because the original values are gone.
         warn: Emit a warning when values are replaced or a lazy fallback is
             applied.
 
@@ -359,18 +303,24 @@ def sanitize_flux_nonfinite(
         ValueError: If ``check`` is not ``"lazy"`` or ``"count"``.
 
     Warns:
-        NonFiniteFluxWarning: If ``warn`` is ``True`` and values are counted as
-        non-finite in count mode, or when lazy fallback sanitation is applied.
+        NonFiniteFluxWarning: If values cannot be counted because a lazy
+            replacement already occurred, or if ``warn`` is ``True`` and values
+            are replaced or a lazy fallback is applied.
     """
     if check not in ("lazy", "count"):
         raise ValueError("`check` must be either 'lazy' or 'count'.")
 
     metadata = FluxNonFiniteMetadata.from_attrs(flux.attrs)
-    if (
-        trust_attrs
-        and attrs_declare_zero_filled_nonfinite(flux.attrs)
-        and (check == "lazy" or (metadata is not None and metadata.checked == NONFINITE_CHECKED_COMPUTED))
-    ):
+    if trust_attrs and metadata is not None and metadata.declares_zero_fill():
+        if check == "count" and metadata.checked != NONFINITE_CHECKED_COMPUTED:
+            warnings.warn(
+                (
+                    f"Flux {source or '<unknown>'} was already zero-filled without counting; "
+                    "the original non-finite count cannot be recovered."
+                ),
+                NonFiniteFluxWarning,
+                stacklevel=2,
+            )
         return flux
 
     finite = xr.apply_ufunc(np.isfinite, flux, dask="allowed")
@@ -410,7 +360,7 @@ def sanitize_flux_nonfinite(
             warnings.warn(
                 (
                     f"Flux {source or '<unknown>'} has not declared a non-finite policy; "
-                    f"lazily replacing any non-finite values with 0.0 for {context}."
+                    f"applying a lazy zero-fill guard for {context}."
                 ),
                 NonFiniteFluxWarning,
                 stacklevel=2,
@@ -419,54 +369,7 @@ def sanitize_flux_nonfinite(
     return sanitized
 
 
-def sanitize_fp_all_fluxes(
-    fp_all: dict,
-    *,
-    context: str,
-    check: FluxNonFiniteCheck = "lazy",
-    trust_attrs: bool = True,
-    warn: bool = False,
-) -> dict:
-    """Sanitize all flux entries in an ``fp_all`` mapping.
-
-    Args:
-        fp_all: Legacy footprint/flux mapping. Flux entries are expected under
-            ``fp_all[".flux"]`` as objects with a ``data`` dataset containing a
-            ``"flux"`` variable.
-        context: Human-readable processing context used in metadata and
-            warnings.
-        check: ``"lazy"`` to avoid computing counts, or ``"count"`` to compute
-            exact count/total/fraction metadata.
-        trust_attrs: If ``True``, skip entries that already declare a zero-fill
-            policy.
-        warn: Emit warnings for replacements or lazy fallbacks.
-
-    Returns:
-        The input mapping, modified in place where flux entries are found.
-    """
-    flux_entries = fp_all.get(".flux")
-    if not isinstance(flux_entries, Mapping):
-        return fp_all
-
-    for source, flux_data in flux_entries.items():
-        data = getattr(flux_data, "data", None)
-        if not isinstance(data, xr.Dataset) or "flux" not in data:
-            continue
-        data["flux"] = sanitize_flux_nonfinite(
-            data["flux"],
-            context=context,
-            source=str(source),
-            check=check,
-            trust_attrs=trust_attrs,
-            warn=warn,
-        )
-
-    return fp_all
-
-
-def copy_flux_nonfinite_attrs(
-    target: xr.Dataset | xr.DataArray, flux: xr.Dataset | xr.DataArray
-) -> xr.Dataset | xr.DataArray:
+def copy_flux_nonfinite_attrs(target: _XarrayObjectT, flux: xr.Dataset | xr.DataArray) -> _XarrayObjectT:
     """Copy machine-readable non-finite flux metadata onto an output object.
 
     Args:
@@ -478,9 +381,11 @@ def copy_flux_nonfinite_attrs(
         A shallow copy of ``target`` with local JSON non-finite metadata copied
         from ``flux`` when present.
     """
+    metadata = FluxNonFiniteMetadata.from_attrs(flux.attrs)
+    if metadata is None:
+        return target
+
     result = target.copy(deep=False)
     result.attrs = dict(target.attrs)
-    metadata = FluxNonFiniteMetadata.from_attrs(flux.attrs)
-    if metadata is not None:
-        result.attrs[NONFINITE_METADATA_ATTR] = metadata.to_json()
+    result.attrs[NONFINITE_METADATA_ATTR] = metadata.to_json()
     return result

--- a/openghg_inversions/flux_sanitization.py
+++ b/openghg_inversions/flux_sanitization.py
@@ -39,24 +39,6 @@ _UPSTREAM_POLICY_ATTRS = (
     "openghg:missing_value_policy",
     "openghg:non_finite_policy",
 )
-_LEGACY_NONFINITE_POLICY_ATTR = "openghg_inversions:non_finite_policy"
-_LEGACY_NONFINITE_FILL_VALUE_ATTR = "openghg_inversions:non_finite_fill_value"
-_LEGACY_NONFINITE_CHECKED_ATTR = "openghg_inversions:non_finite_checked"
-_LEGACY_NONFINITE_COUNT_ATTR = "openghg_inversions:non_finite_count"
-_LEGACY_NONFINITE_TOTAL_ATTR = "openghg_inversions:non_finite_total"
-_LEGACY_NONFINITE_FRACTION_ATTR = "openghg_inversions:non_finite_fraction"
-_LEGACY_NONFINITE_CONTEXT_ATTR = "openghg_inversions:non_finite_context"
-_LEGACY_NONFINITE_SOURCE_ATTR = "openghg_inversions:non_finite_source"
-_LEGACY_LOCAL_ATTRS = (
-    _LEGACY_NONFINITE_POLICY_ATTR,
-    _LEGACY_NONFINITE_FILL_VALUE_ATTR,
-    _LEGACY_NONFINITE_CHECKED_ATTR,
-    _LEGACY_NONFINITE_COUNT_ATTR,
-    _LEGACY_NONFINITE_TOTAL_ATTR,
-    _LEGACY_NONFINITE_FRACTION_ATTR,
-    _LEGACY_NONFINITE_CONTEXT_ATTR,
-    _LEGACY_NONFINITE_SOURCE_ATTR,
-)
 
 
 class NonFiniteFluxWarning(UserWarning):
@@ -105,28 +87,13 @@ class FluxNonFiniteMetadata:
             attrs: Attribute mapping from a DataArray or Dataset.
 
         Returns:
-            Parsed metadata when local JSON metadata or legacy per-field
-            metadata is present, otherwise ``None``.
+            Parsed metadata when local JSON metadata is present, otherwise
+            ``None``.
         """
         raw_metadata = attrs.get(NONFINITE_METADATA_ATTR)
         if raw_metadata is not None:
             return cls.from_json(raw_metadata)
-
-        legacy_policy = attrs.get(_LEGACY_NONFINITE_POLICY_ATTR)
-        if legacy_policy is None:
-            return None
-
-        return cls(
-            schema_version=1,
-            policy=str(legacy_policy),
-            fill_value=float(attrs.get(_LEGACY_NONFINITE_FILL_VALUE_ATTR, 0.0)),
-            checked=str(attrs.get(_LEGACY_NONFINITE_CHECKED_ATTR, NONFINITE_CHECKED_NOT_COUNTED)),
-            context=_optional_str(attrs.get(_LEGACY_NONFINITE_CONTEXT_ATTR)),
-            source=_optional_str(attrs.get(_LEGACY_NONFINITE_SOURCE_ATTR)),
-            count=_optional_int(attrs.get(_LEGACY_NONFINITE_COUNT_ATTR)),
-            total=_optional_int(attrs.get(_LEGACY_NONFINITE_TOTAL_ATTR)),
-            fraction=_optional_float(attrs.get(_LEGACY_NONFINITE_FRACTION_ATTR)),
-        )
+        return None
 
     @classmethod
     def from_json(cls, value: object) -> "FluxNonFiniteMetadata":
@@ -228,9 +195,9 @@ def attrs_declare_zero_filled_nonfinite(attrs: Mapping[Any, Any]) -> bool:
         attrs: Attribute mapping from a DataArray or Dataset.
 
     Returns:
-        ``True`` when local metadata, legacy local metadata, or recognised
-        upstream OpenGHG metadata declares that non-finite flux values have
-        already been zero-filled.
+        ``True`` when local JSON metadata or recognised upstream OpenGHG
+        metadata declares that non-finite flux values have already been
+        zero-filled.
     """
     local_metadata = FluxNonFiniteMetadata.from_attrs(attrs)
     if local_metadata is not None and local_metadata.declares_zero_fill():
@@ -327,8 +294,8 @@ def _with_nonfinite_attrs(
 
     Returns:
         A shallow copy of ``flux`` with JSON metadata attached under
-        ``NONFINITE_METADATA_ATTR``, stale legacy per-field attrs removed, and a
-        new CF-style ``history`` entry appended.
+        ``NONFINITE_METADATA_ATTR`` and a new CF-style ``history`` entry
+        appended.
     """
     result = flux.copy(deep=False)
     attrs = dict(flux.attrs)
@@ -341,8 +308,6 @@ def _with_nonfinite_attrs(
         fraction=fraction,
     )
     attrs[NONFINITE_METADATA_ATTR] = metadata.to_json()
-    for attr in _LEGACY_LOCAL_ATTRS:
-        attrs.pop(attr, None)
 
     _append_history(
         attrs,
@@ -511,8 +476,7 @@ def copy_flux_nonfinite_attrs(
 
     Returns:
         A shallow copy of ``target`` with local JSON non-finite metadata copied
-        from ``flux`` when present. Legacy local attrs are normalised to the
-        current JSON attr.
+        from ``flux`` when present.
     """
     result = target.copy(deep=False)
     result.attrs = dict(target.attrs)

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -664,6 +664,7 @@ def fixedbasisMCMC(
     paris_postprocessing: bool = False,
     paris_postprocessing_kwargs: dict | None = None,
     power: dict | float = 1.99,
+    flux_non_finite_check: Literal["lazy", "count"] = "lazy",
     return_basis_objects: bool = False,
     **kwargs,
 ) -> xr.Dataset | dict | InversionOutput:
@@ -793,6 +794,9 @@ def fixedbasisMCMC(
             - "mcmc_results": return the results of `fixedbasisMCMC` with no further processing
         paris_postprocessing_kwargs: Dict of kwargs to pass to `make_paris_outputs`.
         power: Power to raise pollution event size to if using pollution events from obs. Default is 1.99.
+        flux_non_finite_check: Non-finite flux handling mode. ``"lazy"``
+            applies zero-fill lazily and records attrs; ``"count"`` computes
+            count metadata once and warns if non-finite values are present.
         return_basis_objects: If True, include retained basis objects in ``output_format="mcmc_args"``
             debug output. Fixedbasis output modes that construct modern inversion output retain them
             internally regardless of this setting. They are not passed to ``inferpymc``.
@@ -875,6 +879,7 @@ def fixedbasisMCMC(
         min_error_options=min_error_options,
         return_basis_objects=return_basis_objects or needs_modern_inv_out,
         merged_data_only=output_format == "merged_data",
+        flux_non_finite_check=flux_non_finite_check,
     )
 
     if output_format == "merged_data":

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -664,7 +664,6 @@ def fixedbasisMCMC(
     paris_postprocessing: bool = False,
     paris_postprocessing_kwargs: dict | None = None,
     power: dict | float = 1.99,
-    flux_non_finite_check: Literal["lazy", "count"] = "lazy",
     return_basis_objects: bool = False,
     **kwargs,
 ) -> xr.Dataset | dict | InversionOutput:
@@ -794,17 +793,22 @@ def fixedbasisMCMC(
             - "mcmc_results": return the results of `fixedbasisMCMC` with no further processing
         paris_postprocessing_kwargs: Dict of kwargs to pass to `make_paris_outputs`.
         power: Power to raise pollution event size to if using pollution events from obs. Default is 1.99.
-        flux_non_finite_check: Non-finite flux handling mode. ``"lazy"``
-            applies zero-fill lazily and records attrs; ``"count"`` computes
-            count metadata once and warns if non-finite values are present.
         return_basis_objects: If True, include retained basis objects in ``output_format="mcmc_args"``
             debug output. Fixedbasis output modes that construct modern inversion output retain them
             internally regardless of this setting. They are not passed to ``inferpymc``.
+        flux_non_finite_check: Non-finite flux handling mode. ``"lazy"``
+            applies zero-fill lazily and records attrs; ``"count"`` computes
+            count metadata once and warns if non-finite values are present.
 
     Returns:
         xr.Dataset | dict: Results from the inversion in a Dataset if skip_post_processing==False,
             in a dictionary if True.
     """
+    flux_non_finite_check = cast(
+        Literal["lazy", "count"],
+        kwargs.pop("flux_non_finite_check", "lazy"),
+    )
+
     # Check if any observations are column based.
     if inlet is not None:
         is_column = any(i == "column" for i in inlet)

--- a/openghg_inversions/inversion_data/get_data.py
+++ b/openghg_inversions/inversion_data/get_data.py
@@ -28,6 +28,7 @@ from openghg_inversions.inversion_data.getters import (
 )
 from openghg_inversions.inversion_data.scenario import merged_scenario_data
 from openghg_inversions.inversion_data.serialise import _save_merged_data
+from openghg_inversions.flux_sanitization import FluxNonFiniteCheck
 
 
 logger = logging.getLogger(__name__)
@@ -186,6 +187,7 @@ def data_processing_surface_notracer(
     merged_data_name: str | None = None,
     merged_data_dir: str | None = None,
     output_name: str | None = None,
+    flux_non_finite_check: FluxNonFiniteCheck = "lazy",
 ) -> tuple[dict, list, list, list, list, list]:
     """Retrieve and prepare fixed-surface datasets from specified OpenGHG object stores.
 
@@ -221,6 +223,9 @@ def data_processing_surface_notracer(
         obs_store: Name of object store to retrieve observations data from.
         footprint_store: Name of object store to retrieve footprints data from.
         emissions_store: Name of object store to retrieve emissions data from.
+        flux_non_finite_check: Non-finite flux handling mode. ``"lazy"``
+            applies zero-fill lazily and records attrs; ``"count"`` computes
+            count metadata once and warns if non-finite values are present.
         split_by_sectors: If True, calculate sector-resolved ``fp_x_flux_sectoral`` in ModelScenario.
             If False (default), combine all flux sources into a single ``fp_x_flux`` pathway.
         averagingerror: Adds the variability in the averaging period to the measurement
@@ -270,6 +275,7 @@ def data_processing_surface_notracer(
         start_date=start_date,
         end_date=end_date,
         store=emissions_store,
+        flux_non_finite_check=flux_non_finite_check,
     )
     fp_all[".flux"] = flux_dict
     fp_all[".split_by_sectors"] = split_by_sectors

--- a/openghg_inversions/inversion_data/getters.py
+++ b/openghg_inversions/inversion_data/getters.py
@@ -18,8 +18,17 @@ import pandas as pd
 import xarray as xr
 
 from openghg.dataobjects import ObsData, FluxData, FootprintData
-from openghg.retrieve import get_flux, get_footprint, get_obs_column, get_obs_surface, search_footprints, search_flux
+from openghg.retrieve import (
+    get_flux,
+    get_footprint,
+    get_obs_column,
+    get_obs_surface,
+    search_footprints,
+    search_flux,
+)
 from openghg.types import SearchError
+
+from openghg_inversions.flux_sanitization import FluxNonFiniteCheck, sanitize_flux_nonfinite
 
 
 logger = logging.getLogger(__name__)
@@ -54,6 +63,7 @@ def get_flux_data(
     start_date: str,
     end_date: str,
     store: str | None = None,
+    flux_non_finite_check: FluxNonFiniteCheck = "lazy",
 ) -> dict[str, FluxData]:
     """Get flux data and add to dict."""
     flux_dict = {}
@@ -123,7 +133,9 @@ def get_flux_data(
         ):
             flux_data.data.flux.attrs["time_period"] = existing_time_period_str
         elif "month" in existing_time_period_str.lower():
-            logger.warning("Monthly flux detected, but inversion period is {time_period.days} days. Setting flux time_period to 'monthly'.")
+            logger.warning(
+                "Monthly flux detected, but inversion period is {time_period.days} days. Setting flux time_period to 'monthly'."
+            )
             flux_data.data.flux.attrs["time_period"] = existing_time_period_str
         else:
             flux_data.data.flux.attrs["time_period"] = inferred_time_period_str
@@ -132,9 +144,16 @@ def get_flux_data(
         flux_dict[source] = flux_data
 
     # cast to float32 to avoid up-casting H matrix
-    for v in flux_dict.values():
+    for source, v in flux_dict.items():
         if v.data.flux.dtype != "float32":
             v.data["flux"] = v.data.flux.astype("float32")
+        v.data["flux"] = sanitize_flux_nonfinite(
+            v.data["flux"],
+            context="OpenGHG flux retrieval",
+            source=source,
+            check=flux_non_finite_check,
+            warn=flux_non_finite_check == "count",
+        )
 
     return flux_dict
 
@@ -147,9 +166,9 @@ def get_obs_data(
     start_date: str,
     end_date: str,
     domain: str | None = None,
-    platform : str | None = None,
-    satellite : str | None = None,
-    max_level : int | None = None,
+    platform: str | None = None,
+    satellite: str | None = None,
+    max_level: int | None = None,
     data_level: str | None = None,
     average: str | None = None,
     instrument: str | None = None,
@@ -164,7 +183,7 @@ def get_obs_data(
             raise AttributeError(
                 "If you are using column-based data (i.e. platform is 'satellite' or 'site-column'), you need to pass max_level"
             )
-            
+
     if stores is None or isinstance(stores, str):
         stores = [stores]
 
@@ -186,14 +205,14 @@ def get_obs_data(
                     species=species,
                     max_level=max_level,
                     satellite=satellite,
-                    platform = platform, 
+                    platform=platform,
                     domain=domain,
                     selection=selection,
                     start_date=start_date,
                     end_date=end_date,
                     store=store,
                 )
-            elif inlet=="column":
+            elif inlet == "column":
                 obs_data = get_obs_column(
                     site=site,
                     species=species.lower(),
@@ -257,7 +276,7 @@ def get_footprint_to_match(
     obs: ObsData,
     domain: str,
     model: str | None = None,
-    platform : str | None = None,
+    platform: str | None = None,
     start_date: str | None = None,
     end_date: str | None = None,
     met_model: str | None = None,
@@ -399,7 +418,7 @@ def get_footprint_data(
     fp_species: str | None,
     fp_height: str | None,
     site: str | None = None,
-    platform : str | None = None,
+    platform: str | None = None,
     averaging_period: str | None = None,
     obs_data: ObsData | None = None,
     stores: str | None | Iterable[str | None] = None,
@@ -432,7 +451,7 @@ def get_footprint_data(
                     fp_species=fp_species,
                     averaging_period=averaging_period,
                 )
-        elif platform=="satellite":
+        elif platform == "satellite":
             # current convention: for satellite data, the site name
             # has format satellitename-obs_region
             # or format satellitename-obs_region-selection
@@ -443,8 +462,10 @@ def get_footprint_data(
                 _selection = split_site_name[2]
             else:
                 _selection = None
+
             def get_func(store):
-                return get_footprint(domain=domain,
+                return get_footprint(
+                    domain=domain,
                     satellite=satellite,
                     obs_region=obs_region,
                     inlet=fp_height,
@@ -452,7 +473,8 @@ def get_footprint_data(
                     start_date=start_date,
                     end_date=end_date,
                     species=fp_species,
-                    store=store)
+                    store=store,
+                )
         else:
 
             def get_func(store):
@@ -468,9 +490,7 @@ def get_footprint_data(
                     species=fp_species,
                 )
     except SearchError:
-        print(
-            f"\nNo obs data found for {site} with inlet {fp_height} and in store {store}."
-            )
+        print(f"\nNo obs data found for {site} with inlet {fp_height} and in store {store}.")
 
     if stores is None or isinstance(stores, str):
         stores = [stores]

--- a/openghg_inversions/inversion_data/getters.py
+++ b/openghg_inversions/inversion_data/getters.py
@@ -65,7 +65,26 @@ def get_flux_data(
     store: str | None = None,
     flux_non_finite_check: FluxNonFiniteCheck = "lazy",
 ) -> dict[str, FluxData]:
-    """Get flux data and add to dict."""
+    """Retrieve, normalize, and sanitize flux data for an inversion.
+
+    Args:
+        sources: OpenGHG flux source names.
+        species: Species associated with the requested flux.
+        domain: Model domain.
+        start_date: Inversion start date.
+        end_date: Inversion end date.
+        store: Optional OpenGHG object-store name.
+        flux_non_finite_check: ``"lazy"`` to apply zero-fill without counting,
+            or ``"count"`` to compute exact non-finite counts and warn when
+            replacements are made.
+
+    Returns:
+        Retrieved flux objects keyed by source. Each ``flux`` variable is cast
+        to ``float32`` and has the non-finite policy applied.
+
+    Raises:
+        SearchError: If no flux data can be found before the requested end date.
+    """
     flux_dict = {}
 
     for source in sources:

--- a/openghg_inversions/inversion_data/preparation.py
+++ b/openghg_inversions/inversion_data/preparation.py
@@ -27,6 +27,7 @@ from openghg_inversions.basis import basis_functions_wrapper, make_basis_functio
 from openghg_inversions.basis._helpers import _legacy_multisource_h_if_needed, bc_sensitivity
 from openghg_inversions.basis.basis_functions import BasisFunctions
 from openghg_inversions.filters import filtering
+from openghg_inversions.flux_sanitization import FluxNonFiniteCheck, sanitize_fp_all_fluxes
 from openghg_inversions.inversion_data.get_data import convert_to_list, data_processing_surface_notracer
 from openghg_inversions.inversion_data.serialise import load_merged_data
 from openghg_inversions.inversion_inputs import make_inv_inputs
@@ -275,6 +276,7 @@ def _prepare_merged_data(
     save_merged_data: bool = False,
     merged_data_dir: str | None = None,
     merged_data_name: str | None = None,
+    flux_non_finite_check: FluxNonFiniteCheck = "lazy",
 ) -> _MergedInversionData:
     """Gather or reload merged data and align site metadata.
 
@@ -352,12 +354,20 @@ def _prepare_merged_data(
             merged_data_name=merged_data_name,
             merged_data_dir=merged_data_dir,
             output_name=output_name,
+            flux_non_finite_check=flux_non_finite_check,
         )
 
     if fp_all is None:
         raise RuntimeError("Data preparation did not create or load merged data.")
     if not sites:
         raise ValueError("No sites remain after data gathering.")
+
+    sanitize_fp_all_fluxes(
+        fp_all,
+        context="merged inversion data preparation",
+        check=flux_non_finite_check,
+        warn=flux_non_finite_check == "count",
+    )
 
     return _MergedInversionData(
         fp_all=fp_all,
@@ -523,6 +533,7 @@ def prepare_fixedbasis_inversion_data(
     min_error_options: dict | None = None,
     return_basis_objects: bool = False,
     merged_data_only: bool = False,
+    flux_non_finite_check: FluxNonFiniteCheck = "lazy",
 ) -> FixedBasisPreparedData:
     """Prepare data for legacy fixedbasisMCMC and its output adapters."""
     merged = _prepare_merged_data(
@@ -557,6 +568,7 @@ def prepare_fixedbasis_inversion_data(
         save_merged_data=save_merged_data,
         merged_data_dir=merged_data_dir,
         merged_data_name=merged_data_name,
+        flux_non_finite_check=flux_non_finite_check,
     )
 
     if merged_data_only:
@@ -672,6 +684,7 @@ def prepare_rhime_inputs(
     basis_output_path: str | None = None,
     min_error: MinErrorConfig = 0.0,
     min_error_options: dict | None = None,
+    flux_non_finite_check: FluxNonFiniteCheck = "lazy",
 ) -> RhimePreparedInputs:
     """Prepare modern RHIME inputs without exposing legacy fixedbasis containers.
 
@@ -691,6 +704,9 @@ def prepare_rhime_inputs(
         use_tracer: Unsupported placeholder for tracer inversions, where an
             additional species constrains the primary species through linked
             forward models.
+        flux_non_finite_check: Non-finite flux handling mode. ``"lazy"``
+            applies zero-fill lazily and records attrs; ``"count"`` computes
+            count metadata once and warns if non-finite values are present.
 
     Returns:
         Modern RHIME prepared inputs containing canonical ``inv_inputs`` and a
@@ -729,6 +745,7 @@ def prepare_rhime_inputs(
             save_merged_data=save_merged_data,
             merged_data_dir=merged_data_dir,
             merged_data_name=merged_data_name,
+            flux_non_finite_check=flux_non_finite_check,
         )
 
     with timed(

--- a/openghg_inversions/inversion_data/preparation.py
+++ b/openghg_inversions/inversion_data/preparation.py
@@ -13,7 +13,7 @@ forward models that are not represented here.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal, cast
@@ -27,7 +27,7 @@ from openghg_inversions.basis import basis_functions_wrapper, make_basis_functio
 from openghg_inversions.basis._helpers import _legacy_multisource_h_if_needed, bc_sensitivity
 from openghg_inversions.basis.basis_functions import BasisFunctions
 from openghg_inversions.filters import filtering
-from openghg_inversions.flux_sanitization import FluxNonFiniteCheck, sanitize_fp_all_fluxes
+from openghg_inversions.flux_sanitization import FluxNonFiniteCheck, sanitize_flux_nonfinite
 from openghg_inversions.inversion_data.get_data import convert_to_list, data_processing_surface_notracer
 from openghg_inversions.inversion_data.serialise import load_merged_data
 from openghg_inversions.inversion_inputs import make_inv_inputs
@@ -362,12 +362,18 @@ def _prepare_merged_data(
     if not sites:
         raise ValueError("No sites remain after data gathering.")
 
-    sanitize_fp_all_fluxes(
-        fp_all,
-        context="merged inversion data preparation",
-        check=flux_non_finite_check,
-        warn=flux_non_finite_check == "count",
-    )
+    flux_entries = fp_all.get(".flux")
+    if isinstance(flux_entries, Mapping):
+        for source, flux_data in flux_entries.items():
+            data = getattr(flux_data, "data", None)
+            if isinstance(data, xr.Dataset) and "flux" in data:
+                data["flux"] = sanitize_flux_nonfinite(
+                    data["flux"],
+                    context="merged inversion data preparation",
+                    source=str(source),
+                    check=flux_non_finite_check,
+                    warn=flux_non_finite_check == "count",
+                )
 
     return _MergedInversionData(
         fp_all=fp_all,

--- a/openghg_inversions/postprocessing/_basis_products.py
+++ b/openghg_inversions/postprocessing/_basis_products.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+from typing import cast
+
 import xarray as xr
 
 from openghg_inversions.array_ops import align_sparse_lat_lon, sparse_xr_dot
 from openghg_inversions.basis.basis_functions import BasisFunctions
+from openghg_inversions.flux_sanitization import copy_flux_nonfinite_attrs, sanitize_flux_nonfinite
 
 BASIS_RECONSTRUCTION_PATH_ATTR = "basis_reconstruction_path"
 BASIS_ARTIFACT_SOURCE_OUTPUT_ATTR = "basis_artifact_source"
@@ -127,6 +130,25 @@ def _operator_region_flux_mean(basis_functions: BasisFunctions, flux: xr.DataArr
     return ((basis * flux).sum(grid_dims) / basis.sum(grid_dims)).fillna(0.0)
 
 
+def _sanitize_postprocessing_flux(flux: xr.DataArray, *, context: str) -> xr.DataArray:
+    """Apply the late fallback non-finite policy for old retained artifacts."""
+    return sanitize_flux_nonfinite(
+        flux,
+        context=context,
+        warn=True,
+    )
+
+
+def _with_flux_nonfinite_metadata(ds: xr.Dataset, flux: xr.DataArray) -> xr.Dataset:
+    """Propagate non-finite flux policy metadata onto output datasets."""
+    return cast(xr.Dataset, copy_flux_nonfinite_attrs(ds, flux))
+
+
+def _with_flux_nonfinite_dataarray_metadata(da: xr.DataArray, flux: xr.DataArray) -> xr.DataArray:
+    """Propagate non-finite flux policy metadata onto output arrays."""
+    return cast(xr.DataArray, copy_flux_nonfinite_attrs(da, flux))
+
+
 def reconstruct_flux_stats(
     basis_functions: BasisFunctions,
     flux: xr.DataArray,
@@ -135,12 +157,13 @@ def reconstruct_flux_stats(
     report_flux_on_inversion_grid: bool,
 ) -> xr.Dataset:
     """Reconstruct gridded flux statistics with the retained basis operator."""
+    flux = _sanitize_postprocessing_flux(flux, context="operator-backed flux reconstruction")
     if report_flux_on_inversion_grid:
         region_flux = _operator_region_flux_mean(basis_functions, flux)
         state = _to_operator_state_dim(stats_ds, basis_functions) * region_flux
-        return _interpolate_dataset(state, basis_functions, weights=None)
+        return _with_flux_nonfinite_metadata(_interpolate_dataset(state, basis_functions, weights=None), flux)
 
-    return _interpolate_dataset(stats_ds, basis_functions, weights=flux)
+    return _with_flux_nonfinite_metadata(_interpolate_dataset(stats_ds, basis_functions, weights=flux), flux)
 
 
 def reconstruct_scale_factor_stats(
@@ -161,9 +184,11 @@ def make_x_to_country_matrix(
     sparse: bool = False,
 ) -> xr.DataArray:
     """Construct a basis-state to country-total matrix."""
+    flux = _sanitize_postprocessing_flux(flux, context="operator-backed country flux reconstruction")
     trace_state_dim = _trace_state_dim(x_trace, basis_functions)
     basis = align_sparse_lat_lon(basis_functions.operator.basis_matrix, flux)
     basis = _from_operator_state_dim(basis, basis_functions, trace_state_dim)
     flux_x_basis = align_sparse_lat_lon(flux * basis, area_grid)
     result = sparse_xr_dot(country_matrix, area_grid * flux_x_basis)
-    return result if sparse else result.as_numpy()
+    result = result if sparse else result.as_numpy()
+    return _with_flux_nonfinite_dataarray_metadata(result, flux)

--- a/openghg_inversions/postprocessing/_basis_products.py
+++ b/openghg_inversions/postprocessing/_basis_products.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import cast
-
 import xarray as xr
 
 from openghg_inversions.array_ops import align_sparse_lat_lon, sparse_xr_dot
@@ -130,25 +128,6 @@ def _operator_region_flux_mean(basis_functions: BasisFunctions, flux: xr.DataArr
     return ((basis * flux).sum(grid_dims) / basis.sum(grid_dims)).fillna(0.0)
 
 
-def _sanitize_postprocessing_flux(flux: xr.DataArray, *, context: str) -> xr.DataArray:
-    """Apply the late fallback non-finite policy for old retained artifacts."""
-    return sanitize_flux_nonfinite(
-        flux,
-        context=context,
-        warn=True,
-    )
-
-
-def _with_flux_nonfinite_metadata(ds: xr.Dataset, flux: xr.DataArray) -> xr.Dataset:
-    """Propagate non-finite flux policy metadata onto output datasets."""
-    return cast(xr.Dataset, copy_flux_nonfinite_attrs(ds, flux))
-
-
-def _with_flux_nonfinite_dataarray_metadata(da: xr.DataArray, flux: xr.DataArray) -> xr.DataArray:
-    """Propagate non-finite flux policy metadata onto output arrays."""
-    return cast(xr.DataArray, copy_flux_nonfinite_attrs(da, flux))
-
-
 def reconstruct_flux_stats(
     basis_functions: BasisFunctions,
     flux: xr.DataArray,
@@ -156,14 +135,33 @@ def reconstruct_flux_stats(
     *,
     report_flux_on_inversion_grid: bool,
 ) -> xr.Dataset:
-    """Reconstruct gridded flux statistics with the retained basis operator."""
-    flux = _sanitize_postprocessing_flux(flux, context="operator-backed flux reconstruction")
+    """Reconstruct gridded flux statistics with the retained basis operator.
+
+    Args:
+        basis_functions: Retained basis operator and flux metadata.
+        flux: Prior flux used to weight or scale reconstructed statistics.
+        stats_ds: Statistics in basis-state space.
+        report_flux_on_inversion_grid: Report region-mean flux when ``True``;
+            otherwise interpolate with prior-flux weights.
+
+    Returns:
+        Reconstructed gridded statistics carrying non-finite policy metadata.
+
+    Warns:
+        NonFiniteFluxWarning: If old retained flux has no sanitation metadata
+            and the lazy zero-fill backstop is applied.
+    """
+    flux = sanitize_flux_nonfinite(
+        flux,
+        context="operator-backed flux reconstruction",
+        warn=True,
+    )
     if report_flux_on_inversion_grid:
         region_flux = _operator_region_flux_mean(basis_functions, flux)
         state = _to_operator_state_dim(stats_ds, basis_functions) * region_flux
-        return _with_flux_nonfinite_metadata(_interpolate_dataset(state, basis_functions, weights=None), flux)
+        return copy_flux_nonfinite_attrs(_interpolate_dataset(state, basis_functions, weights=None), flux)
 
-    return _with_flux_nonfinite_metadata(_interpolate_dataset(stats_ds, basis_functions, weights=flux), flux)
+    return copy_flux_nonfinite_attrs(_interpolate_dataset(stats_ds, basis_functions, weights=flux), flux)
 
 
 def reconstruct_scale_factor_stats(
@@ -183,12 +181,32 @@ def make_x_to_country_matrix(
     area_grid: xr.DataArray,
     sparse: bool = False,
 ) -> xr.DataArray:
-    """Construct a basis-state to country-total matrix."""
-    flux = _sanitize_postprocessing_flux(flux, context="operator-backed country flux reconstruction")
+    """Construct a basis-state to country-total matrix.
+
+    Args:
+        basis_functions: Retained basis operator used for reconstruction.
+        flux: Prior flux on the operator grid.
+        x_trace: Trace dataset providing the state-dimension convention.
+        country_matrix: Country masks aligned to the flux grid.
+        area_grid: Grid-cell areas used to form country totals.
+        sparse: Preserve sparse output when ``True``.
+
+    Returns:
+        State-to-country matrix carrying non-finite policy metadata.
+
+    Warns:
+        NonFiniteFluxWarning: If old retained flux has no sanitation metadata
+            and the lazy zero-fill backstop is applied.
+    """
+    flux = sanitize_flux_nonfinite(
+        flux,
+        context="operator-backed country flux reconstruction",
+        warn=True,
+    )
     trace_state_dim = _trace_state_dim(x_trace, basis_functions)
     basis = align_sparse_lat_lon(basis_functions.operator.basis_matrix, flux)
     basis = _from_operator_state_dim(basis, basis_functions, trace_state_dim)
     flux_x_basis = align_sparse_lat_lon(flux * basis, area_grid)
     result = sparse_xr_dot(country_matrix, area_grid * flux_x_basis)
     result = result if sparse else result.as_numpy()
-    return _with_flux_nonfinite_dataarray_metadata(result, flux)
+    return copy_flux_nonfinite_attrs(result, flux)

--- a/openghg_inversions/postprocessing/_country_codes.py
+++ b/openghg_inversions/postprocessing/_country_codes.py
@@ -84,7 +84,9 @@ def extend_abbrs(x: str) -> str:
 
     # add extension pattern to all but last part
     extended_parts = [convert_abbr(p) for p in parts[:-1] if p]
-    return drop_extra_whitespace(r" ".join(extended_parts) + ' ' + parts[-1]).strip()  # last part would typically have its own whitespace
+    return drop_extra_whitespace(
+        r" ".join(extended_parts) + " " + parts[-1]
+    ).strip()  # last part would typically have its own whitespace
 
 
 # ISO country code info
@@ -110,9 +112,12 @@ def iso3to2(alpha3: str) -> str:
 
 # CONVERSION FUNCTIONS
 def to_string(x: Any) -> str:
-    """Convert to string, decoding if x is bytes."""
+    """Convert to string, decoding if x is bytes-like."""
     if isinstance(x, bytes):
         return x.decode("utf-8")
+    decode = getattr(x, "decode", None)
+    if callable(decode):
+        return str(decode("utf-8"))
     return str(x)
 
 
@@ -161,9 +166,9 @@ def get_country_code(
 
     if preprocess(x) in ("ocean", "sea", "land"):
         return x
-    
+
     # hard-code a few exceptions for the EASTASIA names in UKMO files
-    if x in ['NE', 'NW', 'SE', 'SW']:
+    if x in ["NE", "NW", "SE", "SW"]:
         return x
 
     # first try to match long names, ignoring "The " at the beginning of a name
@@ -225,8 +230,10 @@ class CountryInfo:
     test equality. (This also works if comparing a `CountryInfo` object to a string.)
     """
 
-    def __init__(self, country_name: str | CountryInfo) -> None:
-        self.input_name = country_name if isinstance(country_name, str) else country_name.input_name
+    def __init__(self, country_name: Any) -> None:
+        self.input_name = (
+            country_name.input_name if isinstance(country_name, CountryInfo) else to_string(country_name)
+        )
 
         iso3166 = get_iso3166_codes()
 

--- a/openghg_inversions/postprocessing/make_outputs.py
+++ b/openghg_inversions/postprocessing/make_outputs.py
@@ -7,7 +7,7 @@ import pandas as pd
 import xarray as xr
 
 from openghg_inversions.basis.basis_functions import BasisFunctions
-from openghg_inversions.flux_sanitization import FluxNonFiniteMetadata, copy_flux_nonfinite_attrs
+from openghg_inversions.flux_sanitization import copy_flux_nonfinite_attrs
 from openghg_inversions.postprocessing.countries import Countries, paris_regions_dict
 from openghg_inversions.postprocessing._basis_products import (
     add_basis_reconstruction_metadata,
@@ -342,8 +342,9 @@ def _set_multisector_flux_attrs(
 def _copy_first_flux_nonfinite_metadata(ds: xr.Dataset, sources: list[xr.Dataset]) -> xr.Dataset:
     """Copy the first available non-finite flux metadata from source datasets."""
     for source in sources:
-        if FluxNonFiniteMetadata.from_attrs(source.attrs) is not None:
-            return cast(xr.Dataset, copy_flux_nonfinite_attrs(ds, source))
+        result = copy_flux_nonfinite_attrs(ds, source)
+        if result is not ds:
+            return result
     return ds
 
 
@@ -376,8 +377,6 @@ def _multisector_flux_trace_parts(
         ],
         dim="sector",
     ).sum("sector")
-    total_flux_trace = _copy_first_flux_nonfinite_metadata(total_flux_trace, sector_flux_traces)
-
     return sectors, sector_flux_traces, total_flux_trace
 
 

--- a/openghg_inversions/postprocessing/make_outputs.py
+++ b/openghg_inversions/postprocessing/make_outputs.py
@@ -7,6 +7,7 @@ import pandas as pd
 import xarray as xr
 
 from openghg_inversions.basis.basis_functions import BasisFunctions
+from openghg_inversions.flux_sanitization import FluxNonFiniteMetadata, copy_flux_nonfinite_attrs
 from openghg_inversions.postprocessing.countries import Countries, paris_regions_dict
 from openghg_inversions.postprocessing._basis_products import (
     add_basis_reconstruction_metadata,
@@ -338,6 +339,14 @@ def _set_multisector_flux_attrs(
     return ds
 
 
+def _copy_first_flux_nonfinite_metadata(ds: xr.Dataset, sources: list[xr.Dataset]) -> xr.Dataset:
+    """Copy the first available non-finite flux metadata from source datasets."""
+    for source in sources:
+        if FluxNonFiniteMetadata.from_attrs(source.attrs) is not None:
+            return cast(xr.Dataset, copy_flux_nonfinite_attrs(ds, source))
+    return ds
+
+
 def _multisector_flux_trace_parts(
     inv_out: InversionOutput,
     report_flux_on_inversion_grid: bool = True,
@@ -367,6 +376,7 @@ def _multisector_flux_trace_parts(
         ],
         dim="sector",
     ).sum("sector")
+    total_flux_trace = _copy_first_flux_nonfinite_metadata(total_flux_trace, sector_flux_traces)
 
     return sectors, sector_flux_traces, total_flux_trace
 
@@ -381,6 +391,7 @@ def make_multisector_flux_trace_outputs(
         report_flux_on_inversion_grid=report_flux_on_inversion_grid,
     )
     result = xr.merge([total_flux_trace, *sector_flux_traces]).as_numpy()
+    result = _copy_first_flux_nonfinite_metadata(result, [total_flux_trace, *sector_flux_traces])
     return add_basis_reconstruction_metadata(result, inv_out.basis_functions)
 
 
@@ -411,6 +422,7 @@ def make_sector_flux_outputs(
             outputs.append(_sector_scale_factor_stats(inv_out, sector, scale_stats_args))
 
     result = _set_multisector_flux_attrs(xr.merge(outputs), inv_out, sectors).as_numpy()
+    result = _copy_first_flux_nonfinite_metadata(result, [total_flux_trace, *sector_flux_traces])
     return add_basis_reconstruction_metadata(result, inv_out.basis_functions)
 
 

--- a/openghg_inversions/postprocessing/make_paris_outputs.py
+++ b/openghg_inversions/postprocessing/make_paris_outputs.py
@@ -15,6 +15,7 @@ from openghg.util import timestamp_now  # pyright: ignore[reportPrivateImportUsa
 from openghg_inversions import convert
 from openghg_inversions.array_ops import align_sparse_lat_lon, sparse_xr_dot
 from openghg_inversions.config.version import code_version
+from openghg_inversions.flux_sanitization import copy_flux_nonfinite_attrs
 from openghg_inversions.postprocessing._basis_products import add_basis_reconstruction_metadata
 from openghg_inversions.postprocessing.countries import Countries
 from openghg_inversions.postprocessing.inversion_output import InversionOutput
@@ -991,6 +992,7 @@ def paris_flux_output(
 
     result.attrs = make_global_attrs("flux")
     result.attrs["paris_flux_template_version"] = template_files.flux_version
+    result = cast(xr.Dataset, copy_flux_nonfinite_attrs(result, flux_outs))
 
     result = _cast_float_data_vars_to_float32(result).as_numpy()
     return add_basis_reconstruction_metadata(result, inv_out.basis_functions)
@@ -1130,6 +1132,7 @@ def paris_flux_output_latest(
     )
     result.attrs = make_global_attrs("flux", species=species, domain=domain)
     result.attrs["paris_flux_template_version"] = template_files.flux_version
+    result = cast(xr.Dataset, copy_flux_nonfinite_attrs(result, flux_outs))
 
     result = _cast_data_vars_to_template_dtypes(result, template_files.flux)
     return add_basis_reconstruction_metadata(result, inv_out.basis_functions)

--- a/openghg_inversions/postprocessing/make_paris_outputs.py
+++ b/openghg_inversions/postprocessing/make_paris_outputs.py
@@ -992,7 +992,7 @@ def paris_flux_output(
 
     result.attrs = make_global_attrs("flux")
     result.attrs["paris_flux_template_version"] = template_files.flux_version
-    result = cast(xr.Dataset, copy_flux_nonfinite_attrs(result, flux_outs))
+    result = copy_flux_nonfinite_attrs(result, flux_outs)
 
     result = _cast_float_data_vars_to_float32(result).as_numpy()
     return add_basis_reconstruction_metadata(result, inv_out.basis_functions)
@@ -1132,7 +1132,7 @@ def paris_flux_output_latest(
     )
     result.attrs = make_global_attrs("flux", species=species, domain=domain)
     result.attrs["paris_flux_template_version"] = template_files.flux_version
-    result = cast(xr.Dataset, copy_flux_nonfinite_attrs(result, flux_outs))
+    result = copy_flux_nonfinite_attrs(result, flux_outs)
 
     result = _cast_data_vars_to_template_dtypes(result, template_files.flux)
     return add_basis_reconstruction_metadata(result, inv_out.basis_functions)

--- a/tests/postprocessing/test_country_codes.py
+++ b/tests/postprocessing/test_country_codes.py
@@ -1,5 +1,6 @@
 import re
 
+import numpy as np
 import pytest
 
 from openghg_inversions.postprocessing._country_codes import (
@@ -89,6 +90,13 @@ def test_country_info_list_modes(country_code, expected):
 
     # convert to list to get list of strings according to country_code
     assert list(country_list) == expected
+
+
+def test_country_info_list_decodes_numpy_bytes_labels():
+    """Country labels loaded as numpy bytes are decoded before code lookup."""
+    country_list = CountryInfoList([np.bytes_("China"), np.bytes_("Ocean")], country_code="alpha3")
+
+    assert list(country_list) == ["CHN", "Ocean"]
 
 
 def test_country_info_list_extend():

--- a/tests/test_basis_functions.py
+++ b/tests/test_basis_functions.py
@@ -36,12 +36,14 @@ from openghg_inversions.basis.basis_functions import (
     BASIS_ARTIFACT_SOURCE_ATTR,
     BasisFunctions,
     basis_functions_from_fp_all_flat_basis,
+    flux_from_fp_all,
 )
 from openghg_inversions.basis.operators import (
     BucketBasisOperator,
     MultiSourceBucketBasisOperator,
 )
 from openghg_inversions.basis._helpers import apply_fp_basis_functions, fp_sensitivity
+from openghg_inversions.flux_sanitization import NONFINITE_POLICY_ATTR, NONFINITE_POLICY_ZERO_FILL
 from openghg_inversions.inversion_data import data_processing_surface_notracer
 
 from helpers import basis_function, footprint
@@ -139,6 +141,45 @@ def test_basis_weights_from_fp_all_applies_abs_flux_and_mask():
 
     expected = flux.mean("time").where(mask, drop=True)
     xr.testing.assert_allclose(weights, expected)
+
+
+def test_flux_from_fp_all_sanitizes_nonfinite_single_source():
+    """Retained single-source flux replaces non-finite cells with zero."""
+    fp_all = _simple_fp_all_for_basis_weights()
+    flux = fp_all[".flux"]["test-source"].data.flux.copy()
+    flux.values[0, 0, 0] = np.nan
+    flux.values[1, 1, 1] = np.inf
+    fp_all[".flux"]["test-source"] = SimpleNamespace(data=xr.Dataset({"flux": flux}))
+
+    retained_flux = flux_from_fp_all(fp_all)
+
+    assert np.isfinite(retained_flux.values).all()
+    assert retained_flux.values[0, 0, 0] == 0.0
+    assert retained_flux.values[1, 1, 1] == 0.0
+    assert retained_flux.attrs[NONFINITE_POLICY_ATTR] == NONFINITE_POLICY_ZERO_FILL
+
+
+def test_flux_from_fp_all_sanitizes_nonfinite_multisource():
+    """Retained multisource flux replaces non-finite cells after source stacking."""
+    fp_all = _simple_fp_all_for_basis_weights()
+    base_flux = fp_all[".flux"]["test-source"].data.flux
+    flux_a = base_flux.copy()
+    flux_b = (2.0 * base_flux).copy()
+    flux_a.values[0, 0, 0] = np.nan
+    flux_b.values[1, 1, 1] = -np.inf
+    fp_all[".flux"] = {
+        "a": SimpleNamespace(data=xr.Dataset({"flux": flux_a})),
+        "b": SimpleNamespace(data=xr.Dataset({"flux": flux_b})),
+    }
+    fp_all[".split_by_sectors"] = True
+
+    retained_flux = flux_from_fp_all(fp_all)
+
+    assert retained_flux.dims[0] == "source"
+    assert np.isfinite(retained_flux.values).all()
+    assert float(retained_flux.sel(source="a").isel(time=0, lat=0, lon=0)) == 0.0
+    assert float(retained_flux.sel(source="b").isel(time=1, lat=1, lon=1)) == 0.0
+    assert retained_flux.attrs[NONFINITE_POLICY_ATTR] == NONFINITE_POLICY_ZERO_FILL
 
 
 def _basis_weights_with_nonfinite_cells() -> xr.DataArray:
@@ -1156,6 +1197,7 @@ def test_basisfunctions_roundtrip_datatree_single_source():
 
     assert isinstance(bf2.operator, BucketBasisOperator)
     assert bf2.basis_artifact_source == "generated"
+    assert bf2.flux.attrs[NONFINITE_POLICY_ATTR] == NONFINITE_POLICY_ZERO_FILL
     xr.testing.assert_identical(bf2.flux, bf.flux)
     xr.testing.assert_identical(bf2.operator.basis_flat, bf.operator.basis_flat)
     xr.testing.assert_identical(bf2.operator.basis_matrix, bf.operator.basis_matrix)
@@ -1594,7 +1636,8 @@ def test_load_basis_functions_prefers_datatree_schema(tmp_path):
     assert isinstance(loaded, BasisFunctions)
     xr.testing.assert_identical(loaded.flat_basis(), bf.operator.basis_flat.rename("basis"))
     xr.testing.assert_identical(loaded.operator.basis_matrix, bf.operator.basis_matrix)
-    xr.testing.assert_identical(loaded.flux, current_flux)
+    xr.testing.assert_allclose(loaded.flux, current_flux)
+    assert loaded.flux.attrs[NONFINITE_POLICY_ATTR] == NONFINITE_POLICY_ZERO_FILL
 
 
 def test_datatree_basis_artifact_can_use_basisfunctions_state_labels(tmp_path):
@@ -1751,7 +1794,8 @@ def test_load_basis_functions_falls_back_to_legacy_flat(tmp_path):
     assert loaded.basis_artifact_path == str(saved_path)
     assert isinstance(loaded, BasisFunctions)
     xr.testing.assert_identical(loaded.operator.basis_matrix, expected.operator.basis_matrix)
-    xr.testing.assert_identical(loaded.flux, expected.flux)
+    xr.testing.assert_allclose(loaded.flux, flux)
+    assert loaded.flux.attrs[NONFINITE_POLICY_ATTR] == NONFINITE_POLICY_ZERO_FILL
 
 
 def test_basis_artifact_metadata_properties_accept_plain_keys():

--- a/tests/test_basis_functions.py
+++ b/tests/test_basis_functions.py
@@ -43,7 +43,11 @@ from openghg_inversions.basis.operators import (
     MultiSourceBucketBasisOperator,
 )
 from openghg_inversions.basis._helpers import apply_fp_basis_functions, fp_sensitivity
-from openghg_inversions.flux_sanitization import NONFINITE_POLICY_ATTR, NONFINITE_POLICY_ZERO_FILL
+from openghg_inversions.flux_sanitization import (
+    FluxNonFiniteMetadata,
+    NONFINITE_POLICY_ZERO_FILL,
+    sanitize_flux_nonfinite,
+)
 from openghg_inversions.inversion_data import data_processing_surface_notracer
 
 from helpers import basis_function, footprint
@@ -116,6 +120,13 @@ def _simple_fp_all_for_basis_weights() -> dict:
     }
 
 
+def _flux_nonfinite_metadata(data: xr.DataArray | xr.Dataset) -> FluxNonFiniteMetadata:
+    """Return parsed non-finite flux metadata from an xarray object."""
+    metadata = FluxNonFiniteMetadata.from_attrs(data.attrs)
+    assert metadata is not None
+    return metadata
+
+
 def test_basis_weights_from_fp_all_matches_current_weight_definition():
     """Weight helper matches the current mean-footprint times mean-flux convention."""
     fp_all = _simple_fp_all_for_basis_weights()
@@ -156,7 +167,7 @@ def test_flux_from_fp_all_sanitizes_nonfinite_single_source():
     assert np.isfinite(retained_flux.values).all()
     assert retained_flux.values[0, 0, 0] == 0.0
     assert retained_flux.values[1, 1, 1] == 0.0
-    assert retained_flux.attrs[NONFINITE_POLICY_ATTR] == NONFINITE_POLICY_ZERO_FILL
+    assert _flux_nonfinite_metadata(retained_flux).policy == NONFINITE_POLICY_ZERO_FILL
 
 
 def test_flux_from_fp_all_sanitizes_nonfinite_multisource():
@@ -179,7 +190,30 @@ def test_flux_from_fp_all_sanitizes_nonfinite_multisource():
     assert np.isfinite(retained_flux.values).all()
     assert float(retained_flux.sel(source="a").isel(time=0, lat=0, lon=0)) == 0.0
     assert float(retained_flux.sel(source="b").isel(time=1, lat=1, lon=1)) == 0.0
-    assert retained_flux.attrs[NONFINITE_POLICY_ATTR] == NONFINITE_POLICY_ZERO_FILL
+    metadata = _flux_nonfinite_metadata(retained_flux)
+    assert metadata.policy == NONFINITE_POLICY_ZERO_FILL
+    assert metadata.context == "retained basis flux from fp_all"
+    assert metadata.source is None
+
+
+def test_flux_from_fp_all_refreshes_source_stacked_metadata() -> None:
+    """Source-stacked flux gets aggregate metadata instead of first-source attrs."""
+    fp_all = _simple_fp_all_for_basis_weights()
+    base_flux = fp_all[".flux"]["test-source"].data.flux
+    flux_a = sanitize_flux_nonfinite(base_flux.copy(), context="source a", source="a")
+    flux_b = sanitize_flux_nonfinite((2.0 * base_flux).copy(), context="source b", source="b")
+    fp_all[".flux"] = {
+        "a": SimpleNamespace(data=xr.Dataset({"flux": flux_a})),
+        "b": SimpleNamespace(data=xr.Dataset({"flux": flux_b})),
+    }
+    fp_all[".split_by_sectors"] = True
+
+    retained_flux = flux_from_fp_all(fp_all)
+    metadata = _flux_nonfinite_metadata(retained_flux)
+
+    assert metadata.policy == NONFINITE_POLICY_ZERO_FILL
+    assert metadata.context == "retained basis flux from fp_all"
+    assert metadata.source is None
 
 
 def _basis_weights_with_nonfinite_cells() -> xr.DataArray:
@@ -1197,7 +1231,7 @@ def test_basisfunctions_roundtrip_datatree_single_source():
 
     assert isinstance(bf2.operator, BucketBasisOperator)
     assert bf2.basis_artifact_source == "generated"
-    assert bf2.flux.attrs[NONFINITE_POLICY_ATTR] == NONFINITE_POLICY_ZERO_FILL
+    assert _flux_nonfinite_metadata(bf2.flux).policy == NONFINITE_POLICY_ZERO_FILL
     xr.testing.assert_identical(bf2.flux, bf.flux)
     xr.testing.assert_identical(bf2.operator.basis_flat, bf.operator.basis_flat)
     xr.testing.assert_identical(bf2.operator.basis_matrix, bf.operator.basis_matrix)
@@ -1637,7 +1671,7 @@ def test_load_basis_functions_prefers_datatree_schema(tmp_path):
     xr.testing.assert_identical(loaded.flat_basis(), bf.operator.basis_flat.rename("basis"))
     xr.testing.assert_identical(loaded.operator.basis_matrix, bf.operator.basis_matrix)
     xr.testing.assert_allclose(loaded.flux, current_flux)
-    assert loaded.flux.attrs[NONFINITE_POLICY_ATTR] == NONFINITE_POLICY_ZERO_FILL
+    assert _flux_nonfinite_metadata(loaded.flux).policy == NONFINITE_POLICY_ZERO_FILL
 
 
 def test_datatree_basis_artifact_can_use_basisfunctions_state_labels(tmp_path):
@@ -1795,7 +1829,7 @@ def test_load_basis_functions_falls_back_to_legacy_flat(tmp_path):
     assert isinstance(loaded, BasisFunctions)
     xr.testing.assert_identical(loaded.operator.basis_matrix, expected.operator.basis_matrix)
     xr.testing.assert_allclose(loaded.flux, flux)
-    assert loaded.flux.attrs[NONFINITE_POLICY_ATTR] == NONFINITE_POLICY_ZERO_FILL
+    assert _flux_nonfinite_metadata(loaded.flux).policy == NONFINITE_POLICY_ZERO_FILL
 
 
 def test_basis_artifact_metadata_properties_accept_plain_keys():

--- a/tests/test_basis_functions.py
+++ b/tests/test_basis_functions.py
@@ -45,6 +45,7 @@ from openghg_inversions.basis.operators import (
 from openghg_inversions.basis._helpers import apply_fp_basis_functions, fp_sensitivity
 from openghg_inversions.flux_sanitization import (
     FluxNonFiniteMetadata,
+    NONFINITE_CHECKED_COMPUTED,
     NONFINITE_POLICY_ZERO_FILL,
     sanitize_flux_nonfinite,
 )
@@ -214,6 +215,39 @@ def test_flux_from_fp_all_refreshes_source_stacked_metadata() -> None:
     assert metadata.policy == NONFINITE_POLICY_ZERO_FILL
     assert metadata.context == "retained basis flux from fp_all"
     assert metadata.source is None
+
+
+def test_flux_from_fp_all_preserves_single_source_count_metadata() -> None:
+    """A retained single source keeps an exact audit performed at ingestion."""
+    fp_all = _simple_fp_all_for_basis_weights()
+    flux = fp_all[".flux"]["test-source"].data.flux.copy()
+    flux.values[0, 0, 0] = np.nan
+    sanitized = sanitize_flux_nonfinite(
+        flux,
+        context="OpenGHG flux retrieval",
+        source="test-source",
+        check="count",
+    )
+    fp_all[".flux"]["test-source"] = SimpleNamespace(data=xr.Dataset({"flux": sanitized}))
+
+    retained_flux = flux_from_fp_all(fp_all)
+    metadata = _flux_nonfinite_metadata(retained_flux)
+
+    assert metadata.checked == NONFINITE_CHECKED_COMPUTED
+    assert metadata.count == 1
+    assert metadata.context == "OpenGHG flux retrieval"
+
+
+def test_basis_constructor_does_not_resanitize_retained_flux() -> None:
+    """Constructing a basis from sanitized flux preserves its graph and history."""
+    fp_all = _simple_fp_all_for_basis_weights()
+    retained_flux = flux_from_fp_all(fp_all)
+    basis_flat = xr.ones_like(retained_flux.isel(time=0), dtype=int)
+
+    basis_functions = BasisFunctions.from_flat_basis(basis_flat=basis_flat, flux=retained_flux)
+
+    assert basis_functions.flux is retained_flux
+    assert basis_functions.flux.attrs["history"] == retained_flux.attrs["history"]
 
 
 def _basis_weights_with_nonfinite_cells() -> xr.DataArray:

--- a/tests/test_flux_sanitization.py
+++ b/tests/test_flux_sanitization.py
@@ -1,18 +1,17 @@
 import numpy as np
+from pathlib import Path
 import pytest
 import xarray as xr
 
 from openghg_inversions.flux_sanitization import (
-    NONFINITE_CHECKED_ATTR,
     NONFINITE_CHECKED_COMPUTED,
     NONFINITE_CHECKED_NOT_COUNTED,
-    NONFINITE_COUNT_ATTR,
-    NONFINITE_FILL_VALUE_ATTR,
-    NONFINITE_FRACTION_ATTR,
-    NONFINITE_POLICY_ATTR,
+    NONFINITE_METADATA_ATTR,
     NONFINITE_POLICY_ZERO_FILL,
-    NONFINITE_TOTAL_ATTR,
+    FluxNonFiniteMetadata,
     NonFiniteFluxWarning,
+    attrs_declare_zero_filled_nonfinite,
+    copy_flux_nonfinite_attrs,
     sanitize_flux_nonfinite,
 )
 
@@ -28,11 +27,19 @@ def _nonfinite_flux() -> xr.DataArray:
     )
 
 
+def _metadata(data: xr.DataArray | xr.Dataset) -> FluxNonFiniteMetadata:
+    """Return parsed non-finite metadata from an xarray object."""
+    metadata = FluxNonFiniteMetadata.from_attrs(data.attrs)
+    assert metadata is not None
+    return metadata
+
+
 def test_sanitize_flux_nonfinite_lazy_preserves_shape_dtype_and_attrs() -> None:
     """Lazy sanitation replaces non-finite values and records the policy without counts."""
     flux = _nonfinite_flux()
 
     sanitized = sanitize_flux_nonfinite(flux, context="unit test")
+    metadata = _metadata(sanitized)
 
     assert sanitized.name == "flux"
     assert sanitized.dtype == np.dtype("float32")
@@ -40,10 +47,13 @@ def test_sanitize_flux_nonfinite_lazy_preserves_shape_dtype_and_attrs() -> None:
     xr.testing.assert_equal(sanitized.lon, flux.lon)
     np.testing.assert_allclose(sanitized.values, np.array([[1.0, 0.0], [0.0, 0.0]], dtype=np.float32))
     assert sanitized.attrs["units"] == "mol/m2/s"
-    assert sanitized.attrs[NONFINITE_POLICY_ATTR] == NONFINITE_POLICY_ZERO_FILL
-    assert sanitized.attrs[NONFINITE_FILL_VALUE_ATTR] == 0.0
-    assert sanitized.attrs[NONFINITE_CHECKED_ATTR] == NONFINITE_CHECKED_NOT_COUNTED
-    assert NONFINITE_COUNT_ATTR not in sanitized.attrs
+    assert isinstance(sanitized.attrs[NONFINITE_METADATA_ATTR], str)
+    assert metadata.schema_version == 1
+    assert metadata.policy == NONFINITE_POLICY_ZERO_FILL
+    assert metadata.fill_value == 0.0
+    assert metadata.checked == NONFINITE_CHECKED_NOT_COUNTED
+    assert metadata.context == "unit test"
+    assert metadata.count is None
     assert "history" in sanitized.attrs
 
 
@@ -61,12 +71,13 @@ def test_sanitize_flux_nonfinite_count_audits_lazy_metadata() -> None:
     sanitized = sanitize_flux_nonfinite(_nonfinite_flux(), context="unit test")
 
     audited = sanitize_flux_nonfinite(sanitized, context="audit test", check="count")
+    metadata = _metadata(audited)
 
     assert audited is not sanitized
-    assert audited.attrs[NONFINITE_CHECKED_ATTR] == NONFINITE_CHECKED_COMPUTED
-    assert audited.attrs[NONFINITE_COUNT_ATTR] == 0
-    assert audited.attrs[NONFINITE_TOTAL_ATTR] == 4
-    assert audited.attrs[NONFINITE_FRACTION_ATTR] == 0.0
+    assert metadata.checked == NONFINITE_CHECKED_COMPUTED
+    assert metadata.count == 0
+    assert metadata.total == 4
+    assert metadata.fraction == 0.0
 
 
 def test_sanitize_flux_nonfinite_count_records_exact_metadata() -> None:
@@ -75,8 +86,59 @@ def test_sanitize_flux_nonfinite_count_records_exact_metadata() -> None:
 
     with pytest.warns(NonFiniteFluxWarning, match="contains 3 non-finite values"):
         sanitized = sanitize_flux_nonfinite(flux, context="audit test", check="count", warn=True)
+    metadata = _metadata(sanitized)
 
-    assert sanitized.attrs[NONFINITE_CHECKED_ATTR] == NONFINITE_CHECKED_COMPUTED
-    assert sanitized.attrs[NONFINITE_COUNT_ATTR] == 3
-    assert sanitized.attrs[NONFINITE_TOTAL_ATTR] == 4
-    assert sanitized.attrs[NONFINITE_FRACTION_ATTR] == 0.75
+    assert metadata.checked == NONFINITE_CHECKED_COMPUTED
+    assert metadata.count == 3
+    assert metadata.total == 4
+    assert metadata.fraction == 0.75
+
+
+def test_sanitize_flux_nonfinite_json_metadata_survives_netcdf_roundtrip(tmp_path: Path) -> None:
+    """The canonical metadata attr is a string that survives NetCDF serialization."""
+    sanitized = sanitize_flux_nonfinite(_nonfinite_flux(), context="roundtrip test", check="count")
+    path = tmp_path / "flux.nc"
+
+    sanitized.to_dataset().to_netcdf(path, engine="scipy")
+    with xr.open_dataset(path, engine="scipy") as loaded:
+        loaded_metadata = _metadata(loaded["flux"])
+
+    assert isinstance(sanitized.attrs[NONFINITE_METADATA_ATTR], str)
+    assert loaded_metadata.policy == NONFINITE_POLICY_ZERO_FILL
+    assert loaded_metadata.checked == NONFINITE_CHECKED_COMPUTED
+    assert loaded_metadata.count == 3
+    assert loaded_metadata.total == 4
+
+
+def test_copy_flux_nonfinite_attrs_normalises_legacy_field_attrs() -> None:
+    """Legacy per-field metadata is read but copied as the canonical JSON attr."""
+    target = xr.Dataset(attrs={"title": "output"})
+    legacy_flux = xr.DataArray(
+        [1.0],
+        attrs={
+            "openghg_inversions:non_finite_policy": "zero_fill",
+            "openghg_inversions:non_finite_fill_value": 0.0,
+            "openghg_inversions:non_finite_checked": "computed",
+            "openghg_inversions:non_finite_count": 2,
+            "openghg_inversions:non_finite_total": 10,
+            "openghg_inversions:non_finite_fraction": 0.2,
+        },
+    )
+
+    result = copy_flux_nonfinite_attrs(target, legacy_flux)
+    metadata = _metadata(result)
+
+    assert result.attrs["title"] == "output"
+    assert metadata.policy == NONFINITE_POLICY_ZERO_FILL
+    assert metadata.checked == NONFINITE_CHECKED_COMPUTED
+    assert metadata.count == 2
+    assert metadata.total == 10
+    assert metadata.fraction == 0.2
+    assert "openghg_inversions:non_finite_policy" not in result.attrs
+
+
+def test_attrs_declare_zero_filled_nonfinite_accepts_json_metadata() -> None:
+    """Trusted attrs include the canonical JSON metadata attr."""
+    metadata = FluxNonFiniteMetadata(context="unit test")
+
+    assert attrs_declare_zero_filled_nonfinite({NONFINITE_METADATA_ATTR: metadata.to_json()})

--- a/tests/test_flux_sanitization.py
+++ b/tests/test_flux_sanitization.py
@@ -1,5 +1,8 @@
-import numpy as np
 from pathlib import Path
+
+import dask.array as da
+from dask.callbacks import Callback
+import numpy as np
 import pytest
 import xarray as xr
 
@@ -54,6 +57,23 @@ def test_sanitize_flux_nonfinite_lazy_preserves_shape_dtype_and_attrs() -> None:
     assert metadata.context == "unit test"
     assert metadata.count is None
     assert "history" in sanitized.attrs
+
+
+def test_sanitize_flux_nonfinite_lazy_mask_is_dask_safe() -> None:
+    """Shape-preserving lazy masking builds no tasks and computes correctly."""
+    flux = _nonfinite_flux().chunk({"lat": 1, "lon": 2})
+    executed_tasks: list[object] = []
+
+    with Callback(pretask=lambda *args: executed_tasks.append(args[0])):
+        sanitized = sanitize_flux_nonfinite(flux, context="lazy dask test")
+
+    assert executed_tasks == []
+    assert isinstance(sanitized.data, da.Array)
+    assert sanitized.chunks == flux.chunks
+    np.testing.assert_allclose(
+        sanitized.compute().values,
+        np.array([[1.0, 0.0], [0.0, 0.0]], dtype=np.float32),
+    )
 
 
 def test_sanitize_flux_nonfinite_is_idempotent_when_attrs_are_trusted() -> None:

--- a/tests/test_flux_sanitization.py
+++ b/tests/test_flux_sanitization.py
@@ -10,7 +10,6 @@ from openghg_inversions.flux_sanitization import (
     NONFINITE_POLICY_ZERO_FILL,
     FluxNonFiniteMetadata,
     NonFiniteFluxWarning,
-    attrs_declare_zero_filled_nonfinite,
     copy_flux_nonfinite_attrs,
     sanitize_flux_nonfinite,
 )
@@ -66,18 +65,19 @@ def test_sanitize_flux_nonfinite_is_idempotent_when_attrs_are_trusted() -> None:
     assert again is sanitized
 
 
-def test_sanitize_flux_nonfinite_count_audits_lazy_metadata() -> None:
-    """Count mode computes metadata even when lazy zero-fill attrs are present."""
+def test_sanitize_flux_nonfinite_count_does_not_invent_counts_after_lazy_fill() -> None:
+    """Count mode preserves lazy metadata when original non-finite values are gone."""
     sanitized = sanitize_flux_nonfinite(_nonfinite_flux(), context="unit test")
 
-    audited = sanitize_flux_nonfinite(sanitized, context="audit test", check="count")
+    with pytest.warns(NonFiniteFluxWarning, match="original non-finite count cannot be recovered"):
+        audited = sanitize_flux_nonfinite(sanitized, context="audit test", check="count")
     metadata = _metadata(audited)
 
-    assert audited is not sanitized
-    assert metadata.checked == NONFINITE_CHECKED_COMPUTED
-    assert metadata.count == 0
-    assert metadata.total == 4
-    assert metadata.fraction == 0.0
+    assert audited is sanitized
+    assert metadata.checked == NONFINITE_CHECKED_NOT_COUNTED
+    assert metadata.count is None
+    assert metadata.total is None
+    assert metadata.fraction is None
 
 
 def test_sanitize_flux_nonfinite_count_records_exact_metadata() -> None:
@@ -92,6 +92,16 @@ def test_sanitize_flux_nonfinite_count_records_exact_metadata() -> None:
     assert metadata.count == 3
     assert metadata.total == 4
     assert metadata.fraction == 0.75
+
+
+def test_sanitize_flux_nonfinite_count_metadata_is_idempotent() -> None:
+    """Repeated count mode trusts an exact audit without rescanning the data."""
+    sanitized = sanitize_flux_nonfinite(_nonfinite_flux(), context="audit test", check="count")
+
+    again = sanitize_flux_nonfinite(sanitized, context="second audit", check="count")
+
+    assert again is sanitized
+    assert _metadata(again).count == 3
 
 
 def test_sanitize_flux_nonfinite_json_metadata_survives_netcdf_roundtrip(tmp_path: Path) -> None:
@@ -124,10 +134,3 @@ def test_copy_flux_nonfinite_attrs_copies_json_metadata() -> None:
     assert result.attrs["title"] == "output"
     assert metadata.policy == NONFINITE_POLICY_ZERO_FILL
     assert metadata.context == "copy test"
-
-
-def test_attrs_declare_zero_filled_nonfinite_accepts_json_metadata() -> None:
-    """Trusted attrs include the canonical JSON metadata attr."""
-    metadata = FluxNonFiniteMetadata(context="unit test")
-
-    assert attrs_declare_zero_filled_nonfinite({NONFINITE_METADATA_ATTR: metadata.to_json()})

--- a/tests/test_flux_sanitization.py
+++ b/tests/test_flux_sanitization.py
@@ -1,0 +1,82 @@
+import numpy as np
+import pytest
+import xarray as xr
+
+from openghg_inversions.flux_sanitization import (
+    NONFINITE_CHECKED_ATTR,
+    NONFINITE_CHECKED_COMPUTED,
+    NONFINITE_CHECKED_NOT_COUNTED,
+    NONFINITE_COUNT_ATTR,
+    NONFINITE_FILL_VALUE_ATTR,
+    NONFINITE_FRACTION_ATTR,
+    NONFINITE_POLICY_ATTR,
+    NONFINITE_POLICY_ZERO_FILL,
+    NONFINITE_TOTAL_ATTR,
+    NonFiniteFluxWarning,
+    sanitize_flux_nonfinite,
+)
+
+
+def _nonfinite_flux() -> xr.DataArray:
+    """Build a tiny flux field containing NaN and infinite values."""
+    return xr.DataArray(
+        np.array([[1.0, np.nan], [np.inf, -np.inf]], dtype=np.float32),
+        dims=("lat", "lon"),
+        coords={"lat": [10.0, 20.0], "lon": [1.0, 2.0]},
+        name="flux",
+        attrs={"units": "mol/m2/s"},
+    )
+
+
+def test_sanitize_flux_nonfinite_lazy_preserves_shape_dtype_and_attrs() -> None:
+    """Lazy sanitation replaces non-finite values and records the policy without counts."""
+    flux = _nonfinite_flux()
+
+    sanitized = sanitize_flux_nonfinite(flux, context="unit test")
+
+    assert sanitized.name == "flux"
+    assert sanitized.dtype == np.dtype("float32")
+    xr.testing.assert_equal(sanitized.lat, flux.lat)
+    xr.testing.assert_equal(sanitized.lon, flux.lon)
+    np.testing.assert_allclose(sanitized.values, np.array([[1.0, 0.0], [0.0, 0.0]], dtype=np.float32))
+    assert sanitized.attrs["units"] == "mol/m2/s"
+    assert sanitized.attrs[NONFINITE_POLICY_ATTR] == NONFINITE_POLICY_ZERO_FILL
+    assert sanitized.attrs[NONFINITE_FILL_VALUE_ATTR] == 0.0
+    assert sanitized.attrs[NONFINITE_CHECKED_ATTR] == NONFINITE_CHECKED_NOT_COUNTED
+    assert NONFINITE_COUNT_ATTR not in sanitized.attrs
+    assert "history" in sanitized.attrs
+
+
+def test_sanitize_flux_nonfinite_is_idempotent_when_attrs_are_trusted() -> None:
+    """A second trusted call returns the same object without rebuilding the graph."""
+    sanitized = sanitize_flux_nonfinite(_nonfinite_flux(), context="unit test")
+
+    again = sanitize_flux_nonfinite(sanitized, context="second pass")
+
+    assert again is sanitized
+
+
+def test_sanitize_flux_nonfinite_count_audits_lazy_metadata() -> None:
+    """Count mode computes metadata even when lazy zero-fill attrs are present."""
+    sanitized = sanitize_flux_nonfinite(_nonfinite_flux(), context="unit test")
+
+    audited = sanitize_flux_nonfinite(sanitized, context="audit test", check="count")
+
+    assert audited is not sanitized
+    assert audited.attrs[NONFINITE_CHECKED_ATTR] == NONFINITE_CHECKED_COMPUTED
+    assert audited.attrs[NONFINITE_COUNT_ATTR] == 0
+    assert audited.attrs[NONFINITE_TOTAL_ATTR] == 4
+    assert audited.attrs[NONFINITE_FRACTION_ATTR] == 0.0
+
+
+def test_sanitize_flux_nonfinite_count_records_exact_metadata() -> None:
+    """Count mode computes exact non-finite count metadata and warns when needed."""
+    flux = _nonfinite_flux()
+
+    with pytest.warns(NonFiniteFluxWarning, match="contains 3 non-finite values"):
+        sanitized = sanitize_flux_nonfinite(flux, context="audit test", check="count", warn=True)
+
+    assert sanitized.attrs[NONFINITE_CHECKED_ATTR] == NONFINITE_CHECKED_COMPUTED
+    assert sanitized.attrs[NONFINITE_COUNT_ATTR] == 3
+    assert sanitized.attrs[NONFINITE_TOTAL_ATTR] == 4
+    assert sanitized.attrs[NONFINITE_FRACTION_ATTR] == 0.75

--- a/tests/test_flux_sanitization.py
+++ b/tests/test_flux_sanitization.py
@@ -110,31 +110,20 @@ def test_sanitize_flux_nonfinite_json_metadata_survives_netcdf_roundtrip(tmp_pat
     assert loaded_metadata.total == 4
 
 
-def test_copy_flux_nonfinite_attrs_normalises_legacy_field_attrs() -> None:
-    """Legacy per-field metadata is read but copied as the canonical JSON attr."""
+def test_copy_flux_nonfinite_attrs_copies_json_metadata() -> None:
+    """Canonical JSON metadata is copied while preserving existing target attrs."""
     target = xr.Dataset(attrs={"title": "output"})
-    legacy_flux = xr.DataArray(
+    flux = xr.DataArray(
         [1.0],
-        attrs={
-            "openghg_inversions:non_finite_policy": "zero_fill",
-            "openghg_inversions:non_finite_fill_value": 0.0,
-            "openghg_inversions:non_finite_checked": "computed",
-            "openghg_inversions:non_finite_count": 2,
-            "openghg_inversions:non_finite_total": 10,
-            "openghg_inversions:non_finite_fraction": 0.2,
-        },
+        attrs={NONFINITE_METADATA_ATTR: FluxNonFiniteMetadata(context="copy test").to_json()},
     )
 
-    result = copy_flux_nonfinite_attrs(target, legacy_flux)
+    result = copy_flux_nonfinite_attrs(target, flux)
     metadata = _metadata(result)
 
     assert result.attrs["title"] == "output"
     assert metadata.policy == NONFINITE_POLICY_ZERO_FILL
-    assert metadata.checked == NONFINITE_CHECKED_COMPUTED
-    assert metadata.count == 2
-    assert metadata.total == 10
-    assert metadata.fraction == 0.2
-    assert "openghg_inversions:non_finite_policy" not in result.attrs
+    assert metadata.context == "copy test"
 
 
 def test_attrs_declare_zero_filled_nonfinite_accepts_json_metadata() -> None:

--- a/tests/test_get_data.py
+++ b/tests/test_get_data.py
@@ -1,5 +1,6 @@
 import copy
 import logging
+from types import SimpleNamespace
 from unittest import mock
 
 import numpy as np
@@ -10,6 +11,8 @@ from openghg.retrieve import get_obs_surface
 from openghg.types import SearchError
 
 import openghg_inversions.inversion_data.get_data
+import openghg_inversions.inversion_data.getters as getters_module
+from openghg_inversions.flux_sanitization import FluxNonFiniteMetadata, NonFiniteFluxWarning
 from openghg_inversions.inversion_data.serialise import (
     fp_all_from_dataset,
     make_combined_scenario,
@@ -275,3 +278,33 @@ def test_flux_time_period_inference(end_date, time_period, tac_ch4_data_args):
 
     source = tac_ch4_data_args["emissions_name"][0]
     assert flux_data[source].data.flux.attrs["time_period"] == time_period
+
+
+def test_get_flux_data_count_mode_audits_original_values(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Retrieval count mode records exact NaN and infinity replacements once."""
+    flux = xr.DataArray(
+        np.array([[[1.0, np.nan], [np.inf, 2.0]]]),
+        dims=("time", "lat", "lon"),
+        coords={"time": [np.datetime64("2019-01-01")]},
+        name="flux",
+    )
+    flux_data = SimpleNamespace(data=xr.Dataset({"flux": flux}, attrs={"time_period": "1 year"}))
+    monkeypatch.setattr(getters_module, "adjust_flux_start_date", lambda *args: np.datetime64("2019-01-01"))
+    monkeypatch.setattr(getters_module, "get_flux", lambda **kwargs: flux_data)
+
+    with pytest.warns(NonFiniteFluxWarning, match="contains 2 non-finite values"):
+        result = get_flux_data(
+            sources=["test-source"],
+            species="co2",
+            domain="EUROPE",
+            start_date="2019-01-01",
+            end_date="2020-01-01",
+            flux_non_finite_check="count",
+        )
+
+    sanitized = result["test-source"].data["flux"]
+    metadata = FluxNonFiniteMetadata.from_attrs(sanitized.attrs)
+    assert metadata is not None
+    assert metadata.count == 2
+    assert metadata.total == 4
+    assert np.isfinite(sanitized.values).all()

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -204,6 +204,7 @@ def test_fixedbasisMCMC_uses_fixedbasis_preparation_contract_for_mcmc_args(monke
         outputname="contract",
         output_format="mcmc_args",
         return_basis_objects=True,
+        flux_non_finite_check="count",
         use_bc=False,
     )
 
@@ -211,6 +212,7 @@ def test_fixedbasisMCMC_uses_fixedbasis_preparation_contract_for_mcmc_args(monke
     assert captured_kwargs["split_by_sectors"] is False
     assert captured_kwargs["return_basis_objects"] is True
     assert captured_kwargs["merged_data_only"] is False
+    assert captured_kwargs["flux_non_finite_check"] == "count"
     assert isinstance(result, dict)
     assert result["inv_inputs"] is prepared.inv_inputs
     assert result["basis_objects"] is prepared.basis_objects

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -28,6 +28,11 @@ from openghg_inversions.basis.basis_functions import (
     BasisFunctions,
 )
 from openghg_inversions.cli import main
+from openghg_inversions.flux_sanitization import (
+    NONFINITE_POLICY_ATTR,
+    NONFINITE_POLICY_ZERO_FILL,
+    NonFiniteFluxWarning,
+)
 from openghg_inversions.inversion_data import RhimePreparedInputs, prepare_rhime_inputs
 from openghg_inversions.inversion_inputs import make_inv_inputs
 from openghg_inversions.basis.operators import BasisMeta, BasisOperator, BucketBasisOperator
@@ -244,6 +249,20 @@ def _two_region_basis_functions_matching_country_grid(country_file: Path) -> Bas
         flux=flux,
         operator_kwargs={"state_dim": "region"},
         metadata={BASIS_ARTIFACT_SOURCE_ATTR: "two-region-test"},
+    )
+
+
+def _unsanitized_nonfinite_basis_functions_matching_country_grid(country_file: Path) -> BasisFunctions:
+    """Build an old-style basis artifact whose retained flux has non-finite values."""
+    basis_functions = _two_region_basis_functions_matching_country_grid(country_file)
+    flux = basis_functions.flux.copy()
+    flux.values[0, 0] = np.nan
+    flux.values[-1, -1] = np.inf
+    flux.attrs = {"units": "mol/m2/s"}
+    return type(basis_functions)(
+        operator=basis_functions.operator,
+        flux=flux,
+        metadata=dict(basis_functions.metadata),
     )
 
 
@@ -2653,6 +2672,29 @@ def test_modern_operator_flux_and_country_outputs_run_on_nonuniform_basis(
     assert "country_posterior_mean" in modern_country
 
 
+@pytest.mark.parametrize("report_flux_on_inversion_grid", [False, True])
+def test_modern_flux_outputs_backfill_unsanitized_nonfinite_flux(
+    europe_country_file: Path,
+    report_flux_on_inversion_grid: bool,
+) -> None:
+    """Flux postprocessing zero-fills old retained flux artifacts with non-finite values."""
+    from openghg_inversions.postprocessing.make_outputs import make_flux_outputs
+
+    basis_functions = _unsanitized_nonfinite_basis_functions_matching_country_grid(europe_country_file)
+    inv_out = _modern_postprocessing_inv_out(europe_country_file, basis_functions=basis_functions)
+
+    with pytest.warns(NonFiniteFluxWarning, match="lazily replacing any non-finite values"):
+        outputs = make_flux_outputs(
+            inv_out,
+            include_scale_factors=False,
+            report_flux_on_inversion_grid=report_flux_on_inversion_grid,
+        )
+
+    assert "flux_posterior_mean" in outputs
+    assert np.isfinite(outputs["flux_posterior_mean"].values).all()
+    assert outputs.attrs[NONFINITE_POLICY_ATTR] == NONFINITE_POLICY_ZERO_FILL
+
+
 def test_modern_paris_flux_outputs_use_retained_basis_operator(
     monkeypatch: pytest.MonkeyPatch,
     europe_country_file: Path,
@@ -2685,6 +2727,21 @@ def test_modern_paris_flux_outputs_use_retained_basis_operator(
         assert flux_outputs[name].dtype == np.dtype("float32")
     assert operator.interpolate_calls
     assert operator.basis_matrix_accesses
+
+
+def test_modern_paris_flux_outputs_backfill_unsanitized_nonfinite_flux(europe_country_file: Path) -> None:
+    """PARIS flux output completes when old retained flux artifacts contain non-finite values."""
+    from openghg_inversions.postprocessing.make_paris_outputs import paris_flux_output
+
+    basis_functions = _unsanitized_nonfinite_basis_functions_matching_country_grid(europe_country_file)
+    inv_out = _modern_postprocessing_inv_out(europe_country_file, basis_functions=basis_functions)
+
+    with pytest.warns(NonFiniteFluxWarning, match="lazily replacing any non-finite values"):
+        flux_outputs = paris_flux_output(inv_out, country_file=europe_country_file)
+
+    assert "flux_total_posterior" in flux_outputs
+    assert np.isfinite(flux_outputs["flux_total_posterior"].values).all()
+    assert flux_outputs.attrs[NONFINITE_POLICY_ATTR] == NONFINITE_POLICY_ZERO_FILL
 
 
 def test_observation_inputs_for_outputs_stay_dataset_based() -> None:

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -29,7 +29,7 @@ from openghg_inversions.basis.basis_functions import (
 )
 from openghg_inversions.cli import main
 from openghg_inversions.flux_sanitization import (
-    NONFINITE_POLICY_ATTR,
+    FluxNonFiniteMetadata,
     NONFINITE_POLICY_ZERO_FILL,
     NonFiniteFluxWarning,
 )
@@ -76,6 +76,13 @@ def rhime_inv_inputs(mhd_and_tac_fp_data) -> xr.Dataset:
         min_error=0.0,
         start_date="2019-01-01",
     )
+
+
+def _flux_nonfinite_metadata(data: xr.DataArray | xr.Dataset) -> FluxNonFiniteMetadata:
+    """Return parsed non-finite flux metadata from an xarray object."""
+    metadata = FluxNonFiniteMetadata.from_attrs(data.attrs)
+    assert metadata is not None
+    return metadata
 
 
 @pytest.fixture
@@ -2581,6 +2588,7 @@ def test_multisector_flux_outputs_reconstruct_sector_and_total_flux() -> None:
     assert float(outputs["flux_total_posterior_mean"].item()) == 2.0
     assert float(outputs["flux_total_posterior_stdev"].item()) == 0.0
     assert float(outputs["flux_ff_posterior_stdev"].item()) > 0.0
+    assert _flux_nonfinite_metadata(outputs).policy == NONFINITE_POLICY_ZERO_FILL
 
 
 def test_multisector_flux_outputs_support_source_specific_basis(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -2604,6 +2612,7 @@ def test_multisector_flux_outputs_support_source_specific_basis(monkeypatch: pyt
     assert "flux_total_posterior_mean" in outputs
     assert "flux_total_posterior_mode" in outputs
     assert float(outputs["flux_total_posterior_mean"].item()) == 2.0
+    assert _flux_nonfinite_metadata(outputs).policy == NONFINITE_POLICY_ZERO_FILL
 
 
 def test_modern_flux_outputs_use_retained_basis_operator(
@@ -2692,7 +2701,7 @@ def test_modern_flux_outputs_backfill_unsanitized_nonfinite_flux(
 
     assert "flux_posterior_mean" in outputs
     assert np.isfinite(outputs["flux_posterior_mean"].values).all()
-    assert outputs.attrs[NONFINITE_POLICY_ATTR] == NONFINITE_POLICY_ZERO_FILL
+    assert _flux_nonfinite_metadata(outputs).policy == NONFINITE_POLICY_ZERO_FILL
 
 
 def test_modern_paris_flux_outputs_use_retained_basis_operator(
@@ -2741,7 +2750,7 @@ def test_modern_paris_flux_outputs_backfill_unsanitized_nonfinite_flux(europe_co
 
     assert "flux_total_posterior" in flux_outputs
     assert np.isfinite(flux_outputs["flux_total_posterior"].values).all()
-    assert flux_outputs.attrs[NONFINITE_POLICY_ATTR] == NONFINITE_POLICY_ZERO_FILL
+    assert _flux_nonfinite_metadata(flux_outputs).policy == NONFINITE_POLICY_ZERO_FILL
 
 
 def test_observation_inputs_for_outputs_stay_dataset_based() -> None:
@@ -3050,6 +3059,7 @@ def test_latest_paris_flux_output_processes_multisector_total(
         expected_country.data.todense(),
         rtol=1e-6,
     )
+    assert _flux_nonfinite_metadata(flux_outputs).policy == NONFINITE_POLICY_ZERO_FILL
 
     flux_outputs.to_netcdf(tmp_path / "latest_multisector_flux.nc")
 

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -2692,7 +2692,7 @@ def test_modern_flux_outputs_backfill_unsanitized_nonfinite_flux(
     basis_functions = _unsanitized_nonfinite_basis_functions_matching_country_grid(europe_country_file)
     inv_out = _modern_postprocessing_inv_out(europe_country_file, basis_functions=basis_functions)
 
-    with pytest.warns(NonFiniteFluxWarning, match="lazily replacing any non-finite values"):
+    with pytest.warns(NonFiniteFluxWarning, match="applying a lazy zero-fill guard"):
         outputs = make_flux_outputs(
             inv_out,
             include_scale_factors=False,
@@ -2745,7 +2745,7 @@ def test_modern_paris_flux_outputs_backfill_unsanitized_nonfinite_flux(europe_co
     basis_functions = _unsanitized_nonfinite_basis_functions_matching_country_grid(europe_country_file)
     inv_out = _modern_postprocessing_inv_out(europe_country_file, basis_functions=basis_functions)
 
-    with pytest.warns(NonFiniteFluxWarning, match="lazily replacing any non-finite values"):
+    with pytest.warns(NonFiniteFluxWarning, match="applying a lazy zero-fill guard"):
         flux_outputs = paris_flux_output(inv_out, country_file=europe_country_file)
 
     assert "flux_total_posterior" in flux_outputs


### PR DESCRIPTION
* **Summary of changes**

Closes #495 by treating retained flux as another surface of the same non-finite flux root cause that PR #474 fixed for generated-basis weights.

- Adds `sanitize_flux_nonfinite()` for lazy zero-fill sanitation of `NaN`, `+Inf`, and `-Inf` flux values, with optional count-mode auditing.
- Records machine-readable sanitation metadata through `FluxNonFiniteMetadata`, serialized into one namespaced JSON attr: `openghg_inversions:non_finite_flux`.
- Keeps that metadata contract local and canonical. It does not guess future OpenGHG attribute names; openghg/openghg#1680 tracks definition of an upstream contract.
- Applies sanitation during flux ingestion/preparation, merged-data recovery, retained `BasisFunctions` flux construction, and operator-backed postprocessing reconstruction so old unsanitized retained artifacts get a backstop.
- Avoids repeated scans and duplicate dask graphs/history entries when valid local metadata is already present.
- Preserves exact count metadata from single-source ingestion. Multi-source stacking/combining refreshes aggregate metadata because alignment can introduce non-finite cells and source-specific counts are not aggregate counts.
- Does not fabricate an exact count when count mode is requested after a prior lazy fill; the original non-finite values are no longer recoverable.
- Propagates sanitation metadata through multisector flux outputs and PARIS flux outputs after reductions/merges.
- Keeps PR #474's generated-basis weight sanitation as the algorithm guard now that #474 is merged into `devel`.
- Fixes byte-like country labels exposed by the OCO2 PARIS run so `numpy.bytes_` labels do not fail country-code conversion.

Closes #496.
Closes #497.
Closes #498.

Follow-up work is tracked in:

- openghg/openghg#1680 for the authoritative missing-value policy metadata;
- openghg/openghg#1682 for shared xarray JSON/history utilities; and
- #500 for consolidating sanitation after the inversion data-preparation refactor.

* **OCO2 HPC-CI evidence**

Final pixi run succeeded:

- Run directory: `/group/chem/acrg/test_inversions/runs/oco2-satellite_20260708_011822Z`
- Output directory: `/group/chem/acrg/test_inversions/runs/oco2-satellite_20260708_011822Z/outputs`
- SLURM job: `18052524`
- `seff 18052524`: `COMPLETED (exit code 0)`, wall time `00:28:18`, memory utilized `8.67 GB`
- Generated basis completed: `rhime.prepare_inputs.basis_build seconds=29.138565 nbasis=32`
- Sampler completed: `rhime.sampler_total seconds=160.345810 divergences=0`
- Trace save completed: `rhime.output.trace_save seconds=2.823421 path=...trace.nc`
- PARIS postprocess completed: `rhime.output.paris_postprocess seconds=417.754412`
- PARIS NetCDF writes completed: concentration `seconds=0.096311`, flux `seconds=67.048875`
- Run ended with `exit_code=0` and `status=OK`

The earlier venv reproduction had already cleared the issue #495 sparse/dense failure path but failed later with `RuntimeError: NetCDF: HDF error` during NetCDF write. Re-running under pixi completed successfully, consistent with the suspected netCDF4/h5netcdf/HDF wheel conflict rather than a retained-flux sparse/dense regression.

* **Please check if the PR fulfills these requirements**

- [x] Closes #495, closes #496, closes #497, and closes #498
- [x] Tests added and passing
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry to the `CHANGELOG.md` file
- [ ] Added any new requirements to `requirements.txt`

Full local pre-PR validation:

```bash
tox
```

Results:

- `py310-openghgCur`: `502 passed, 8 skipped, 6 xfailed`
- `py310-openghgPrev`: `502 passed, 8 skipped, 6 xfailed`
- `py310-openghgDev`: `502 passed, 8 skipped, 6 xfailed`
- `lint`: passed

Additional focused checks:

```bash
uv run ruff check <all changed Python files>
uv run pyright openghg_inversions/flux_sanitization.py openghg_inversions/basis/basis_functions.py openghg_inversions/postprocessing/_basis_products.py openghg_inversions/postprocessing/make_outputs.py openghg_inversions/postprocessing/make_paris_outputs.py
```

Result: both passed.

Lazy dask-mask verification was also run in the current, previous, and development OpenGHG tox environments:

```bash
pytest tests/test_flux_sanitization.py -q
```

Each environment passed all 8 tests. The regression test verifies that lazy sanitation executes no tasks while constructing the graph, remains dask-backed, preserves chunks, and computes the expected zero-filled values.