### PR TITLE
Add experimental dyadic stochastic local search core

### DIFF
--- a/docs/plans/dyadic_partition_inference.md
+++ b/docs/plans/dyadic_partition_inference.md
@@ -836,6 +836,21 @@ covariance across several partitions. A coherent later alternative is a
 tree-contrast prior or an explicitly induced fine-grid prior with documented
 mass/depth scaling.
 
+This benchmark also differs from the scale-consistent construction in Bocquet,
+Wu, and Chevallier. In that construction the covariance belongs first to the
+fine representation and transforms with the representation projection (using
+\(P\) for that projection by an abuse of notation):
+
+\[
+B_P=PBP^T.
+\]
+
+Using the same numerical \(B_P\) for every partition breaks that transformation
+rule. Phase 0 should therefore accept covariance construction as an explicit
+partition-dependent operation even if the first proof of concept supplies
+\(\tau_x^2I_K\). A Bocquet-faithful projected covariance can then replace the
+benchmark without changing partition state or search control flow.
+
 For the variable-count stretch goal, add an explicit \(p(K)\) or an unconditioned
 proper tree prior and use separate split and merge proposals with their complete
 candidate-count and direction probabilities. Because \(x_P\) remains collapsed,

--- a/docs/plans/dyadic_partition_inference.md
+++ b/docs/plans/dyadic_partition_inference.md
@@ -9,6 +9,10 @@ Its first implementation milestone is to move the useful prototype code into
 this repository with synthetic tests. Subsequent work should refer to that public
 reference implementation rather than to private histories.
 
+The short-term execution checklist, local TAC/MHD data contract, demo artifacts,
+and hackathon stop conditions are maintained separately in
+`docs/plans/dyadic_sls_hackathon.md`.
+
 The motivating problem is an atmospheric inverse model
 
 \[

--- a/docs/plans/dyadic_partition_inference.md
+++ b/docs/plans/dyadic_partition_inference.md
@@ -1,0 +1,1055 @@
+# Dyadic Basis Optimization and Partition Inference
+
+## Status and purpose
+
+This is a design and background note, not an implemented sampler contract. It
+collects the basis-partition work that is currently spread across repository
+branches, planning notes, IPython histories, and a private discussion transcript.
+Its first implementation milestone is to move the useful prototype code into
+this repository with synthetic tests. Subsequent work should refer to that public
+reference implementation rather than to private histories.
+
+The motivating problem is an atmospheric inverse model
+
+\[
+y = H_P x_P + \epsilon,
+\]
+
+where the basis partition \(P\) determines an aggregated emissions block of the
+sensitivity matrix, \(x_P\) contains the corresponding coefficients, and other
+blocks of the inverse problem can remain fixed. The immediate goal is a
+reproducible simulated-annealing (SA) demonstration over dyadic partitions. The
+longer-term goal is posterior inference over both the partition and continuous
+parameters, including non-Gaussian positive priors such as lognormal priors.
+
+This note distinguishes three statuses:
+
+- **Established**: a mathematical result, existing repository behavior, or
+  behavior observed directly in the prototype.
+- **Proposed**: the current implementation recommendation.
+- **Open**: a choice that needs a focused experiment or design decision.
+
+## Executive decisions
+
+1. **Proposed:** collect and test the dyadic data structures, multiscale
+   sensitivity construction, split/merge moves, Python and Numba bisection, and
+   SA runner before implementing joint MCMC. This is Phase 0 below.
+2. **Proposed:** retain SA as a useful optimizer and initializer. Do not describe
+   its DoFS-like energy as a non-Gaussian posterior target.
+3. **Proposed:** make the first joint-inference demonstration fixed-region-count.
+   A paired split-and-merge proposal keeps the continuous dimension fixed and
+   avoids trans-dimensional bookkeeping while testing the important likelihood,
+   partition, and coefficient interactions.
+4. **Proposed:** investigate a tree-contrast product-space sampler next. It is a
+   genuine fixed-dimensional alternative to RJMCMC when all potential node
+   parameters and proper pseudo-priors are included in the augmented state.
+5. **Established:** storing a fixed indicator over all possible multiscale tiles
+   does not by itself avoid RJMCMC. If the mathematical continuous state is a
+   packed vector whose dimension changes with the number of active tiles, the
+   method is trans-dimensional regardless of how the indicator is stored.
+6. **Proposed:** use exact likelihood and prior terms for final partition
+   acceptance. DoFS, split-contrast, projected-flux, or Laplace scores may inform
+   proposals, initialize chains, or provide a delayed-acceptance first stage.
+7. **Proposed:** represent land/ocean, country, inner/outer, and other hard
+   partitions as constraints and groups around the dyadic optimizer. Filtering
+   of observations must occur before any data-dependent basis weights are built.
+
+## Terminology and notation
+
+| Symbol | Meaning |
+| --- | --- |
+| \(y\) | retained observations after filtering |
+| \(G\) | fine-grid contribution/sensitivity matrix for the block being aggregated |
+| \(H_P\) | columns of \(G\) aggregated according to partition \(P\) |
+| \(x_P\) | active region coefficients for \(P\) |
+| \(P\) | a valid partition of the relevant grid cells |
+| \(A(P)\) | active leaf tiles under partition \(P\) |
+| \(R\) | observation-error covariance, or the appropriate effective covariance |
+| \(B_P\) | prior covariance in a linear-Gaussian approximation |
+| \(z\) | unconstrained continuous coordinates, often with \(x=\exp(z)\) |
+| \(q_P\) | proper pseudo-prior for parameters inactive under \(P\) |
+| \(K(P)\) | number of active regions or leaves |
+
+"Multiscale sensitivity" means pre-aggregated columns for candidate tiles. A
+"multiscale weight" is a score derived from those columns. These are not the
+same object and should not share an ambiguous array name.
+
+When hard classes are present, this note uses **superforest** for the collection
+of one predetermined dyadic tree per class or connected component. A valid
+global partition is a pruning of every tree in that superforest.
+
+## Current repository foundations
+
+The repository already contains most of the non-dynamic basis infrastructure:
+
+- `openghg_inversions/basis/algorithms/_constrained.py` defines class-constrained
+  partitioning, a `SplitStrategy`, a `PartitionStep`, axis-parallel splitting,
+  inertial splitting, physical grid geometry, and split-stopping policies.
+- `openghg_inversions/basis/algorithms/_contrast.py` defines observation-space
+  split-contrast scores and acceptance policies. This is directly related to the
+  tree-contrast formulation below.
+- `openghg_inversions/basis/layout.py` defines `BasisPartition`, `BasisLayout`,
+  and state metadata for grouped fixed layouts.
+- `openghg_inversions/basis/operators.py` and
+  `openghg_inversions/basis/basis_functions.py` construct and serialize fixed
+  basis operators.
+- `docs/plans/mask_constrained_basis.md` records land/sea, country, rectangle,
+  fixed-outer-region, layering, geometry, and partition-strategy decisions.
+- `docs/plans/state_vector_grouping.md` and
+  `docs/plans/fixed_outer_regions_grouping.md` describe grouped state-vector
+  metadata and inner/outer semantics.
+- `docs/plans/ogi_048_basis_algorithm_options.md` records real-footprint
+  comparisons and a held-out projected-flux compression score.
+
+These components produce and describe fixed layouts. They do not yet represent
+a partition as dynamic sampler state, retain all fine-grid contributions needed
+to rebuild \(H_P\), or sample over partitions.
+
+The existing RHIME model builders also assume a fixed state dimension. Dynamic
+partition inference should initially be a separate experimental subsystem and
+should not be inserted into the established basis wrappers or
+`fixedbasisMCMC` path.
+
+## Prototype source inventory
+
+The following paths are historical provenance, not intended dependencies. Phase
+0 must preserve the useful behavior in repository-owned code and tests.
+
+### Clean reference branch
+
+Branch `codex/basis-prototype-examples`, commit `b6ce565`, contains:
+
+- `openghg_inversions/basis/algorithms/_experimental_dyadic.py`;
+- `tests/test_experimental_dyadic_basis.py`.
+
+It provides three executable examples:
+
+1. a precomputed dyadic weight array plus threshold bisection;
+2. a small split/merge annealing scaffold;
+3. a Numba implementation of bisection.
+
+The tests pass and make this the best structural starting point. It should not
+be merged wholesale. Its energy is a toy objective, its fixed-temperature loop
+is a local stochastic search rather than a full annealing schedule, its merge
+enumeration is quadratic, and it does not account for asymmetric proposal
+probabilities. Most importantly, it pre-sums an already formed two-dimensional
+weight field, whereas the scientific prototype aggregates observation
+sensitivity before constructing its score.
+
+### Raw multiscale and SA history
+
+`~/Documents/basis_functions/basis_fn_ipython_hist_14aug.py` contains:
+
+- `make_multi`, which repeatedly sums adjacent values to build dyadic spatial
+  levels;
+- `make_weights`, which pads the spatial grid, constructs multiscale observation
+  sensitivities, and derives candidate-tile weights;
+- tile lookup, validity, split, merge, DoFS-change, and random-move helpers;
+- the dense active-tile indicator used by the original local search.
+
+The important scientific operation is
+
+\[
+h_v = \sum_{i \in v} G_{:,i},
+\]
+
+followed by a score based on \(h_v\), \(R\), and tile scale. It is generally
+incorrect to first construct fine-cell scalar weights \(w_i\) and then use
+\(\sum_{i\in v} w_i\), because
+
+\[
+\left(\sum_{i\in v} G_{:,i}\right)^2
+\ne
+\sum_{i\in v} G_{:,i}^2.
+\]
+
+The recorded call path appears to pass a transformed inverse-error array to
+`make_weights`; that convention must be resolved against the intended formula
+rather than copied mechanically.
+
+### Raw bisection, Numba, and optimization history
+
+`~/Documents/basis_functions/basis_fn_ipython_hist_17aug.py` contains repeated
+versions of:
+
+- `bucket_basis`, a non-recursive threshold/bisection partitioner;
+- `bucket_basis_opt`, a threshold search;
+- `simulated_annealing`, with later variants superseding earlier cells;
+- a Numba bisection kernel near the final useful block.
+
+The final Numba kernel has previously shown output parity with the Python
+version and a large warm-call speedup on a favorable synthetic full-split case.
+That is evidence that the kernel is worth preserving, not a general benchmark.
+The masked optimizer cells after it contain overwritten definitions and known
+errors and should not be copied as authoritative code.
+
+### Alternative partition steps
+
+`~/Documents/inversions/src/inversions/basis_algorithms.py` contains the cleaned
+prototype lineage for:
+
+- a small `NodeListPriorityQueue`;
+- greedy partitioning;
+- axis-parallel split steps;
+- inertial split steps.
+
+The repository version in `_constrained.py` is now the preferred implementation
+of those ideas. The raw file remains useful for provenance but does not need to
+be duplicated in the dyadic package.
+
+### Research notes and transcript
+
+- `~/Documents/basis_functions/basis_fns.org` contains contemporary notes about
+  the experiments.
+- `~/Dropbox/acrg_library/Bocquet_Bayesian design of control space for
+  optimal.pdf` is the local paper copy that inspired the prototype's DoFS and
+  multiscale-representation calculations. It is Bocquet, Wu, and Chevallier
+  (2011), Part I, cited publicly by DOI below. The most relevant locations are
+  Section 2.2.2 for the multiscale Jacobian, Section 4.1.2 and Equations (38)-(39)
+  for DFS by representation and tile, and Section 6 for tiling versus qtree
+  storage and optimization.
+- `~/Downloads/ChatGPT-Bayesian_model_selection.md` records the discussion that
+  motivated fixed indicators, product-space inference, collapsed alternatives,
+  and tree contrasts. This document supersedes that transcript as the project
+  design reference; claims from the transcript are not treated as references.
+
+## Phase 0: collect a public, tested reference implementation
+
+This phase is required before either the SA demo or MCMC work. Its purpose is to
+stop depending on private, stateful histories while retaining a traceable route
+back to their scientific intent.
+
+### Proposed location
+
+Use a provisional repository package such as
+`openghg_inversions/basis/experimental/dyadic/`, without re-exporting it from
+the public `openghg_inversions.basis` namespace. Add a runnable synthetic demo
+under `examples/basis/dyadic_sa_demo.py`. A package is preferable to putting all
+logic in an example because the reference implementation needs focused tests
+and will later supply the partition-inference subsystem.
+
+The package name and APIs are provisional. Each module should state the source
+prototype and the semantic differences from it.
+
+### Required code
+
+1. **Tree and tile representation**
+   - immutable tile bounds and level/depth;
+   - parent and child relations;
+   - canonical tile identifiers independent of dense-array offsets;
+   - valid active-leaf partitions and ancestry checks;
+   - conversion between a partition, a dense label map, and active tile IDs.
+2. **Multiscale sensitivity builder**
+   - under the RHIME multiplicative-coefficient convention, construct candidate
+     tile columns by summing fine-grid observation contributions first;
+   - support only the block selected for multiscale aggregation;
+   - preserve a clear observation, tile, and optional source layout;
+   - document memory cost and padding behavior;
+   - expose weight/score construction separately from column aggregation.
+3. **Reference partition algorithms**
+   - cleaned Python threshold bisection;
+   - parity-tested Numba bisection as an optional acceleration;
+   - adapters to current `PartitionStep` implementations where their partition
+     representation is compatible.
+4. **Local moves**
+   - enumerate valid split and merge candidates;
+   - apply and reverse a move without mutating the input state;
+   - return forward and reverse log proposal probabilities;
+   - support a paired split-and-merge fixed-count proposal;
+   - use the standard-library `heapq` pattern through a small priority-queue
+     wrapper where priority-based greedy initialization is needed.
+5. **SA runner**
+   - explicit initial state, objective, temperature schedule, and random seed;
+   - correct handling of asymmetric proposals when configured as a sampler;
+   - optimizer mode that clearly reports that it is not posterior inference;
+   - diagnostics for objective, accepted move, tile count, and best state;
+   - no unbounded history retention by default.
+6. **Synthetic tests and fixtures**
+   - no private data loading;
+   - tile-sum identities against direct fine-grid sums;
+   - valid-partition invariants after every move;
+   - split/merge round trips;
+   - Python/Numba parity;
+   - deterministic SA smoke test;
+   - exact forward-model equality between gathered multiscale columns and a
+     direct aggregation of the fine-grid matrix.
+
+### Provisional migration map
+
+The target names are deliberately descriptive rather than API commitments.
+
+| Historical source | Behavior to preserve | Proposed repository destination | Treatment |
+| --- | --- | --- | --- |
+| `hist_14aug.make_multi` and `np_sum_adj` | dyadic adjacent aggregation | `experimental/dyadic/multiscale.py` | re-express with explicit axes, shapes, and padding |
+| `hist_14aug.make_weights` | sum observation contributions, then score candidate tiles | `experimental/dyadic/multiscale.py` and `scores.py` | split aggregation from scoring; resolve the inverse-error convention |
+| `hist_14aug.make_dyadic_graph`, `get_shape`, `get_ell`, `get_slice` | node relationships and grid slices | `experimental/dyadic/tree.py` | replace implicit array offsets with stable node IDs |
+| `hist_14aug.get_tiles`, `get_basis_array`, `basis_valid` | active-tile decoding, labels, and validity | `experimental/dyadic/state.py` | make state immutable and validation explicit |
+| `hist_14aug.get_split`, `get_merge`, `get_move`, `apply_move` | local partition transitions | `experimental/dyadic/proposals.py` | return new state plus forward/reverse log proposal probabilities |
+| `hist_14aug.dof_change` | cheap local score delta | `experimental/dyadic/scores.py` | test against full recomputation and current `_contrast.py` |
+| `hist_17aug.bucket_basis` | non-recursive threshold bisection | `experimental/dyadic/bisection.py` | retain one cleaned reference definition |
+| final useful `hist_17aug` Numba kernel | accelerated bisection | `experimental/dyadic/_numba.py` | add only after Python semantics and parity tests are fixed |
+| `hist_17aug.simulated_annealing` and `ApplyStepCondition` | local stochastic partition search | `experimental/dyadic/annealing.py` | rewrite around explicit objective, schedule, RNG, and diagnostics |
+| branch `b6ce565` | clean data structures and smoke tests | all modules above | use as scaffold, not as the scientific score definition |
+| merged `_constrained.py` | greedy queue, mask constraints, axis and inertial steps | existing module | reuse or adapt; do not copy prototype implementations |
+| merged `_contrast.py` | mass-preserving observation contrast and design scores | existing module | reuse as the canonical split-contrast algebra |
+
+The first Phase 0 PR should include this table in a package-level provenance
+file with exact source line/commit references updated at extraction time. Once
+the extracted tests cover the intended behavior, later design documents and
+issues should link to repository symbols rather than the historical paths.
+
+### Explicit exclusions
+
+Do not initially copy:
+
+- notebook data-loading code or absolute paths;
+- earlier overwritten SA definitions;
+- the broken masked optimizer experiments;
+- the brute-force SciPy threshold wrapper unless a benchmark demonstrates a
+  need for it;
+- duplicate inertial or constrained split implementations;
+- an API coupled to `fp_all`;
+- a PyMC step method before the standalone transition kernel is validated.
+
+### Phase 0 deliverables
+
+- one importable experimental package in this repository;
+- one synthetic SA example with plots or tabular diagnostics;
+- focused tests runnable without atmospheric data;
+- a provenance table mapping each retained function to its prototype source;
+- a short benchmark separating compile time, warm Numba time, Python time,
+  memory use, and problem shape.
+
+## Dyadic representation and validity
+
+### Established prototype behavior
+
+The original state is a dense indicator over all candidate dyadic rectangles.
+An active indicator denotes a current basis tile. A valid partition covers each
+included grid cell exactly once and contains no active ancestor/descendant pair.
+Splits replace one active tile with children. Merges replace a complete sibling
+set with their parent.
+
+The indicator is useful for cheap lookup and serialization, but it should not be
+the sole source of validity. An immutable partition state with an active-leaf set
+makes invariants explicit, while a dense indicator can be derived for vectorized
+calculations or trace output.
+
+### Split orientation in two dimensions
+
+There is an important complication hidden by the word "tree". If every
+rectangle may split along either the x or y axis, there is not one unique binary
+tree unless the orientation is part of the node state. Different split orders
+can also create the same final rectangles, which can unintentionally multiply
+prior mass.
+
+The first demo should choose one of:
+
+- a canonical orientation rule, such as alternating axes or using a fixed tree;
+- an explicit node decision in `{stop, split_x, split_y}` with a canonical
+  representation of equivalent partitions;
+- a quadtree in which a split has a fixed set of children.
+
+**Proposed:** begin with a canonical binary tree for exact inference. Keep the
+more flexible x/y choice in optimizer experiments until duplicate
+representations and prior probabilities are defined.
+
+## Objectives and what they mean
+
+### Degrees of freedom for signal
+
+For a suitable linear-Gaussian model, the degrees of freedom for signal (DFS)
+can be written as the trace of the averaging-kernel operator. One equivalent
+form is
+
+\[
+\operatorname{DFS}(P)
+= \operatorname{tr}\left[
+B_P H_P^T (H_P B_P H_P^T + R)^{-1} H_P
+\right].
+\]
+
+This is a principled information criterion only when the likelihood, prior,
+covariance definitions, and aggregation-error treatment match its derivation.
+The prototype calculations were specifically inspired by Bocquet, Wu, and
+Chevallier's multiscale control-space design, rather than only by this generic
+fixed-representation formula.
+
+In their notation, Equation (38) rewrites the DFS score for an admissible
+representation \(\omega\) as
+
+\[
+J_\omega
+= \operatorname{tr}\left[
+\Pi_\omega B H^T(R+HBH^T)^{-1}H
+\right],
+\]
+
+where \(\Pi_\omega\) is the representation projector. The denominator uses the
+fine-grid innovation covariance because their scale-covariant aggregation-error
+construction makes \(R_\omega+H_\omega B_\omega H_\omega^T=R+HBH^T\). Equation
+(39) then associates a normalized DFS contribution with each candidate tile.
+This gives the precomputed tile scores used by the prototype a clear source.
+
+That formulation is not automatically identical to recomputing the generic DFS
+formula independently for every gathered \(H_P\). Equivalence depends on using
+the same prolongation, prior covariance, normalization, and aggregation-error
+model as the paper. Phase 0 must write down which of these assumptions the
+prototype retained before its incremental `dof_change` is treated as an exact
+score.
+
+The paper describes coarse-graining its multiscale Jacobian by averaging. For a
+RHIME multiplicative region coefficient, the corresponding observation column
+is normally the sum of fine-cell footprint-times-flux contributions in that
+region. These are compatible only after the coefficient and prolongation
+normalizations are specified. The public reference implementation should test
+the RHIME forward-model identity directly instead of copying either "sum" or
+"average" without that convention.
+
+The same paper is also the source for the multiscale memory tradeoff: for a
+dyadic 2D-plus-time tiling dictionary it reports up to eight times the finest-grid
+Jacobian storage, while its more restrictive quaternary-tree spatial dictionary
+requires at most eight-thirds. Those factors apply to that hierarchy and should
+not be presented as universal costs for every dyadic implementation.
+
+For lognormal or other non-Gaussian priors, a Gaussian DFS is not the true
+partition posterior and should not be presented as one. It remains useful as:
+
+- an SA objective for generating efficient initial partitions;
+- an informed split/merge proposal score;
+- a pseudo-prior calibration statistic;
+- a first-stage delayed-acceptance screen;
+- a diagnostic for comparison with earlier experiments.
+
+The original SA used a DoFS-like change plus a one-sided penalty when the region
+count exceeded a target. It generally operated as fixed-temperature local
+search unless the caller changed temperature. It did not include a Hastings
+ratio, so it was not an exact fixed-temperature MCMC kernel. Those properties
+are acceptable for an optimizer if they are explicit.
+
+### Split-contrast score
+
+The repository's `_contrast.py` expresses a candidate split as one new
+observation-space contrast. If parent \(G\) has children \(A\) and \(B\), with
+prior masses \(\mu_A\), \(\mu_B\), and \(\mu_G=\mu_A+\mu_B\), define
+
+\[
+f_\delta
+= \frac{\mu_B}{\mu_G}h_A
+- \frac{\mu_A}{\mu_G}h_B.
+\]
+
+For contrast prior scale \(\tau\) and design covariance \(S\),
+
+\[
+\lambda = \tau^2 f_\delta^T S^{-1} f_\delta,
+\qquad
+\operatorname{DFS}_{\mathrm{contrast}} = \frac{\lambda}{1+\lambda},
+\qquad
+\operatorname{EIG}_{\mathrm{contrast}} = \frac{1}{2}\log(1+\lambda).
+\]
+
+These formulas explain why a precomputed multiscale sensitivity array makes
+local split scoring cheap: the new direction can be constructed from a few
+child-column lookups. They describe the conditional scalar information in the
+new contrast. They equal the global change between the complete parent and
+split models only when \(S\) is the appropriate baseline marginal or conditional
+covariance and the added contrast is independent under the stated Gaussian
+prior. Calibration still requires a scientifically meaningful contrast prior
+and covariance. Without those conditions, the repository's `delta_dfs` and
+`delta_eig` fields are ranking proxies rather than global partition deltas.
+
+Under those Gaussian conditions, with an independent zero-mean contrast prior
+and residual \(r\) centered under the baseline model, the corresponding local
+log Bayes factor also contains a residual-dependent term:
+
+\[
+\log BF_{1,0}
+= -\frac{1}{2}\log(1+\lambda)
++ \frac{1}{2}
+  \frac{\tau^2(f_\delta^T S^{-1}r)^2}{1+\lambda}.
+\]
+
+The first term penalizes the additional contrast and the second rewards fit to
+the realized observations. This makes the conceptual difference precise:
+\(\lambda\), DFS, and expected information describe what the observing system
+could resolve under the specified Gaussian design, while a marginal likelihood
+or Bayes factor also responds to the observed data.
+
+### Predictive and compression scores
+
+The OGI-048 experiments compare held-out full-grid modeled observations with
+modeled observations obtained after replacing the prior flux by region means.
+This is a useful compression score. It does not use observed mole fractions and
+is not posterior predictive accuracy.
+
+Directly comparing prior modeled observations with all multiplicative basis
+coefficients set to one is uninformative: any complete basis preserves the sum
+exactly, so the error is zero. A region-mean projected-flux comparison avoids
+that identity and measures information lost by compression.
+
+Additional useful scores are:
+
+- temporal or site holdout projected-flux NRMSE for basis construction;
+- observed-\(y\) posterior predictive RMSE or log predictive density after an
+  inversion;
+- an outer holdout for comparing tuning rules or complexity priors;
+- positive-versus-negative flux preservation where signed fluxes matter.
+
+### When holdout data are required
+
+Bayesian inference over \(P\) and \(x_P\) may use all observations once through
+the joint posterior. This is not double use of the data, and holdout is not
+required for the posterior to be mathematically valid.
+
+Holdout or cross-fitting becomes important when:
+
+- observations are used to select a single partition \(P^*\), after which an
+  ordinary fixed-partition posterior is reported without accounting for
+  selection uncertainty;
+- a complexity penalty, proposal heuristic, or approximation is tuned and then
+  assessed on the same observations;
+- predictive performance is the evaluation target.
+
+If holdout data tune the partition and are also used to report performance, an
+outer holdout or nested scheme is needed. Conversely, DoFS and projected-prior
+scores can depend on the observation operator and error model without using the
+realized observed values \(y\); this differs from fitting the partition directly
+to residuals.
+
+## Joint Bayesian target
+
+The desired non-Gaussian target is
+
+\[
+p(P,x_P,\theta\mid y)
+\propto
+p(y\mid x_P,P,\theta)
+p(x_P\mid P,\theta)
+p(P\mid\theta)
+p(\theta),
+\]
+
+where \(\theta\) includes observation-error, prior, boundary-condition, and
+other model parameters. A prior on \(P\) replaces the SA region-count penalty.
+Possibilities include a leaf-count prior or a depth-dependent split prior.
+
+The inference method must preserve this target. Scores used only for proposal
+selection do not need to equal the target, provided their forward and reverse
+proposal probabilities appear in the Metropolis-Hastings ratio. Approximate
+targets require a correction step if exact posterior inference is claimed.
+
+### Inference choices are composable
+
+"Collapsed," "fixed-count," "product-space," and "RJMCMC" answer different
+questions. Collapsing describes whether continuous parameters are integrated
+out. Fixed or variable count describes the partition support. Product-space and
+RJMCMC describe how parameters across models are represented and moved.
+
+| Choice | Strength | Main limitation | Recommended use |
+| --- | --- | --- | --- |
+| SA optimization | cheap use of local scores; good initialization | not posterior inference | first scientific demo and chain initialization |
+| fixed-\(K\) sampling | fixed continuous dimension and controlled comparison | does not infer uncertainty in \(K\) | first exact joint sampler |
+| Gaussian collapsing | exact fast structure scores when conjugate | not directly available for lognormal coefficients | tiny oracle, Gaussian benchmark, or conditional block |
+| product space | globally fixed dimension and ordinary fixed-shape traces | memory, pseudo-priors, and inactive-variable geometry | preferred variable-\(K\) prototype after fixed-\(K\) |
+| RJMCMC | native packed variable-dimensional state | mappings, Jacobians, proposals, and ragged output | defer until product-space limitations are measured |
+
+For example, one can run collapsed fixed-\(K\) partition sampling, collapsed
+variable-\(K\) product-space sampling, or non-collapsed RJMCMC. The terms are
+not competing names for one decision.
+
+## Collapsed partition inference
+
+### Exact linear-Gaussian case
+
+With a Gaussian likelihood and conditionally Gaussian prior, coefficients can
+be integrated out:
+
+\[
+p(P\mid y) \propto p(y\mid P)p(P).
+\]
+
+This is not "basis selection only" in the sense of discarding coefficient
+uncertainty. The joint posterior factorizes as
+
+\[
+p(P,x_P\mid y)=p(P\mid y)p(x_P\mid P,y).
+\]
+
+One may sample \(P\) from its marginal posterior and then draw \(x_P\) from its
+conditional posterior. Model-averaged quantities follow from both draws.
+
+Using the same \(y\) in these two conditional operations is not double counting;
+it is ordinary probability factorization. The problematic workflow is selecting
+one \(P^*\) from \(y\), treating it as fixed, and reporting a conditional
+posterior as though no selection occurred.
+
+### Non-Gaussian case
+
+For lognormal \(x_P\), the coefficient integral is generally unavailable.
+Laplace integration can provide an approximate partition score, initializer, or
+proposal. It is not exact merely because the subsequent coefficient update uses
+NUTS. Exact alternatives include:
+
+- delayed acceptance with a final exact likelihood/prior correction;
+- an unbiased pseudo-marginal likelihood estimator;
+- direct joint sampling of partition and continuous state.
+
+The first two need separate numerical validation. In particular, plugging a
+biased approximate marginal likelihood directly into MH generally changes the
+stationary distribution.
+
+## Fixed-count joint inference
+
+**Proposed first joint sampler.** Keep \(K(P)=K\) constant by proposing a split
+in one part of the partition and a merge elsewhere. Store a continuous vector of
+fixed length \(K\), gather the active multiscale columns, and update the
+continuous parameters conditional on the current partition.
+
+This is ordinary Metropolis-Hastings-within-Gibbs, not RJMCMC, because the
+continuous state remains in \(\mathbb{R}^K\). It still needs:
+
+- a reversible pairing between old and proposed coefficients, or a proposal for
+  the proposed partition's coefficients;
+- forward and reverse probabilities for selecting split and merge candidates;
+- exact likelihood and prior evaluation;
+- tests that the gathered \(H_P\) is in the same order as \(x_P\).
+
+This experiment answers whether local partition moves and conditional NUTS mix
+adequately before variable dimension and pseudo-priors are introduced.
+
+## Product-space inference with pseudo-priors
+
+### Construction
+
+Let \(z\) contain coordinates for every potential tree node or split contrast.
+For partition \(P\), let \(z_A\) denote active coordinates and \(z_I\) inactive
+coordinates. A product-space target has the form
+
+\[
+\pi(P,z,\theta)
+\propto
+p(P)
+p(y\mid P,z_A,\theta)
+p(z_A\mid P,\theta)
+q_P(z_I\mid\theta)
+p(\theta),
+\]
+
+where \(q_P\) is a proper pseudo-prior that integrates to one. The full state
+dimension is fixed. The inactive variables are not multiplied by zero and then
+forgotten; their pseudo-prior densities are part of the augmented target and
+strongly affect switching efficiency.
+
+This is the Carlin-Chib product-space construction. Dellaportas, Forster, and
+Ntzoufras (2002), especially their discussion of Carlin-Chib and Metropolised
+Carlin-Chib methods, is an appropriate comparison reference. The foundational
+pseudo-prior reference is Carlin and Chib (1995).
+
+### Is it different from RJMCMC?
+
+Yes, if the complete parameter vector is fixed and proper pseudo-priors define
+the inactive coordinates. There is then no map between Euclidean spaces of
+different dimensions and no reversible-jump Jacobian.
+
+No, if the implementation keeps only a packed active vector whose length changes
+with \(K(P)\). A fixed-length indicator or multiscale matrix does not alter that
+mathematical dimension change. A sampler that constructs and destroys active
+coefficients must perform the equivalent of RJ dimension matching even if the
+bookkeeping is described differently.
+
+### Are there three Gibbs steps?
+
+There are naturally three update blocks, but they are not all necessarily Gibbs
+updates:
+
+1. **Inactive pseudo-prior refresh.** Draw selected inactive coordinates from
+   \(q_P\). This can be an exact Gibbs/direct draw when \(q_P\) is simple.
+2. **Partition update.** Propose a valid split/merge or tree decision and accept
+   it using the augmented target. This is normally MH. Original finite-model
+   Carlin-Chib can Gibbs-sample a model indicator when all model probabilities
+   can be enumerated; that is unrealistic for a large partition space.
+3. **Active continuous update.** Update active coefficients and shared
+   hyperparameters conditional on \(P\), potentially using NUTS.
+
+A practical order is inactive refresh, partition move, active update, so newly
+activated coordinates have plausible values. It is not necessary to refresh
+every inactive coordinate on every sweep. A proposal can draw only the
+coordinates required by a proposed split and include that draw in its proposal
+density.
+
+### PyMC feasibility
+
+PyMC supports compound step methods for fixed model graphs and can combine
+Metropolis-family updates with NUTS. That does not automatically provide
+dynamic active-only NUTS:
+
+- NUTS normally has a fixed compiled variable list and fixed point shapes;
+- applying NUTS to every potential tile may make the dimension and inactive
+  geometry unnecessarily large;
+- changing the set of NUTS variables with \(P\) likely requires custom sampler
+  orchestration, cached conditional kernels, or a fixed-count packed state;
+- changes in discrete structure can alter continuous geometry and make a single
+  globally adapted mass matrix inefficient. Once tuning is frozen, a mismatched
+  metric affects performance rather than invalidating a correctly
+  Metropolis-corrected NUTS kernel;
+- PyMC's external NUTS backends require a fully continuous model. An initial
+  mixed discrete/continuous product-space prototype would therefore need native
+  `nuts_sampler="pymc"` or framework-independent outer orchestration rather than
+  the NumPyro, BlackJAX, or nutpie routes.
+
+Therefore the initial fixed-count sampler should precede a PyMC product-space
+integration. The partition transition kernel should be framework-independent
+and tested before wrapping it as a PyMC step method.
+
+## Tree of split contrasts
+
+### Motivation
+
+A coefficient for every possible tile is redundant because parent and child
+coefficients describe overlapping common modes. A tree of contrasts instead
+stores:
+
+- one root/common coefficient;
+- one potential contrast \(\delta_v\) for each potential split;
+- partition decisions that activate an ancestry-closed subset of contrasts.
+
+This gives each split one explicit new degree of freedom and aligns directly
+with the cheap split-contrast calculation in `_contrast.py`.
+
+### Additive mass-preserving transform
+
+For parent \(G=A\cup B\), let \(\alpha_G\) be the parent coefficient and
+\(\delta=\alpha_A-\alpha_B\). Define
+
+\[
+\alpha_A
+= \alpha_G + \frac{\mu_B}{\mu_G}\delta,
+\qquad
+\alpha_B
+= \alpha_G - \frac{\mu_A}{\mu_G}\delta.
+\]
+
+Then
+
+\[
+\mu_A\alpha_A + \mu_B\alpha_B = \mu_G\alpha_G.
+\]
+
+The absolute Jacobian determinant of
+\((\alpha_G,\delta)\mapsto(\alpha_A,\alpha_B)\) is one. Swapping the child order
+changes the signs of \(\delta\) and \(f_\delta\), but does not change the scalar
+information scores.
+
+Activating \(\delta\) preserves the parent common mode while adding exactly the
+child contrast direction \(f_\delta\) defined earlier.
+
+### Positive/lognormal transform
+
+For positive multiplicative coefficients, write \(x=\exp(z)\) and let
+\(\delta=z_A-z_B\). An exact positive mass-preserving transform is
+
+\[
+x_B
+= \frac{\mu_G x_G}{\mu_A\exp(\delta)+\mu_B},
+\qquad
+x_A = \exp(\delta)x_B.
+\]
+
+This preserves \(\mu_Ax_A+\mu_Bx_B=\mu_Gx_G\) and gives a useful positive split
+coordinate. It does not preserve independent lognormal priors on the child
+coefficients: Gaussian root and contrast coordinates generally induce
+correlated, non-lognormal child marginals because of the normalizing
+denominator. The prior must be defined and evaluated in one parameterization
+rather than inferred from positivity alone.
+
+In a product-space parameterization all potential \(\delta_v\) already exist,
+so changing activation changes only the deterministic mapping to leaf
+coefficients. There is no dimension-changing Jacobian. In a packed
+trans-dimensional implementation, the same transform can serve as an RJMCMC
+dimension-matching map. For the map
+\((x_G,\delta)\mapsto(x_A,x_B)\), its absolute Jacobian
+\(x_Ax_B/x_G\) must be included.
+
+### Cheap DoFS and local Gaussian proposals
+
+Under a local Gaussian approximation, the new contrast has scalar information
+\(\lambda\) as defined above. Given residual \(r\), a Gaussian prior variance
+\(\tau^2\), and observation covariance \(R\), a local conditional approximation
+is
+
+\[
+V_\delta
+= \left(\tau^{-2}+f_\delta^T R^{-1}f_\delta\right)^{-1},
+\qquad
+m_\delta
+= V_\delta f_\delta^T R^{-1}r.
+\]
+
+This can initialize or propose a newly active contrast and can guide its
+pseudo-prior. For a non-Gaussian positive model it remains a local surrogate;
+the true non-Gaussian likelihood and prior must determine final acceptance.
+
+### Open contrast questions
+
+- What mass \(\mu\) should be preserved: area, prior flux, absolute flux, or a
+  group-specific quantity?
+- Should the prior be specified directly on tree contrasts or induced from a
+  desired prior on leaf coefficients?
+- How should contrast scales vary by depth, tile area, land/ocean class, or
+  inner/outer group?
+- Does the positive transform give adequate NUTS geometry near very small
+  coefficients?
+- How should x/y split orientation be encoded without duplicate partition
+  representations?
+
+## Masks, layers, and grouped state vectors
+
+Land/ocean, country, positive/negative flux, user rectangles, and inner/outer
+regions are not merely plotting metadata. They can define hard boundaries,
+different weight fields, different priors, and different posterior summaries.
+
+The current fixed-layout design should remain the external representation:
+
+- `BasisLayout` identifies partitions and groups;
+- xarray coordinates identify group, partition, and local region in retained
+  artifacts;
+- fixed InTEM outer regions remain a familiar compatibility option;
+- inner and outer generated regions can use different weights.
+
+Dynamic inference needs an additional immutable `PartitionState` with active
+tile IDs, decisions, and group-local topology. It should not mutate
+`BasisLayout` on every MCMC transition. A sampled or selected partition can be
+converted to `BasisLayout` for output, plotting, or a subsequent fixed-basis
+inversion.
+
+**Proposed initial scope:** run one independent dyadic tree per hard class or
+group. Allocate or infer complexity within each group and combine their active
+columns in a stable group order. This avoids tiles crossing land/ocean or
+inner/outer boundaries. Layer intersections and disconnected components should
+be resolved before tree construction and flagged when they produce tiny or
+pathological parts.
+
+## Filtering and data flow
+
+The current compatibility weight in `_functions.py` multiplies temporal mean
+flux by the measurement-weighted mean footprint. Absolute flux is optional and
+off by default. A scientifically common alternative is to form time-resolved
+footprint-times-flux contributions, often using absolute flux, and then average
+over retained sites and times. These definitions are not generally equivalent
+and should be named separately. Under either data-dependent definition, if
+observations are filtered after the calculation, rejected observations influence
+the basis even though they do not enter the inversion.
+
+**Required ordering:** load data, apply all observation filters, construct the
+fine-grid contribution matrix from retained observations, then build multiscale
+columns and weights. Any train/holdout split must occur before basis fitting for
+the corresponding evaluation.
+
+The prepared experimental input should contain at least:
+
+- retained \(y\), uncertainty/covariance inputs, and observation coordinates;
+- the unreduced fine-grid contribution block \(G\);
+- fixed design blocks such as boundary conditions;
+- grid coordinates, cell area, and hard region classes;
+- source/group metadata;
+- a record of filtering and any train/holdout membership.
+
+This is intentionally lower level than `fp_all`. Weight builders can adapt
+footprints and flux into \(G\), but the partition algorithms should consume
+NumPy arrays and explicit metadata.
+
+## Proposed implementation sequence
+
+### Phase 0: public code consolidation
+
+Implement the package, demo, tests, provenance table, and benchmark described
+above. Do not add MCMC yet.
+
+### Phase 1: scientifically faithful SA demo
+
+1. Build multiscale observation columns with the raw prototype's sum-then-score
+   semantics.
+2. Initialize with the current greedy or bisection partitioner.
+3. Offer explicit objective components: Gaussian DFS/contrast proxy, projected
+   flux compression, and complexity prior/penalty.
+4. Add a real cooling schedule and best-state tracking.
+5. Compare against direct recomputation on small problems.
+6. Demonstrate optional hard land/ocean and inner/outer classes.
+
+The result is an optimizer and experimental basis generator, not posterior
+inference.
+
+### Phase 2: exact fixed-count joint sampler
+
+1. Implement paired split-and-merge proposals with exact proposal ratios.
+2. Gather \(H_P\) into a fixed \(K\)-column operator.
+3. Update the fixed-length continuous state conditional on \(P\).
+4. Use the true non-Gaussian model target for partition acceptance.
+5. Use SA/contrast only for initialization or informed proposals.
+6. Validate against exhaustive enumeration on a tiny tree.
+
+This phase establishes whether active-only conditional NUTS and local partition
+moves are viable without pseudo-prior complexity.
+
+### Phase 3: tree-contrast product-space prototype
+
+1. Build a tiny variable-count enumerator that provides exact partition
+   probabilities for the chosen tree and priors.
+2. Choose a canonical tree and define the full contrast coordinate set.
+3. Specify proper pseudo-priors, initially from local Gaussian approximations.
+4. Implement inactive refresh, partition MH, and active continuous update as
+   separate framework-independent blocks.
+5. Compare full-vector, active-only, and cached-kernel execution strategies.
+6. Measure partition switching, active and inactive effective sample sizes,
+   likelihood cost, and sensitivity to pseudo-prior calibration.
+7. Compare posterior results with exact enumeration and Phase 2 fixed-count
+   results.
+
+### Phase 4: scale-up and alternatives
+
+Only after Phases 2 and 3:
+
+- scale variable-count inference to realistic trees and assess alternative
+  partition and leaf-count priors;
+- compare product-space with a direct RJMCMC split/merge implementation;
+- evaluate delayed acceptance using DFS, contrast, or Laplace surrogates;
+- investigate SMC or parallel tempering for multimodal partitions;
+- consider pseudo-marginal methods only if an unbiased useful estimator exists;
+- support multiple independently optimized groups and time-varying partitions.
+
+## Validation requirements
+
+### Deterministic and algebraic tests
+
+- every valid partition covers each included cell exactly once;
+- no active node has an active ancestor or descendant;
+- every split has a valid inverse merge;
+- proposal probabilities normalize on tiny states;
+- additive and positive contrast transforms preserve their stated mass;
+- gathered multiscale columns equal direct fine-grid aggregation;
+- Python and Numba kernels agree over random small arrays;
+- label and grouped-layout conversion preserves stable ordering.
+
+### MCMC correctness tests
+
+- detailed balance for every transition on a tiny enumerated state space;
+- sampled partition frequencies agree with exact probabilities in a conjugate
+  toy model;
+- fixed-partition continuous results agree with the ordinary model;
+- product-space marginal probabilities are invariant to normalized
+  pseudo-priors, within Monte Carlo error;
+- simulation-based calibration or posterior coverage for a small generated
+  problem;
+- checkpoint/restart reproduces the transition stream from saved RNG state.
+
+### Scientific evaluation
+
+- train/holdout projected-flux compression from OGI-048;
+- posterior predictive performance on an outer holdout;
+- DFS or expected-information diagnostics under their calibrated Gaussian
+  assumptions;
+- sensitivity to complexity priors, pseudo-priors, tree orientation, and group
+  boundaries;
+- land/ocean and inner/outer posterior summaries using group metadata;
+- runtime and memory scaling in observations, fine cells, possible tiles, and
+  active tiles.
+
+## Risks and exactness boundaries
+
+- A toy pre-summed weight tree is not a faithful replacement for multiscale
+  observation columns.
+- A fixed indicator does not make a packed variable-length coefficient state
+  fixed-dimensional.
+- An uncorrected Laplace, DoFS, or projected-flux acceptance rule targets an
+  approximation, not the desired posterior.
+- Poor pseudo-priors can make a formally correct product-space chain practically
+  immobile.
+- Applying NUTS to all potential inactive coordinates may remove the intended
+  computational advantage.
+- Reusing one adapted NUTS geometry across substantially different partitions
+  may mix poorly even when the compound chain is valid.
+- Allowing arbitrary x/y split histories can assign unintended multiplicity to
+  equivalent partitions.
+- Dynamic ragged region coordinates do not fit ordinary xarray traces. Store
+  fixed node decisions/contrasts or cell-level reconstructed fields during
+  sampling, and convert selected partitions to fixed layouts afterward.
+- Data filtering after basis construction leaks excluded observations into the
+  basis design.
+
+## Open design questions
+
+1. Is the first exact demonstration fixed \(K\) only, or should a tiny conjugate
+   variable-\(K\) enumerator be built alongside it as a test oracle?
+2. Which canonical dyadic tree best matches the useful partitions: alternating
+   binary axes, geometry-chosen axes recorded in the state, or quadtree splits?
+3. What is the intended formula and convention for the prototype's inverse-error
+   input to `make_weights`?
+4. Should multiscale columns be stored densely, chunked by observation/tile, or
+   generated through prefix sums and an operator interface?
+5. Which variables define \(\mu\) and the contrast prior at each split?
+6. Can group-specific trees share a total complexity prior while retaining
+   independent weights and priors?
+7. Is a custom PyMC step method sufficient, or should partition inference use a
+   framework-independent outer sampler that calls cached PyMC conditional
+   kernels?
+8. Which pseudo-prior family gives acceptable switching for lognormal contrasts?
+9. Should the first delayed-acceptance experiment use the existing contrast
+   score, a Laplace approximation, or both?
+10. What trace representation is needed for posterior maps, group summaries,
+    and model averaging without a ragged `region` dimension?
+
+## References
+
+### Statistical and inverse-problem references
+
+- Andrieu, C. and Roberts, G. O. (2009). "The pseudo-marginal approach for
+  efficient Monte Carlo computations." *The Annals of Statistics*, 37(2),
+  697-725. <https://doi.org/10.1214/07-AOS574>.
+- Bocquet, M., Wu, L., and Chevallier, F. (2011). "Bayesian design of control
+  space for optimal assimilation of observations. Part I: Consistent multiscale
+  formalism." *Quarterly Journal of the Royal Meteorological Society*, 137(658),
+  1340-1356. <https://doi.org/10.1002/qj.837>.
+- Carlin, B. P. and Chib, S. (1995). "Bayesian Model Choice Via Markov Chain
+  Monte Carlo Methods." *Journal of the Royal Statistical Society: Series B*,
+  57(3), 473-484. <https://doi.org/10.1111/j.2517-6161.1995.tb02042.x>.
+- Christen, J. A. and Fox, C. (2005). "Markov chain Monte Carlo Using an
+  Approximation." *Journal of Computational and Graphical Statistics*, 14(4),
+  795-810. <https://doi.org/10.1198/106186005X76983>.
+- Dellaportas, P., Forster, J. J., and Ntzoufras, I. (2002). "On Bayesian model
+  and variable selection using MCMC." *Statistics and Computing*, 12(1), 27-36.
+  <https://doi.org/10.1023/A:1013164120801>.
+- Godsill, S. J. (2001). "On the Relationship Between Markov Chain Monte Carlo
+  Methods for Model Uncertainty." *Journal of Computational and Graphical
+  Statistics*, 10(2), 230-248.
+  <https://doi.org/10.1198/10618600152627924>.
+- Green, P. J. (1995). "Reversible jump Markov chain Monte Carlo computation and
+  Bayesian model determination." *Biometrika*, 82(4), 711-732.
+  <https://doi.org/10.1093/biomet/82.4.711>.
+
+The Dellaportas citation is sometimes reported incorrectly as volume 16, pages
+57-68. The verified 2002 article is volume 12(1), pages 27-36. Volume 16,
+pages 57-68 corresponds to a different Dellaportas paper.
+
+### Software reference
+
+- PyMC, "Compound Steps in Sampling." The example documents fixed-graph
+  Metropolis-within-Gibbs combinations and cautions about changing continuous
+  geometry when discrete and NUTS updates are mixed:
+  <https://www.pymc.io/projects/examples/en/stable/howto/sampling_compound_step.html>.
+- PyMC, `pymc.sample` API. This records the current native and external NUTS
+  sampler options and the continuous-model restriction on external samplers:
+  <https://www.pymc.io/projects/docs/en/stable/api/generated/pymc.sample.html>.
+
+### Repository reference points
+
+- `docs/plans/mask_constrained_basis.md`
+- `docs/plans/state_vector_grouping.md`
+- `docs/plans/fixed_outer_regions_grouping.md`
+- `docs/plans/ogi_048_basis_algorithm_options.md`
+- `openghg_inversions/basis/algorithms/_constrained.py`
+- `openghg_inversions/basis/algorithms/_contrast.py`
+- `openghg_inversions/basis/layout.py`
+- `openghg_inversions/basis/operators.py`
+- `openghg_inversions/basis/basis_functions.py`
+- branch `codex/basis-prototype-examples`, commit `b6ce565`

--- a/docs/plans/dyadic_partition_inference.md
+++ b/docs/plans/dyadic_partition_inference.md
@@ -36,21 +36,23 @@ This note distinguishes three statuses:
    SA runner before implementing joint MCMC. This is Phase 0 below.
 2. **Proposed:** retain SA as a useful optimizer and initializer. Do not describe
    its DoFS-like energy as a non-Gaussian posterior target.
-3. **Proposed:** make the first joint-inference demonstration fixed-region-count.
-   A paired split-and-merge proposal keeps the continuous dimension fixed and
-   avoids trans-dimensional bookkeeping while testing the important likelihood,
-   partition, and coefficient interactions.
-4. **Proposed:** investigate a tree-contrast product-space sampler next. It is a
+3. **Proposed:** make the first statistically exact demonstration fixed-count
+   and linear-Gaussian, with the continuous coefficients analytically collapsed.
+   This tests partition probabilities and DoFS-informed local proposals without
+   requiring NUTS adaptation or coefficient transport.
+4. **Proposed:** treat non-Gaussian fixed-count continuous sampling as a later
+   experiment, not as a prerequisite for the partition proof of concept.
+5. **Proposed:** investigate a tree-contrast product-space sampler next. It is a
    genuine fixed-dimensional alternative to RJMCMC when all potential node
    parameters and proper pseudo-priors are included in the augmented state.
-5. **Established:** storing a fixed indicator over all possible multiscale tiles
+6. **Established:** storing a fixed indicator over all possible multiscale tiles
    does not by itself avoid RJMCMC. If the mathematical continuous state is a
    packed vector whose dimension changes with the number of active tiles, the
    method is trans-dimensional regardless of how the indicator is stored.
-6. **Proposed:** use exact likelihood and prior terms for final partition
+7. **Proposed:** use exact likelihood and prior terms for final partition
    acceptance. DoFS, split-contrast, projected-flux, or Laplace scores may inform
    proposals, initialize chains, or provide a delayed-acceptance first stage.
-7. **Proposed:** represent land/ocean, country, inner/outer, and other hard
+8. **Proposed:** represent land/ocean, country, inner/outer, and other hard
    partitions as constraints and groups around the dyadic optimizer. Filtering
    of observations must occur before any data-dependent basis weights are built.
 
@@ -601,10 +603,82 @@ stationary distribution.
 
 ## Fixed-count joint inference
 
-**Proposed first joint sampler.** Keep \(K(P)=K\) constant by proposing a split
-in one part of the partition and a merge elsewhere. Store a continuous vector of
-fixed length \(K\), gather the active multiscale columns, and update the
-continuous parameters conditional on the current partition.
+Keep \(K(P)=K\) constant by proposing a split in one part of the partition and a
+merge elsewhere. There are two materially different fixed-count experiments.
+
+### Collapsed Gaussian fixed-count sampler
+
+**Proposed first exact partition sampler.** Suppose
+
+\[
+x_P\mid P \sim N(m_P,B_P),
+\qquad
+y\mid x_P,P \sim N(b+H_Px_P,R).
+\]
+
+For this benchmark, \(b\), \(m_P\), \(B_P\), and \(R\) are fixed model inputs.
+Estimating partition-specific nuisance parameters and then substituting their
+point estimates into the expression below would be an empirical-Bayes
+approximation, not the same collapsed posterior. Gaussian nuisance terms can be
+included by enlarging the Gaussian state and collapsing them jointly; unknown
+scales, truncations, and other non-Gaussian terms require separate treatment.
+
+Then
+
+\[
+y\mid P \sim N(b+H_Pm_P,S_P),
+\qquad
+S_P=R+H_PB_PH_P^T,
+\]
+
+with residual \(r_P=y-b-H_Pm_P\). The exact log marginal likelihood is
+
+\[
+\log p(y\mid P)
+=-\frac{1}{2}\left[
+n\log(2\pi)+\log|S_P|+r_P^TS_P^{-1}r_P
+\right].
+\]
+
+It should be evaluated by a Cholesky factor \(S_P=L_PL_P^T\), using
+\(2\sum_i\log(L_P)_{ii}\) for the log determinant and a triangular solve for
+the quadratic form. For the benchmark, require symmetric positive-definite
+\(R\) and proper \(B_P\), and report a diagnostic failure rather than silently
+adding arbitrary jitter.
+
+The fixed-count target is
+
+\[
+\pi_K(P)
+\propto
+p(y\mid P)p(P\mid K),
+\qquad P\in\mathcal P_K.
+\]
+
+This sampler has no continuous state during the partition update. It therefore
+needs neither NUTS nor a split/merge coefficient transform. Conditional Gaussian
+coefficient draws can be generated afterward when model-averaged coefficient or
+field summaries are required.
+
+The exact conditional moments are
+
+\[
+m_{P\mid y}
+=m_P+B_PH_P^TS_P^{-1}r_P,
+\qquad
+B_{P\mid y}
+=B_P-B_PH_P^TS_P^{-1}H_PB_P.
+\]
+
+This is the smallest statistically defensible route from the stochastic local
+search to posterior partition inference. It also supplies an exact oracle for
+testing later non-Gaussian methods.
+
+### Non-Gaussian fixed-count sampler
+
+For the intended lognormal model, retain a continuous vector of fixed length
+\(K\), gather the active multiscale columns, and update the continuous parameters
+conditional on the current partition.
 
 This is ordinary Metropolis-Hastings-within-Gibbs, not RJMCMC, because the
 continuous state remains in \(\mathbb{R}^K\). It still needs:
@@ -617,6 +691,288 @@ continuous state remains in \(\mathbb{R}^K\). It still needs:
 
 This experiment answers whether local partition moves and conditional NUTS mix
 adequately before variable dimension and pseudo-priors are introduced.
+
+### NUTS feasibility and deferred work
+
+Fixed dimension is sufficient for a valid conditional NUTS trajectory, but it
+does not give packed coefficient positions stable spatial meaning. PyMC's native
+compound sampler learns one step size and one metric per NUTS instance and
+chain. During warmup, all visited partitions feed those same adapters without a
+partition label. The resulting metric is either dominated by the partitions
+visited during warmup or is a generic compromise across their different
+conditional geometries.
+
+Once adaptation is frozen, a positive-definite but poorly matched metric affects
+efficiency rather than the invariant distribution. The practical risks are
+divergences, excessive tree depth, very small global step size, and failure to
+move after reaching a partition not represented during warmup.
+
+Any later conditional-NUTS experiment should therefore use:
+
+- canonical node IDs as region identity, with packed indices derived only for
+  computation;
+- exact agreement between coefficient packing and \(H_P\) column order;
+- prior-whitened log-coefficients;
+- identity or diagonal geometry before dense adaptation is considered;
+- structure moves active throughout discarded warmup;
+- several distinct valid initial partitions;
+- adaptation frozen for all retained draws;
+- diagnostics stratified by structural summaries rather than only by packed
+  coefficient index.
+
+PyMC has no built-in structure-indexed metric or step-size cache. A joint
+partition move that also transports affected coefficients requires a custom
+step or external orchestrator; the default compound assignment will not design
+that transport. External NUTS backends are not available when a separate
+discrete step is present, so this route would initially use native PyMC NUTS.
+
+This work is intentionally deferred. Elliptical slice sampling, pCN, or a simple
+fixed diagonal HMC kernel in prior-whitened coordinates are useful exact
+comparators for the lognormal model because they do not require one learned
+posterior metric to remain meaningful across partitions.
+
+## Hackathon proof of concept
+
+### Objective
+
+Demonstrate that the existing DoFS-guided stochastic local search (SLS) can
+become an exact posterior partition sampler under a transparent linear-Gaussian
+toy model.
+The DoFS calculation guides computation but does not replace the likelihood,
+coefficient prior, or partition prior.
+
+The minimum successful result is fixed \(K\). Variable \(K\) is a stretch goal
+that is unusually accessible in the collapsed Gaussian case because there is no
+variable-dimensional coefficient vector left in the sampled state.
+
+### Metropolized local search
+
+Let \(\mathcal N_K(P)\) be the unique fixed-count neighboring partitions
+obtained by one compatible split and one compatible merge. Enumerate neighbors
+as canonical partitions, not as move histories, because more than one history
+may otherwise produce the same proposed state.
+
+If the implementation first enumerates move paths rather than unique states,
+the proposal probability for \(P'\) is the sum over every path that produces
+\(P'\). Deduplicating states without summing their path probabilities would
+change the proposal law.
+
+For the linear-Gaussian model, define the full DoFS diagnostic
+
+\[
+D(P)=\operatorname{tr}\left[
+B_PH_P^TS_P^{-1}H_P
+\right].
+\]
+
+The neighbor score \(d(P,P')\) can be \(D(P')\), or equivalently
+\(D(P')-D(P)\) within a fixed current-state normalization. A prototype local
+split-contrast calculation may replace this only after it is shown to rank or
+reproduce the direct full-matrix change under the benchmark assumptions. Define
+the proposal with a uniform floor:
+
+\[
+q_\beta(P'\mid P)
+= \frac{\varepsilon}{|\mathcal N_K(P)|}
++ (1-\varepsilon)
+  \frac{\exp\{\beta d(P,P')\}}
+       {\sum_{Q\in\mathcal N_K(P)}\exp\{\beta d(P,Q)\}}.
+\]
+
+Use stable log-sum-exp evaluation. The floor protects irreducibility and avoids
+turning a heuristic zero into an impossible posterior transition. The exact MH
+acceptance probability is
+
+\[
+\alpha(P,P')
+= \min\left\{
+1,
+\frac{p(y\mid P')p(P'\mid K)q_\beta(P\mid P')}
+     {p(y\mid P )p(P \mid K)q_\beta(P'\mid P)}
+\right\}.
+\]
+
+This is a one-step Metropolized version of the local search. The DoFS score and
+proposal temperature \(\beta\) affect efficiency but not the target. Choose or
+tune \(\beta\) during pilot runs, then freeze it before retaining production
+draws. The reverse normalizer must be recomputed on \(\mathcal N_K(P')\).
+
+Include an explicit lazy/self-loop probability so aperiodicity does not depend
+on a rejection happening somewhere. For a fixed finite binary tree, valid
+remove-maximal-split/add-feasible-split exchanges should connect the fixed-count
+frontiers; verify this on every enumerated toy support because mixed split
+arities, hard masks, per-group count constraints, or score thresholds can break
+that argument.
+
+Do not use a long stochastic-search trajectory as one proposal in the first
+demo: its total forward and reverse path probabilities are harder to compute.
+The existing search remains valuable as an initializer. Exact delayed
+acceptance with a DoFS first stage is another future option, but it is not needed
+for the minimum demonstration.
+
+### Partition prior
+
+For the toy fixed-count target, begin with either:
+
+- a uniform prior over unique valid canonical \(K\)-leaf partitions; or
+- a stated depth-dependent tree prior conditioned on \(K\).
+
+A prior depending only on \(K\) is constant in the fixed-count experiment. A
+uniform distribution over split histories is not generally uniform over
+geometric partitions. The implementation must test that the fixed-count neighbor
+graph is connected for every demonstrated \(K\).
+
+The coefficient prior across partitions is a separate and consequential model
+choice. Using \(B_P=\tau_x^2I_K\) and a fixed prior mean is acceptable for the
+toy, but independent equal-variance region multipliers at every resolution do
+not generally induce the same fine-grid prior. Marginal likelihood, especially
+when \(K\) varies, can be dominated by this normalization. The demo must label
+the convention as a benchmark prior and compare its induced fine-grid mean and
+covariance across several partitions. A coherent later alternative is a
+tree-contrast prior or an explicitly induced fine-grid prior with documented
+mass/depth scaling.
+
+For the variable-count stretch goal, add an explicit \(p(K)\) or an unconditioned
+proper tree prior and use separate split and merge proposals with their complete
+candidate-count and direction probabilities. Because \(x_P\) remains collapsed,
+this is a discrete-space MH extension rather than RJMCMC.
+
+If fixed-count and variable-count kernels are mixed, use fixed mixture weights
+or include any state-dependent mixture normalization in the transition
+probability. State-dependent selection among individually invariant kernels is
+not automatically invariant.
+
+### Synthetic experiment
+
+Use a small canonical binary tree and completely synthetic arrays first:
+
+1. Construct smooth footprint-like rows over a small grid and a base flux field.
+2. Select a hidden valid partition and Gaussian region coefficients.
+3. Form \(H_P\) by summing fine-cell footprint-times-flux contributions within
+   each active region.
+4. Simulate \(y=H_Px_P+\epsilon\) with known \(R\).
+5. Use the same declared \(B_P\), \(R\), and aggregation convention in the DoFS
+   score and collapsed target.
+
+For any later OGI example, apply observation filtering before constructing the
+fine-grid or multiscale \(H\) and before computing DoFS proposal scores. A basis
+proposal influenced by observations that are later excluded is a different
+data-dependent procedure and can leak filtered information into the design.
+
+For a very small tree, enumerate all valid fixed-count partitions and normalize
+their exact posterior probabilities. This is the test oracle. The MCMC
+frequencies must agree with it within Monte Carlo error before scaling up.
+
+Construct the oracle independently of the sampler transition helpers. Build the
+full transition matrix and verify row normalization, pairwise detailed balance,
+\(\pi^TT=\pi^T\), graph connectivity, and agreement between its stationary
+distribution and the independently normalized target. Include unequal neighbor
+counts, duplicate move paths, extreme DoFS scores, nonzero prior means, and leaf
+ordering permutations in focused tests.
+
+Useful demo outputs are:
+
+- initial greedy partition, best local-search partition, posterior MAP
+  partition, and posterior cell-level split probabilities;
+- DoFS and collapsed log-posterior traces shown separately;
+- empirical versus exactly enumerated partition probabilities;
+- uniform-neighbor versus DoFS-informed proposal acceptance and partition ESS;
+- optional posterior \(K\) for the variable-count stretch goal.
+
+An OGI footprint/flux case is a follow-up only after the synthetic oracle works.
+The real-data route adds loading, filtering, covariance, and scientific-prior
+questions without strengthening the first correctness demonstration.
+
+### Initial states and poor local mixing
+
+The empirical observation that bucket, quadtree, or greedy construction gives a
+much better start than growth from one root is expected. Local split/merge moves
+must traverse a long, narrow graph from the root and can become trapped in a
+single high-score basin. An annealing schedule changes acceptance but not that
+graph.
+
+Use a portfolio of initial partitions drawn from the exact sampler's support:
+
+- one strong greedy or local-search result;
+- randomized greedy constructions;
+- random valid growth to \(K\);
+- compatible variants of existing basis algorithms.
+
+Starting from an optimized, even data-informed, state does not change the exact
+stationary distribution after convergence. Starting every chain from the same
+state does weaken multimodality diagnostics.
+
+If paired moves fail, add proposal kernels rather than tuning NUTS:
+
+- global split/merge pairing;
+- fixed-leaf-count subtree prune-and-regrow;
+- boundary relocation or tree rotations;
+- multiple-try selection with exact correction;
+- frozen independence proposals generated by randomized local searches;
+- tempering or SMC if separated modes remain.
+
+Moves do not need to be physically interpretable to be valid. Physical
+preferences belong in \(p(P\mid K)\); proposal moves belong in \(q\). A bit-level
+move is acceptable as a secondary kernel if it has a clear action on canonical
+partitions, computable reverse probability, and does not destroy connectivity.
+
+### Work that transfers to later methods
+
+| Work item | Product space | RJMCMC | Long-term value |
+| --- | --- | --- | --- |
+| Canonical tree, node IDs, masks, and exact-cover validation | direct reuse | direct reuse | high |
+| Multiscale \(H\), tile lookup, and label conversion | direct reuse | direct reuse | high |
+| Partition prior and canonical probability | direct reuse | direct reuse | high |
+| Neighbor enumeration and exact proposal probabilities | reuse for indicator moves | reuse for split/merge moves | high |
+| DoFS-informed proposal with uniform floor | reuse for structure proposals | reuse for structure proposals | high |
+| Greedy/local-search initialization portfolio | reuse for chain initialization | reuse for chain initialization | high |
+| Tiny exhaustive enumerator and detailed-balance tests | oracle for product-space marginals | oracle for RJ frequencies | high |
+| Collapsed Gaussian target | benchmark and possible conditional block | benchmark and proposal calibration | medium-high |
+| Fixed-count paired move | reuse directly at fixed count | split and merge pieces remain useful | medium-high |
+| Synthetic generator and posterior diagnostics | regression and calibration fixtures | regression and calibration fixtures | high |
+| Packed-coordinate NUTS adaptation experiments | little direct reuse | little direct reuse | low; defer |
+| Non-Gaussian coefficient transport | useful only for active-only product variants | direct RJ relevance | medium; defer until needed |
+
+This scope deliberately spends almost no time on the least transferable fixed-K
+work. A failed local partition kernel is still informative: the exact oracle can
+show whether failure is caused by poor traversal rather than an incorrect target,
+and the same state, prior, and proposal tests remain prerequisites for more
+elaborate methods.
+
+### One-day scope and stop conditions
+
+The minimum coherent implementation has four work packets:
+
+1. Extract only canonical tree/state and multiscale-column code needed by the
+   toy; defer Numba, masks, real data, and general public APIs.
+2. Implement the collapsed Gaussian target and exhaustive tiny-tree oracle.
+3. Implement uniform and DoFS-informed fixed-count MH over unique neighbors.
+4. Produce deterministic tests and the comparison plots listed above.
+
+On a canonical 4-by-4 toy tree, this is plausibly one focused implementation
+day: roughly one work block for state/enumeration, two for the Cholesky target
+and DoFS score, one for proposals/MH, two for transition-matrix tests, and one
+for the runnable comparison. This forecast assumes direct synthetic arrays and
+the minimal extraction of existing dyadic helpers. Real footprints, Numba,
+arbitrary split geometry, or PyMC integration would move it beyond the intended
+hackathon scope.
+
+The first three packets constitute the scientific result. Plot polish and
+variable \(K\) are secondary. If time remains, variable count requires a tree
+prior and split/merge proposal accounting, but not NUTS or RJ coefficient maps.
+
+Stop or narrow the demo if:
+
+- incremental and direct DoFS calculations disagree;
+- MCMC frequencies fail the exact tiny-tree oracle;
+- the fixed-count proposal graph is disconnected;
+- neighbor enumeration is already too expensive at the toy scale;
+- all chains remain in their initializer's basin under both uniform and informed
+  proposals.
+
+Even the last result is useful if exact enumeration confirms substantial mass in
+multiple basins: it gives direct evidence that local-move geometry, rather than
+NUTS tuning, is the next problem to solve.
 
 ## Product-space inference with pseudo-priors
 
@@ -880,17 +1236,35 @@ above. Do not add MCMC yet.
 The result is an optimizer and experimental basis generator, not posterior
 inference.
 
-### Phase 2: exact fixed-count joint sampler
+### Phase 2a: exact collapsed fixed-count sampler
 
-1. Implement paired split-and-merge proposals with exact proposal ratios.
+1. Implement paired split-and-merge neighbor enumeration with exact proposal
+   probabilities.
 2. Gather \(H_P\) into a fixed \(K\)-column operator.
-3. Update the fixed-length continuous state conditional on \(P\).
-4. Use the true non-Gaussian model target for partition acceptance.
-5. Use SA/contrast only for initialization or informed proposals.
-6. Validate against exhaustive enumeration on a tiny tree.
+3. Compute the exact collapsed Gaussian \(p(y\mid P)\).
+4. Compare uniform and DoFS-informed local proposals.
+5. Use stochastic local search only for initialization and proposal scores.
+6. Validate sampled partition frequencies against exhaustive enumeration.
 
-This phase establishes whether active-only conditional NUTS and local partition
-moves are viable without pseudo-prior complexity.
+This phase establishes the partition state, target, proposal, and local-mixing
+behavior without coefficient transport or NUTS. The hackathon proof of concept
+is a deliberately narrow slice through Phases 0, 1, and 2a rather than a
+requirement to finish all earlier productionization work first.
+
+### Phase 2b: non-Gaussian fixed-count sampler
+
+1. Add canonical node-keyed active coefficients and prior whitening.
+2. Implement a full-rank reversible proposal for coefficients affected by a
+   paired partition move.
+3. Compare elliptical slice sampling, pCN, fixed diagonal HMC, and conditional
+   native PyMC NUTS for the continuous block.
+4. Use the true non-Gaussian likelihood and prior for final acceptance.
+5. Diagnose partition switching before investing in structure-specific metrics
+   or additional NUTS adaptation machinery.
+
+This phase is optional evidence for the active-only non-Gaussian route. It is
+not a prerequisite for product-space or RJMCMC work if Phase 2a already exposes
+poor local partition traversal.
 
 ### Phase 3: tree-contrast product-space prototype
 
@@ -903,7 +1277,7 @@ moves are viable without pseudo-prior complexity.
 5. Compare full-vector, active-only, and cached-kernel execution strategies.
 6. Measure partition switching, active and inactive effective sample sizes,
    likelihood cost, and sensitivity to pseudo-prior calibration.
-7. Compare posterior results with exact enumeration and Phase 2 fixed-count
+7. Compare posterior results with exact enumeration and Phase 2a fixed-count
    results.
 
 ### Phase 4: scale-up and alternatives

--- a/docs/plans/dyadic_sls_hackathon.md
+++ b/docs/plans/dyadic_sls_hackathon.md
@@ -65,6 +65,20 @@ must call this an equal-region-multiplier-uncertainty benchmark. The value of
 defaults. Sensitivity to at least two plausible \(\tau\) values should be
 reported before making scientific claims.
 
+This benchmark does not preserve the covariance transformation used by
+Bocquet, Wu, and Chevallier. Their scale-consistent representation starts from
+a fine-grid covariance \(B\) and projects it for each partition:
+
+\[
+B_P=PBP^T,
+\]
+
+where \(P\) denotes the representation projection. Reusing one numerical
+covariance form for every \(P\) breaks that assumption. Keep \(B_P\)
+construction behind an explicit partition-dependent callable from the first
+implementation so a projected covariance can be substituted later without
+rewriting the objective or search loop.
+
 At fixed \(K\), SLS accepts improvements and may accept losses using
 
 \[
@@ -275,7 +289,8 @@ Responsibilities:
   ordering, split/merge application, label and boundary rendering data.
 - `multiscale.py`: sum-preserving coarsening, candidate observation columns,
   active-column gathering, and direct-aggregation parity helpers.
-- `objectives.py`: full Gaussian DFS, prototype quadratic score, and structured
+- `objectives.py`: full Gaussian DFS, explicit partition-dependent covariance
+  construction, prototype quadratic score, and structured
   objective/diagnostic results.
 - `initializers.py`: canonical greedy, threshold/bucket, random, and optional
   quadtree-style starts.

--- a/docs/plans/dyadic_sls_hackathon.md
+++ b/docs/plans/dyadic_sls_hackathon.md
@@ -1,0 +1,558 @@
+# Dyadic Stochastic Local Search Hackathon Plan
+
+## Status and relationship to the design note
+
+This is the operational plan for extracting the dyadic prototype and producing
+a reproducible stochastic local search (SLS) demonstration. The durable
+scientific background, prototype inventory, exactness boundaries, and later
+partition-inference design remain in
+`docs/plans/dyadic_partition_inference.md`.
+
+This plan is intentionally narrower and may be updated as implementation work
+progresses. It records work packets, decisions, commands, expected artifacts,
+acceptance criteria, and stop conditions. The first result is an optimizer and
+basis initializer, not posterior inference.
+
+## Demonstration objective
+
+Produce a runnable example that:
+
+1. constructs a canonical dyadic partition over the EUROPE test grid;
+2. builds observation-by-grid contributions from committed TAC and MHD data;
+3. starts from a useful greedy or bisection partition rather than one root;
+4. improves a declared Gaussian design score with reproducible split/merge SLS;
+5. reports the scientific score, region count, temperature, acceptance, and
+   best-so-far state separately;
+6. emits a static comparison, a bounded diagnostics table, and a GIF; and
+7. leaves reusable partition, multiscale-design, move, and test infrastructure
+   for the later collapsed partition sampler.
+
+The minimum scientific result is a fixed-region-count comparison. A
+variable-count search and complexity trade-off are secondary.
+
+## Scope decisions
+
+### Primary search
+
+Use a fixed region count, initially \(K=64\), and a paired move that merges one
+active sibling pair and splits one compatible active leaf. This avoids mixing
+an arbitrary region penalty into the principal objective and directly exercises
+the move structure needed by the planned fixed-\(K\) partition sampler.
+
+The primary utility is the full Gaussian degrees of freedom for signal:
+
+\[
+D(P)
+=\operatorname{tr}\left[
+B_PH_P^T(H_PB_PH_P^T+R)^{-1}H_P
+\right].
+\]
+
+For computation with diagonal \(R\), use
+
+\[
+A_P=B_P^{-1}+H_P^TR^{-1}H_P,
+\qquad
+D(P)=K-\operatorname{tr}(A_P^{-1}B_P^{-1}),
+\]
+
+evaluated by stable Cholesky solves. The two formulas must agree in small
+tests.
+
+The first real-data run may use \(B_P=\tau^2I_K\), but the manifest and figures
+must call this an equal-region-multiplier-uncertainty benchmark. The value of
+\(\tau\) and the construction of \(R\) are explicit inputs, not hidden
+defaults. Sensitivity to at least two plausible \(\tau\) values should be
+reported before making scientific claims.
+
+At fixed \(K\), SLS accepts improvements and may accept losses using
+
+\[
+\Pr(\text{accept loss }L)=\exp(-L/T),
+\qquad
+L=\max(0,D(P)-D(P')).
+\]
+
+This is optimizer behavior. It is not an MH posterior transition, even if the
+move implementation also exposes forward and reverse candidate probabilities.
+
+### Secondary scores
+
+Do not combine every diagnostic into one objective. Record:
+
+- combined TAC/MHD full DFS, used by the primary search;
+- TAC-only and MHD-only DFS recomputed for diagnostics;
+- region count \(K\);
+- current and best objective;
+- temperature and rolling acceptance;
+- optional cumulative split-contrast DFS/EIG diagnostics;
+- optional projected-flux compression diagnostics;
+- region depth, area, and aspect-ratio summaries; and
+- evaluation count and runtime.
+
+TAC-only and MHD-only DFS do not generally add to combined DFS. Label them as
+separate recomputations.
+
+The historical score
+
+\[
+s_v=\frac{1}{a_v}\sum_i p_i h_{iv}^2,
+\qquad
+h_{iv}=\sum_{c\in v}G_{ic},
+\]
+
+should be retained as a provenance and performance comparison. Here \(p_i\)
+must mean observation precision \(1/\sigma_i^2\), and \(a_v\) is an explicitly
+documented support/area normalization. Until its prior, prolongation, and
+aggregation-error assumptions are reconciled with the Bocquet construction,
+call it the **prototype quadratic design score**, not exact DFS.
+
+The existing `split_contrast_score` is another useful diagnostic. It must not
+double-apply flux: either pass footprints as the contribution and flux/prior
+mass as `cell_weight`, or pass footprint-times-flux contributions with unit
+cell weights under an explicitly different coefficient convention.
+
+### Optional variable-count search
+
+After the fixed-\(K\) run works, allow single split or merge moves and optimize
+
+\[
+U_\lambda(P)=D(P)-\lambda K(P).
+\]
+
+Show \(D(P)\), \(K(P)\), and \(\lambda K(P)\) separately and prefer a small
+\(\lambda\) sweep or DFS-versus-\(K\) Pareto plot over selecting one opaque
+combined metric. Do not call \(\lambda K\) a posterior prior term.
+
+### Canonical support
+
+Use one deterministic binary dyadic tree:
+
+- tiles have immutable bounds and stable IDs;
+- children exactly and disjointly cover their parent;
+- split the longer axis, with one documented tie rule for square tiles;
+- a partition is an immutable active-leaf frontier;
+- a valid partition covers every included grid cell exactly once; and
+- only true siblings may merge.
+
+This is less flexible than the historical independent x/y interval graph but
+avoids duplicate geometric states and is reusable by exact partition inference.
+Flexible split orientation remains an optimizer experiment until equivalent
+partition histories are canonicalized.
+
+## Local TAC/MHD data contract
+
+### Committed inputs
+
+Use only repository-owned test data for the first real run:
+
+| Input | File | Relevant content |
+| --- | --- | --- |
+| Prepared two-site rows | `tests/data/frozen_mhd_tac_make_inv_inputs_hbmcmc.npz` | 47 production-aligned times, sites, observations, errors, and minimum errors |
+| TAC footprints | `tests/data/footprints_tac_europe_name_185m_2019-01-01_2019-01-07_data.nc` | `fp(lat, lon, time)`, 168 hourly rows |
+| MHD footprints | `tests/data/footprints_mhd_europe_name_10m_2019-01-01_2019-01-07_data.nc` | `srr(time, latitude, longitude)`, 168 hourly rows |
+| Flux | `tests/data/flux_total_ch4_europe_edgar7_2019-01-01_2019-12-31_data.nc` | annual `flux(lat, lon)` |
+| TAC processed reference | `tests/data/merged_data_test_tac_combined_scenario_v14.nc` | 24-hour production-path comparison |
+| Raw observations | `tests/data/obs_*_ch4_*.nc` | optional full-week preparation validation |
+
+The recommended first route uses the frozen one-day rows:
+
+- 23 MHD rows from 1 January 01:00 through 23:00;
+- 24 TAC rows from 1 January 00:00 through 23:00;
+- site-major order, MHD followed by TAC; and
+- prepared `error` and `min_error` vectors in ppb.
+
+This gives an exact, deterministic two-site integration fixture without
+reimplementing OpenGHG hourly observation aggregation. The full local week can
+later provide 333 rows, but that requires reproducing the production averaging
+semantics and is not on the first critical path.
+
+The one-day design has rank at most 47. A (K=64) visualization can still test
+the optimizer, but it cannot imply that all 64 regional directions are
+independently resolved. Report the achieved DFS against this rank bound and
+include a (K=32) sensitivity run if time permits.
+
+The footprint grids are exactly equal. Flux coordinates differ from footprint
+coordinates by at most approximately \(7.7\times10^{-6}\) degrees. The loader
+must verify equal shapes and `allclose(..., rtol=0, atol=1e-4)`, then adopt one
+canonical footprint grid. It must not rely on an accidental exact xarray join.
+
+### Preparation order
+
+1. Load frozen times, site indicators, observations, errors, and minimum errors.
+2. Normalize MHD names to `fp`, `lat`, and `lon` and transpose both footprint
+   arrays to `(time, lat, lon)`.
+3. Select each site's footprint rows using its exact frozen times.
+4. Load the annual flux, drop its singleton time dimension, validate coordinate
+   tolerance, and adopt the footprint coordinates.
+5. Form
+
+   \[
+   G_{i,c}=\mathrm{footprint}_{i,c}\,\mathrm{flux}_c\,10^9
+   \]
+
+   in ppb per unit fine-cell multiplier.
+6. Concatenate MHD and TAC in the frozen site-major order, retaining site and
+   time coordinates.
+7. Apply any row mask simultaneously to observations, errors, minimum errors,
+   \(G\), and optional fixed design blocks.
+8. Only then coarsen, pad, construct multiscale columns, or compute scores.
+
+The expected fine-grid array has shape `(47, 293, 391)`. Its row sums can be
+checked against the frozen prepared sensitivity row sums. TAC day-one
+`fp_x_flux` can also be checked directly against the merged NetCDF reference.
+
+Observed mole-fraction values are not inputs to DFS or the SLS objective. They
+remain useful for later synthetic-observation or posterior demonstrations. Do
+not fit the real total mole fractions with emissions enhancement \(G\) alone;
+that would omit the background/boundary contribution.
+
+For the first covariance benchmark, compare and declare one of:
+
+- \(R=\operatorname{diag}(\mathrm{error}^2)\); or
+- \(R=\operatorname{diag}(\max(\mathrm{error},\mathrm{min\_error})^2)\).
+
+The second is a conservative fixed-covariance approximation. Neither is the
+same as RHIME's inferred model-error process.
+
+The first one-day demo should apply no additional scientific filter. If filters
+are added later, build the row mask before \(G\), multiscale columns, or scores,
+and verify that perturbing an excluded row cannot alter the result.
+
+### Sum-preserving reduction
+
+The native grid is 293 by 391 cells. Coarsen contributions by spatial **sum**,
+never mean, before padding. The initial candidate is factor-4 coarsening,
+giving approximately 74 by 98 physical cells, padded to a 128 by 128 tree.
+
+Carry a coarsened physical-support count or area field so:
+
+- padded cells do not contribute to scores;
+- padded-only leaves never count as scientific regions;
+- partially supported tiles use declared physical support in normalization;
+- rendering clips to the physical grid; and
+- direct fine-grid and coarsened total-contribution identities can be tested.
+
+Benchmark factor 4 and factor 8 in a short dry run. Prefer factor 4 if candidate
+columns, one DFS evaluation, and a 500-step search fit comfortably within the
+event memory/runtime budget; otherwise report and use factor 8.
+
+## Phase 0A: demo-enabling extraction
+
+Phase 0A is the minimum reusable implementation needed by the SLS demo.
+
+### Package layout
+
+Keep provisional code isolated and do not re-export it from
+`openghg_inversions.basis`:
+
+```text
+openghg_inversions/basis/experimental/
+    __init__.py
+    dyadic/
+        __init__.py
+        tree.py
+        state.py
+        multiscale.py
+        objectives.py
+        initializers.py
+        proposals.py
+        search.py
+examples/basis/
+    dyadic_sls_demo.py
+tests/basis/experimental/
+    test_dyadic_tree.py
+    test_dyadic_multiscale.py
+    test_dyadic_objectives.py
+    test_dyadic_search.py
+```
+
+Responsibilities:
+
+- `tree.py`: tile/node IDs, bounds, parent/children, canonical orientation,
+  sibling checks, padding/support metadata.
+- `state.py`: immutable active frontier, exact-cover validation, stable
+  ordering, split/merge application, label and boundary rendering data.
+- `multiscale.py`: sum-preserving coarsening, candidate observation columns,
+  active-column gathering, and direct-aggregation parity helpers.
+- `objectives.py`: full Gaussian DFS, prototype quadratic score, and structured
+  objective/diagnostic results.
+- `initializers.py`: canonical greedy, threshold/bucket, random, and optional
+  quadtree-style starts.
+- `proposals.py`: immutable split, merge, and paired moves; enumeration,
+  apply/reverse, candidate counts, and optional `log_q`.
+- `search.py`: schedules, seeded SLS runner, bounded trace callbacks, current
+  and best states, stop reasons, and manifests.
+- `dyadic_sls_demo.py`: local test-data loading, configuration, plotting, CSV
+  and GIF output. Core modules perform no file loading or plotting.
+
+### Prototype extraction map
+
+Use the cleaned branch `codex/basis-prototype-examples` at commit `b6ce565` as
+a structural scaffold, not as the scientific objective:
+
+- `Tile`, padding, multiscale-axis, label, and loop scaffolding are useful;
+- replace scalar pre-summed weights with observation-space candidate columns;
+- discard the toy `_tile_information_score` and `_tiling_energy`;
+- strengthen merge checks to require true dyadic siblings;
+- replace mutable lists/dense indicators with an immutable partition;
+- replace the global RNG with a caller-supplied generator; and
+- replace the fixed-temperature result with a complete bounded trace.
+
+Preserve the scientific operation from
+`~/Documents/basis_functions/basis_fn_ipython_hist_14aug.py`:
+
+\[
+h_v=\sum_{c\in v}G_{:,c},
+\]
+
+then score \(h_v\). Do not pre-score fine cells and sum scalar scores.
+
+Record exact historical symbol and line provenance in the experimental package
+documentation at extraction time. The current repository implementations of
+axis-parallel, inertial, priority-queue, and contrast logic should be adapted
+where compatible rather than copied from `~/Documents/inversions`.
+
+### Required tests
+
+1. Candidate tile columns equal direct sums of \(G\) over tile cells.
+2. A counterexample proves sum-then-square differs from summing cell scores.
+3. Gathered \(H_P\) equals direct fine-grid aggregation.
+4. Every initial and proposed partition is an exact active frontier.
+5. Split followed by the corresponding merge restores identical state.
+6. Adjacent non-sibling rectangles cannot merge.
+7. Moves and search do not mutate their inputs.
+8. Incremental prototype-score changes equal full recomputation.
+9. The two Gaussian DFS formulas agree on a small positive-definite case.
+10. Leaf ordering changes neither DFS nor rendered coverage.
+11. Fixed-\(K\) paired moves preserve \(K\).
+12. Seeded SLS produces an identical trace and never loses the best initializer
+    score.
+13. Zero temperature rejects losses; positive temperature can accept a
+    controlled loss.
+14. Invalid variance/precision, support, coordinate, and shape inputs fail
+    clearly.
+15. Padded cells do not alter scientific coverage or score normalization.
+
+### Local integration tests
+
+1. Assert frozen site counts, ordering, endpoint times, and positive errors.
+2. Reject grids outside tolerance and explicitly accept the known flux offset.
+3. Assert TAC \(G\) agrees with merged `fp_x_flux`.
+4. Assert fine-grid \(G\) row sums agree with frozen prepared sensitivity row
+   sums within a declared floating tolerance.
+5. Assert every gathered \(H_P\) column equals the corresponding direct cell
+   sum.
+6. Apply a row mask and assert every observation-aligned array remains
+   synchronized.
+7. Perturb an excluded row and verify multiscale columns, scores, and seeded SLS
+   output are unchanged.
+
+## Phase 0B: deferred consolidation
+
+These items are useful but not on the critical path to the first TAC/MHD GIF:
+
+- parity-tested Numba threshold bisection;
+- compile-time versus warm-call benchmarks;
+- full-week OpenGHG-compatible observation preparation;
+- arbitrary x/y split histories;
+- masks and one tree per land/ocean, country, or inner/outer group;
+- production data adapters;
+- checkpoint/restart;
+- public API naming and exports; and
+- performance-oriented incremental full-DFS updates.
+
+Promote an item from 0B only if profiling shows it blocks the real demo or it is
+needed to avoid implementing semantics that will immediately be discarded.
+
+## SLS demo work packets
+
+### D0: data and score dry run
+
+- Load frozen TAC/MHD rows, raw footprints, and flux.
+- Confirm shapes, row order, grid tolerance, units, and memory.
+- Validate \(G\) against the merged TAC and frozen row-total references.
+- Build factor-4 and factor-8 \(G\) arrays.
+- Time one full DFS evaluation at \(K=64\).
+- Freeze \(\tau\), covariance choice, coarsening, and target \(K\) in a run
+  manifest.
+
+**Gate:** no search implementation should silently compensate for unresolved
+units, double flux weighting, or an infeasible DFS cost.
+
+### D1: synthetic reference
+
+- Build a 4 by 4 and an 8 by 8 synthetic contribution field.
+- Exercise tree/state, initializers, moves, scores, and SLS.
+- Compare full DFS with an independent implementation.
+- Save one small deterministic trace used by tests.
+
+**Gate:** all algebraic and state-invariant tests pass before the real run.
+
+### D2: initializers
+
+Implement starts that lie in the same canonical support:
+
+1. canonical greedy: repeatedly split the feasible leaf with greatest declared
+   score gain;
+2. canonical bucket/threshold bisection;
+3. canonical quadtree-style growth represented by two binary levels;
+4. random valid growth as a control.
+
+The existing production bucket/quadtree label maps are useful external
+baselines but cannot automatically seed the canonical tree if their rectangles
+are outside its support. Do not silently relabel or approximate them. Record any
+deterministic repair needed to reach exactly \(K\).
+
+The minimum real run requires greedy plus random. Bucket and quadtree are
+strongly preferred comparison starts but may follow the first working GIF.
+
+### D3: search schedule
+
+Use a discarded pilot over valid paired moves from all initializer families:
+
+1. collect positive DFS losses from 100-200 proposals;
+2. choose \(T_0\) so the median sampled loss has approximately 0.8 acceptance;
+3. choose \(T_f\) so it has approximately 0.01 acceptance;
+4. freeze the schedule before comparison runs;
+5. spend 10% of evaluations at \(T_0\), 80% geometrically cooling to \(T_f\),
+   and 10% at zero temperature for polishing.
+
+Run equal evaluation budgets and at least three seeds per available initializer.
+Five seeds are preferred for the final comparison. Include zero-temperature
+hill climbing and no-search baselines.
+
+If different starts remain in different basins, report that result rather than
+continuing to tune temperature indefinitely.
+
+### D4: visualization
+
+Generate:
+
+```text
+docs/plans/figures/dyadic_sls/
+    tac_mhd_sls.gif
+    tac_mhd_sls_summary.png
+    tac_mhd_sls_trace.csv
+    tac_mhd_sls_runs.csv
+    tac_mhd_sls_manifest.json
+```
+
+The static summary is the scientific result; the GIF explains the search.
+
+Each frame should contain:
+
+- partition boundaries over a fixed combined sensitivity/design background;
+- the most recent accepted split and merge highlighted for one frame;
+- current and best DFS traces;
+- region count, with the fixed target shown;
+- temperature and rolling acceptance;
+- iteration, accepted-move count, initializer, seed, and run ID; and
+- a concise statement that the objective is Gaussian benchmark DFS.
+
+Use stable boundaries or depth shading rather than recoloring regenerated
+integer region labels, which causes flicker. Keep color limits fixed.
+
+Capture the initial state, every new best, every tenth accepted move or every
+1% of evaluations, and final/best states. Cap the GIF near 120-150 frames at
+8-12 frames per second. Matplotlib's Pillow writer should avoid a new direct
+animation dependency. Preserve the diagnostics CSV independently of the GIF.
+
+Tests should verify rendering with the non-interactive `Agg` backend and a few
+frames, not compare GIF bytes.
+
+## Acceptance criteria
+
+Phase 0A and the SLS demo are complete when:
+
+- core code has no dependency on private prototype paths or OpenGHG retrieval;
+- provenance points from retained behavior to repository-owned symbols/tests;
+- all partition and direct-aggregation invariants pass;
+- the fixed-\(K\) search starts and ends at exactly \(K=64\);
+- full DFS is evaluated under explicit \(B_P\) and \(R\);
+- repeated runs from the same manifest reproduce proposals, accepted states,
+  best state, and numeric diagnostics;
+- combined, TAC-only, MHD-only, and best-so-far diagnostics are distinguishable;
+- greedy/random and no-search/hill-climbing controls receive equal budgets;
+- the best state is never worse than its initializer;
+- runtime and peak-memory summaries are recorded;
+- the static figure and GIF identify assumptions and do not use posterior or
+  convergence language; and
+- focused pytest, Ruff, and configured type checking pass.
+
+## Stop and fallback conditions
+
+Stop and fix correctness rather than polishing output if:
+
+- candidate columns differ from direct grid sums;
+- incremental and direct score changes disagree;
+- any state fails exact-cover or ancestry invariants;
+- TAC/MHD coordinate or row alignment is ambiguous;
+- full DFS formulas disagree;
+- padded cells affect scientific coverage or score;
+- fixed-\(K\) moves cannot connect the demonstrated support; or
+- deterministic replay changes.
+
+Narrow transparently if the real run is too expensive:
+
+1. increase sum-preserving spatial coarsening from factor 4 to factor 8;
+2. reduce the evaluation budget;
+3. reduce \(K\); then
+4. use the prototype quadratic score for the animation while retaining sparse
+   full-DFS checkpoints, clearly labelling the distinction.
+
+Do not silently replace full DFS with a proxy or add Numba before profiling
+identifies the bottleneck.
+
+## Commit and review sequence
+
+Develop on one working branch with logical commits so it can be split later:
+
+1. operational plan and source-provenance update;
+2. tree/state/multiscale core with synthetic tests;
+3. objectives, initializers, moves, and deterministic SLS tests;
+4. local TAC/MHD preparation and real-data integration test;
+5. demo script, static report, GIF, and recorded run manifest; and
+6. optional performance or initializer comparisons.
+
+The natural review split is:
+
+- **PR A:** experimental Phase 0A core and synthetic tests, with no atmospheric
+  file loading;
+- **PR B:** local TAC/MHD adapter, demo, diagnostics, and generated evidence;
+- **PR C:** deferred Numba/benchmark/generalization only if justified.
+
+PR B may be developed against PR A for the hackathon, but current production
+basis interfaces and `fixedbasisMCMC` must remain untouched.
+
+## Effort forecast
+
+- Small synthetic SLS using extracted structure: approximately 1 focused day.
+- First technically credible TAC/MHD fixed-\(K\) run and static figure:
+  approximately 2-4 focused days.
+- Multi-initializer comparison, robust replay, and polished GIF:
+  approximately 4-6 focused days total.
+- Full Phase 0 including Numba, generalized support, benchmarks, checkpointing,
+  and masks: approximately 6-9 focused days.
+
+A faster first animation is possible with the prototype quadratic score, but it
+must not be presented as calibrated DFS. The recommended order is correctness
+and a static fixed-\(K\) result first, then GIF polish.
+
+## Deferred connection to partition inference
+
+The following Phase 0A work transfers directly to the collapsed fixed-\(K\)
+sampler:
+
+- canonical tree and immutable partition state;
+- active multiscale-column gathering;
+- full Gaussian DFS and collapsed-target linear algebra;
+- paired split/merge neighbor enumeration;
+- stable node ordering;
+- deterministic initializers;
+- manifests and trace diagnostics; and
+- exhaustive small-state/state-invariant tests.
+
+The SLS acceptance rule and cooling schedule do not transfer into the posterior
+target. They remain useful for initialization and for constructing an informed,
+fully normalized proposal whose Hastings correction is added later.

--- a/docs/plans/dyadic_sls_hackathon.md
+++ b/docs/plans/dyadic_sls_hackathon.md
@@ -13,6 +13,24 @@ progresses. It records work packets, decisions, commands, expected artifacts,
 acceptance criteria, and stop conditions. The first result is an optimizer and
 basis initializer, not posterior inference.
 
+### Implementation status
+
+As of 17 July 2026, Phase 0A is implemented on
+`codex/dyadic-sls-core`:
+
+- exact unpadded rectangular dyadic trees and immutable partition frontiers;
+- sum-preserving multiscale design columns and direct-sum parity checks;
+- full Gaussian DFS with a partition-dependent covariance-builder boundary;
+- explicitly labelled isotropic and historical quadratic benchmark scores;
+- greedy, random, and threshold initializers;
+- split, merge, and unique fixed-count paired proposals; and
+- seeded stochastic local search with a piecewise geometric schedule.
+
+The combined core gate is 49 focused tests plus Ruff and Pyright. The next
+branch owns the TAC/MHD adapter, real-data checks, run manifest, static figure,
+trace, and GIF. No production basis interface or `fixedbasisMCMC` code is
+touched.
+
 ## Demonstration objective
 
 Produce a runnable example that:
@@ -236,13 +254,12 @@ and verify that perturbing an excluded row cannot alter the result.
 ### Sum-preserving reduction
 
 The native grid is 293 by 391 cells. Coarsen contributions by spatial **sum**,
-never mean, before padding. The initial candidate is factor-4 coarsening,
-giving approximately 74 by 98 physical cells, padded to a 128 by 128 tree.
+never mean. The initial candidate is factor-4 coarsening, giving a 74 by 98
+grid. The implemented canonical tree supports this exact rectangle, so the POC
+does not pad to a power-of-two square.
 
 Carry a coarsened physical-support count or area field so:
 
-- padded cells do not contribute to scores;
-- padded-only leaves never count as scientific regions;
 - partially supported tiles use declared physical support in normalization;
 - rendering clips to the physical grid; and
 - direct fine-grid and coarsened total-contribution identities can be tested.
@@ -284,7 +301,7 @@ tests/basis/experimental/
 Responsibilities:
 
 - `tree.py`: tile/node IDs, bounds, parent/children, canonical orientation,
-  sibling checks, padding/support metadata.
+  sibling checks, and exact rectangular support.
 - `state.py`: immutable active frontier, exact-cover validation, stable
   ordering, split/merge application, label and boundary rendering data.
 - `multiscale.py`: sum-preserving coarsening, candidate observation columns,
@@ -347,7 +364,8 @@ where compatible rather than copied from `~/Documents/inversions`.
     controlled loss.
 14. Invalid variance/precision, support, coordinate, and shape inputs fail
     clearly.
-15. Padded cells do not alter scientific coverage or score normalization.
+15. Partial boundary blocks preserve their physical support and total design
+    contribution.
 
 ### Local integration tests
 
@@ -504,7 +522,7 @@ Stop and fix correctness rather than polishing output if:
 - any state fails exact-cover or ancestry invariants;
 - TAC/MHD coordinate or row alignment is ambiguous;
 - full DFS formulas disagree;
-- padded cells affect scientific coverage or score;
+- partial boundary blocks affect total design contribution incorrectly;
 - fixed-\(K\) moves cannot connect the demonstrated support; or
 - deterministic replay changes.
 

--- a/openghg_inversions/basis/experimental/__init__.py
+++ b/openghg_inversions/basis/experimental/__init__.py
@@ -1,0 +1,8 @@
+"""Provisional basis-generation components under active development.
+
+Modules below this namespace are intentionally excluded from the stable
+``openghg_inversions.basis`` API. Their interfaces may change while the
+algorithms and scientific contracts are evaluated.
+"""
+
+__all__: list[str] = []

--- a/openghg_inversions/basis/experimental/dyadic/PROVENANCE.md
+++ b/openghg_inversions/basis/experimental/dyadic/PROVENANCE.md
@@ -1,0 +1,47 @@
+# Experimental dyadic SLS provenance
+
+This package extracts the reusable mechanics from private exploratory code so
+that the hackathon demonstration can cite public, reviewable source. It remains
+experimental and is not part of the supported basis-function API.
+
+## Historical sources
+
+- `~/Documents/basis_functions/basis_fn_ipython_hist_14aug.py`
+  - `make_weights`: pre-sums sensitivities over dyadic tiles and evaluates the
+    original quadratic design proxy.
+  - `get_split`, `get_merge`, `apply_move`, and `dof_change`: local dyadic tree
+    moves and cheap score differences.
+  - `ApplyStepCondition`: temperature-based acceptance with a region-count
+    penalty. This is stochastic local search, not posterior MCMC.
+- `~/Documents/basis_functions/hist_17aug.py`
+  - later Python and Numba bisection/search experiments.
+- branch `codex/basis-prototype-examples`, commit `b6ce565`
+  - the first cleaned executable scaffold for dyadic indexing, precomputed
+    multiscale sums, and local search.
+
+The implementation here intentionally replaces mutable indicator matrices and
+notebook-global random state with immutable partition states, explicit random
+generators, independently testable proposals, and complete diagnostic traces.
+
+## Score terminology
+
+The historical quadratic score for a tile `v` is proportional to
+
+```text
+sum_i precision[i] * (sum_{cell in v} G[i, cell])**2 / area[v]
+```
+
+It is retained as a fast **prototype quadratic design score**. It must not be
+described as exact degrees of freedom for signal (DFS). The benchmark also
+computes Gaussian DFS from an explicitly supplied prior covariance.
+
+For a partition projection matrix `P` and fine-grid prior covariance `B`, the
+Bocquet-consistent covariance is partition-dependent:
+
+```text
+B_partition = P @ B @ P.T
+```
+
+Using the same isotropic covariance for every partition is permitted only as a
+clearly labelled proof-of-concept benchmark.
+

--- a/openghg_inversions/basis/experimental/dyadic/__init__.py
+++ b/openghg_inversions/basis/experimental/dyadic/__init__.py
@@ -1,0 +1,79 @@
+"""Experimental canonical binary partitions for rectangular grids.
+
+This package provides a small, pure-NumPy representation of one deterministic
+binary tree, immutable active frontiers, partition objectives, local proposals,
+and a generic stochastic local-search runner. It is provisional and is not
+re-exported from :mod:`openghg_inversions.basis`.
+"""
+
+from .initializers import InitializationResult, greedy_partition, random_partition, threshold_partition
+from .multiscale import CoarsenedGrid, MultiscaleDesign, direct_gather, sum_coarsen_grid
+from .objectives import (
+    CovarianceBuilder,
+    GaussianDFSObjective,
+    IsotropicRegionCovariance,
+    direct_observation_space_dfs,
+    gaussian_dfs,
+    prototype_quadratic_tile_scores,
+)
+from .proposals import (
+    MergeMove,
+    Move,
+    PairedMove,
+    PairedNeighbor,
+    SplitMove,
+    apply_move,
+    enumerate_merge_moves,
+    enumerate_paired_moves,
+    enumerate_paired_neighbors,
+    enumerate_split_moves,
+    reverse_move,
+)
+from .search import (
+    PiecewiseGeometricSchedule,
+    SearchProposal,
+    SearchResult,
+    SearchStep,
+    TemperatureSchedule,
+    stochastic_local_search,
+)
+from .state import PartitionState
+from .tree import DyadicTree, NodeId, Tile
+
+__all__ = [
+    "CoarsenedGrid",
+    "CovarianceBuilder",
+    "DyadicTree",
+    "GaussianDFSObjective",
+    "InitializationResult",
+    "IsotropicRegionCovariance",
+    "MergeMove",
+    "Move",
+    "MultiscaleDesign",
+    "NodeId",
+    "PairedMove",
+    "PairedNeighbor",
+    "PartitionState",
+    "PiecewiseGeometricSchedule",
+    "SearchProposal",
+    "SearchResult",
+    "SearchStep",
+    "SplitMove",
+    "TemperatureSchedule",
+    "Tile",
+    "apply_move",
+    "direct_gather",
+    "direct_observation_space_dfs",
+    "enumerate_merge_moves",
+    "enumerate_paired_moves",
+    "enumerate_paired_neighbors",
+    "enumerate_split_moves",
+    "gaussian_dfs",
+    "greedy_partition",
+    "prototype_quadratic_tile_scores",
+    "random_partition",
+    "reverse_move",
+    "stochastic_local_search",
+    "sum_coarsen_grid",
+    "threshold_partition",
+]

--- a/openghg_inversions/basis/experimental/dyadic/initializers.py
+++ b/openghg_inversions/basis/experimental/dyadic/initializers.py
@@ -1,0 +1,181 @@
+"""Construct deterministic and seeded initial dyadic partitions.
+
+The initializers in this module grow the canonical binary tree through
+``PartitionState.split``.  They therefore return valid active frontiers without
+depending on dense label maps or mutating a caller-owned state.  Greedy growth
+uses :mod:`heapq` with node identifiers as its deterministic tie-breaker;
+random growth is reproducible when supplied the same NumPy generator state.
+"""
+
+from __future__ import annotations
+
+import heapq
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import numpy as np
+
+from .state import PartitionState
+from .tree import DyadicTree, Tile
+
+
+@dataclass(frozen=True, slots=True)
+class InitializationResult:
+    """A tree partition and the ordered splits used to construct it.
+
+    Attributes:
+        state: Final immutable partition state.
+        split_history: Node identifiers in the order in which they were split.
+    """
+
+    state: PartitionState
+    split_history: tuple[int, ...]
+
+
+def greedy_partition(
+    tree: DyadicTree,
+    target_regions: int,
+    split_gain: Callable[[int], float],
+) -> InitializationResult:
+    """Grow an exact-size partition by repeatedly taking the best split.
+
+    Candidate nodes are ordered by decreasing ``split_gain``.  Equal gains are
+    resolved by increasing node identifier, making the result independent of
+    set iteration order.
+
+    Args:
+        tree: Canonical dyadic tree to partition.
+        target_regions: Required number of active regions, at least one.
+        split_gain: Callable returning the priority gain for a splittable node
+            identifier.
+
+    Returns:
+        The final partition and its split history.
+
+    Raises:
+        ValueError: If ``target_regions`` is less than one or exceeds the
+            number of leaves available from ``tree``.
+    """
+    _validate_target_regions(target_regions)
+    state = PartitionState.root(tree)
+    split_history: list[int] = []
+    candidates: list[tuple[float, int]] = []
+    _push_greedy_candidate(candidates, tree, tree.root_id, split_gain)
+
+    while len(state.active) < target_regions:
+        if not candidates:
+            raise _impossible_target_error(target_regions)
+
+        _, node_id = heapq.heappop(candidates)
+        state = state.split(tree, node_id)
+        split_history.append(node_id)
+        children = tree.children(node_id)
+        if not children:  # pragma: no cover - guarded when queued.
+            raise RuntimeError(f"Queued node {node_id} cannot be split.")
+        for child_id in children:
+            _push_greedy_candidate(candidates, tree, child_id, split_gain)
+
+    state.validate(tree)
+    return InitializationResult(state=state, split_history=tuple(split_history))
+
+
+def random_partition(
+    tree: DyadicTree,
+    target_regions: int,
+    rng: np.random.Generator,
+) -> InitializationResult:
+    """Grow an exact-size random partition using a caller-supplied generator.
+
+    At each step this function samples uniformly from the currently splittable
+    active nodes, sorted by node identifier before indexing.  The input tree and
+    all intermediate partition states remain unmodified.
+
+    Args:
+        tree: Canonical dyadic tree to partition.
+        target_regions: Required number of active regions, at least one.
+        rng: NumPy random generator controlling every random choice.
+
+    Returns:
+        The final partition and its split history.
+
+    Raises:
+        ValueError: If ``target_regions`` is less than one or exceeds the
+            number of leaves available from ``tree``.
+    """
+    _validate_target_regions(target_regions)
+    state = PartitionState.root(tree)
+    split_history: list[int] = []
+
+    while len(state.active) < target_regions:
+        candidates = tuple(node_id for node_id in state.ordered_active() if tree.children(node_id))
+        if not candidates:
+            raise _impossible_target_error(target_regions)
+
+        node_id = candidates[int(rng.integers(len(candidates)))]
+        state = state.split(tree, node_id)
+        split_history.append(node_id)
+
+    state.validate(tree)
+    return InitializationResult(state=state, split_history=tuple(split_history))
+
+
+def threshold_partition(
+    tree: DyadicTree,
+    tile_score: Callable[[Tile], float],
+    threshold: float,
+) -> InitializationResult:
+    """Split each eligible tile whose score is strictly above a threshold.
+
+    Nodes are visited depth first, with each tree-provided first child visited
+    before its sibling.  ``tile_score`` receives the tile object returned by
+    ``tree.tile(node_id)``; leaves above the threshold remain active because
+    they cannot be split.
+
+    Args:
+        tree: Canonical dyadic tree to partition.
+        tile_score: Callable assigning a scalar score to a tree tile.
+        threshold: Split threshold, applied using ``score > threshold``.
+
+    Returns:
+        The final partition and its deterministic split history.
+    """
+    state = PartitionState.root(tree)
+    split_history: list[int] = []
+    pending = [tree.root_id]
+
+    while pending:
+        node_id = pending.pop()
+        children = tree.children(node_id)
+        if not children or tile_score(tree.tile(node_id)) <= threshold:
+            continue
+
+        state = state.split(tree, node_id)
+        split_history.append(node_id)
+        first_child, second_child = children
+        pending.append(second_child)
+        pending.append(first_child)
+
+    state.validate(tree)
+    return InitializationResult(state=state, split_history=tuple(split_history))
+
+
+def _push_greedy_candidate(
+    candidates: list[tuple[float, int]],
+    tree: DyadicTree,
+    node_id: int,
+    split_gain: Callable[[int], float],
+) -> None:
+    """Push a splittable node onto a max-gain heap with stable tie ordering."""
+    if tree.children(node_id):
+        heapq.heappush(candidates, (-float(split_gain(node_id)), node_id))
+
+
+def _validate_target_regions(target_regions: int) -> None:
+    """Reject region targets outside the non-empty partition domain."""
+    if target_regions < 1:
+        raise ValueError("target_regions must be at least 1.")
+
+
+def _impossible_target_error(target_regions: int) -> ValueError:
+    """Build the common error for targets larger than a tree can supply."""
+    return ValueError(f"Cannot construct {target_regions} regions from the available tree leaves.")

--- a/openghg_inversions/basis/experimental/dyadic/multiscale.py
+++ b/openghg_inversions/basis/experimental/dyadic/multiscale.py
@@ -1,0 +1,260 @@
+"""Pure-NumPy construction of sum-preserving dyadic design matrices.
+
+The fine-grid input convention is ``(observation, row, column)``.  A candidate
+column for a dyadic tile is the sum of its fine-cell columns, matching a model
+in which one regional multiplier applies to every cell in the tile.  Internal
+node columns are built from child columns, while :func:`direct_gather` provides
+an intentionally independent grid-slice implementation for parity tests.
+
+This module handles design aggregation only.  Prior covariance is partition
+dependent: a Bocquet-consistent objective should supply the covariance for a
+partition as ``B_P = P B P.T`` rather than assume one covariance applies to
+every gathered design.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import numpy.typing as npt
+
+from .state import PartitionState
+from .tree import DyadicTree, Tile
+
+
+@dataclass(frozen=True)
+class CoarsenedGrid:
+    """A sum-preserving coarsened observation grid and its physical support.
+
+    Attributes:
+        values: Coarsened values with shape ``(observation, coarse_row,
+            coarse_column)``.  Boundary blocks contain sums over their partial
+            physical support; no zero padding is included in the sums.
+        support_counts: Number of fine cells contributing to each coarse block,
+            with shape ``(coarse_row, coarse_column)``.
+    """
+
+    values: np.ndarray
+    support_counts: np.ndarray
+
+
+@dataclass(frozen=True)
+class MultiscaleDesign:
+    """Candidate observation columns for every node in a dyadic tree.
+
+    Columns in ``values`` use the deterministic node order of the tree.  The
+    current tree contract assigns contiguous integer IDs, so column ``node_id``
+    is ``values[:, node_id]``.
+
+    Attributes:
+        values: Candidate matrix with shape ``(observation, tree_node)``.
+        tree: Tree whose node IDs define the columns.
+
+    Notes:
+        This class deliberately does not store a prior covariance.  A
+        Bocquet-consistent covariance must be constructed for each partition as
+        ``B_P = P B P.T``.  An isotropic covariance is only a proof-of-concept
+        benchmark, not a substitute for that aggregation.
+    """
+
+    values: np.ndarray
+    tree: DyadicTree
+
+    @classmethod
+    def from_grid(cls, grid: npt.ArrayLike, tree: DyadicTree) -> MultiscaleDesign:
+        """Build all candidate columns from a finite fine-grid design.
+
+        Args:
+            grid: Fine-grid contributions with shape ``(observation, row,
+                column)``.
+            tree: Deterministic tree whose shape equals the grid's spatial
+                shape and whose node IDs are contiguous from zero.
+
+        Returns:
+            A design containing one summed observation column per tree node.
+
+        Raises:
+            ValueError: If the grid is not finite and three-dimensional, its
+                shape does not match the tree, the tree IDs are not contiguous,
+                or the tree topology is inconsistent with cell leaves.
+        """
+        values = _finite_float_array(grid, name="grid")
+        if values.ndim != 3:
+            raise ValueError("grid must have shape (observation, row, column).")
+        if values.shape[0] == 0 or values.shape[1] == 0 or values.shape[2] == 0:
+            raise ValueError("grid dimensions must all be non-empty.")
+        if tuple(values.shape[1:]) != tuple(tree.shape):
+            raise ValueError(f"grid spatial shape {values.shape[1:]} does not match tree shape {tree.shape}.")
+
+        try:
+            node_count = len(tree.nodes)
+        except TypeError as exc:  # pragma: no cover - concrete tree invariant.
+            raise ValueError("tree.nodes must be a sized deterministic collection.") from exc
+        if node_count < 1:
+            raise ValueError("tree must contain at least one node.")
+        if tree.root_id < 0 or tree.root_id >= node_count:
+            raise ValueError("tree.root_id is outside the contiguous node ID range.")
+
+        columns = np.empty((values.shape[0], node_count), dtype=float)
+        visited: set[int] = set()
+        visiting: set[int] = set()
+
+        def build(node_id: int) -> np.ndarray:
+            """Build one node column recursively and memoize it."""
+            if node_id < 0 or node_id >= node_count:
+                raise ValueError(f"child node ID {node_id} is outside the tree node range.")
+            if node_id in visited:
+                return columns[:, node_id]
+            if node_id in visiting:
+                raise ValueError("tree contains a cycle.")
+
+            visiting.add(node_id)
+            tile = tree.tile(node_id)
+            children = tuple(tree.children(node_id))
+            if children:
+                if tile.is_cell:
+                    raise ValueError("a cell tile cannot have children.")
+                column = np.zeros(values.shape[0], dtype=float)
+                for child_id in children:
+                    column += build(child_id)
+            else:
+                if not tile.is_cell or tile.area != 1:
+                    raise ValueError("every childless tree node must be a one-cell tile.")
+                row_start, row_stop, col_start, col_stop = _validated_bounds(tile, tree.shape)
+                column = values[:, row_start:row_stop, col_start:col_stop].reshape(values.shape[0])
+
+            columns[:, node_id] = column
+            visiting.remove(node_id)
+            visited.add(node_id)
+            return columns[:, node_id]
+
+        build(tree.root_id)
+        if len(visited) != node_count:
+            raise ValueError("tree contains nodes that are unreachable from its root.")
+        return cls(values=columns, tree=tree)
+
+    @property
+    def H(self) -> np.ndarray:
+        """Return the candidate matrix using its conventional mathematical name."""
+        return self.values
+
+    def gather(self, state: PartitionState) -> np.ndarray:
+        """Gather active columns in the state's stable active-node order.
+
+        Args:
+            state: Partition state associated with this design's tree.
+
+        Returns:
+            Matrix with shape ``(observation, active_region)``.
+
+        Raises:
+            ValueError: If an active node ID is outside the candidate matrix.
+        """
+        active = state.ordered_active()
+        if any(node_id < 0 or node_id >= self.values.shape[1] for node_id in active):
+            raise ValueError("state contains a node ID outside the design.")
+        return self.values[:, active]
+
+
+def sum_coarsen_grid(grid: npt.ArrayLike, factor: int) -> CoarsenedGrid:
+    """Sum spatial blocks while retaining boundary support counts.
+
+    Args:
+        grid: Finite values with shape ``(observation, row, column)``.
+        factor: Positive integer block width along both spatial axes.
+
+    Returns:
+        Coarsened values and the number of physical fine cells in each block.
+        Partial boundary blocks are retained rather than dropped or averaged.
+
+    Raises:
+        TypeError: If ``factor`` is not an integer.
+        ValueError: If ``grid`` is not finite and three-dimensional, has an
+            empty spatial axis, or ``factor`` is not positive.
+    """
+    values = _finite_float_array(grid, name="grid")
+    if values.ndim != 3:
+        raise ValueError("grid must have shape (observation, row, column).")
+    if values.shape[1] == 0 or values.shape[2] == 0:
+        raise ValueError("grid spatial dimensions must be non-empty.")
+    if isinstance(factor, bool) or not isinstance(factor, (int, np.integer)):
+        raise TypeError("factor must be an integer.")
+    if factor <= 0:
+        raise ValueError("factor must be positive.")
+
+    row_starts = np.arange(0, values.shape[1], factor)
+    col_starts = np.arange(0, values.shape[2], factor)
+    coarsened = np.add.reduceat(values, row_starts, axis=1)
+    coarsened = np.add.reduceat(coarsened, col_starts, axis=2)
+
+    row_counts = np.minimum(factor, values.shape[1] - row_starts)
+    col_counts = np.minimum(factor, values.shape[2] - col_starts)
+    support_counts = np.multiply.outer(row_counts, col_counts)
+    return CoarsenedGrid(values=coarsened, support_counts=support_counts)
+
+
+def direct_gather(
+    grid: npt.ArrayLike,
+    tree: DyadicTree,
+    state: PartitionState,
+) -> np.ndarray:
+    """Gather active columns by direct fine-grid tile sums.
+
+    This helper intentionally does not use :class:`MultiscaleDesign`; it is a
+    small reference implementation for checking precomputed-column parity.
+
+    Args:
+        grid: Finite fine-grid contributions with shape ``(observation, row,
+            column)``.
+        tree: Tree defining the active tile bounds.
+        state: Partition whose stable active order defines output columns.
+
+    Returns:
+        Directly aggregated matrix with shape ``(observation, active_region)``.
+
+    Raises:
+        ValueError: If the grid is invalid or does not match the tree shape, or
+            a tile has invalid bounds.
+    """
+    values = _finite_float_array(grid, name="grid")
+    if values.ndim != 3:
+        raise ValueError("grid must have shape (observation, row, column).")
+    if tuple(values.shape[1:]) != tuple(tree.shape):
+        raise ValueError(f"grid spatial shape {values.shape[1:]} does not match tree shape {tree.shape}.")
+
+    columns = []
+    for node_id in state.ordered_active():
+        bounds = _validated_bounds(tree.tile(node_id), tree.shape)
+        row_start, row_stop, col_start, col_stop = bounds
+        columns.append(values[:, row_start:row_stop, col_start:col_stop].sum(axis=(1, 2)))
+    if not columns:
+        return np.empty((values.shape[0], 0), dtype=float)
+    return np.column_stack(columns)
+
+
+def _finite_float_array(values: npt.ArrayLike, *, name: str) -> np.ndarray:
+    """Convert an array-like input to a finite floating-point array."""
+    array = np.asarray(values)
+    if np.iscomplexobj(array):
+        raise ValueError(f"{name} must be real-valued.")
+    array = np.asarray(array, dtype=float)
+    if not np.all(np.isfinite(array)):
+        raise ValueError(f"{name} must contain only finite values.")
+    return array
+
+
+def _validated_bounds(tile: Tile, shape: tuple[int, int]) -> tuple[int, int, int, int]:
+    """Return integer tile bounds after validating them against ``shape``."""
+    try:
+        row_start, row_stop, col_start, col_stop = tile.bounds
+    except (TypeError, ValueError) as exc:
+        raise ValueError("tile.bounds must contain four integer indices.") from exc
+    bounds = (row_start, row_stop, col_start, col_stop)
+    if any(isinstance(value, bool) or not isinstance(value, (int, np.integer)) for value in bounds):
+        raise ValueError("tile bounds must be integers.")
+    if not (0 <= row_start < row_stop <= shape[0] and 0 <= col_start < col_stop <= shape[1]):
+        raise ValueError(f"tile bounds {bounds} lie outside tree shape {shape}.")
+    if (row_stop - row_start) * (col_stop - col_start) != tile.area:
+        raise ValueError("tile area is inconsistent with its bounds.")
+    return bounds

--- a/openghg_inversions/basis/experimental/dyadic/objectives.py
+++ b/openghg_inversions/basis/experimental/dyadic/objectives.py
@@ -1,0 +1,274 @@
+"""Gaussian design objectives and explicitly labelled prototype tile scores.
+
+The principal score is linear-Gaussian degrees of freedom for signal (DFS).
+It is evaluated with state-space Cholesky solves and diagonal observation-error
+covariance.  Partition covariance is never cached by the objective: callers
+provide a builder that is invoked for each state/design evaluation.  For a
+Bocquet-consistent construction that builder should return ``B_P = P B P.T``.
+The included isotropic builder is only a proof-of-concept benchmark.
+
+The historical quadratic tile score is retained separately.  It aggregates
+fine-cell observation contributions before squaring, but it is a proxy and not
+exact DFS unless additional covariance, prolongation, and normalization
+assumptions are established.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import numpy as np
+import numpy.typing as npt
+
+from .multiscale import MultiscaleDesign
+from .state import PartitionState
+
+CovarianceBuilder = Callable[[PartitionState, MultiscaleDesign], npt.ArrayLike]
+
+
+@dataclass(frozen=True)
+class IsotropicRegionCovariance:
+    """Build isotropic region covariance as a proof-of-concept benchmark.
+
+    This benchmark returns ``tau**2 * I`` for each active partition.  It is not
+    the Bocquet-consistent aggregate ``B_P = P B P.T`` and should not be labelled
+    as such.
+
+    Args:
+        tau: Positive finite prior standard deviation for every active regional
+            coefficient.
+
+    Raises:
+        ValueError: If ``tau`` is not positive and finite.
+    """
+
+    tau: float
+
+    def __post_init__(self) -> None:
+        """Validate the benchmark prior scale."""
+        if not np.isfinite(self.tau) or self.tau <= 0.0:
+            raise ValueError("tau must be positive and finite.")
+
+    def __call__(self, state: PartitionState, design: MultiscaleDesign) -> np.ndarray:
+        """Return isotropic covariance for the state's active regions.
+
+        Args:
+            state: Partition whose active-region count sets the matrix size.
+            design: Associated design, accepted to satisfy the covariance-builder
+                interface and intentionally unused by this benchmark.
+
+        Returns:
+            Positive-definite covariance with shape ``(K, K)``.
+        """
+        del design
+        active_count = len(state.ordered_active())
+        return self.tau**2 * np.eye(active_count)
+
+
+@dataclass(frozen=True)
+class GaussianDFSObjective:
+    """Evaluate Gaussian DFS with covariance rebuilt for every partition.
+
+    Args:
+        r_diag: Positive diagonal of the observation-error covariance ``R``.
+        covariance_builder: Callable receiving ``(state, design)`` and returning
+            the active covariance ``B_P``.  A Bocquet-consistent implementation
+            should construct ``B_P = P B P.T`` for that partition; it must not
+            assume one fixed ``B`` applies to every ``P``.
+
+    Raises:
+        ValueError: If ``r_diag`` is not a positive finite one-dimensional
+            array.
+    """
+
+    r_diag: npt.ArrayLike
+    covariance_builder: CovarianceBuilder
+
+    def __post_init__(self) -> None:
+        """Validate and freeze the observation covariance diagonal."""
+        r_diag = _positive_vector(self.r_diag, name="r_diag")
+        r_diag.setflags(write=False)
+        object.__setattr__(self, "r_diag", r_diag)
+        if not callable(self.covariance_builder):
+            raise TypeError("covariance_builder must be callable.")
+
+    def score(self, state: PartitionState, design: MultiscaleDesign) -> float:
+        """Evaluate DFS for one partition/design pair.
+
+        Args:
+            state: Active partition to score.
+            design: Multiscale design from which active columns are gathered.
+
+        Returns:
+            Gaussian degrees of freedom for signal.
+
+        Raises:
+            ValueError: If the gathered design, covariance, or observation
+                covariance has incompatible or invalid values.
+        """
+        design_matrix = design.gather(state)
+        covariance = self.covariance_builder(state, design)
+        return gaussian_dfs(design_matrix, covariance, self.r_diag)
+
+    def __call__(self, state: PartitionState, design: MultiscaleDesign) -> float:
+        """Delegate callable objective evaluation to :meth:`score`."""
+        return self.score(state, design)
+
+
+def gaussian_dfs(H: npt.ArrayLike, B: npt.ArrayLike, r_diag: npt.ArrayLike) -> float:
+    """Compute Gaussian DFS with stable coefficient-space Cholesky solves.
+
+    The evaluated identity is
+    ``K - tr(A^-1 B^-1)``, where
+    ``A = B^-1 + H.T R^-1 H`` and ``R = diag(r_diag)``.  Cholesky whitening by
+    ``B`` avoids explicitly forming either matrix inverse.
+
+    Args:
+        H: Observation-by-state design matrix with shape ``(N, K)``.
+        B: Symmetric positive-definite state covariance with shape ``(K, K)``.
+        r_diag: Positive observation covariance diagonal with shape ``(N,)``.
+
+    Returns:
+        Gaussian degrees of freedom for signal as a scalar.
+
+    Raises:
+        ValueError: If dimensions are incompatible, inputs are non-finite,
+            ``r_diag`` is not positive, or ``B`` is not symmetric positive
+            definite.
+    """
+    design = _finite_float_array(H, name="H")
+    covariance = _finite_float_array(B, name="B")
+    errors = _positive_vector(r_diag, name="r_diag")
+    _validate_gaussian_shapes(design, covariance, errors)
+
+    covariance_cholesky = _positive_definite_cholesky(covariance, name="B")
+    whitened_design = design @ covariance_cholesky
+    information = np.eye(design.shape[1]) + (whitened_design.T / errors[np.newaxis, :]) @ whitened_design
+    information_cholesky = _positive_definite_cholesky(information, name="state information")
+    inverse_information = _cholesky_solve(information_cholesky, np.eye(design.shape[1]))
+    return float(design.shape[1] - np.trace(inverse_information))
+
+
+def direct_observation_space_dfs(
+    H: npt.ArrayLike,
+    B: npt.ArrayLike,
+    r_diag: npt.ArrayLike,
+) -> float:
+    """Compute DFS directly in observation space for small parity tests.
+
+    This independent helper evaluates
+    ``tr((H B H.T + R)^-1 H B H.T)``.  Its ``N``-by-``N`` factorization is useful
+    as a test oracle but is not the preferred implementation when observations
+    outnumber active state dimensions.
+
+    Args:
+        H: Observation-by-state design matrix with shape ``(N, K)``.
+        B: Symmetric positive-definite state covariance with shape ``(K, K)``.
+        r_diag: Positive observation covariance diagonal with shape ``(N,)``.
+
+    Returns:
+        Gaussian degrees of freedom for signal as a scalar.
+
+    Raises:
+        ValueError: If dimensions or numerical validity requirements are not
+            satisfied.
+    """
+    design = _finite_float_array(H, name="H")
+    covariance = _finite_float_array(B, name="B")
+    errors = _positive_vector(r_diag, name="r_diag")
+    _validate_gaussian_shapes(design, covariance, errors)
+    _positive_definite_cholesky(covariance, name="B")
+
+    projected_covariance = design @ covariance @ design.T
+    innovation = projected_covariance + np.diag(errors)
+    innovation_cholesky = _positive_definite_cholesky(innovation, name="innovation covariance")
+    averaging_kernel = _cholesky_solve(innovation_cholesky, projected_covariance)
+    return float(np.trace(averaging_kernel))
+
+
+def prototype_quadratic_tile_scores(
+    H: npt.ArrayLike,
+    observation_precision: npt.ArrayLike,
+    support_normalization: npt.ArrayLike,
+) -> np.ndarray:
+    """Compute the historical sum-then-square tile-score proxy.
+
+    For already aggregated candidate columns ``h_iv``, this evaluates
+    ``score_v = sum_i precision_i * h_iv**2 / support_v``.  ``H`` must therefore
+    be formed by summing fine-cell contributions before this function is called.
+    The result is explicitly a prototype quadratic proxy, not exact DFS.
+
+    Args:
+        H: Aggregated observation-by-tile columns with shape ``(N, V)``.
+        observation_precision: Explicit positive values ``1 / variance_i`` with
+            shape ``(N,)``.
+        support_normalization: Explicit positive physical support or area for
+            each tile, with shape ``(V,)``.
+
+    Returns:
+        One non-negative proxy score per candidate tile.
+
+    Raises:
+        ValueError: If inputs are non-finite, have incompatible dimensions, or
+            precision/support values are not positive.
+    """
+    design = _finite_float_array(H, name="H")
+    precision = _positive_vector(observation_precision, name="observation_precision")
+    support = _positive_vector(support_normalization, name="support_normalization")
+    if design.ndim != 2:
+        raise ValueError("H must be a two-dimensional observation-by-tile matrix.")
+    if precision.shape[0] != design.shape[0]:
+        raise ValueError("observation_precision length must match H observations.")
+    if support.shape[0] != design.shape[1]:
+        raise ValueError("support_normalization length must match H tiles.")
+    return np.sum(precision[:, np.newaxis] * np.square(design), axis=0) / support
+
+
+def _finite_float_array(values: npt.ArrayLike, *, name: str) -> np.ndarray:
+    """Convert an array-like input to a finite floating-point array."""
+    array = np.asarray(values)
+    if np.iscomplexobj(array):
+        raise ValueError(f"{name} must be real-valued.")
+    array = np.asarray(array, dtype=float)
+    if not np.all(np.isfinite(array)):
+        raise ValueError(f"{name} must contain only finite values.")
+    return array
+
+
+def _positive_vector(values: npt.ArrayLike, *, name: str) -> np.ndarray:
+    """Validate a finite one-dimensional vector with strictly positive values."""
+    vector = _finite_float_array(values, name=name)
+    if vector.ndim != 1:
+        raise ValueError(f"{name} must be one-dimensional.")
+    if np.any(vector <= 0.0):
+        raise ValueError(f"{name} must contain only positive values.")
+    return vector
+
+
+def _validate_gaussian_shapes(H: np.ndarray, B: np.ndarray, r_diag: np.ndarray) -> None:
+    """Validate dimensions shared by the two Gaussian DFS implementations."""
+    if H.ndim != 2:
+        raise ValueError("H must be a two-dimensional observation-by-state matrix.")
+    if H.shape[0] == 0 or H.shape[1] == 0:
+        raise ValueError("H dimensions must both be non-empty.")
+    if B.shape != (H.shape[1], H.shape[1]):
+        raise ValueError("B must have shape (H states, H states).")
+    if r_diag.shape[0] != H.shape[0]:
+        raise ValueError("r_diag length must match H observations.")
+    if not np.allclose(B, B.T, rtol=1e-12, atol=1e-12):
+        raise ValueError("B must be symmetric.")
+
+
+def _positive_definite_cholesky(matrix: np.ndarray, *, name: str) -> np.ndarray:
+    """Return a Cholesky factor or raise a domain-specific ``ValueError``."""
+    try:
+        return np.linalg.cholesky(matrix)
+    except np.linalg.LinAlgError as exc:
+        raise ValueError(f"{name} must be positive definite.") from exc
+
+
+def _cholesky_solve(cholesky: np.ndarray, right_hand_side: np.ndarray) -> np.ndarray:
+    """Solve a positive-definite system from its lower Cholesky factor."""
+    intermediate = np.linalg.solve(cholesky, right_hand_side)
+    return np.linalg.solve(cholesky.T, intermediate)

--- a/openghg_inversions/basis/experimental/dyadic/proposals.py
+++ b/openghg_inversions/basis/experimental/dyadic/proposals.py
@@ -1,0 +1,239 @@
+"""Enumerate and apply immutable local moves on dyadic partitions.
+
+Single split and merge moves change the active-region count by one.  A paired
+move first merges active siblings and then splits another active leaf, keeping
+the count fixed.  Paired neighbors are deduplicated by their resulting active
+frontier; their proposal probability is uniform over those unique states.
+
+This module describes only proposal geometry.  It deliberately contains no
+posterior target or acceptance calculation.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import TypeAlias
+
+from .state import PartitionState
+from .tree import DyadicTree
+
+
+@dataclass(frozen=True, slots=True)
+class SplitMove:
+    """Split one active node into its two children."""
+
+    node_id: int
+
+    def reverse(self) -> MergeMove:
+        """Return the merge that restores the pre-split partition."""
+        return MergeMove(parent_id=self.node_id)
+
+
+@dataclass(frozen=True, slots=True)
+class MergeMove:
+    """Merge two active sibling nodes into their parent."""
+
+    parent_id: int
+
+    def reverse(self) -> SplitMove:
+        """Return the split that restores the pre-merge partition."""
+        return SplitMove(node_id=self.parent_id)
+
+
+@dataclass(frozen=True, slots=True)
+class PairedMove:
+    """Merge one sibling pair, then split a different active leaf.
+
+    Attributes:
+        merge_parent_id: Parent identifier whose active children are merged.
+        split_node_id: Active node identifier split after the merge.
+    """
+
+    merge_parent_id: int
+    split_node_id: int
+
+    @property
+    def merge(self) -> MergeMove:
+        """Return the merge component of the paired move."""
+        return MergeMove(parent_id=self.merge_parent_id)
+
+    @property
+    def split(self) -> SplitMove:
+        """Return the split component of the paired move."""
+        return SplitMove(node_id=self.split_node_id)
+
+    def reverse(self) -> PairedMove:
+        """Return the paired move restoring the source partition.
+
+        The forward split must be merged first, after which the forward merge
+        parent is active and can be split again.
+        """
+        return PairedMove(
+            merge_parent_id=self.split_node_id,
+            split_node_id=self.merge_parent_id,
+        )
+
+
+Move: TypeAlias = SplitMove | MergeMove | PairedMove
+
+
+@dataclass(frozen=True, slots=True)
+class PairedNeighbor:
+    """A unique fixed-count neighbor and its uniform forward log probability.
+
+    Attributes:
+        state: Partition obtained by applying ``move``.
+        move: Deterministic representative move for this resulting state.
+        log_q: Natural logarithm of the uniform probability over all unique
+            paired neighbors of the source state.
+    """
+
+    state: PartitionState
+    move: PairedMove
+    log_q: float
+
+
+def enumerate_split_moves(tree: DyadicTree, state: PartitionState) -> tuple[SplitMove, ...]:
+    """Return splittable active nodes in stable identifier order.
+
+    Args:
+        tree: Tree defining child relationships.
+        state: Valid active partition frontier.
+
+    Returns:
+        One split move for every active node with children.
+    """
+    state.validate(tree)
+    return tuple(SplitMove(node_id=node_id) for node_id in state.ordered_active() if tree.children(node_id))
+
+
+def enumerate_merge_moves(tree: DyadicTree, state: PartitionState) -> tuple[MergeMove, ...]:
+    """Return parents whose two children are active, without duplicates.
+
+    Args:
+        tree: Tree defining parent and child relationships.
+        state: Valid active partition frontier.
+
+    Returns:
+        Merge moves ordered by increasing parent identifier.
+    """
+    state.validate(tree)
+    parent_ids: set[int] = set()
+    for node_id in state.active:
+        parent_id = tree.parent(node_id)
+        if parent_id is None:
+            continue
+        children = tree.children(parent_id)
+        if children and all(child_id in state.active for child_id in children):
+            parent_ids.add(parent_id)
+    return tuple(MergeMove(parent_id=parent_id) for parent_id in sorted(parent_ids))
+
+
+def enumerate_paired_moves(tree: DyadicTree, state: PartitionState) -> tuple[PairedMove, ...]:
+    """Return one deterministic move for each unique fixed-count neighbor.
+
+    Candidate moves merge an active sibling pair and then split a splittable
+    leaf in the intermediate partition.  Re-splitting the just-merged parent is
+    excluded because it would be a no-op.  If several candidates produce the
+    same active frontier, only the first lexicographically generated move is
+    retained.
+
+    Args:
+        tree: Tree defining partition relationships.
+        state: Valid source partition.
+
+    Returns:
+        Paired moves ordered first by merge parent and then by split node.
+    """
+    return tuple(neighbor.move for neighbor in enumerate_paired_neighbors(tree, state))
+
+
+def enumerate_paired_neighbors(
+    tree: DyadicTree,
+    state: PartitionState,
+) -> tuple[PairedNeighbor, ...]:
+    """Enumerate unique fixed-count neighbors with uniform forward ``log_q``.
+
+    Args:
+        tree: Tree defining partition relationships.
+        state: Valid source partition.
+
+    Returns:
+        Unique neighbor records.  Every record has ``log_q = -log(N)``, where
+        ``N`` is the number of unique returned states.  An isolated state
+        returns an empty tuple.
+    """
+    state.validate(tree)
+    unique: dict[frozenset[int], tuple[PartitionState, PairedMove]] = {}
+
+    for merge_move in enumerate_merge_moves(tree, state):
+        merged_state = apply_move(tree, state, merge_move)
+        for split_move in enumerate_split_moves(tree, merged_state):
+            if split_move.node_id == merge_move.parent_id:
+                continue
+            move = PairedMove(
+                merge_parent_id=merge_move.parent_id,
+                split_node_id=split_move.node_id,
+            )
+            neighbor_state = apply_move(tree, state, move)
+            unique.setdefault(neighbor_state.active, (neighbor_state, move))
+
+    if not unique:
+        return ()
+
+    log_q = -math.log(len(unique))
+    return tuple(
+        PairedNeighbor(state=neighbor_state, move=move, log_q=log_q)
+        for neighbor_state, move in unique.values()
+    )
+
+
+def apply_move(tree: DyadicTree, state: PartitionState, move: Move) -> PartitionState:
+    """Apply a valid local move and return a new partition state.
+
+    Args:
+        tree: Tree defining partition relationships.
+        state: Source partition, which is never mutated.
+        move: Split, merge, or merge-then-split move to apply.
+
+    Returns:
+        The validated destination partition.
+
+    Raises:
+        TypeError: If ``move`` is not a supported move type.
+        ValueError: Propagated by ``PartitionState`` when the requested move is
+            invalid for ``state``.
+    """
+    state.validate(tree)
+    if isinstance(move, SplitMove):
+        result = state.split(tree, move.node_id)
+    elif isinstance(move, MergeMove):
+        result = state.merge(tree, move.parent_id)
+    elif isinstance(move, PairedMove):
+        if move.merge_parent_id == move.split_node_id:
+            raise ValueError("A paired move cannot re-split its merged parent.")
+        result = state.merge(tree, move.merge_parent_id)
+        result = result.split(tree, move.split_node_id)
+    else:
+        raise TypeError(f"Unsupported move type: {type(move).__name__}.")
+
+    result.validate(tree)
+    return result
+
+
+def reverse_move(move: Move) -> Move:
+    """Return the local move that reverses ``move`` on its destination state.
+
+    Args:
+        move: Split, merge, or paired move to reverse.
+
+    Returns:
+        The corresponding inverse move.
+
+    Raises:
+        TypeError: If ``move`` is not a supported move type.
+    """
+    if isinstance(move, (SplitMove, MergeMove, PairedMove)):
+        return move.reverse()
+    raise TypeError(f"Unsupported move type: {type(move).__name__}.")

--- a/openghg_inversions/basis/experimental/dyadic/search.py
+++ b/openghg_inversions/basis/experimental/dyadic/search.py
@@ -1,0 +1,259 @@
+"""Generic stochastic local search for experimental dyadic partitions.
+
+The runner in this module is an optimizer. Its temperature-based acceptance
+rule is not a Metropolis-Hastings posterior transition because it does not
+include a target density or forward/reverse proposal probabilities.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from math import exp
+from typing import Generic, Protocol, TypeVar
+
+import numpy as np
+
+
+StateT = TypeVar("StateT")
+MoveT = TypeVar("MoveT")
+
+
+class TemperatureSchedule(Protocol):
+    """Return the optimizer temperature for one zero-based iteration."""
+
+    def __call__(self, iteration: int, total_iterations: int, /) -> float:
+        """Return a finite non-negative temperature."""
+        ...
+
+
+@dataclass(frozen=True)
+class PiecewiseGeometricSchedule:
+    """Hold, geometrically cool, and finish with zero-temperature polishing.
+
+    Args:
+        initial_temperature: Temperature during the initial hold period.
+        final_temperature: Positive temperature at the end of geometric cooling.
+        hold_fraction: Fraction of iterations spent at the initial temperature.
+        polish_fraction: Fraction of iterations spent at zero temperature.
+    """
+
+    initial_temperature: float
+    final_temperature: float
+    hold_fraction: float = 0.1
+    polish_fraction: float = 0.1
+
+    def __post_init__(self) -> None:
+        """Validate schedule parameters."""
+        if not np.isfinite(self.initial_temperature) or self.initial_temperature <= 0.0:
+            raise ValueError("initial_temperature must be positive and finite.")
+        if not np.isfinite(self.final_temperature) or self.final_temperature <= 0.0:
+            raise ValueError("final_temperature must be positive and finite.")
+        if self.final_temperature > self.initial_temperature:
+            raise ValueError("final_temperature must not exceed initial_temperature.")
+        if not 0.0 <= self.hold_fraction < 1.0:
+            raise ValueError("hold_fraction must be in [0, 1).")
+        if not 0.0 <= self.polish_fraction < 1.0:
+            raise ValueError("polish_fraction must be in [0, 1).")
+        if self.hold_fraction + self.polish_fraction >= 1.0:
+            raise ValueError("hold_fraction and polish_fraction must sum to less than 1.")
+
+    def __call__(self, iteration: int, total_iterations: int) -> float:
+        """Return the temperature for one iteration.
+
+        Args:
+            iteration: Zero-based iteration index.
+            total_iterations: Total number of configured search iterations.
+
+        Returns:
+            Initial, geometrically cooled, or zero polishing temperature.
+
+        Raises:
+            ValueError: If the iteration bounds are invalid.
+        """
+        if total_iterations < 1:
+            raise ValueError("total_iterations must be positive.")
+        if iteration < 0 or iteration >= total_iterations:
+            raise ValueError("iteration must be within total_iterations.")
+
+        hold_steps = int(total_iterations * self.hold_fraction)
+        polish_steps = int(total_iterations * self.polish_fraction)
+        cool_stop = total_iterations - polish_steps
+        if iteration < hold_steps:
+            return self.initial_temperature
+        if iteration >= cool_stop:
+            return 0.0
+
+        cool_steps = max(cool_stop - hold_steps, 1)
+        progress = (iteration - hold_steps) / max(cool_steps - 1, 1)
+        ratio = self.final_temperature / self.initial_temperature
+        return float(self.initial_temperature * ratio**progress)
+
+
+@dataclass(frozen=True)
+class SearchProposal(Generic[StateT, MoveT]):
+    """One candidate state and the move metadata that produced it."""
+
+    state: StateT
+    move: MoveT
+
+
+@dataclass(frozen=True)
+class SearchStep(Generic[StateT, MoveT]):
+    """Diagnostics for one evaluated search proposal."""
+
+    iteration: int
+    temperature: float
+    candidate_score: float
+    current_score: float
+    best_score: float
+    accepted: bool
+    new_best: bool
+    current_state: StateT
+    move: MoveT
+
+
+@dataclass(frozen=True)
+class SearchResult(Generic[StateT, MoveT]):
+    """Initial, final, and best states from stochastic local search."""
+
+    initial_state: StateT
+    final_state: StateT
+    best_state: StateT
+    initial_score: float
+    final_score: float
+    best_score: float
+    accepted_moves: int
+    evaluated_moves: int
+    trace: tuple[SearchStep[StateT, MoveT], ...]
+    stop_reason: str
+
+
+ProposalFunction = Callable[[StateT, np.random.Generator], SearchProposal[StateT, MoveT] | None]
+ObjectiveFunction = Callable[[StateT], float]
+
+
+def stochastic_local_search(
+    initial_state: StateT,
+    *,
+    objective: ObjectiveFunction[StateT],
+    propose: ProposalFunction[StateT, MoveT],
+    schedule: TemperatureSchedule,
+    iterations: int,
+    rng: np.random.Generator,
+    record_every: int = 1,
+) -> SearchResult[StateT, MoveT]:
+    """Maximize an objective with temperature-controlled local proposals.
+
+    Args:
+        initial_state: Immutable state from which the search starts.
+        objective: Callable returning a finite score to maximize.
+        propose: Callable returning a candidate state and move metadata. Returning
+            None stops the search because no proposal is available.
+        schedule: Temperature schedule used for accepting score decreases.
+        iterations: Maximum number of proposal evaluations.
+        rng: Random generator owned by the caller.
+        record_every: Record every Nth evaluated proposal. Accepted moves, new
+            best states, and the final iteration are always recorded.
+
+    Returns:
+        Search result containing final/best states and a bounded trace.
+
+    Raises:
+        ValueError: If configuration or objective values are invalid.
+
+    Notes:
+        The acceptance probability for a score decrease loss is
+        exp(-loss / temperature). Proposal probabilities are deliberately
+        absent; this function performs optimization, not posterior sampling.
+    """
+    if iterations < 0:
+        raise ValueError("iterations must be non-negative.")
+    if record_every < 1:
+        raise ValueError("record_every must be positive.")
+
+    current_state = initial_state
+    current_score = _finite_score(objective(current_state))
+    initial_score = current_score
+    best_state = current_state
+    best_score = current_score
+    accepted_moves = 0
+    evaluated_moves = 0
+    trace: list[SearchStep[StateT, MoveT]] = []
+    stop_reason = "iteration_limit"
+
+    for iteration in range(iterations):
+        proposal = propose(current_state, rng)
+        if proposal is None:
+            stop_reason = "no_proposal"
+            break
+
+        temperature = float(schedule(iteration, iterations))
+        if not np.isfinite(temperature) or temperature < 0.0:
+            raise ValueError("schedule returned an invalid temperature.")
+
+        candidate_score = _finite_score(objective(proposal.state))
+        score_change = candidate_score - current_score
+        accepted = score_change >= 0.0
+        if not accepted and temperature > 0.0:
+            accepted = bool(rng.random() < exp(score_change / temperature))
+
+        evaluated_moves += 1
+        if accepted:
+            current_state = proposal.state
+            current_score = candidate_score
+            accepted_moves += 1
+
+        new_best = current_score > best_score
+        if new_best:
+            best_state = current_state
+            best_score = current_score
+
+        should_record = (
+            evaluated_moves % record_every == 0 or accepted or new_best or iteration == iterations - 1
+        )
+        if should_record:
+            trace.append(
+                SearchStep(
+                    iteration=iteration,
+                    temperature=temperature,
+                    candidate_score=candidate_score,
+                    current_score=current_score,
+                    best_score=best_score,
+                    accepted=accepted,
+                    new_best=new_best,
+                    current_state=current_state,
+                    move=proposal.move,
+                )
+            )
+
+    return SearchResult(
+        initial_state=initial_state,
+        final_state=current_state,
+        best_state=best_state,
+        initial_score=initial_score,
+        final_score=current_score,
+        best_score=best_score,
+        accepted_moves=accepted_moves,
+        evaluated_moves=evaluated_moves,
+        trace=tuple(trace),
+        stop_reason=stop_reason,
+    )
+
+
+def _finite_score(score: float) -> float:
+    """Return a finite floating score."""
+    value = float(score)
+    if not np.isfinite(value):
+        raise ValueError("objective must return a finite score.")
+    return value
+
+
+__all__ = [
+    "PiecewiseGeometricSchedule",
+    "SearchProposal",
+    "SearchResult",
+    "SearchStep",
+    "TemperatureSchedule",
+    "stochastic_local_search",
+]

--- a/openghg_inversions/basis/experimental/dyadic/state.py
+++ b/openghg_inversions/basis/experimental/dyadic/state.py
@@ -1,0 +1,164 @@
+"""Immutable active-frontier states for canonical dyadic trees.
+
+A valid partition state is an exact frontier through one
+:class:`~openghg_inversions.basis.experimental.dyadic.tree.DyadicTree`: active
+tiles cover the root exactly once and no active tile is an ancestor of another.
+Split and merge operations return new states and never mutate their input.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from .tree import DyadicTree, NodeId
+
+
+@dataclass(frozen=True, slots=True)
+class PartitionState:
+    """Immutable set of active tile IDs forming a dyadic partition frontier.
+
+    The constructor normalizes the supplied collection to a ``frozenset``.
+    Call :meth:`validate` when associating a state with a particular tree.
+
+    Attributes:
+        active: Active tile IDs. A valid set covers its tree's root exactly
+            once without ancestor/descendant overlap.
+    """
+
+    active: frozenset[NodeId]
+
+    def __post_init__(self) -> None:
+        """Normalize active IDs to an immutable set."""
+        object.__setattr__(self, "active", frozenset(self.active))
+
+    @classmethod
+    def root(cls, tree: DyadicTree) -> PartitionState:
+        """Create the coarsest valid state containing only the root.
+
+        Args:
+            tree: Tree whose root should form the partition.
+
+        Returns:
+            A valid one-tile partition state.
+        """
+        return cls(active=frozenset({tree.root_id}))
+
+    def ordered_active(self) -> tuple[NodeId, ...]:
+        """Return active node IDs in stable ascending tree order."""
+        return tuple(sorted(self.active))
+
+    def validate(self, tree: DyadicTree) -> None:
+        """Validate that this state is an exact frontier over ``tree``.
+
+        Validation checks that every active ID belongs to the tree, that no
+        active node has an active ancestor, and that every root-to-cell path
+        encounters an active node. Together these establish exact, non-
+        overlapping coverage of the root.
+
+        Args:
+            tree: Canonical tree against which to validate the state.
+
+        Raises:
+            ValueError: If the active set is empty, includes an unknown node,
+                overlaps through ancestry, or leaves part of the root
+                uncovered.
+        """
+        if not self.active:
+            raise ValueError("A partition state must contain at least one active tile.")
+
+        for node_id in self.active:
+            try:
+                tree.tile(node_id)
+            except KeyError as error:
+                raise ValueError(f"Active node ID {node_id!r} is not in the tree.") from error
+
+        for node_id in self.ordered_active():
+            ancestor_id = tree.parent(node_id)
+            while ancestor_id is not None:
+                if ancestor_id in self.active:
+                    raise ValueError("A partition state cannot contain active ancestor and descendant tiles.")
+                ancestor_id = tree.parent(ancestor_id)
+
+        pending = [tree.root_id]
+        while pending:
+            node_id = pending.pop()
+            if node_id in self.active:
+                continue
+            child_ids = tree.children(node_id)
+            if not child_ids:
+                raise ValueError("Active tiles do not exactly cover the tree root.")
+            pending.extend(child_ids)
+
+    def split(self, tree: DyadicTree, node_id: NodeId) -> PartitionState:
+        """Replace one active tile with its two canonical children.
+
+        Args:
+            tree: Tree defining the partition and child relationships.
+            node_id: Active non-cell node to split.
+
+        Returns:
+            A new valid partition state; this state is unchanged.
+
+        Raises:
+            ValueError: If this state is invalid for ``tree``, ``node_id`` is
+                not active, or ``node_id`` is already a cell.
+        """
+        self.validate(tree)
+        if node_id not in self.active:
+            raise ValueError(f"Node {node_id!r} is not active and cannot be split.")
+        child_ids = tree.children(node_id)
+        if not child_ids:
+            raise ValueError(f"Cell node {node_id!r} cannot be split.")
+        return PartitionState(active=(self.active - {node_id}) | frozenset(child_ids))
+
+    def merge(self, tree: DyadicTree, parent_id: NodeId) -> PartitionState:
+        """Replace two active sibling tiles with their parent.
+
+        Args:
+            tree: Tree defining the partition and sibling relationships.
+            parent_id: Parent whose complete child pair should be merged.
+
+        Returns:
+            A new valid partition state; this state is unchanged.
+
+        Raises:
+            KeyError: If ``parent_id`` is not in ``tree``.
+            ValueError: If this state is invalid, ``parent_id`` is a cell, or
+                both true children of ``parent_id`` are not active.
+        """
+        self.validate(tree)
+        child_ids = tree.children(parent_id)
+        if not child_ids:
+            raise ValueError(f"Cell node {parent_id!r} has no children to merge.")
+        if not frozenset(child_ids).issubset(self.active):
+            raise ValueError("A merge requires both active children of the same parent.")
+        return PartitionState(active=(self.active - frozenset(child_ids)) | {parent_id})
+
+    def to_labels(self, tree: DyadicTree) -> np.ndarray:
+        """Render this partition as compact positive integer labels.
+
+        Labels are assigned from one in :meth:`ordered_active` order, giving a
+        deterministic packed representation while canonical node IDs remain
+        available separately as region identity.
+
+        Args:
+            tree: Tree providing tile bounds and output shape.
+
+        Returns:
+            A NumPy integer array with ``tree.shape`` and one positive label per
+            active tile.
+
+        Raises:
+            ValueError: If this state is not an exact frontier over ``tree``.
+        """
+        self.validate(tree)
+        labels = np.zeros(tree.shape, dtype=np.int64)
+        for label, node_id in enumerate(self.ordered_active(), start=1):
+            tile = tree.tile(node_id)
+            labels[tile.row_start : tile.row_stop, tile.col_start : tile.col_stop] = label
+        return labels
+
+
+__all__ = ["PartitionState"]

--- a/openghg_inversions/basis/experimental/dyadic/tree.py
+++ b/openghg_inversions/basis/experimental/dyadic/tree.py
@@ -1,0 +1,277 @@
+"""Canonical binary tree geometry for exact rectangular grids.
+
+The tree recursively bisects the longer dimension of each tile at its integer
+midpoint. Rows win ties for square tiles. Every non-cell tile therefore has two
+ordered children that cover it exactly without overlap, and recursion ends at
+individual grid cells.
+
+Node IDs are zero-based integers assigned in depth-first preorder, visiting the
+upper or left child first. This makes IDs and node ordering deterministic for a
+given root shape while keeping all IDs contiguous.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from operator import index
+from typing import TypeAlias
+
+NodeId: TypeAlias = int
+
+
+@dataclass(frozen=True, slots=True)
+class Tile:
+    """Immutable rectangular node in a canonical dyadic tree.
+
+    Bounds use half-open row and column index intervals.
+
+    Attributes:
+        node_id: Stable integer identifier assigned in depth-first preorder.
+        row_start: Inclusive first row index.
+        row_stop: Exclusive final row index.
+        col_start: Inclusive first column index.
+        col_stop: Exclusive final column index.
+        depth: Number of edges between this tile and the root.
+    """
+
+    node_id: NodeId
+    row_start: int
+    row_stop: int
+    col_start: int
+    col_stop: int
+    depth: int
+
+    @property
+    def height(self) -> int:
+        """Return the number of rows covered by the tile."""
+        return self.row_stop - self.row_start
+
+    @property
+    def width(self) -> int:
+        """Return the number of columns covered by the tile."""
+        return self.col_stop - self.col_start
+
+    @property
+    def area(self) -> int:
+        """Return the number of grid cells covered by the tile."""
+        return self.height * self.width
+
+    @property
+    def bounds(self) -> tuple[int, int, int, int]:
+        """Return half-open row and column bounds as one tuple."""
+        return self.row_start, self.row_stop, self.col_start, self.col_stop
+
+    @property
+    def is_cell(self) -> bool:
+        """Return whether the tile contains exactly one grid cell."""
+        return self.height == 1 and self.width == 1
+
+
+@dataclass(frozen=True, slots=True)
+class DyadicTree:
+    """Complete canonical binary partition tree for one rectangular shape.
+
+    Construct trees with :meth:`from_shape`. The stored tuples are ordered by
+    contiguous node ID, so iteration and downstream array construction are
+    deterministic.
+
+    Attributes:
+        shape: Exact unpadded ``(rows, columns)`` root shape.
+    """
+
+    shape: tuple[int, int]
+    _nodes: tuple[Tile, ...]
+    _children: tuple[tuple[NodeId, ...], ...]
+    _parents: tuple[NodeId | None, ...]
+    _leaf_ids: tuple[NodeId, ...]
+
+    @classmethod
+    def from_shape(cls, shape: tuple[int, int]) -> DyadicTree:
+        """Build the complete canonical tree for an exact 2D shape.
+
+        Tiles are assigned contiguous IDs in depth-first preorder. Each tile
+        is bisected along its longer dimension; rows win ties. Odd lengths are
+        split at ``start + length // 2``, so the second child receives the
+        extra row or column.
+
+        Args:
+            shape: Positive ``(rows, columns)`` grid shape.
+
+        Returns:
+            An immutable tree whose leaves are the individual grid cells.
+
+        Raises:
+            TypeError: If either extent is not an integer.
+            ValueError: If ``shape`` is not length two or has a non-positive
+                extent.
+        """
+        rows, cols = _validate_shape(shape)
+        nodes: list[Tile] = []
+        children: list[list[NodeId]] = []
+        parents: list[NodeId | None] = []
+        pending: list[tuple[int, int, int, int, int, NodeId | None]] = [(0, rows, 0, cols, 0, None)]
+
+        while pending:
+            row_start, row_stop, col_start, col_stop, depth, parent_id = pending.pop()
+            node_id = len(nodes)
+            tile = Tile(node_id, row_start, row_stop, col_start, col_stop, depth)
+            nodes.append(tile)
+            children.append([])
+            parents.append(parent_id)
+            if parent_id is not None:
+                children[parent_id].append(node_id)
+
+            child_bounds = _split_bounds(tile)
+            if child_bounds is None:
+                continue
+
+            first, second = child_bounds
+            # The stack is last-in, first-out; push the second child first to
+            # assign preorder IDs to the upper or left subtree first.
+            pending.append((*second, depth + 1, node_id))
+            pending.append((*first, depth + 1, node_id))
+
+        child_ids = tuple(tuple(node_children) for node_children in children)
+        leaf_ids = tuple(node.node_id for node in nodes if not child_ids[node.node_id])
+        return cls(
+            shape=(rows, cols),
+            _nodes=tuple(nodes),
+            _children=child_ids,
+            _parents=tuple(parents),
+            _leaf_ids=leaf_ids,
+        )
+
+    @property
+    def root_id(self) -> NodeId:
+        """Return the stable root node ID."""
+        return 0
+
+    @property
+    def nodes(self) -> tuple[Tile, ...]:
+        """Return all tiles in stable node-ID order."""
+        return self._nodes
+
+    @property
+    def leaf_ids(self) -> tuple[NodeId, ...]:
+        """Return cell-node IDs in stable node-ID order."""
+        return self._leaf_ids
+
+    def tile(self, node_id: NodeId) -> Tile:
+        """Return the tile associated with a node ID.
+
+        Args:
+            node_id: Integer node identifier in this tree.
+
+        Returns:
+            The immutable tile for ``node_id``.
+
+        Raises:
+            KeyError: If ``node_id`` does not identify a node in this tree.
+        """
+        return self._nodes[self._node_index(node_id)]
+
+    def children(self, node_id: NodeId) -> tuple[NodeId, ...]:
+        """Return a node's ordered child IDs.
+
+        Args:
+            node_id: Integer node identifier in this tree.
+
+        Returns:
+            Two child IDs for a non-cell tile, or an empty tuple for a cell.
+
+        Raises:
+            KeyError: If ``node_id`` does not identify a node in this tree.
+        """
+        return self._children[self._node_index(node_id)]
+
+    def parent(self, node_id: NodeId) -> NodeId | None:
+        """Return a node's parent ID, or ``None`` for the root.
+
+        Args:
+            node_id: Integer node identifier in this tree.
+
+        Returns:
+            The parent node ID, or ``None`` when ``node_id`` is the root.
+
+        Raises:
+            KeyError: If ``node_id`` does not identify a node in this tree.
+        """
+        return self._parents[self._node_index(node_id)]
+
+    def _node_index(self, node_id: NodeId) -> int:
+        """Return a checked tuple index for ``node_id``."""
+        if isinstance(node_id, bool):
+            raise KeyError(f"Unknown dyadic node ID {node_id!r}.")
+        try:
+            node_index = index(node_id)
+        except TypeError as error:
+            raise KeyError(f"Unknown dyadic node ID {node_id!r}.") from error
+        if node_index < 0 or node_index >= len(self._nodes):
+            raise KeyError(f"Unknown dyadic node ID {node_id!r}.")
+        return node_index
+
+
+def _validate_shape(shape: tuple[int, int]) -> tuple[int, int]:
+    """Validate and normalize a positive two-dimensional grid shape.
+
+    Args:
+        shape: Candidate ``(rows, columns)`` shape.
+
+    Returns:
+        The shape as a pair of built-in integers.
+
+    Raises:
+        TypeError: If either extent is not an integer.
+        ValueError: If the shape is not length two or an extent is not
+            positive.
+    """
+    try:
+        extents = tuple(shape)
+    except TypeError as error:
+        raise ValueError("Dyadic tree shape must contain exactly two extents.") from error
+    if len(extents) != 2:
+        raise ValueError("Dyadic tree shape must contain exactly two extents.")
+
+    normalized: list[int] = []
+    for extent in extents:
+        if isinstance(extent, bool):
+            raise TypeError("Dyadic tree extents must be integers.")
+        try:
+            value = index(extent)
+        except TypeError as error:
+            raise TypeError("Dyadic tree extents must be integers.") from error
+        if value <= 0:
+            raise ValueError("Dyadic tree extents must be positive.")
+        normalized.append(value)
+    return normalized[0], normalized[1]
+
+
+def _split_bounds(
+    tile: Tile,
+) -> tuple[tuple[int, int, int, int], tuple[int, int, int, int]] | None:
+    """Return canonical child bounds for one tile.
+
+    Args:
+        tile: Tile to bisect along its longer dimension. Rows win ties.
+
+    Returns:
+        Upper/lower or left/right child bounds, or ``None`` when ``tile`` is a
+        cell.
+    """
+    if tile.is_cell:
+        return None
+    if tile.height >= tile.width:
+        midpoint = tile.row_start + tile.height // 2
+        return (
+            (tile.row_start, midpoint, tile.col_start, tile.col_stop),
+            (midpoint, tile.row_stop, tile.col_start, tile.col_stop),
+        )
+
+    midpoint = tile.col_start + tile.width // 2
+    return (
+        (tile.row_start, tile.row_stop, tile.col_start, midpoint),
+        (tile.row_start, tile.row_stop, midpoint, tile.col_stop),
+    )
+
+
+__all__ = ["DyadicTree", "NodeId", "Tile"]

--- a/tests/basis/experimental/test_dyadic_initializers.py
+++ b/tests/basis/experimental/test_dyadic_initializers.py
@@ -1,0 +1,90 @@
+"""Tests for deterministic and random dyadic partition initializers."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from openghg_inversions.basis.experimental.dyadic.initializers import (
+    greedy_partition,
+    random_partition,
+    threshold_partition,
+)
+from openghg_inversions.basis.experimental.dyadic.tree import DyadicTree
+
+
+def test_greedy_partition_reaches_exact_target_with_stable_ties() -> None:
+    """Equal greedy gains should be resolved by increasing node identifier."""
+    tree = DyadicTree.from_shape((4, 4))
+
+    result = greedy_partition(tree, target_regions=4, split_gain=lambda node_id: 1.0)
+
+    assert result.split_history == (0, 1, 2)
+    assert len(result.state.active) == 4
+    result.state.validate(tree)
+
+
+def test_greedy_partition_uses_highest_available_gain() -> None:
+    """Greedy growth should reconsider child gains after every selected split."""
+    tree = DyadicTree.from_shape((4, 4))
+    first_child, second_child = tree.children(tree.root_id)
+    favoured_grandchild = tree.children(first_child)[1]
+    gains = {first_child: 2.0, second_child: 1.0, favoured_grandchild: 3.0}
+
+    result = greedy_partition(
+        tree,
+        target_regions=4,
+        split_gain=lambda node_id: gains.get(node_id, 0.0),
+    )
+
+    assert result.split_history == (tree.root_id, first_child, favoured_grandchild)
+    assert len(result.state.active) == 4
+
+
+def test_random_partition_is_reproducible_for_generator_seed() -> None:
+    """Fresh generators with the same seed should produce identical growth."""
+    tree = DyadicTree.from_shape((4, 4))
+
+    first = random_partition(tree, 9, np.random.default_rng(174))
+    second = random_partition(tree, 9, np.random.default_rng(174))
+
+    assert first == second
+    assert len(first.state.active) == 9
+    first.state.validate(tree)
+
+
+def test_threshold_partition_scores_tiles_and_uses_strict_comparison() -> None:
+    """Threshold growth should split scored tiles only while score is greater."""
+    tree = DyadicTree.from_shape((4, 4))
+    first_child, second_child = tree.children(tree.root_id)
+    second_grandchild = tree.children(second_child)[1]
+    scores = {
+        tree.root_id: 10.0,
+        first_child: 5.0,
+        second_child: 6.0,
+        second_grandchild: 7.0,
+    }
+
+    result = threshold_partition(
+        tree,
+        tile_score=lambda tile: scores.get(tile.node_id, 0.0),
+        threshold=5.0,
+    )
+
+    assert result.split_history == (tree.root_id, second_child, second_grandchild)
+    assert len(result.state.active) == 4
+    result.state.validate(tree)
+
+
+@pytest.mark.parametrize("target_regions", [0, -1, 17])
+def test_greedy_partition_rejects_impossible_targets(target_regions: int) -> None:
+    """Greedy growth should reject empty or over-capacity targets."""
+    with pytest.raises(ValueError, match="target_regions|Cannot construct"):
+        greedy_partition(DyadicTree.from_shape((4, 4)), target_regions, lambda node_id: 0.0)
+
+
+@pytest.mark.parametrize("target_regions", [0, -1, 17])
+def test_random_partition_rejects_impossible_targets(target_regions: int) -> None:
+    """Random growth should reject empty or over-capacity targets."""
+    with pytest.raises(ValueError, match="target_regions|Cannot construct"):
+        random_partition(DyadicTree.from_shape((4, 4)), target_regions, np.random.default_rng(1))

--- a/tests/basis/experimental/test_dyadic_multiscale.py
+++ b/tests/basis/experimental/test_dyadic_multiscale.py
@@ -1,0 +1,94 @@
+"""Tests for sum-preserving dyadic multiscale design construction."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from openghg_inversions.basis.experimental.dyadic.multiscale import (
+    MultiscaleDesign,
+    direct_gather,
+    sum_coarsen_grid,
+)
+from openghg_inversions.basis.experimental.dyadic.state import PartitionState
+from openghg_inversions.basis.experimental.dyadic.tree import DyadicTree
+
+
+def test_sum_coarsen_grid_preserves_partial_blocks_and_support() -> None:
+    """Coarsening should sum partial boundaries and count their fine cells."""
+    grid = np.arange(1.0, 31.0).reshape(2, 3, 5)
+
+    result = sum_coarsen_grid(grid, factor=2)
+
+    expected = np.empty((2, 2, 3))
+    for row in range(2):
+        for column in range(3):
+            expected[:, row, column] = grid[:, row * 2 : (row + 1) * 2, column * 2 : (column + 1) * 2].sum(
+                axis=(1, 2)
+            )
+    np.testing.assert_array_equal(result.values, expected)
+    np.testing.assert_array_equal(result.support_counts, [[4, 4, 2], [2, 2, 1]])
+    np.testing.assert_array_equal(result.values.sum(axis=(1, 2)), grid.sum(axis=(1, 2)))
+
+
+def test_candidate_columns_equal_direct_tile_sums() -> None:
+    """Every recursively constructed candidate should equal a direct grid sum."""
+    grid = np.arange(1.0, 13.0).reshape(3, 2, 2)
+    tree = DyadicTree.from_shape((2, 2))
+
+    design = MultiscaleDesign.from_grid(grid, tree)
+
+    for node_id, tile in enumerate(tree.nodes):
+        row_start, row_stop, col_start, col_stop = tile.bounds
+        expected = grid[:, row_start:row_stop, col_start:col_stop].sum(axis=(1, 2))
+        np.testing.assert_array_equal(design.H[:, node_id], expected)
+    np.testing.assert_array_equal(design.H[:, 0], design.H[:, 1] + design.H[:, 4])
+
+
+def test_gather_matches_independent_direct_aggregation() -> None:
+    """Stable gathered columns should match direct active-tile aggregation."""
+    grid = np.arange(1.0, 13.0).reshape(3, 2, 2)
+    tree = DyadicTree.from_shape((2, 2))
+    state = PartitionState(frozenset({1, 5, 6}))
+    design = MultiscaleDesign.from_grid(grid, tree)
+
+    gathered = design.gather(state)
+
+    np.testing.assert_array_equal(gathered, direct_gather(grid, tree, state))
+    np.testing.assert_array_equal(gathered[:, 1], grid[:, 1, 0])
+    np.testing.assert_array_equal(gathered[:, 2], grid[:, 1, 1])
+
+
+def test_multiscale_design_integrates_with_concrete_tree_and_state() -> None:
+    """The concrete experimental types should satisfy the design contracts."""
+    grid = np.arange(24.0).reshape(2, 3, 4)
+    tree = DyadicTree.from_shape((3, 4))
+    state = PartitionState.root(tree).split(tree, tree.root_id)
+
+    design = MultiscaleDesign.from_grid(grid, tree)
+
+    np.testing.assert_array_equal(design.gather(state), direct_gather(grid, tree, state))
+
+
+def test_multiscale_rejects_invalid_inputs() -> None:
+    """Multiscale helpers should reject invalid factors, values, and shapes."""
+    tree = DyadicTree.from_shape((2, 2))
+    with pytest.raises(ValueError, match="positive"):
+        sum_coarsen_grid(np.ones((1, 2, 2)), factor=0)
+    with pytest.raises(TypeError, match="integer"):
+        sum_coarsen_grid(np.ones((1, 2, 2)), factor=1.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="finite"):
+        sum_coarsen_grid(np.array([[[np.nan]]]), factor=1)
+    with pytest.raises(ValueError, match="spatial shape"):
+        MultiscaleDesign.from_grid(np.ones((1, 2, 3)), tree)
+    with pytest.raises(ValueError, match="finite"):
+        MultiscaleDesign.from_grid(np.full((1, 2, 2), np.inf), tree)
+
+
+def test_gather_rejects_unknown_node_id() -> None:
+    """Gathering should fail clearly when a state references no candidate column."""
+    tree = DyadicTree.from_shape((2, 2))
+    design = MultiscaleDesign.from_grid(np.ones((1, 2, 2)), tree)
+
+    with pytest.raises(ValueError, match="outside"):
+        design.gather(PartitionState(frozenset({7})))

--- a/tests/basis/experimental/test_dyadic_objectives.py
+++ b/tests/basis/experimental/test_dyadic_objectives.py
@@ -1,0 +1,132 @@
+"""Tests for Gaussian DFS and the historical quadratic design proxy."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from openghg_inversions.basis.experimental.dyadic.multiscale import MultiscaleDesign
+from openghg_inversions.basis.experimental.dyadic.objectives import (
+    GaussianDFSObjective,
+    IsotropicRegionCovariance,
+    direct_observation_space_dfs,
+    gaussian_dfs,
+    prototype_quadratic_tile_scores,
+)
+from openghg_inversions.basis.experimental.dyadic.state import PartitionState
+from openghg_inversions.basis.experimental.dyadic.tree import DyadicTree
+
+
+def test_sum_then_square_differs_from_summing_cell_scores() -> None:
+    """Opposing cell signals should cancel before the prototype square."""
+    fine_cell_columns = np.array([[1.0, -1.0]])
+    tile_column = fine_cell_columns.sum(axis=1, keepdims=True)
+
+    tile_score = prototype_quadratic_tile_scores(tile_column, [1.0], [2.0])
+    fine_scores = prototype_quadratic_tile_scores(fine_cell_columns, [1.0], [1.0, 1.0])
+
+    np.testing.assert_array_equal(tile_score, [0.0])
+    assert fine_scores.sum() == 2.0
+
+
+def test_gaussian_dfs_formulas_agree() -> None:
+    """State-space and direct observation-space Gaussian formulas should agree."""
+    design = np.array([[1.0, 0.3], [-0.2, 1.4], [0.7, -0.5]])
+    covariance = np.array([[1.8, 0.4], [0.4, 0.9]])
+    r_diag = np.array([0.5, 1.2, 0.8])
+
+    state_space = gaussian_dfs(design, covariance, r_diag)
+    observation_space = direct_observation_space_dfs(design, covariance, r_diag)
+
+    assert state_space == pytest.approx(observation_space, rel=1e-12, abs=1e-12)
+    assert 0.0 <= state_space <= design.shape[1]
+
+
+def test_gaussian_dfs_is_invariant_to_state_permutation() -> None:
+    """Permuting design columns and both covariance axes should preserve DFS."""
+    design = np.array([[1.0, 0.3, -0.1], [-0.2, 1.4, 0.6], [0.7, -0.5, 1.1]])
+    covariance = np.array([[1.8, 0.4, 0.2], [0.4, 0.9, -0.1], [0.2, -0.1, 1.2]])
+    r_diag = np.array([0.5, 1.2, 0.8])
+    permutation = np.array([2, 0, 1])
+
+    expected = gaussian_dfs(design, covariance, r_diag)
+    actual = gaussian_dfs(
+        design[:, permutation],
+        covariance[np.ix_(permutation, permutation)],
+        r_diag,
+    )
+
+    assert actual == pytest.approx(expected, rel=1e-12, abs=1e-12)
+
+
+def test_covariance_builder_is_called_for_each_state_and_design() -> None:
+    """Objective evaluation should rebuild covariance on every score call."""
+    tree = DyadicTree.from_shape((2, 2))
+    design = MultiscaleDesign.from_grid(np.arange(8.0).reshape(2, 2, 2), tree)
+    first_state = PartitionState.root(tree)
+    second_state = first_state.split(tree, tree.root_id)
+    calls: list[tuple[PartitionState, MultiscaleDesign]] = []
+
+    def covariance_builder(state: PartitionState, current_design: MultiscaleDesign) -> np.ndarray:
+        """Record each call and return state-specific isotropic covariance."""
+        calls.append((state, current_design))
+        return np.eye(len(state.ordered_active())) * (1.0 + len(calls))
+
+    objective = GaussianDFSObjective([0.5, 0.8], covariance_builder)
+
+    objective.score(first_state, design)
+    objective(second_state, design)
+
+    assert calls == [(first_state, design), (second_state, design)]
+
+
+def test_isotropic_covariance_is_an_explicit_positive_benchmark() -> None:
+    """The isotropic builder should return tau-squared on each active diagonal."""
+    builder = IsotropicRegionCovariance(tau=1.5)
+    tree = DyadicTree.from_shape((2, 2))
+    design = MultiscaleDesign.from_grid(np.ones((1, 2, 2)), tree)
+    state = PartitionState(frozenset({1, 5, 6}))
+
+    covariance = builder(state, design)
+
+    np.testing.assert_array_equal(covariance, 2.25 * np.eye(3))
+    with pytest.raises(ValueError, match="positive"):
+        IsotropicRegionCovariance(tau=0.0)
+
+
+def test_gaussian_dfs_rejects_invalid_inputs() -> None:
+    """Gaussian DFS should reject incompatible, non-finite, or non-SPD inputs."""
+    valid_design = np.ones((2, 2))
+    valid_covariance = np.eye(2)
+    with pytest.raises(ValueError, match="two-dimensional"):
+        gaussian_dfs(np.ones(2), valid_covariance, np.ones(2))
+    with pytest.raises(ValueError, match="shape"):
+        gaussian_dfs(valid_design, np.eye(3), np.ones(2))
+    with pytest.raises(ValueError, match="positive"):
+        gaussian_dfs(valid_design, valid_covariance, [1.0, 0.0])
+    with pytest.raises(ValueError, match="symmetric"):
+        gaussian_dfs(valid_design, [[1.0, 1.0], [0.0, 1.0]], np.ones(2))
+    with pytest.raises(ValueError, match="positive definite"):
+        gaussian_dfs(valid_design, [[1.0, 2.0], [2.0, 1.0]], np.ones(2))
+    with pytest.raises(ValueError, match="finite"):
+        gaussian_dfs([[1.0, np.nan], [0.0, 1.0]], valid_covariance, np.ones(2))
+
+
+def test_prototype_scores_reject_invalid_precision_and_support() -> None:
+    """The quadratic proxy should require explicit positive matching vectors."""
+    design = np.ones((2, 3))
+    with pytest.raises(ValueError, match="length"):
+        prototype_quadratic_tile_scores(design, [1.0], np.ones(3))
+    with pytest.raises(ValueError, match="positive"):
+        prototype_quadratic_tile_scores(design, np.ones(2), [1.0, 0.0, 1.0])
+    with pytest.raises(ValueError, match="length"):
+        prototype_quadratic_tile_scores(design, np.ones(2), np.ones(2))
+
+
+def test_objective_rejects_invalid_observation_covariance() -> None:
+    """Objective construction should reject non-vector or non-positive R diagonals."""
+    builder = IsotropicRegionCovariance(1.0)
+    with pytest.raises(ValueError, match="one-dimensional"):
+        GaussianDFSObjective([[1.0]], builder)
+    with pytest.raises(ValueError, match="positive"):
+        GaussianDFSObjective([-1.0], builder)

--- a/tests/basis/experimental/test_dyadic_proposals.py
+++ b/tests/basis/experimental/test_dyadic_proposals.py
@@ -1,0 +1,109 @@
+"""Tests for immutable split, merge, and paired dyadic proposal moves."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from openghg_inversions.basis.experimental.dyadic.proposals import (
+    MergeMove,
+    PairedMove,
+    SplitMove,
+    apply_move,
+    enumerate_merge_moves,
+    enumerate_paired_moves,
+    enumerate_paired_neighbors,
+    enumerate_split_moves,
+    reverse_move,
+)
+from openghg_inversions.basis.experimental.dyadic.state import PartitionState
+from openghg_inversions.basis.experimental.dyadic.tree import DyadicTree
+
+
+def _four_region_state(tree: DyadicTree) -> PartitionState:
+    """Return the partition containing all four grandchildren of the root."""
+    state = PartitionState.root(tree).split(tree, tree.root_id)
+    for node_id in state.ordered_active():
+        state = state.split(tree, node_id)
+    return state
+
+
+def test_split_and_merge_moves_round_trip_without_mutation() -> None:
+    """A split and its reverse merge should restore the identical source state."""
+    tree = DyadicTree.from_shape((4, 4))
+    source = PartitionState.root(tree)
+    source_active = source.active
+    split = SplitMove(node_id=tree.root_id)
+
+    split_state = apply_move(tree, source, split)
+    restored = apply_move(tree, split_state, reverse_move(split))
+
+    assert restored == source
+    assert source.active is source_active
+    assert reverse_move(MergeMove(parent_id=tree.root_id)) == split
+
+
+def test_move_enumeration_returns_only_valid_stable_candidates() -> None:
+    """Single-move enumeration should expose splittable leaves and true siblings."""
+    tree = DyadicTree.from_shape((4, 4))
+    state = _four_region_state(tree)
+    root_children = tree.children(tree.root_id)
+
+    assert enumerate_split_moves(tree, state) == tuple(
+        SplitMove(node_id) for node_id in state.ordered_active()
+    )
+    assert enumerate_merge_moves(tree, state) == tuple(MergeMove(node_id) for node_id in root_children)
+
+
+def test_paired_moves_preserve_region_count_and_exclude_no_op() -> None:
+    """Every paired move should preserve K and avoid re-splitting its merge parent."""
+    tree = DyadicTree.from_shape((4, 4))
+    source = _four_region_state(tree)
+    source_active = source.active
+
+    moves = enumerate_paired_moves(tree, source)
+
+    assert moves
+    assert all(move.merge_parent_id != move.split_node_id for move in moves)
+    assert all(len(apply_move(tree, source, move).active) == len(source.active) for move in moves)
+    assert source.active is source_active
+
+
+def test_paired_neighbors_are_unique_and_uniform() -> None:
+    """Neighbor records should deduplicate states and normalize uniform ``log_q``."""
+    tree = DyadicTree.from_shape((4, 4))
+    source = _four_region_state(tree)
+
+    neighbors = enumerate_paired_neighbors(tree, source)
+    active_frontiers = [neighbor.state.active for neighbor in neighbors]
+
+    assert len(active_frontiers) == len(set(active_frontiers))
+    assert sum(math.exp(neighbor.log_q) for neighbor in neighbors) == pytest.approx(1.0)
+    assert {neighbor.log_q for neighbor in neighbors} == {-math.log(len(neighbors))}
+
+
+def test_every_paired_neighbor_has_a_reverse_edge() -> None:
+    """Each fixed-count edge should have an enumerable move back to its source."""
+    tree = DyadicTree.from_shape((4, 4))
+    source = _four_region_state(tree)
+
+    for neighbor in enumerate_paired_neighbors(tree, source):
+        reverse = neighbor.move.reverse()
+        assert isinstance(reverse, PairedMove)
+        assert apply_move(tree, neighbor.state, reverse) == source
+        assert reverse in enumerate_paired_moves(tree, neighbor.state)
+
+
+def test_paired_move_rejects_no_op_resplit() -> None:
+    """A merge followed by splitting the same parent should be rejected."""
+    tree = DyadicTree.from_shape((4, 4))
+    source = _four_region_state(tree)
+    merge_parent = tree.children(tree.root_id)[0]
+
+    with pytest.raises(ValueError, match="re-split"):
+        apply_move(
+            tree,
+            source,
+            PairedMove(merge_parent_id=merge_parent, split_node_id=merge_parent),
+        )

--- a/tests/basis/experimental/test_dyadic_search.py
+++ b/tests/basis/experimental/test_dyadic_search.py
@@ -1,0 +1,187 @@
+"""Tests for the experimental stochastic local-search runner."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from openghg_inversions.basis.experimental.dyadic.search import (
+    PiecewiseGeometricSchedule,
+    SearchProposal,
+    SearchResult,
+    stochastic_local_search,
+)
+from openghg_inversions.basis.experimental.dyadic.initializers import random_partition
+from openghg_inversions.basis.experimental.dyadic.proposals import PairedMove, enumerate_paired_neighbors
+from openghg_inversions.basis.experimental.dyadic.state import PartitionState
+from openghg_inversions.basis.experimental.dyadic.tree import DyadicTree
+
+
+def test_piecewise_schedule_holds_cools_and_polishes() -> None:
+    """The schedule should expose its three configured temperature phases."""
+    schedule = PiecewiseGeometricSchedule(
+        initial_temperature=10.0,
+        final_temperature=0.1,
+        hold_fraction=0.2,
+        polish_fraction=0.2,
+    )
+
+    temperatures = [schedule(index, 10) for index in range(10)]
+
+    assert temperatures[:2] == [10.0, 10.0]
+    assert temperatures[-2:] == [0.0, 0.0]
+    assert all(left >= right for left, right in zip(temperatures, temperatures[1:]))
+    assert temperatures[2] == pytest.approx(10.0)
+    assert temperatures[7] == pytest.approx(0.1)
+
+
+def test_zero_temperature_search_tracks_best_without_accepting_losses() -> None:
+    """A zero-temperature search should keep improvements and reject losses."""
+    candidates = iter([1, 0, 3, 2])
+
+    def propose(state: int, rng: np.random.Generator) -> SearchProposal[int, str] | None:
+        """Return the next deterministic integer candidate."""
+        del state, rng
+        try:
+            candidate = next(candidates)
+        except StopIteration:
+            return None
+        return SearchProposal(candidate, f"to-{candidate}")
+
+    result = stochastic_local_search(
+        0,
+        objective=float,
+        propose=propose,
+        schedule=lambda iteration, total: 0.0,
+        iterations=4,
+        rng=np.random.default_rng(1),
+    )
+
+    assert result.final_state == 3
+    assert result.best_state == 3
+    assert result.best_score == 3.0
+    assert result.accepted_moves == 2
+    assert [step.accepted for step in result.trace] == [True, False, True, False]
+
+
+def test_positive_temperature_search_is_seeded_and_reproducible() -> None:
+    """The same random seed should reproduce every accepted state."""
+
+    def run(seed: int) -> SearchResult[int, int]:
+        """Run a random-walk optimizer for one seed."""
+
+        def propose(state: int, rng: np.random.Generator) -> SearchProposal[int, int]:
+            """Propose a unit random-walk move."""
+            move = int(rng.choice([-1, 1]))
+            return SearchProposal(state + move, move)
+
+        return stochastic_local_search(
+            0,
+            objective=lambda state: -abs(state - 2),
+            propose=propose,
+            schedule=lambda iteration, total: 2.0,
+            iterations=20,
+            rng=np.random.default_rng(seed),
+            record_every=3,
+        )
+
+    first = run(42)
+    second = run(42)
+
+    assert first == second
+    assert first.best_score >= first.initial_score
+    assert len(first.trace) <= first.evaluated_moves
+
+
+def test_fixed_count_dyadic_moves_compose_with_search_runner() -> None:
+    """Paired partition proposals should preserve a valid fixed-size frontier."""
+    tree = DyadicTree.from_shape((4, 4))
+    initial = random_partition(tree, target_regions=6, rng=np.random.default_rng(8)).state
+
+    def propose(
+        state: PartitionState,
+        rng: np.random.Generator,
+    ) -> SearchProposal[PartitionState, PairedMove] | None:
+        """Sample uniformly from the state's unique paired neighbors."""
+        neighbors = enumerate_paired_neighbors(tree, state)
+        if not neighbors:
+            return None
+        neighbor = neighbors[int(rng.integers(len(neighbors)))]
+        return SearchProposal(neighbor.state, neighbor.move)
+
+    result = stochastic_local_search(
+        initial,
+        objective=lambda state: -float(sum(state.active)),
+        propose=propose,
+        schedule=lambda iteration, total: 0.5,
+        iterations=30,
+        rng=np.random.default_rng(9),
+    )
+
+    result.final_state.validate(tree)
+    result.best_state.validate(tree)
+    assert len(result.final_state.active) == len(initial.active) == 6
+    assert result.best_score >= result.initial_score
+
+
+def test_search_stops_when_no_proposal_is_available() -> None:
+    """A missing proposal should stop cleanly without evaluating a move."""
+    result = stochastic_local_search(
+        "root",
+        objective=lambda state: 1.0,
+        propose=lambda state, rng: None,
+        schedule=lambda iteration, total: 0.0,
+        iterations=5,
+        rng=np.random.default_rng(2),
+    )
+
+    assert result.stop_reason == "no_proposal"
+    assert result.evaluated_moves == 0
+    assert result.final_state == "root"
+    assert result.trace == ()
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"iterations": -1}, "iterations"),
+        ({"record_every": 0}, "record_every"),
+    ],
+)
+def test_search_rejects_invalid_configuration(kwargs: dict[str, int], message: str) -> None:
+    """Invalid bounds should fail before any proposal is evaluated."""
+    options = {"iterations": 1, "record_every": 1}
+    options.update(kwargs)
+
+    with pytest.raises(ValueError, match=message):
+        stochastic_local_search(
+            0,
+            objective=float,
+            propose=lambda state, rng: SearchProposal(state, None),
+            schedule=lambda iteration, total: 0.0,
+            rng=np.random.default_rng(3),
+            **options,
+        )
+
+
+def test_search_rejects_non_finite_scores_and_temperatures() -> None:
+    """Non-finite numerical inputs should not enter the optimizer trace."""
+    with pytest.raises(ValueError, match="objective"):
+        stochastic_local_search(
+            0,
+            objective=lambda state: np.nan,
+            propose=lambda state, rng: SearchProposal(state, None),
+            schedule=lambda iteration, total: 0.0,
+            iterations=1,
+            rng=np.random.default_rng(4),
+        )
+
+    with pytest.raises(ValueError, match="temperature"):
+        stochastic_local_search(
+            0,
+            objective=float,
+            propose=lambda state, rng: SearchProposal(state, None),
+            schedule=lambda iteration, total: np.inf,
+            iterations=1,
+            rng=np.random.default_rng(5),
+        )

--- a/tests/basis/experimental/test_dyadic_tree.py
+++ b/tests/basis/experimental/test_dyadic_tree.py
@@ -1,0 +1,158 @@
+"""Tests for exact canonical dyadic trees and immutable partition states."""
+
+from dataclasses import FrozenInstanceError
+
+import numpy as np
+import pytest
+
+from openghg_inversions.basis.experimental.dyadic import DyadicTree, PartitionState, Tile
+
+
+def _tile_mask(tree: DyadicTree, node_id: int) -> np.ndarray:
+    """Return a Boolean grid mask for one tree tile."""
+    tile = tree.tile(node_id)
+    mask = np.zeros(tree.shape, dtype=bool)
+    mask[tile.row_start : tile.row_stop, tile.col_start : tile.col_stop] = True
+    return mask
+
+
+def test_single_cell_tree_has_one_immutable_root() -> None:
+    """A 1x1 shape is represented by one root that is also the only leaf."""
+    tree = DyadicTree.from_shape((1, 1))
+
+    assert tree.shape == (1, 1)
+    assert tree.root_id == 0
+    assert tree.nodes == (Tile(0, 0, 1, 0, 1, 0),)
+    assert tree.children(tree.root_id) == ()
+    assert tree.parent(tree.root_id) is None
+    assert tree.leaf_ids == (tree.root_id,)
+    assert tree.tile(tree.root_id).is_cell
+
+    with pytest.raises(FrozenInstanceError):
+        tree.tile(tree.root_id).depth = 1  # type: ignore[misc]
+
+
+def test_odd_non_square_tree_uses_exact_midpoint_geometry() -> None:
+    """Odd rectangular roots split their longer axis without padded cells."""
+    tree = DyadicTree.from_shape((3, 5))
+    first_id, second_id = tree.children(tree.root_id)
+    first = tree.tile(first_id)
+    second = tree.tile(second_id)
+
+    assert first == Tile(first_id, 0, 3, 0, 2, 1)
+    assert second == Tile(second_id, 0, 3, 2, 5, 1)
+    assert first.area + second.area == 15
+    assert len(tree.nodes) == 2 * 15 - 1
+
+    first_child = tree.tile(tree.children(first_id)[0])
+    assert (first_child.row_start, first_child.row_stop) == (0, 1)
+
+
+def test_square_tiles_split_rows_on_ties() -> None:
+    """The canonical square-tile tie rule bisects rows before columns."""
+    tree = DyadicTree.from_shape((2, 2))
+    first, second = (tree.tile(node_id) for node_id in tree.children(tree.root_id))
+
+    assert (first.row_start, first.row_stop, first.col_start, first.col_stop) == (0, 1, 0, 2)
+    assert (second.row_start, second.row_stop, second.col_start, second.col_stop) == (1, 2, 0, 2)
+
+
+def test_node_ids_and_order_are_stable_for_equal_shapes() -> None:
+    """Repeated construction assigns identical contiguous preorder node IDs."""
+    first = DyadicTree.from_shape((3, 5))
+    second = DyadicTree.from_shape((3, 5))
+
+    assert first.nodes == second.nodes
+    assert tuple(tile.node_id for tile in first.nodes) == tuple(range(len(first.nodes)))
+    assert tuple(first.children(tile.node_id) for tile in first.nodes) == tuple(
+        second.children(tile.node_id) for tile in second.nodes
+    )
+    assert tuple(first.parent(tile.node_id) for tile in first.nodes) == tuple(
+        second.parent(tile.node_id) for tile in second.nodes
+    )
+
+
+def test_every_parent_is_covered_exactly_by_its_children() -> None:
+    """Canonical child pairs are disjoint and exactly cover every parent."""
+    tree = DyadicTree.from_shape((5, 3))
+
+    for parent in tree.nodes:
+        child_ids = tree.children(parent.node_id)
+        if not child_ids:
+            assert parent.is_cell
+            continue
+        child_coverage = sum((_tile_mask(tree, node_id) for node_id in child_ids), np.zeros(tree.shape, int))
+        np.testing.assert_array_equal(child_coverage, _tile_mask(tree, parent.node_id))
+        assert sum(tree.tile(node_id).area for node_id in child_ids) == parent.area
+
+
+def test_split_and_merge_round_trip_without_mutation() -> None:
+    """Splitting then merging returns the root state without changing inputs."""
+    tree = DyadicTree.from_shape((3, 5))
+    root_state = PartitionState.root(tree)
+    original_active = root_state.active
+
+    split_state = root_state.split(tree, tree.root_id)
+    merged_state = split_state.merge(tree, tree.root_id)
+
+    assert root_state.active is original_active
+    assert root_state == PartitionState.root(tree)
+    assert split_state.active == frozenset(tree.children(tree.root_id))
+    assert merged_state == root_state
+    assert split_state is not root_state
+    assert merged_state is not split_state
+
+
+@pytest.mark.parametrize(
+    "state, message",
+    [
+        (PartitionState(active=frozenset()), "at least one"),
+        (PartitionState(active=frozenset({999})), "not in the tree"),
+    ],
+)
+def test_validation_rejects_empty_and_unknown_active_sets(
+    state: PartitionState,
+    message: str,
+) -> None:
+    """Validation rejects states that cannot identify a tree frontier."""
+    tree = DyadicTree.from_shape((2, 3))
+
+    with pytest.raises(ValueError, match=message):
+        state.validate(tree)
+
+
+def test_validation_rejects_gaps_and_ancestor_overlap() -> None:
+    """Validation independently rejects incomplete and overlapping frontiers."""
+    tree = DyadicTree.from_shape((2, 3))
+    first_child = tree.children(tree.root_id)[0]
+
+    with pytest.raises(ValueError, match="exactly cover"):
+        PartitionState(active=frozenset({first_child})).validate(tree)
+    with pytest.raises(ValueError, match="ancestor and descendant"):
+        PartitionState(active=frozenset({tree.root_id, first_child})).validate(tree)
+
+
+def test_labels_are_positive_compact_and_follow_stable_active_order() -> None:
+    """Label rendering packs exact active tiles in deterministic node-ID order."""
+    tree = DyadicTree.from_shape((3, 5))
+    state = PartitionState.root(tree).split(tree, tree.root_id)
+    labels = state.to_labels(tree)
+    first_id, second_id = state.ordered_active()
+
+    assert labels.shape == tree.shape
+    assert labels.dtype == np.int64
+    assert set(np.unique(labels)) == {1, 2}
+    assert np.all(labels[_tile_mask(tree, first_id)] == 1)
+    assert np.all(labels[_tile_mask(tree, second_id)] == 2)
+
+
+def test_adjacent_non_siblings_cannot_be_merged() -> None:
+    """Geometrically adjacent leaves with different parents are not mergeable."""
+    tree = DyadicTree.from_shape((1, 4))
+    state = PartitionState(active=frozenset(tree.leaf_ids))
+    middle_left, middle_right = tree.leaf_ids[1:3]
+
+    assert tree.tile(middle_left).col_stop == tree.tile(middle_right).col_start
+    assert tree.parent(middle_left) != tree.parent(middle_right)
+    with pytest.raises(ValueError, match="both active children of the same parent"):
+        state.merge(tree, tree.root_id)


### PR DESCRIPTION
* **Summary of changes**

Adds an isolated experimental dyadic partition package for the hackathon proof of concept. It includes exact rectangular tree/frontier state, sum-preserving multiscale design columns, Gaussian DFS with a partition-dependent covariance-builder boundary, benchmark/prototype scores, deterministic initializers, split/merge/paired proposals, seeded stochastic local search, provenance, and the operational plan.

This does not modify or re-export production basis interfaces and does not touch `fixedbasisMCMC`. Related to #449. A stacked follow-up PR will add the TAC/MHD test-data demo and generated evidence.

The isotropic `B_P` implementation is explicitly labelled as a POC benchmark. Bocquet-consistent use requires rebuilding `B_P = P B P^T` for each partition; the API already accepts that callable.

* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [x] Tests added and passing (`49 passed`)
- [x] Documentation and tutorials updated/added
- [ ] Added an entry to the `CHANGELOG.md` file (experimental API, intentionally omitted)
- [x] Added any new requirements to `requirements.txt` (none required)

Additional checks: Ruff and targeted Pyright pass.