### PR TITLE
Experimental exact dyadic product-space kernel

### DIFF
--- a/openghg_inversions/basis/experimental/dyadic/__init__.py
+++ b/openghg_inversions/basis/experimental/dyadic/__init__.py
@@ -6,7 +6,7 @@ partition objectives, local proposals, and stochastic local search. It is
 provisional and is not re-exported from :mod:`openghg_inversions.basis`.
 """
 
-from .initializers import InitializationResult, greedy_partition, random_partition, threshold_partition
+from .contrast import TreeContrastLayout
 from .demo_runner import (
     DemoSearchConfig,
     DemoSearchRun,
@@ -22,6 +22,12 @@ from .dynamic_programming import (
     AdditivePartitionSolution,
     additive_partition_frontier,
     optimal_additive_partition,
+)
+from .enumeration import enumerate_partitions
+from .gaussian_product_space import (
+    GaussianConditional,
+    GaussianProductSpaceTarget,
+    PartitionLogPrior,
 )
 from .gaussian_projection import (
     BocquetProjection,
@@ -40,6 +46,7 @@ from .gaussian_projection import (
     restriction_for_prolongation,
 )
 from .grid_covariance import SeparableGridCovariance
+from .initializers import InitializationResult, greedy_partition, random_partition, threshold_partition
 from .multiscale import CoarsenedGrid, MultiscaleDesign, direct_gather, sum_coarsen_grid
 from .objectives import (
     CovarianceBuilder,
@@ -71,6 +78,15 @@ from .proposals import (
     enumerate_split_moves,
     reverse_move,
 )
+from .product_space import (
+    LogAugmentedDensity,
+    PartitionMove,
+    PartitionNeighbor,
+    ProductSpaceState,
+    ProductSpaceTransition,
+    enumerate_partition_neighbors,
+    partition_metropolis_step,
+)
 from .rhime_gaussian import NativePosteriorMarginals, RHIMEGaussianMultiscale
 from .search import (
     PiecewiseGeometricSchedule,
@@ -92,12 +108,15 @@ __all__ = [
     "DemoSearchRun",
     "DyadicTree",
     "GaussianDFSObjective",
+    "GaussianConditional",
     "GaussianPartitionDiagnostics",
     "GaussianPartitionObjectives",
     "GaussianPosterior",
     "GaussianProjectionAnalysis",
+    "GaussianProductSpaceTarget",
     "InitializationResult",
     "IsotropicRegionCovariance",
+    "LogAugmentedDensity",
     "MergeMove",
     "Move",
     "MultiscaleDesign",
@@ -105,9 +124,14 @@ __all__ = [
     "NodeId",
     "PairedMove",
     "PairedNeighbor",
+    "PartitionLogPrior",
+    "PartitionMove",
+    "PartitionNeighbor",
     "PartitionState",
     "PiecewiseGeometricSchedule",
     "ProjectedVariableKSearchRun",
+    "ProductSpaceState",
+    "ProductSpaceTransition",
     "RHIMEGaussianMultiscale",
     "SearchProposal",
     "SearchResult",
@@ -116,6 +140,7 @@ __all__ = [
     "SplitMove",
     "TemperatureSchedule",
     "Tile",
+    "TreeContrastLayout",
     "VariableKSearchConfig",
     "VariableKSearchRun",
     "apply_move",
@@ -125,6 +150,8 @@ __all__ = [
     "direct_gather",
     "direct_observation_space_dfs",
     "enumerate_merge_moves",
+    "enumerate_partition_neighbors",
+    "enumerate_partitions",
     "enumerate_paired_moves",
     "enumerate_paired_neighbors",
     "enumerate_split_moves",
@@ -139,6 +166,7 @@ __all__ = [
     "native_gaussian_posterior",
     "greedy_partition",
     "optimal_additive_partition",
+    "partition_metropolis_step",
     "prototype_quadratic_tile_scores",
     "projected_bayesian_information_gain",
     "projected_bayesian_kl",

--- a/openghg_inversions/basis/experimental/dyadic/contrast.py
+++ b/openghg_inversions/basis/experimental/dyadic/contrast.py
@@ -1,0 +1,248 @@
+"""Fixed root-and-contrast coordinates for dyadic partition frontiers.
+
+The coordinate vector has a permanent layout for one complete dyadic tree. Its
+first value is the mean anomaly over the root tile and every non-terminal tree
+node contributes one mass-preserving child contrast. A partition activates the
+root coordinate and only the contrasts above its active frontier. Partition
+updates can therefore leave the coordinate vector fixed while changing which
+entries enter the likelihood.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import numpy.typing as npt
+
+from .state import PartitionState
+from .tree import DyadicTree, NodeId
+
+
+@dataclass(frozen=True, slots=True)
+class TreeContrastLayout:
+    """Stable root-and-split coordinate layout for one dyadic tree.
+
+    Construct layouts with :meth:`from_tree`. Coordinate zero is the root mean
+    anomaly. Subsequent coordinates correspond to splittable nodes in stable
+    node-ID order.
+
+    Attributes:
+        tree: Complete canonical dyadic tree described by the layout.
+        split_node_ids: Splittable node IDs in coordinate order after the root
+            mean coordinate.
+    """
+
+    tree: DyadicTree
+    split_node_ids: tuple[NodeId, ...]
+
+    def __post_init__(self) -> None:
+        """Reject layouts that do not exactly describe their complete tree."""
+        if not isinstance(self.tree, DyadicTree):
+            raise TypeError("tree must be a DyadicTree.")
+        expected = tuple(tile.node_id for tile in self.tree.nodes if self.tree.children(tile.node_id))
+        if self.split_node_ids != expected:
+            raise ValueError("split_node_ids must contain every splittable node in stable tree order.")
+        if self.coordinate_count != len(self.tree.leaf_ids):
+            raise ValueError("A binary contrast layout must have one coordinate per finest grid cell.")
+
+    @classmethod
+    def from_tree(cls, tree: DyadicTree) -> TreeContrastLayout:
+        """Construct the fixed contrast layout for a complete dyadic tree.
+
+        Args:
+            tree: Tree whose non-terminal nodes define contrast coordinates.
+
+        Returns:
+            Stable layout with one coordinate per finest-grid degree of
+            freedom.
+
+        Raises:
+            TypeError: If ``tree`` is not a :class:`DyadicTree`.
+            ValueError: If a non-terminal node does not have exactly two
+                children or the resulting layout is not square at the finest
+                grid scale.
+        """
+        if not isinstance(tree, DyadicTree):
+            raise TypeError("tree must be a DyadicTree.")
+
+        split_node_ids: list[NodeId] = []
+        for tile in tree.nodes:
+            children = tree.children(tile.node_id)
+            if children and len(children) != 2:
+                raise ValueError("Every dyadic split must have exactly two children.")
+            if children:
+                split_node_ids.append(tile.node_id)
+
+        layout = cls(tree=tree, split_node_ids=tuple(split_node_ids))
+        if layout.coordinate_count != len(tree.leaf_ids):
+            raise ValueError("A binary contrast layout must have one coordinate per finest grid cell.")
+        return layout
+
+    @property
+    def coordinate_count(self) -> int:
+        """Return the permanent number of inner product-space coordinates."""
+        return 1 + len(self.split_node_ids)
+
+    def contrast_index(self, node_id: NodeId) -> int:
+        """Return the permanent coordinate index for one possible split.
+
+        Args:
+            node_id: Non-terminal node whose child contrast is requested.
+
+        Returns:
+            Coordinate index after the root mean coordinate.
+
+        Raises:
+            KeyError: If ``node_id`` is not a splittable tree node.
+        """
+        try:
+            return self.split_node_ids.index(node_id) + 1
+        except ValueError as error:
+            raise KeyError(f"Node {node_id!r} does not define a split contrast.") from error
+
+    def active_split_ids(self, partition: PartitionState) -> tuple[NodeId, ...]:
+        """Return split nodes above a partition's active frontier.
+
+        Args:
+            partition: Valid active frontier on :attr:`tree`.
+
+        Returns:
+            Split-node IDs in stable tree order. A split is active exactly when
+            the frontier descends through that node.
+        """
+        partition.validate(self.tree)
+        active_splits: set[NodeId] = set()
+        pending = [self.tree.root_id]
+        while pending:
+            node_id = pending.pop()
+            if node_id in partition.active:
+                continue
+            children = self.tree.children(node_id)
+            if not children:  # pragma: no cover - guarded by partition validation.
+                raise ValueError("Partition frontier does not cover the tree root.")
+            active_splits.add(node_id)
+            pending.extend(children)
+        return tuple(node_id for node_id in self.split_node_ids if node_id in active_splits)
+
+    def active_coordinate_indices(self, partition: PartitionState) -> tuple[int, ...]:
+        """Return the root and active-contrast coordinate indices."""
+        return (0, *(self.contrast_index(node_id) for node_id in self.active_split_ids(partition)))
+
+    def inactive_coordinate_indices(self, partition: PartitionState) -> tuple[int, ...]:
+        """Return contrast indices below the partition frontier."""
+        active = set(self.active_coordinate_indices(partition))
+        return tuple(index for index in range(1, self.coordinate_count) if index not in active)
+
+    def decoder(self, partition: PartitionState) -> np.ndarray:
+        """Build the linear map from fixed coordinates to active-region means.
+
+        For a split ``G = L union R`` with grid-cell counts ``n_L`` and
+        ``n_R``, the child means are
+
+        ``a_L = a_G + n_R / n_G * delta_G`` and
+        ``a_R = a_G - n_L / n_G * delta_G``.
+
+        Args:
+            partition: Valid active frontier on :attr:`tree`.
+
+        Returns:
+            Matrix with shape ``(active_region, coordinate)``. Rows follow
+            :meth:`PartitionState.ordered_active`; inactive columns are zero.
+        """
+        partition.validate(self.tree)
+        root_row: npt.NDArray[np.float64] = np.zeros(self.coordinate_count, dtype=float)
+        root_row[0] = 1.0
+        rows_by_node: dict[NodeId, np.ndarray] = {}
+        pending: list[tuple[NodeId, np.ndarray]] = [(self.tree.root_id, root_row)]
+
+        while pending:
+            node_id, parent_row = pending.pop()
+            if node_id in partition.active:
+                rows_by_node[node_id] = parent_row
+                continue
+
+            left_id, right_id = self.tree.children(node_id)
+            left_area = self.tree.tile(left_id).area
+            right_area = self.tree.tile(right_id).area
+            total_area = left_area + right_area
+            contrast_index = self.contrast_index(node_id)
+
+            left_row = parent_row.copy()
+            left_row[contrast_index] += right_area / total_area
+            right_row = parent_row.copy()
+            right_row[contrast_index] -= left_area / total_area
+            pending.append((right_id, right_row))
+            pending.append((left_id, left_row))
+
+        return np.vstack([rows_by_node[node_id] for node_id in partition.ordered_active()])
+
+    def decode(self, partition: PartitionState, coordinates: npt.ArrayLike) -> np.ndarray:
+        """Decode fixed coordinates into active-region mean anomalies.
+
+        Args:
+            partition: Valid active frontier on :attr:`tree`.
+            coordinates: Finite one-dimensional vector with
+                :attr:`coordinate_count` values.
+
+        Returns:
+            Active-region means in stable partition order.
+
+        Raises:
+            ValueError: If ``coordinates`` has the wrong shape or contains a
+                non-finite value.
+        """
+        source = np.asarray(coordinates)
+        if np.iscomplexobj(source):
+            raise ValueError("coordinates must be real-valued.")
+        values = np.asarray(source, dtype=float)
+        if values.shape != (self.coordinate_count,):
+            raise ValueError(f"coordinates must have shape ({self.coordinate_count},).")
+        if not np.all(np.isfinite(values)):
+            raise ValueError("coordinates must contain only finite values.")
+        return self.decoder(partition) @ values
+
+    def prior_variances(self, scale: float) -> np.ndarray:
+        """Return primitive Gaussian variances for all fixed coordinates.
+
+        These variances are induced by independent finest-grid anomalies with
+        standard deviation ``scale``. The root mean has variance
+        ``scale**2 / n_root`` and a split contrast has variance
+        ``scale**2 * (1 / n_left + 1 / n_right)``.
+
+        Args:
+            scale: Positive finite finest-grid anomaly standard deviation.
+
+        Returns:
+            Positive variances in permanent coordinate order.
+
+        Raises:
+            ValueError: If ``scale`` is not positive and finite.
+        """
+        if isinstance(scale, bool):
+            raise ValueError("scale must be positive and finite.")
+        try:
+            scale_value = float(scale)
+        except (TypeError, ValueError, OverflowError) as error:
+            raise ValueError("scale must be positive and finite.") from error
+        if not np.isfinite(scale_value) or scale_value <= 0.0:
+            raise ValueError("scale must be positive and finite.")
+
+        with np.errstate(over="ignore", invalid="ignore"):
+            variance = float(np.multiply(scale_value, scale_value))
+        if not np.isfinite(variance) or variance <= 0.0:
+            raise ValueError("scale produces non-finite primitive variances.")
+
+        result: npt.NDArray[np.float64] = np.empty(self.coordinate_count, dtype=float)
+        result[0] = variance / self.tree.tile(self.tree.root_id).area
+        for node_id in self.split_node_ids:
+            left_id, right_id = self.tree.children(node_id)
+            left_area = self.tree.tile(left_id).area
+            right_area = self.tree.tile(right_id).area
+            result[self.contrast_index(node_id)] = variance * (1.0 / left_area + 1.0 / right_area)
+        if not np.all(np.isfinite(result)) or np.any(result <= 0.0):
+            raise ValueError("scale produces non-finite primitive variances.")
+        return result
+
+
+__all__ = ["TreeContrastLayout"]

--- a/openghg_inversions/basis/experimental/dyadic/enumeration.py
+++ b/openghg_inversions/basis/experimental/dyadic/enumeration.py
@@ -1,0 +1,144 @@
+"""Exhaustive enumeration of canonical dyadic partition frontiers.
+
+This module provides a small exact oracle for tests and experiments.  At each
+tree node, a valid frontier either keeps that node active or combines one
+recursively enumerated frontier from each ordered child.  The resulting order
+is deterministic: the unsplit frontier appears first, followed by child
+products in recursive tree order.
+
+The number of frontiers grows exponentially with the number of grid cells, and
+every returned state is materialized.  This implementation is therefore
+intended only for tiny trees where exhaustive enumeration is useful as a
+correctness oracle, not for production partition searches.
+"""
+
+from __future__ import annotations
+
+from operator import index
+
+from .state import PartitionState
+from .tree import DyadicTree, NodeId
+
+
+def enumerate_partitions(
+    tree: DyadicTree,
+    *,
+    region_count: int | None = None,
+) -> tuple[PartitionState, ...]:
+    """Enumerate every valid partition frontier of a tiny dyadic tree.
+
+    Frontiers are ordered recursively with the unsplit root first.  Split
+    frontiers then follow the Cartesian-product order of the recursively
+    enumerated first and second child frontiers.  Supplying ``region_count``
+    retains only states with exactly that many active regions while preserving
+    their relative order.
+
+    Args:
+        tree: Complete canonical dyadic tree to enumerate.
+        region_count: Optional exact number of active regions.  It must be
+            between one and the number of grid-cell leaves, inclusive.
+
+    Returns:
+        All valid partition states, or only those with the requested region
+        count, in deterministic recursive order.
+
+    Raises:
+        TypeError: If ``tree`` is not a :class:`DyadicTree`, or if
+            ``region_count`` is a Boolean or is not integer-like.
+        ValueError: If ``tree`` is not complete and canonical, or if
+            ``region_count`` is outside the valid range.
+
+    Notes:
+        Exhaustive enumeration has exponential time and output-space
+        complexity in the number of grid cells.  Use this function only for
+        tiny exact-oracle problems.
+    """
+    _validate_tree(tree)
+    normalized_count = _validate_region_count(region_count, tree)
+    frontiers = _enumerate_subtree_frontiers(tree, tree.root_id)
+    return tuple(
+        PartitionState(active=active)
+        for active in frontiers
+        if normalized_count is None or len(active) == normalized_count
+    )
+
+
+def _enumerate_subtree_frontiers(
+    tree: DyadicTree,
+    node_id: NodeId,
+) -> tuple[frozenset[NodeId], ...]:
+    """Recursively enumerate valid frontiers rooted at one tree node.
+
+    Args:
+        tree: Validated complete canonical dyadic tree.
+        node_id: Root of the subtree to enumerate.
+
+    Returns:
+        Subtree frontiers in deterministic recursive order, beginning with the
+        unsplit node.
+    """
+    children = tree.children(node_id)
+    if not children:
+        return (frozenset({node_id}),)
+
+    first_id, second_id = children
+    split_frontiers = tuple(
+        first | second
+        for first in _enumerate_subtree_frontiers(tree, first_id)
+        for second in _enumerate_subtree_frontiers(tree, second_id)
+    )
+    return (frozenset({node_id}), *split_frontiers)
+
+
+def _validate_tree(tree: DyadicTree) -> None:
+    """Require a complete canonical dyadic tree.
+
+    Args:
+        tree: Candidate tree to compare with the canonical tree for its shape.
+
+    Raises:
+        TypeError: If ``tree`` is not a :class:`DyadicTree`.
+        ValueError: If its shape or stored topology is not canonical.
+    """
+    if not isinstance(tree, DyadicTree):
+        raise TypeError("tree must be a DyadicTree.")
+    try:
+        canonical = DyadicTree.from_shape(tree.shape)
+    except (TypeError, ValueError) as error:
+        raise ValueError("tree must have a valid canonical two-dimensional shape.") from error
+    if tree != canonical:
+        raise ValueError("tree must be a complete canonical DyadicTree for its shape.")
+
+
+def _validate_region_count(region_count: int | None, tree: DyadicTree) -> int | None:
+    """Normalize and bound an optional exact region count.
+
+    Args:
+        region_count: Candidate count to normalize through ``operator.index``,
+            or ``None`` to request every frontier.
+        tree: Validated tree providing the maximum grid-cell leaf count.
+
+    Returns:
+        A built-in integer in the valid range, or ``None``.
+
+    Raises:
+        TypeError: If the count is a Boolean or not integer-like.
+        ValueError: If the count is less than one or exceeds the number of
+            grid-cell leaves.
+    """
+    if region_count is None:
+        return None
+    if isinstance(region_count, bool):
+        raise TypeError("region_count must be an integer.")
+    try:
+        normalized = index(region_count)
+    except TypeError as error:
+        raise TypeError("region_count must be an integer.") from error
+    if normalized < 1:
+        raise ValueError("region_count must be at least 1.")
+    if normalized > len(tree.leaf_ids):
+        raise ValueError(f"region_count cannot exceed the tree's {len(tree.leaf_ids)} grid cells.")
+    return normalized
+
+
+__all__ = ["enumerate_partitions"]

--- a/openghg_inversions/basis/experimental/dyadic/gaussian_product_space.py
+++ b/openghg_inversions/basis/experimental/dyadic/gaussian_product_space.py
@@ -1,0 +1,651 @@
+"""Analytic Gaussian target for fixed-coordinate dyadic product spaces.
+
+This module provides a deliberately reduced Gaussian model for validating
+partition inference. The inner domain uses a dynamic dyadic partition and a
+permanent root-and-contrast vector. A separate outer coefficient block remains
+active under every partition and has its own prior covariance. Inactive inner
+contrasts have normalized Gaussian pseudo-priors.
+
+The construction is not the exact Bocquet projection with aggregation error:
+its partition marginal likelihood is intentionally allowed to depend on the
+partition. Synthetic observations can be generated around an explicit
+prior-forward mean, so no boundary-condition product is required.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+
+import numpy as np
+import numpy.typing as npt
+
+from .contrast import TreeContrastLayout
+from .multiscale import MultiscaleDesign
+from .product_space import ProductSpaceState
+from .state import PartitionState
+from .tree import DyadicTree
+
+PartitionLogPrior = Callable[[PartitionState], float]
+
+
+@dataclass(frozen=True, slots=True, eq=False)
+class GaussianConditional:
+    """Conditional Gaussian law for active inner and fixed outer coefficients.
+
+    Attributes:
+        mean: Posterior mean. Active inner coordinates come first, followed by
+            outer coefficients.
+        covariance: Posterior covariance in the same order as :attr:`mean`.
+        active_inner_indices: Permanent inner-coordinate indices represented by
+            the leading entries of :attr:`mean`.
+    """
+
+    mean: np.ndarray
+    covariance: np.ndarray
+    active_inner_indices: tuple[int, ...]
+
+    def __post_init__(self) -> None:
+        """Validate and freeze a directly constructed conditional law."""
+        mean = _vector(self.mean, name="mean")
+        covariance = _positive_definite_matrix(
+            self.covariance,
+            size=mean.size,
+            name="covariance",
+        )
+        indices = tuple(self.active_inner_indices)
+        if any(isinstance(index, bool) or not isinstance(index, (int, np.integer)) for index in indices):
+            raise TypeError("active_inner_indices must contain integers.")
+        if any(index < 0 for index in indices) or len(set(indices)) != len(indices):
+            raise ValueError("active_inner_indices must be unique and non-negative.")
+        if len(indices) > mean.size:
+            raise ValueError("active_inner_indices cannot outnumber conditional coordinates.")
+        object.__setattr__(self, "mean", _frozen(mean))
+        object.__setattr__(self, "covariance", _frozen(covariance))
+        object.__setattr__(self, "active_inner_indices", tuple(int(index) for index in indices))
+
+    def __eq__(self, other: object) -> bool:
+        """Return value equality for posterior moments and active indices."""
+        if not isinstance(other, GaussianConditional):
+            return NotImplemented
+        return (
+            self.active_inner_indices == other.active_inner_indices
+            and np.array_equal(self.mean, other.mean)
+            and np.array_equal(self.covariance, other.covariance)
+        )
+
+    __hash__ = None  # type: ignore[assignment]
+
+
+@dataclass(frozen=True, slots=True, eq=False)
+class GaussianProductSpaceTarget:
+    """Normalized continuous target and exact partition oracle.
+
+    Construct targets with :meth:`from_grid`. All coefficients are anomalies
+    around ``observation_mean``. The inner active prior is induced by IID
+    finest-grid anomalies, while the always-active outer block uses a separate
+    covariance.
+
+    Attributes:
+        observations: Observation vector.
+        observation_mean: Prior-forward observation mean.
+        observation_covariance: Fixed positive-definite error covariance.
+        inner_design: Summed candidate columns for every dyadic node.
+        contrast_layout: Permanent root-and-contrast coordinate layout.
+        inner_prior_variances: Primitive Gaussian variances for all inner
+            coordinates.
+        inactive_pseudo_prior_variances: Normalized pseudo-prior variances for
+            inactive inner contrasts.
+        outer_design: Always-active outer-region design matrix.
+        outer_prior_covariance: Separate positive-definite outer prior
+            covariance.
+        partition_log_prior: Log prior mass for a valid partition. The callable
+            should include its normalizing constant when absolute augmented
+            densities are required.
+    """
+
+    observations: np.ndarray
+    observation_mean: np.ndarray
+    observation_covariance: np.ndarray
+    inner_design: MultiscaleDesign
+    contrast_layout: TreeContrastLayout
+    inner_prior_variances: np.ndarray
+    inactive_pseudo_prior_variances: np.ndarray
+    outer_design: np.ndarray
+    outer_prior_covariance: np.ndarray
+    partition_log_prior: PartitionLogPrior
+
+    def __post_init__(self) -> None:
+        """Enforce target invariants for classmethod and direct construction."""
+        observations = _vector(self.observations, name="observations")
+        if observations.size == 0:
+            raise ValueError("observations must not be empty.")
+        mean = _vector(self.observation_mean, name="observation_mean")
+        if mean.shape != observations.shape:
+            raise ValueError("observation_mean must have the same shape as observations.")
+        error_covariance = _positive_definite_matrix(
+            self.observation_covariance,
+            size=observations.size,
+            name="observation_covariance",
+        )
+        if not isinstance(self.inner_design, MultiscaleDesign):
+            raise TypeError("inner_design must be a MultiscaleDesign.")
+        design_values = _matrix(self.inner_design.values, name="inner_design.values")
+        if design_values.shape != (observations.size, len(self.inner_design.tree.nodes)):
+            raise ValueError("inner_design values must match observations and tree nodes.")
+        if not isinstance(self.contrast_layout, TreeContrastLayout):
+            raise TypeError("contrast_layout must be a TreeContrastLayout.")
+        if self.contrast_layout.tree != self.inner_design.tree:
+            raise ValueError("contrast_layout and inner_design must use the same tree.")
+
+        inner_variances = _positive_variance_vector(
+            self.inner_prior_variances,
+            size=self.contrast_layout.coordinate_count,
+            name="inner_prior_variances",
+        )
+        pseudo_variances = _positive_variance_vector(
+            self.inactive_pseudo_prior_variances,
+            size=self.contrast_layout.coordinate_count,
+            name="inactive_pseudo_prior_variances",
+        )
+        outer_design = _matrix(self.outer_design, name="outer_design")
+        if outer_design.shape[0] != observations.size:
+            raise ValueError("outer_design observation count must match observations.")
+        outer_covariance = _positive_definite_matrix(
+            self.outer_prior_covariance,
+            size=outer_design.shape[1],
+            name="outer_prior_covariance",
+        )
+        if not callable(self.partition_log_prior):
+            raise TypeError("partition_log_prior must be callable.")
+
+        object.__setattr__(self, "observations", _frozen(observations))
+        object.__setattr__(self, "observation_mean", _frozen(mean))
+        object.__setattr__(self, "observation_covariance", _frozen(error_covariance))
+        object.__setattr__(
+            self,
+            "inner_design",
+            MultiscaleDesign(values=_frozen(design_values), tree=self.inner_design.tree),
+        )
+        object.__setattr__(self, "inner_prior_variances", _frozen(inner_variances))
+        object.__setattr__(self, "inactive_pseudo_prior_variances", _frozen(pseudo_variances))
+        object.__setattr__(self, "outer_design", _frozen(outer_design))
+        object.__setattr__(self, "outer_prior_covariance", _frozen(outer_covariance))
+
+    @classmethod
+    def from_grid(
+        cls,
+        observations: npt.ArrayLike,
+        inner_grid_design: npt.ArrayLike,
+        tree: DyadicTree,
+        observation_covariance: npt.ArrayLike,
+        *,
+        observation_mean: npt.ArrayLike | None = None,
+        inner_prior_scale: float = 1.0,
+        inactive_pseudo_prior_scale: float = 1.0,
+        outer_design: npt.ArrayLike | None = None,
+        outer_prior_covariance: npt.ArrayLike | None = None,
+        partition_log_prior: PartitionLogPrior | None = None,
+    ) -> GaussianProductSpaceTarget:
+        """Construct a validated Gaussian product-space target.
+
+        Args:
+            observations: Finite one-dimensional observation vector.
+            inner_grid_design: Fine inner design with shape ``(observation,
+                row, column)``. Columns are summed within active regions.
+            tree: Canonical tree matching the inner design's spatial shape.
+            observation_covariance: Positive-definite covariance of observation
+                and model-data mismatch errors.
+            observation_mean: Optional prior-forward mean. Defaults to zero.
+            inner_prior_scale: Positive finest-grid anomaly standard deviation.
+            inactive_pseudo_prior_scale: Positive multiplier applied to each
+                primitive inner standard deviation in the inactive
+                pseudo-prior.
+            outer_design: Optional always-active outer design with shape
+                ``(observation, outer_region)``.
+            outer_prior_covariance: Positive-definite prior covariance for the
+                outer coefficients. Required when ``outer_design`` has columns.
+            partition_log_prior: Optional log prior mass. Defaults to equal
+                relative weight for every valid partition.
+
+        Returns:
+            Immutable validated target with precomputed multiscale columns.
+
+        Raises:
+            TypeError: If ``partition_log_prior`` is not callable.
+            ValueError: If an array has incompatible shape, contains a
+                non-finite value, a required covariance is missing, or a scale
+                is not positive.
+        """
+        y = _vector(observations, name="observations")
+        if y.size == 0:
+            raise ValueError("observations must not be empty.")
+        source_design = MultiscaleDesign.from_grid(inner_grid_design, tree)
+        design = MultiscaleDesign(values=_frozen(source_design.values), tree=tree)
+        if design.values.shape[0] != y.size:
+            raise ValueError("inner_grid_design observation count must match observations.")
+
+        mean = (
+            np.zeros_like(y)
+            if observation_mean is None
+            else _vector(observation_mean, name="observation_mean")
+        )
+        if mean.shape != y.shape:
+            raise ValueError("observation_mean must have the same shape as observations.")
+        error_covariance = _positive_definite_matrix(
+            observation_covariance,
+            size=y.size,
+            name="observation_covariance",
+        )
+
+        layout = TreeContrastLayout.from_tree(tree)
+        inner_variances = layout.prior_variances(inner_prior_scale)
+        pseudo_scale = _positive_finite_scale(
+            inactive_pseudo_prior_scale,
+            name="inactive_pseudo_prior_scale",
+        )
+        with np.errstate(over="ignore", invalid="ignore"):
+            pseudo_variances = inner_variances * np.multiply(pseudo_scale, pseudo_scale)
+        if not np.all(np.isfinite(pseudo_variances)) or np.any(pseudo_variances <= 0.0):
+            raise ValueError("inactive_pseudo_prior_scale produces non-finite variances.")
+
+        outer_matrix: npt.NDArray[np.float64]
+        if outer_design is None:
+            outer_matrix = np.empty((y.size, 0), dtype=float)
+        else:
+            outer_matrix = _matrix(outer_design, name="outer_design")
+            if outer_matrix.shape[0] != y.size:
+                raise ValueError("outer_design observation count must match observations.")
+
+        outer_count = outer_matrix.shape[1]
+        outer_covariance: npt.NDArray[np.float64]
+        if outer_count == 0:
+            if outer_prior_covariance is not None and np.asarray(outer_prior_covariance).size != 0:
+                raise ValueError("outer_prior_covariance must be empty when outer_design has no columns.")
+            outer_covariance = np.empty((0, 0), dtype=float)
+        else:
+            if outer_prior_covariance is None:
+                raise ValueError("outer_prior_covariance is required when outer_design has columns.")
+            outer_covariance = _positive_definite_matrix(
+                outer_prior_covariance,
+                size=outer_count,
+                name="outer_prior_covariance",
+            )
+
+        if partition_log_prior is None:
+            prior: PartitionLogPrior = _equal_partition_log_weight
+        elif callable(partition_log_prior):
+            prior = partition_log_prior
+        else:
+            raise TypeError("partition_log_prior must be callable.")
+
+        return cls(
+            observations=y,
+            observation_mean=mean,
+            observation_covariance=error_covariance,
+            inner_design=design,
+            contrast_layout=layout,
+            inner_prior_variances=inner_variances,
+            inactive_pseudo_prior_variances=pseudo_variances,
+            outer_design=outer_matrix,
+            outer_prior_covariance=outer_covariance,
+            partition_log_prior=prior,
+        )
+
+    @property
+    def tree(self) -> DyadicTree:
+        """Return the dyadic tree shared by the design and contrast layout."""
+        return self.inner_design.tree
+
+    def log_density(self, state: ProductSpaceState) -> float:
+        """Evaluate the augmented product-space log density.
+
+        Args:
+            state: Partition, permanent inner coordinates, and fixed outer
+                coefficients.
+
+        Returns:
+            Log likelihood plus active priors, inactive normalized
+            pseudo-priors, the outer prior, and partition log prior.
+
+        Raises:
+            ValueError: If state dimensions do not match the target or the
+                partition prior returns a non-finite value.
+        """
+        self._validate_state(state)
+        active_indices = self.contrast_layout.active_coordinate_indices(state.partition)
+        inactive_indices = self.contrast_layout.inactive_coordinate_indices(state.partition)
+        prediction = self.observation_mean.copy()
+        prediction += self.inner_design.gather(state.partition) @ self.contrast_layout.decode(
+            state.partition,
+            state.inner_coordinates,
+        )
+        prediction += self.outer_design @ state.outer_coefficients
+
+        log_prior = _checked_partition_log_prior(self.partition_log_prior(state.partition))
+
+        return float(
+            _multivariate_normal_logpdf(
+                self.observations,
+                prediction,
+                self.observation_covariance,
+            )
+            + _independent_normal_logpdf(
+                state.inner_coordinates[list(active_indices)],
+                self.inner_prior_variances[list(active_indices)],
+            )
+            + _independent_normal_logpdf(
+                state.inner_coordinates[list(inactive_indices)],
+                self.inactive_pseudo_prior_variances[list(inactive_indices)],
+            )
+            + _multivariate_normal_logpdf(
+                state.outer_coefficients,
+                np.zeros_like(state.outer_coefficients),
+                self.outer_prior_covariance,
+            )
+            + log_prior
+        )
+
+    def active_design(self, partition: PartitionState) -> tuple[np.ndarray, tuple[int, ...]]:
+        """Return the likelihood design for active contrast and outer values.
+
+        Args:
+            partition: Valid inner partition.
+
+        Returns:
+            A matrix whose leading columns correspond to returned permanent
+            inner-coordinate indices and whose trailing columns correspond to
+            the always-active outer coefficients, together with those inner
+            indices.
+        """
+        partition.validate(self.tree)
+        active_indices = self.contrast_layout.active_coordinate_indices(partition)
+        decoder = self.contrast_layout.decoder(partition)[:, active_indices]
+        inner = self.inner_design.gather(partition) @ decoder
+        return np.column_stack((inner, self.outer_design)), active_indices
+
+    def log_marginal_partition_density(self, partition: PartitionState) -> float:
+        """Integrate continuous coefficients for one partition exactly.
+
+        Inactive pseudo-priors integrate to one and therefore do not appear in
+        this expression.
+
+        Args:
+            partition: Valid inner partition.
+
+        Returns:
+            Normalized Gaussian log marginal likelihood plus partition log
+            prior.
+        """
+        design, active_indices = self.active_design(partition)
+        prior_covariance = _block_diagonal(
+            np.diag(self.inner_prior_variances[list(active_indices)]),
+            self.outer_prior_covariance,
+        )
+        marginal_covariance = self.observation_covariance + design @ prior_covariance @ design.T
+        log_prior = _checked_partition_log_prior(self.partition_log_prior(partition))
+        return (
+            _multivariate_normal_logpdf(
+                self.observations,
+                self.observation_mean,
+                marginal_covariance,
+            )
+            + log_prior
+        )
+
+    def partition_probabilities(
+        self,
+        partitions: Iterable[PartitionState],
+    ) -> dict[PartitionState, float]:
+        """Normalize exact marginal probabilities over explicit partitions.
+
+        Args:
+            partitions: Non-empty sequence of distinct valid partitions.
+
+        Returns:
+            Mapping from each supplied partition to its normalized probability.
+
+        Raises:
+            ValueError: If no partition is supplied or a partition is repeated.
+        """
+        states = tuple(partitions)
+        if not states:
+            raise ValueError("partitions must not be empty.")
+        if len(set(states)) != len(states):
+            raise ValueError("partitions must be distinct.")
+        log_probabilities = np.array(
+            [self.log_marginal_partition_density(partition) for partition in states],
+            dtype=float,
+        )
+        if np.all(np.isneginf(log_probabilities)):
+            raise ValueError("At least one partition must have positive prior predictive mass.")
+        maximum = float(log_probabilities.max())
+        weights = np.exp(log_probabilities - maximum)
+        weights /= weights.sum()
+        return dict(zip(states, weights, strict=True))
+
+    def conditional_posterior(self, partition: PartitionState) -> GaussianConditional:
+        """Return the exact Gaussian law conditional on one partition.
+
+        Args:
+            partition: Valid inner partition.
+
+        Returns:
+            Posterior for active inner coordinates followed by outer
+            coefficients. Inactive inner coordinates are excluded because
+            their conditional law is their pseudo-prior.
+        """
+        design, active_indices = self.active_design(partition)
+        prior_covariance = _block_diagonal(
+            np.diag(self.inner_prior_variances[list(active_indices)]),
+            self.outer_prior_covariance,
+        )
+        prior_precision = _positive_definite_solve(prior_covariance, np.eye(prior_covariance.shape[0]))
+        solved_design = _positive_definite_solve(self.observation_covariance, design)
+        precision = prior_precision + design.T @ solved_design
+        covariance = _positive_definite_solve(precision, np.eye(precision.shape[0]))
+        residual = self.observations - self.observation_mean
+        mean = covariance @ design.T @ _positive_definite_solve(self.observation_covariance, residual)
+        return GaussianConditional(
+            mean=_frozen(mean),
+            covariance=_frozen(covariance),
+            active_inner_indices=active_indices,
+        )
+
+    def draw_conditional_state(
+        self,
+        partition: PartitionState,
+        rng: np.random.Generator,
+    ) -> ProductSpaceState:
+        """Draw active coefficients and refresh inactive pseudo-prior values.
+
+        Args:
+            partition: Partition held fixed during the Gaussian update.
+            rng: Caller-owned NumPy random generator.
+
+        Returns:
+            A complete product-space state. Active inner and outer values come
+            from their exact conditional posterior; inactive inner contrasts
+            are independent pseudo-prior draws.
+
+        Raises:
+            TypeError: If ``rng`` is not a NumPy random generator.
+        """
+        if not isinstance(rng, np.random.Generator):
+            raise TypeError("rng must be a numpy.random.Generator.")
+        conditional = self.conditional_posterior(partition)
+        joint = conditional.mean + np.linalg.cholesky(conditional.covariance) @ rng.standard_normal(
+            conditional.mean.size
+        )
+        inner: npt.NDArray[np.float64] = np.empty(
+            self.contrast_layout.coordinate_count,
+            dtype=float,
+        )
+        active_count = len(conditional.active_inner_indices)
+        inner[list(conditional.active_inner_indices)] = joint[:active_count]
+        inactive_indices = self.contrast_layout.inactive_coordinate_indices(partition)
+        if inactive_indices:
+            inner[list(inactive_indices)] = rng.normal(
+                scale=np.sqrt(self.inactive_pseudo_prior_variances[list(inactive_indices)])
+            )
+        outer = joint[active_count:]
+        return ProductSpaceState(
+            partition=partition,
+            inner_coordinates=inner,
+            outer_coefficients=outer,
+        )
+
+    def _validate_state(self, state: ProductSpaceState) -> None:
+        """Validate state geometry and permanent coordinate dimensions."""
+        state.partition.validate(self.tree)
+        if state.inner_coordinates.shape != (self.contrast_layout.coordinate_count,):
+            raise ValueError("inner_coordinates must match the target's permanent contrast dimension.")
+        if state.outer_coefficients.shape != (self.outer_design.shape[1],):
+            raise ValueError("outer_coefficients must match the target's outer-region dimension.")
+
+
+def _equal_partition_log_weight(partition: PartitionState) -> float:
+    """Return equal relative weight for every partition."""
+    del partition
+    return 0.0
+
+
+def _checked_partition_log_prior(value: float) -> float:
+    """Return a scalar log prior, allowing negative infinity for zero mass."""
+    try:
+        result = float(value)
+    except (TypeError, ValueError) as error:
+        raise ValueError("partition_log_prior must return a real scalar.") from error
+    if math.isnan(result) or result == math.inf:
+        raise ValueError("partition_log_prior must return a finite scalar or negative infinity.")
+    return result
+
+
+def _independent_normal_logpdf(values: np.ndarray, variances: np.ndarray) -> float:
+    """Return a normalized zero-mean independent Gaussian log density."""
+    if values.size == 0:
+        return 0.0
+    return float(
+        -0.5
+        * (
+            values.size * math.log(2.0 * math.pi)
+            + np.log(variances).sum()
+            + np.square(values).dot(1.0 / variances)
+        )
+    )
+
+
+def _multivariate_normal_logpdf(
+    value: np.ndarray,
+    mean: np.ndarray,
+    covariance: np.ndarray,
+) -> float:
+    """Return a normalized multivariate Gaussian log density by Cholesky solve."""
+    if value.size == 0:
+        return 0.0
+    residual = value - mean
+    cholesky = np.linalg.cholesky(covariance)
+    whitened = np.linalg.solve(cholesky, residual)
+    return float(
+        -0.5
+        * (value.size * math.log(2.0 * math.pi) + 2.0 * np.log(np.diag(cholesky)).sum() + whitened @ whitened)
+    )
+
+
+def _positive_definite_solve(matrix: np.ndarray, right_hand_side: np.ndarray) -> np.ndarray:
+    """Solve a positive-definite system with a Cholesky factorization."""
+    cholesky = np.linalg.cholesky(matrix)
+    intermediate = np.linalg.solve(cholesky, right_hand_side)
+    return np.linalg.solve(cholesky.T, intermediate)
+
+
+def _block_diagonal(first: np.ndarray, second: np.ndarray) -> np.ndarray:
+    """Construct a two-block dense covariance without a SciPy dependency."""
+    result = np.zeros(
+        (first.shape[0] + second.shape[0], first.shape[1] + second.shape[1]),
+        dtype=float,
+    )
+    result[: first.shape[0], : first.shape[1]] = first
+    result[first.shape[0] :, first.shape[1] :] = second
+    return result
+
+
+def _vector(values: npt.ArrayLike, *, name: str) -> np.ndarray:
+    """Return a finite floating-point vector."""
+    source = np.asarray(values)
+    if np.iscomplexobj(source):
+        raise ValueError(f"{name} must be real-valued.")
+    array = np.asarray(source, dtype=float)
+    if array.ndim != 1:
+        raise ValueError(f"{name} must be one-dimensional.")
+    if not np.all(np.isfinite(array)):
+        raise ValueError(f"{name} must contain only finite values.")
+    return array
+
+
+def _matrix(values: npt.ArrayLike, *, name: str) -> np.ndarray:
+    """Return a finite floating-point matrix."""
+    source = np.asarray(values)
+    if np.iscomplexobj(source):
+        raise ValueError(f"{name} must be real-valued.")
+    array = np.asarray(source, dtype=float)
+    if array.ndim != 2:
+        raise ValueError(f"{name} must be two-dimensional.")
+    if not np.all(np.isfinite(array)):
+        raise ValueError(f"{name} must contain only finite values.")
+    return array
+
+
+def _positive_definite_matrix(values: npt.ArrayLike, *, size: int, name: str) -> np.ndarray:
+    """Return a finite symmetric positive-definite square matrix."""
+    matrix = _matrix(values, name=name)
+    if matrix.shape != (size, size):
+        raise ValueError(f"{name} must have shape ({size}, {size}).")
+    if not np.allclose(matrix, matrix.T, rtol=1e-12, atol=1e-12):
+        raise ValueError(f"{name} must be symmetric.")
+    try:
+        np.linalg.cholesky(matrix)
+    except np.linalg.LinAlgError as error:
+        raise ValueError(f"{name} must be positive definite.") from error
+    return matrix
+
+
+def _positive_variance_vector(values: npt.ArrayLike, *, size: int, name: str) -> np.ndarray:
+    """Return a finite positive variance vector with an exact size."""
+    variances = _vector(values, name=name)
+    if variances.shape != (size,):
+        raise ValueError(f"{name} must have shape ({size},).")
+    if np.any(variances <= 0.0):
+        raise ValueError(f"{name} must contain only positive values.")
+    return variances
+
+
+def _positive_finite_scale(value: float, *, name: str) -> float:
+    """Normalize one positive finite scalar scale."""
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be positive and finite.")
+    try:
+        result = float(value)
+    except (TypeError, ValueError, OverflowError) as error:
+        raise ValueError(f"{name} must be positive and finite.") from error
+    if not np.isfinite(result) or result <= 0.0:
+        raise ValueError(f"{name} must be positive and finite.")
+    return result
+
+
+def _frozen(values: np.ndarray) -> np.ndarray:
+    """Copy an array and mark its storage read-only."""
+    source = np.asarray(values)
+    if np.iscomplexobj(source):
+        raise ValueError("Internal arrays must be real-valued.")
+    result = np.asarray(source, dtype=float).copy()
+    result.setflags(write=False)
+    return result
+
+
+__all__ = [
+    "GaussianConditional",
+    "GaussianProductSpaceTarget",
+    "PartitionLogPrior",
+]

--- a/openghg_inversions/basis/experimental/dyadic/product_space.py
+++ b/openghg_inversions/basis/experimental/dyadic/product_space.py
@@ -1,0 +1,266 @@
+"""Framework-independent Metropolis updates for dyadic product spaces.
+
+The transition in this module changes only the discrete partition. Inner
+root-and-contrast coordinates and always-active outer coefficients remain in a
+fixed order and retain exactly the same values. Consequently this kernel has no
+dimension matching transformation and no Jacobian; active-prior and inactive
+pseudo-prior terms belong in the caller-supplied augmented log density.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import TypeAlias
+
+import numpy as np
+import numpy.typing as npt
+
+from .proposals import MergeMove, SplitMove, apply_move, enumerate_merge_moves, enumerate_split_moves
+from .state import PartitionState
+from .tree import DyadicTree
+
+PartitionMove: TypeAlias = SplitMove | MergeMove
+
+
+@dataclass(frozen=True, slots=True, eq=False)
+class ProductSpaceState:
+    """Discrete partition and fixed-dimensional continuous coordinates.
+
+    Array inputs are copied and made read-only so a transition cannot mutate a
+    previous state through shared NumPy storage.
+
+    Attributes:
+        partition: Active dyadic frontier.
+        inner_coordinates: Permanent root-and-contrast coordinate vector.
+        outer_coefficients: Always-active fixed outer-region coefficients.
+    """
+
+    partition: PartitionState
+    inner_coordinates: np.ndarray
+    outer_coefficients: np.ndarray = field(default_factory=lambda: np.empty(0, dtype=float))
+
+    def __post_init__(self) -> None:
+        """Validate, copy, and freeze both continuous coordinate vectors."""
+        if not isinstance(self.partition, PartitionState):
+            raise TypeError("partition must be a PartitionState.")
+        object.__setattr__(
+            self,
+            "inner_coordinates",
+            _frozen_vector(self.inner_coordinates, name="inner_coordinates"),
+        )
+        object.__setattr__(
+            self,
+            "outer_coefficients",
+            _frozen_vector(self.outer_coefficients, name="outer_coefficients"),
+        )
+
+    def __eq__(self, other: object) -> bool:
+        """Return value equality across the partition and both coordinate vectors."""
+        if not isinstance(other, ProductSpaceState):
+            return NotImplemented
+        return (
+            self.partition == other.partition
+            and np.array_equal(self.inner_coordinates, other.inner_coordinates)
+            and np.array_equal(self.outer_coefficients, other.outer_coefficients)
+        )
+
+    __hash__ = None  # type: ignore[assignment]
+
+
+LogAugmentedDensity: TypeAlias = Callable[[ProductSpaceState], float]
+
+
+@dataclass(frozen=True, slots=True)
+class PartitionNeighbor:
+    """Unique split-or-merge destination and its forward probability."""
+
+    partition: PartitionState
+    move: PartitionMove
+    log_q: float
+
+
+@dataclass(frozen=True, slots=True)
+class ProductSpaceTransition:
+    """Complete diagnostic record for one partition Metropolis update.
+
+    Attributes:
+        state: Accepted candidate or unchanged current state.
+        candidate: Proposed state before the accept/reject decision.
+        move: Proposed split or merge, or ``None`` for an isolated tree.
+        accepted: Whether the proposed partition was accepted.
+        current_log_density: Augmented target at the source state.
+        candidate_log_density: Augmented target at the proposed state.
+        log_q_forward: Log proposal probability from source to candidate.
+        log_q_reverse: Log proposal probability from candidate to source.
+        log_acceptance_ratio: Unclipped log Metropolis-Hastings ratio.
+    """
+
+    state: ProductSpaceState
+    candidate: ProductSpaceState
+    move: PartitionMove | None
+    accepted: bool
+    current_log_density: float
+    candidate_log_density: float
+    log_q_forward: float
+    log_q_reverse: float
+    log_acceptance_ratio: float
+
+
+def enumerate_partition_neighbors(
+    tree: DyadicTree,
+    partition: PartitionState,
+) -> tuple[PartitionNeighbor, ...]:
+    """Enumerate unique one-split or one-merge partition neighbors.
+
+    The proposal is uniform over unique destination frontiers. Split
+    destinations precede merge destinations, with both groups following the
+    stable ordering from :mod:`.proposals`.
+
+    Args:
+        tree: Tree defining legal split and merge moves.
+        partition: Valid source partition.
+
+    Returns:
+        Neighbor records with common ``log_q = -log(number_of_neighbors)``.
+        A partition on a one-grid-cell tree has no neighbors.
+    """
+    partition.validate(tree)
+    unique: dict[frozenset[int], tuple[PartitionState, PartitionMove]] = {}
+    moves: tuple[PartitionMove, ...] = (
+        *enumerate_split_moves(tree, partition),
+        *enumerate_merge_moves(tree, partition),
+    )
+    for move in moves:
+        candidate = apply_move(tree, partition, move)
+        unique.setdefault(candidate.active, (candidate, move))
+
+    if not unique:
+        return ()
+    log_q = -math.log(len(unique))
+    return tuple(
+        PartitionNeighbor(partition=candidate, move=move, log_q=log_q) for candidate, move in unique.values()
+    )
+
+
+def partition_metropolis_step(
+    tree: DyadicTree,
+    current: ProductSpaceState,
+    *,
+    log_density: LogAugmentedDensity,
+    rng: np.random.Generator,
+) -> ProductSpaceTransition:
+    """Apply one exact split-or-merge Metropolis-Hastings update.
+
+    The continuous values are held fixed. The supplied target must evaluate the
+    complete normalized product-space density, including the active prior, the
+    inactive pseudo-prior, the partition prior, and any always-active outer
+    block.
+
+    Args:
+        tree: Tree defining the current and proposed partitions.
+        current: Current fixed-dimensional product-space state.
+        log_density: Callable returning the normalized augmented log density.
+        rng: Caller-owned NumPy random generator.
+
+    Returns:
+        Diagnostic transition record containing the accepted state.
+
+    Raises:
+        TypeError: If ``rng`` is not a NumPy generator or ``log_density`` is not
+            callable.
+        ValueError: If the current target density is non-finite, the candidate
+            target is NaN or positive infinity, or the reverse proposal is
+            missing.
+    """
+    if not isinstance(rng, np.random.Generator):
+        raise TypeError("rng must be a numpy.random.Generator.")
+    if not callable(log_density):
+        raise TypeError("log_density must be callable.")
+    current.partition.validate(tree)
+    current_log_density = _checked_log_density(log_density(current), current=True)
+    neighbors = enumerate_partition_neighbors(tree, current.partition)
+
+    if not neighbors:
+        return ProductSpaceTransition(
+            state=current,
+            candidate=current,
+            move=None,
+            accepted=False,
+            current_log_density=current_log_density,
+            candidate_log_density=current_log_density,
+            log_q_forward=0.0,
+            log_q_reverse=0.0,
+            log_acceptance_ratio=-math.inf,
+        )
+
+    neighbor = neighbors[int(rng.integers(len(neighbors)))]
+    candidate = ProductSpaceState(
+        partition=neighbor.partition,
+        inner_coordinates=current.inner_coordinates,
+        outer_coefficients=current.outer_coefficients,
+    )
+    candidate_log_density = _checked_log_density(log_density(candidate), current=False)
+    reverse_neighbors = enumerate_partition_neighbors(tree, candidate.partition)
+    reverse = next(
+        (item for item in reverse_neighbors if item.partition == current.partition),
+        None,
+    )
+    if reverse is None:  # pragma: no cover - protects future proposal extensions.
+        raise ValueError("Proposed partition has no reverse split-or-merge move.")
+
+    log_acceptance_ratio = candidate_log_density - current_log_density + reverse.log_q - neighbor.log_q
+    uniform = float(rng.random())
+    log_uniform = -math.inf if uniform == 0.0 else math.log(uniform)
+    accepted = bool(log_uniform < min(0.0, log_acceptance_ratio))
+    return ProductSpaceTransition(
+        state=candidate if accepted else current,
+        candidate=candidate,
+        move=neighbor.move,
+        accepted=accepted,
+        current_log_density=current_log_density,
+        candidate_log_density=candidate_log_density,
+        log_q_forward=neighbor.log_q,
+        log_q_reverse=reverse.log_q,
+        log_acceptance_ratio=log_acceptance_ratio,
+    )
+
+
+def _frozen_vector(values: npt.ArrayLike, *, name: str) -> np.ndarray:
+    """Return a copied, finite, read-only floating-point vector."""
+    source = np.asarray(values)
+    if np.iscomplexobj(source):
+        raise ValueError(f"{name} must be real-valued.")
+    array = np.asarray(source, dtype=float)
+    if array.ndim != 1:
+        raise ValueError(f"{name} must be one-dimensional.")
+    if not np.all(np.isfinite(array)):
+        raise ValueError(f"{name} must contain only finite values.")
+    result = array.copy()
+    result.setflags(write=False)
+    return result
+
+
+def _checked_log_density(value: float, *, current: bool) -> float:
+    """Validate one scalar log density while allowing rejected ``-inf`` proposals."""
+    try:
+        result = float(value)
+    except (TypeError, ValueError) as error:
+        raise ValueError("log_density must return a real scalar.") from error
+    if math.isnan(result) or result == math.inf or (current and result == -math.inf):
+        if current:
+            raise ValueError("current log density must be finite.")
+        raise ValueError("candidate log density must be finite or negative infinity.")
+    return result
+
+
+__all__ = [
+    "LogAugmentedDensity",
+    "PartitionMove",
+    "PartitionNeighbor",
+    "ProductSpaceState",
+    "ProductSpaceTransition",
+    "enumerate_partition_neighbors",
+    "partition_metropolis_step",
+]

--- a/tests/basis/experimental/test_dyadic_contrast.py
+++ b/tests/basis/experimental/test_dyadic_contrast.py
@@ -1,0 +1,113 @@
+"""Tests for fixed root-and-contrast coordinates on dyadic trees."""
+
+import numpy as np
+import pytest
+
+from openghg_inversions.basis.experimental.dyadic.contrast import TreeContrastLayout
+from openghg_inversions.basis.experimental.dyadic.state import PartitionState
+from openghg_inversions.basis.experimental.dyadic.tree import DyadicTree
+
+
+def test_layout_has_one_coordinate_per_finest_grid_cell() -> None:
+    """A full binary tree should have one root/contrast degree per leaf."""
+    tree = DyadicTree.from_shape((2, 3))
+
+    layout = TreeContrastLayout.from_tree(tree)
+
+    assert layout.coordinate_count == 6
+    assert layout.coordinate_count == len(tree.leaf_ids)
+    assert layout.split_node_ids == tuple(tile.node_id for tile in tree.nodes if tree.children(tile.node_id))
+
+
+def test_active_indices_follow_partition_refinement() -> None:
+    """Splitting a frontier should activate exactly its parent contrast."""
+    tree = DyadicTree.from_shape((1, 3))
+    layout = TreeContrastLayout.from_tree(tree)
+    root = PartitionState.root(tree)
+    first_split = root.split(tree, tree.root_id)
+    splittable_child = next(node_id for node_id in first_split.active if tree.children(node_id))
+    finest = first_split.split(tree, splittable_child)
+
+    assert layout.active_coordinate_indices(root) == (0,)
+    assert layout.active_coordinate_indices(first_split) == (0, layout.contrast_index(tree.root_id))
+    assert layout.active_coordinate_indices(finest) == tuple(range(layout.coordinate_count))
+    assert layout.inactive_coordinate_indices(finest) == ()
+
+
+def test_decoder_preserves_parent_weighted_mean() -> None:
+    """Decoded child means should retain the root mean under area weighting."""
+    tree = DyadicTree.from_shape((1, 3))
+    layout = TreeContrastLayout.from_tree(tree)
+    partition = PartitionState.root(tree).split(tree, tree.root_id)
+    coordinates = np.array([2.5, -1.2, 99.0])
+
+    region_means = layout.decode(partition, coordinates)
+    areas = np.array([tree.tile(node_id).area for node_id in partition.ordered_active()])
+
+    np.testing.assert_allclose(region_means, [1.7, 2.9])
+    assert region_means[0] - region_means[1] == pytest.approx(coordinates[1])
+    assert np.average(region_means, weights=areas) == pytest.approx(coordinates[0])
+    assert np.all(layout.decoder(partition)[:, layout.inactive_coordinate_indices(partition)] == 0.0)
+
+
+@pytest.mark.parametrize("shape", [(1, 3), (2, 2), (2, 3)])
+def test_contrast_prior_recovers_independent_finest_grid_prior(shape: tuple[int, int]) -> None:
+    """Primitive contrast variances should decode to IID finest-grid anomalies."""
+    tree = DyadicTree.from_shape(shape)
+    layout = TreeContrastLayout.from_tree(tree)
+    finest = PartitionState(active=frozenset(tree.leaf_ids))
+    scale = 1.7
+    decoder = layout.decoder(finest)
+
+    decoded_covariance = decoder @ np.diag(layout.prior_variances(scale)) @ decoder.T
+
+    np.testing.assert_allclose(decoded_covariance, scale**2 * np.eye(len(tree.leaf_ids)), atol=1e-12)
+
+
+def test_contrast_prior_recovers_independent_active_region_means() -> None:
+    """A coarse frontier should have variance scaled by each region's area."""
+    tree = DyadicTree.from_shape((2, 3))
+    layout = TreeContrastLayout.from_tree(tree)
+    partition = PartitionState.root(tree).split(tree, tree.root_id)
+    scale = 0.8
+    active_indices = layout.active_coordinate_indices(partition)
+    decoder = layout.decoder(partition)[:, active_indices]
+    covariance = decoder @ np.diag(layout.prior_variances(scale)[list(active_indices)]) @ decoder.T
+    expected = np.diag([scale**2 / tree.tile(node_id).area for node_id in partition.ordered_active()])
+
+    np.testing.assert_allclose(covariance, expected, atol=1e-12)
+
+
+@pytest.mark.parametrize("scale", [0.0, -1.0, np.nan, np.inf])
+def test_prior_variances_reject_invalid_scale(scale: float) -> None:
+    """Primitive prior scales must be positive and finite."""
+    layout = TreeContrastLayout.from_tree(DyadicTree.from_shape((1, 2)))
+
+    with pytest.raises(ValueError, match="scale"):
+        layout.prior_variances(scale)
+
+
+def test_decode_rejects_wrong_coordinate_shape() -> None:
+    """The permanent coordinate vector must match the finest-grid dimension."""
+    tree = DyadicTree.from_shape((1, 2))
+    layout = TreeContrastLayout.from_tree(tree)
+
+    with pytest.raises(ValueError, match="shape"):
+        layout.decode(PartitionState.root(tree), [0.0])
+
+
+def test_direct_layout_construction_enforces_stable_split_ids() -> None:
+    """The public constructor should reject incomplete coordinate layouts."""
+    tree = DyadicTree.from_shape((1, 2))
+
+    with pytest.raises(ValueError, match="split_node_ids"):
+        TreeContrastLayout(tree=tree, split_node_ids=())
+
+
+@pytest.mark.parametrize("scale", [1e154, 1e308])
+def test_prior_variances_reject_overflowing_scale(scale: float) -> None:
+    """Large finite scales must not create infinite primitive variances."""
+    layout = TreeContrastLayout.from_tree(DyadicTree.from_shape((1, 2)))
+
+    with pytest.raises(ValueError, match="non-finite primitive variances"):
+        layout.prior_variances(scale)

--- a/tests/basis/experimental/test_dyadic_enumeration.py
+++ b/tests/basis/experimental/test_dyadic_enumeration.py
@@ -1,0 +1,105 @@
+"""Tests for exhaustive enumeration of tiny dyadic partition frontiers."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from openghg_inversions.basis.experimental.dyadic.enumeration import enumerate_partitions
+from openghg_inversions.basis.experimental.dyadic.tree import DyadicTree
+
+
+@pytest.mark.parametrize(
+    ("shape", "expected_active"),
+    [
+        ((1, 1), ((0,),)),
+        ((1, 2), ((0,), (1, 2))),
+        ((1, 3), ((0,), (1, 2), (1, 3, 4))),
+        (
+            (2, 2),
+            (
+                (0,),
+                (1, 4),
+                (1, 5, 6),
+                (2, 3, 4),
+                (2, 3, 5, 6),
+            ),
+        ),
+    ],
+)
+def test_enumeration_has_expected_counts_and_recursive_order(
+    shape: tuple[int, int],
+    expected_active: tuple[tuple[int, ...], ...],
+) -> None:
+    """Tiny trees should expose every frontier in stable recursive order."""
+    tree = DyadicTree.from_shape(shape)
+
+    states = enumerate_partitions(tree)
+
+    assert tuple(state.ordered_active() for state in states) == expected_active
+    for state in states:
+        state.validate(tree)
+
+
+@pytest.mark.parametrize(
+    ("region_count", "expected_active"),
+    [
+        (1, ((0,),)),
+        (2, ((1, 4),)),
+        (3, ((1, 5, 6), (2, 3, 4))),
+        (4, ((2, 3, 5, 6),)),
+    ],
+)
+def test_exact_region_count_filter_preserves_order(
+    region_count: int,
+    expected_active: tuple[tuple[int, ...], ...],
+) -> None:
+    """An exact region filter should retain matching states without reordering."""
+    tree = DyadicTree.from_shape((2, 2))
+
+    states = enumerate_partitions(tree, region_count=region_count)
+
+    assert tuple(state.ordered_active() for state in states) == expected_active
+
+
+def test_integer_like_region_count_is_accepted() -> None:
+    """NumPy integer scalars should satisfy the integer-like count contract."""
+    tree = DyadicTree.from_shape((1, 2))
+
+    states = enumerate_partitions(tree, region_count=np.int64(2))  # type: ignore[arg-type]
+
+    assert tuple(state.ordered_active() for state in states) == ((1, 2),)
+
+
+def test_four_by_four_reference_tree_has_677_partitions() -> None:
+    """The planned Gaussian reference tree should retain its exact oracle size."""
+    tree = DyadicTree.from_shape((4, 4))
+
+    states = enumerate_partitions(tree)
+
+    assert len(states) == 677
+    assert sum(len(enumerate_partitions(tree, region_count=count)) for count in range(1, 17)) == 677
+
+
+@pytest.mark.parametrize("region_count", [0, -1, 5])
+def test_region_count_rejects_values_outside_grid_cell_range(region_count: int) -> None:
+    """Counts below one or above the grid-cell leaf count should be rejected."""
+    tree = DyadicTree.from_shape((2, 2))
+
+    with pytest.raises(ValueError, match="region_count"):
+        enumerate_partitions(tree, region_count=region_count)
+
+
+@pytest.mark.parametrize("region_count", [True, 1.5, "2"])
+def test_region_count_rejects_boolean_and_nonintegers(region_count: object) -> None:
+    """Boolean and non-integer counts should fail rather than be coerced."""
+    tree = DyadicTree.from_shape((2, 2))
+
+    with pytest.raises(TypeError, match="region_count"):
+        enumerate_partitions(tree, region_count=region_count)  # type: ignore[arg-type]
+
+
+def test_enumeration_rejects_non_tree_input() -> None:
+    """Enumeration should reject inputs that do not satisfy the tree contract."""
+    with pytest.raises(TypeError, match="DyadicTree"):
+        enumerate_partitions(object())  # type: ignore[arg-type]

--- a/tests/basis/experimental/test_dyadic_gaussian_product_space.py
+++ b/tests/basis/experimental/test_dyadic_gaussian_product_space.py
@@ -1,0 +1,279 @@
+"""Tests for the analytic Gaussian dyadic product-space target."""
+
+import math
+
+import numpy as np
+import pytest
+
+from openghg_inversions.basis.experimental.dyadic.enumeration import enumerate_partitions
+from openghg_inversions.basis.experimental.dyadic.gaussian_product_space import (
+    GaussianProductSpaceTarget,
+)
+from openghg_inversions.basis.experimental.dyadic.product_space import (
+    ProductSpaceState,
+    partition_metropolis_step,
+)
+from openghg_inversions.basis.experimental.dyadic.state import PartitionState
+from openghg_inversions.basis.experimental.dyadic.tree import DyadicTree
+
+
+def _target(
+    *,
+    observation: float = 0.0,
+    pseudo_prior_scale: float = 1.0,
+    outer_prior_scale: float = 0.5,
+) -> tuple[GaussianProductSpaceTarget, tuple[PartitionState, ...]]:
+    """Build a one-observation target with three exactly enumerable partitions."""
+    tree = DyadicTree.from_shape((1, 3))
+    partitions = enumerate_partitions(tree)
+    log_uniform = -math.log(len(partitions))
+
+    def prior(partition: PartitionState) -> float:
+        """Assign normalized uniform mass to each enumerated partition."""
+        assert partition in partitions
+        return log_uniform
+
+    target = GaussianProductSpaceTarget.from_grid(
+        observations=np.array([observation]),
+        inner_grid_design=np.array([[[1.0, 2.0, 3.0]]]),
+        tree=tree,
+        observation_covariance=np.array([[1.0]]),
+        inner_prior_scale=1.0,
+        inactive_pseudo_prior_scale=pseudo_prior_scale,
+        outer_design=np.array([[2.0]]),
+        outer_prior_covariance=np.array([[outer_prior_scale**2]]),
+        partition_log_prior=prior,
+    )
+    return target, partitions
+
+
+def test_exact_partition_probabilities_match_scalar_gaussian_oracle() -> None:
+    """Analytic probabilities should match independently derived predictive variances."""
+    target, partitions = _target(observation=0.0)
+
+    probabilities = target.partition_probabilities(partitions)
+
+    # R contributes 1 and the outer block contributes 2**2 * 0.5**2 = 1.
+    # Inner variances are 6**2/3, 1**2 + 5**2/2, and 1**2+2**2+3**2.
+    predictive_variances = np.array([14.0, 15.5, 16.0])
+    expected = 1.0 / np.sqrt(predictive_variances)
+    expected /= expected.sum()
+    np.testing.assert_allclose(list(probabilities.values()), expected, atol=1e-12)
+
+
+def test_exact_partition_probabilities_do_not_depend_on_pseudo_prior() -> None:
+    """Normalized inactive pseudo-priors should integrate out of model probabilities."""
+    narrow, partitions = _target(observation=1.3, pseudo_prior_scale=0.4)
+    broad, _ = _target(observation=1.3, pseudo_prior_scale=3.0)
+
+    narrow_probabilities = narrow.partition_probabilities(partitions)
+    broad_probabilities = broad.partition_probabilities(partitions)
+
+    np.testing.assert_allclose(
+        list(narrow_probabilities.values()),
+        list(broad_probabilities.values()),
+        atol=1e-14,
+    )
+
+
+def test_augmented_density_includes_normalized_inactive_pseudo_priors() -> None:
+    """Changing pseudo-prior scale should retain its partition-dependent normalizer."""
+    unit, partitions = _target(pseudo_prior_scale=1.0)
+    broad, _ = _target(pseudo_prior_scale=2.0)
+    root_state = ProductSpaceState(partitions[0], np.zeros(3), np.zeros(1))
+    finest_state = ProductSpaceState(partitions[-1], np.zeros(3), np.zeros(1))
+
+    root_difference = broad.log_density(root_state) - unit.log_density(root_state)
+    finest_difference = broad.log_density(finest_state) - unit.log_density(finest_state)
+
+    assert root_difference == pytest.approx(-2.0 * math.log(2.0))
+    assert finest_difference == pytest.approx(0.0)
+
+
+def test_conditional_posterior_matches_direct_information_form() -> None:
+    """The active inner and outer block should match a direct Gaussian calculation."""
+    target, partitions = _target(observation=1.2)
+
+    conditional = target.conditional_posterior(partitions[0])
+
+    design = np.array([[6.0, 2.0]])
+    prior_covariance = np.diag([1.0 / 3.0, 0.25])
+    expected_covariance = np.linalg.inv(np.linalg.inv(prior_covariance) + design.T @ design)
+    expected_mean = expected_covariance @ design.T @ np.array([1.2])
+    assert conditional.active_inner_indices == (0,)
+    np.testing.assert_allclose(conditional.mean, expected_mean, atol=1e-12)
+    np.testing.assert_allclose(conditional.covariance, expected_covariance, atol=1e-12)
+    same = target.conditional_posterior(partitions[0])
+    assert conditional == same
+    with pytest.raises(TypeError, match="unhashable"):
+        hash(conditional)
+
+
+def test_refined_conditional_uses_documented_signed_contrast_design() -> None:
+    """A nonzero-data posterior should retain the declared left-minus-right sign."""
+    target, partitions = _target(observation=1.2)
+
+    conditional = target.conditional_posterior(partitions[1])
+
+    # Regional columns are 1 and 5. The unequal-child decoder gives contrast
+    # column 1*(2/3) + 5*(-1/3) = -1 for delta = left - right.
+    design = np.array([[6.0, -1.0, 2.0]])
+    prior_covariance = np.diag([1.0 / 3.0, 1.5, 0.25])
+    expected_covariance = np.linalg.inv(np.linalg.inv(prior_covariance) + design.T @ design)
+    expected_mean = expected_covariance @ design.T @ np.array([1.2])
+
+    np.testing.assert_allclose(conditional.mean, expected_mean, atol=1e-12)
+    np.testing.assert_allclose(conditional.covariance, expected_covariance, atol=1e-12)
+
+
+def test_conditional_draw_has_permanent_inner_and_fixed_outer_dimensions() -> None:
+    """A Gibbs draw should refresh inactive contrasts without changing dimensions."""
+    target, partitions = _target(observation=-0.7, pseudo_prior_scale=1.8)
+
+    state = target.draw_conditional_state(partitions[0], np.random.default_rng(8))
+
+    assert state.partition == partitions[0]
+    assert state.inner_coordinates.shape == (3,)
+    assert state.outer_coefficients.shape == (1,)
+    assert np.all(np.isfinite(state.inner_coordinates))
+    assert np.all(np.isfinite(state.outer_coefficients))
+
+
+def test_outer_prior_is_a_separate_always_active_factor() -> None:
+    """Changing only the outer prior should change its normalized density factor."""
+    narrow, partitions = _target(outer_prior_scale=0.5)
+    broad, _ = _target(outer_prior_scale=1.0)
+    state = ProductSpaceState(partitions[1], np.zeros(3), np.array([0.0]))
+
+    difference = broad.log_density(state) - narrow.log_density(state)
+
+    assert difference == pytest.approx(-math.log(2.0))
+
+
+@pytest.mark.parametrize("pseudo_prior_scale", [0.6, 2.0])
+def test_gibbs_and_partition_mh_frequencies_match_exact_oracle(
+    pseudo_prior_scale: float,
+) -> None:
+    """The complete tiny sampler should recover exact partition probabilities."""
+    target, partitions = _target(observation=1.8, pseudo_prior_scale=pseudo_prior_scale)
+    expected = target.partition_probabilities(partitions)
+    rng = np.random.default_rng(20260717)
+    state = target.draw_conditional_state(partitions[0], rng)
+    counts = {partition: 0 for partition in partitions}
+    draws = 12_000
+    burn_in = 1_000
+
+    for draw in range(draws):
+        state = target.draw_conditional_state(state.partition, rng)
+        state = partition_metropolis_step(
+            target.tree,
+            state,
+            log_density=target.log_density,
+            rng=rng,
+        ).state
+        if draw >= burn_in:
+            counts[state.partition] += 1
+
+    observed = np.array([counts[partition] for partition in partitions], dtype=float)
+    observed /= observed.sum()
+    np.testing.assert_allclose(observed, list(expected.values()), atol=0.05)
+
+
+def test_zero_mass_partition_prior_is_supported() -> None:
+    """Hard partition constraints should give zero density instead of aborting."""
+    target, partitions = _target()
+
+    def root_only_prior(partition: PartitionState) -> float:
+        """Assign all prior mass to the root partition."""
+        return 0.0 if partition == partitions[0] else -math.inf
+
+    constrained = GaussianProductSpaceTarget.from_grid(
+        observations=target.observations,
+        inner_grid_design=np.array([[[1.0, 2.0, 3.0]]]),
+        tree=target.tree,
+        observation_covariance=target.observation_covariance,
+        outer_design=target.outer_design,
+        outer_prior_covariance=target.outer_prior_covariance,
+        partition_log_prior=root_only_prior,
+    )
+    candidate = ProductSpaceState(partitions[1], np.zeros(3), np.zeros(1))
+
+    assert constrained.log_density(candidate) == -math.inf
+    assert constrained.partition_probabilities(partitions) == {
+        partitions[0]: 1.0,
+        partitions[1]: 0.0,
+        partitions[2]: 0.0,
+    }
+
+
+@pytest.mark.parametrize(
+    ("keyword", "value", "message"),
+    [
+        ("inactive_pseudo_prior_scale", 0.0, "inactive_pseudo_prior_scale"),
+        ("outer_prior_covariance", None, "outer_prior_covariance"),
+    ],
+)
+def test_target_rejects_invalid_prior_configuration(
+    keyword: str,
+    value: object,
+    message: str,
+) -> None:
+    """Invalid pseudo-prior and fixed-outer prior settings should fail early."""
+    tree = DyadicTree.from_shape((1, 2))
+    arguments: dict[str, object] = {
+        "observations": [0.0],
+        "inner_grid_design": [[[1.0, 2.0]]],
+        "tree": tree,
+        "observation_covariance": [[1.0]],
+        "outer_design": [[1.0]],
+        "outer_prior_covariance": [[0.25]],
+    }
+    arguments[keyword] = value
+
+    with pytest.raises(ValueError, match=message):
+        GaussianProductSpaceTarget.from_grid(**arguments)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("keyword", "value"),
+    [
+        ("observations", np.array([1.0 + 1.0j])),
+        ("observation_mean", np.array([1.0 + 1.0j])),
+        ("observation_covariance", np.array([[1.0 + 1.0j]])),
+        ("outer_design", np.array([[1.0 + 1.0j]])),
+        ("outer_prior_covariance", np.array([[1.0 + 1.0j]])),
+    ],
+)
+def test_target_rejects_complex_arrays(keyword: str, value: np.ndarray) -> None:
+    """Complex model inputs should fail instead of being silently truncated."""
+    tree = DyadicTree.from_shape((1, 2))
+    arguments: dict[str, object] = {
+        "observations": [0.0],
+        "observation_mean": [0.0],
+        "inner_grid_design": [[[1.0, 2.0]]],
+        "tree": tree,
+        "observation_covariance": [[1.0]],
+        "outer_design": [[1.0]],
+        "outer_prior_covariance": [[0.25]],
+    }
+    arguments[keyword] = value
+
+    with pytest.raises(ValueError, match="real-valued"):
+        GaussianProductSpaceTarget.from_grid(**arguments)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("keyword", ["inner_prior_scale", "inactive_pseudo_prior_scale"])
+@pytest.mark.parametrize("scale", [1e154, 1e308])
+def test_target_rejects_scales_that_overflow_variances(keyword: str, scale: float) -> None:
+    """Extreme finite scales should produce a documented validation error."""
+    tree = DyadicTree.from_shape((1, 2))
+    arguments: dict[str, object] = {
+        "observations": [0.0],
+        "inner_grid_design": [[[1.0, 2.0]]],
+        "tree": tree,
+        "observation_covariance": [[1.0]],
+        keyword: scale,
+    }
+
+    with pytest.raises(ValueError, match="variances"):
+        GaussianProductSpaceTarget.from_grid(**arguments)  # type: ignore[arg-type]

--- a/tests/basis/experimental/test_dyadic_product_space.py
+++ b/tests/basis/experimental/test_dyadic_product_space.py
@@ -1,0 +1,180 @@
+"""Tests for exact fixed-coordinate dyadic partition Metropolis updates."""
+
+import math
+
+import numpy as np
+import pytest
+
+from openghg_inversions.basis.experimental.dyadic.product_space import (
+    ProductSpaceState,
+    enumerate_partition_neighbors,
+    partition_metropolis_step,
+)
+from openghg_inversions.basis.experimental.dyadic.state import PartitionState
+from openghg_inversions.basis.experimental.dyadic.tree import DyadicTree
+
+
+def _one_by_three_partitions() -> tuple[DyadicTree, tuple[PartitionState, ...]]:
+    """Return the three-state partition path for the smallest asymmetric tree."""
+    tree = DyadicTree.from_shape((1, 3))
+    root = PartitionState.root(tree)
+    middle = root.split(tree, tree.root_id)
+    splittable_child = next(node_id for node_id in middle.active if tree.children(node_id))
+    finest = middle.split(tree, splittable_child)
+    return tree, (root, middle, finest)
+
+
+def test_product_space_state_copies_and_freezes_coordinates() -> None:
+    """Stored coordinate vectors should not alias mutable caller arrays."""
+    tree = DyadicTree.from_shape((1, 2))
+    inner = np.array([1.0, 2.0])
+    outer = np.array([3.0])
+    state = ProductSpaceState(PartitionState.root(tree), inner, outer)
+    inner[:] = -1.0
+    outer[:] = -1.0
+
+    np.testing.assert_array_equal(state.inner_coordinates, [1.0, 2.0])
+    np.testing.assert_array_equal(state.outer_coefficients, [3.0])
+    assert not state.inner_coordinates.flags.writeable
+    assert not state.outer_coefficients.flags.writeable
+
+    with pytest.raises(ValueError, match="read-only"):
+        state.inner_coordinates[0] = 4.0
+
+
+def test_product_space_state_has_array_aware_value_equality() -> None:
+    """Equal coordinate values should compare cleanly while states remain unhashable."""
+    tree = DyadicTree.from_shape((1, 2))
+    first = ProductSpaceState(PartitionState.root(tree), [1.0, 2.0], [3.0])
+    second = ProductSpaceState(PartitionState.root(tree), [1.0, 2.0], [3.0])
+    different = ProductSpaceState(PartitionState.root(tree), [1.0, 4.0], [3.0])
+
+    assert first == second
+    assert first != different
+    with pytest.raises(TypeError, match="unhashable"):
+        hash(first)
+
+
+def test_product_space_state_rejects_complex_coordinates() -> None:
+    """Complex coordinates should fail instead of losing their imaginary parts."""
+    tree = DyadicTree.from_shape((1, 2))
+
+    with pytest.raises(ValueError, match="real-valued"):
+        ProductSpaceState(PartitionState.root(tree), np.array([1.0 + 2.0j, 0.0]))
+
+
+def test_neighbor_probabilities_reflect_asymmetric_degrees() -> None:
+    """The 1x3 partition path should have proposal degrees one, two, and one."""
+    tree, partitions = _one_by_three_partitions()
+
+    neighbors = [enumerate_partition_neighbors(tree, partition) for partition in partitions]
+
+    assert [len(items) for items in neighbors] == [1, 2, 1]
+    assert [[math.exp(item.log_q) for item in items] for items in neighbors] == [
+        [1.0],
+        [0.5, 0.5],
+        [1.0],
+    ]
+    for source, items in zip(partitions, neighbors, strict=True):
+        for item in items:
+            assert source in {
+                reverse.partition for reverse in enumerate_partition_neighbors(tree, item.partition)
+            }
+
+
+def test_partition_metropolis_step_keeps_all_continuous_values_fixed() -> None:
+    """An accepted structure update should not transport either coefficient block."""
+    tree, (root, middle, _) = _one_by_three_partitions()
+    current = ProductSpaceState(root, np.array([0.2, -0.4, 0.7]), np.array([1.3, -0.2]))
+
+    transition = partition_metropolis_step(
+        tree,
+        current,
+        log_density=lambda state: 100.0 if state.partition == middle else 0.0,
+        rng=np.random.default_rng(3),
+    )
+
+    assert transition.accepted
+    assert transition.state.partition == middle
+    np.testing.assert_array_equal(transition.state.inner_coordinates, current.inner_coordinates)
+    np.testing.assert_array_equal(transition.state.outer_coefficients, current.outer_coefficients)
+
+
+def test_partition_metropolis_step_rejects_negative_infinite_candidate() -> None:
+    """A zero-density candidate should be rejected without altering the state."""
+    tree, (root, _, _) = _one_by_three_partitions()
+    current = ProductSpaceState(root, np.zeros(3))
+
+    transition = partition_metropolis_step(
+        tree,
+        current,
+        log_density=lambda state: 0.0 if state.partition == root else -math.inf,
+        rng=np.random.default_rng(4),
+    )
+
+    assert not transition.accepted
+    assert transition.state is current
+    assert transition.candidate.partition != root
+    assert transition.log_acceptance_ratio == -math.inf
+
+
+def test_partition_metropolis_step_obeys_detailed_balance_on_each_edge() -> None:
+    """Target, proposal, and acceptance masses should match in both directions."""
+    tree, partitions = _one_by_three_partitions()
+    unnormalized = {
+        partitions[0]: 1.0,
+        partitions[1]: 2.0,
+        partitions[2]: 5.0,
+    }
+
+    for source in partitions:
+        for forward in enumerate_partition_neighbors(tree, source):
+            destination = forward.partition
+            reverse = next(
+                item for item in enumerate_partition_neighbors(tree, destination) if item.partition == source
+            )
+            forward_ratio = (
+                math.log(unnormalized[destination])
+                - math.log(unnormalized[source])
+                + reverse.log_q
+                - forward.log_q
+            )
+            reverse_ratio = -forward_ratio
+            forward_mass = unnormalized[source] * math.exp(forward.log_q) * min(1.0, math.exp(forward_ratio))
+            reverse_mass = (
+                unnormalized[destination] * math.exp(reverse.log_q) * min(1.0, math.exp(reverse_ratio))
+            )
+            assert forward_mass == pytest.approx(reverse_mass)
+
+
+def test_one_grid_cell_tree_returns_an_isolated_transition() -> None:
+    """A tree with one grid cell has no legal structure proposal."""
+    tree = DyadicTree.from_shape((1, 1))
+    current = ProductSpaceState(PartitionState.root(tree), np.zeros(1))
+
+    transition = partition_metropolis_step(
+        tree,
+        current,
+        log_density=lambda state: 0.0,
+        rng=np.random.default_rng(1),
+    )
+
+    assert transition.state is current
+    assert transition.candidate is current
+    assert transition.move is None
+    assert not transition.accepted
+
+
+@pytest.mark.parametrize("value", [np.nan, np.inf, -np.inf])
+def test_current_log_density_must_be_finite(value: float) -> None:
+    """The source state must have a finite augmented target density."""
+    tree = DyadicTree.from_shape((1, 2))
+    current = ProductSpaceState(PartitionState.root(tree), np.zeros(2))
+
+    with pytest.raises(ValueError, match="current log density"):
+        partition_metropolis_step(
+            tree,
+            current,
+            log_density=lambda state: value,
+            rng=np.random.default_rng(1),
+        )


### PR DESCRIPTION
## Summary

- add a permanent root-and-contrast coordinate layout for dyadic partitions
- add exhaustive tiny-tree partition enumeration and an exact split/merge Metropolis-Hastings kernel
- add a normalized Gaussian product-space target with inactive pseudo-priors and a separate always-active outer-region prior block
- add exact marginal/conditional Gaussian oracles and synthetic sampler checks

This is experimental code under `basis.experimental.dyadic`. It does not alter production RHIME or `fixedbasisMCMC`.

## Theory

The background and design derivation are in draft PR #503. In particular, that note distinguishes the fixed contrast state used here from later transported coefficient proposals.

## Validation

- `301 passed` in `tests/basis/experimental`
- Ruff passes on changed modules and tests
- Pyright: 0 errors
- targeted mypy with `--follow-imports=skip`: no issues
- independent scientific subagent review found no algebraic errors after follow-up fixes
