### PR TITLE
Experimental transported product-space proposals

### DIFF
--- a/openghg_inversions/basis/experimental/dyadic/__init__.py
+++ b/openghg_inversions/basis/experimental/dyadic/__init__.py
@@ -98,17 +98,30 @@ from .search import (
 )
 from .state import PartitionState
 from .tree import DyadicTree, NodeId, Tile
+from .transformed_product_space import (
+    AdditiveCoefficientTransform,
+    ContrastAuxiliaryProposal,
+    ContrastSwap,
+    GaussianContrastProposal,
+    TransportedProductSpaceTransition,
+    swap_contrast_coordinate,
+    transported_partition_metropolis_step,
+)
 
 __all__ = [
     "AdditivePartitionSolution",
+    "AdditiveCoefficientTransform",
     "BocquetProjection",
     "CoarsenedGrid",
+    "ContrastAuxiliaryProposal",
+    "ContrastSwap",
     "CovarianceBuilder",
     "DemoSearchConfig",
     "DemoSearchRun",
     "DyadicTree",
     "GaussianDFSObjective",
     "GaussianConditional",
+    "GaussianContrastProposal",
     "GaussianPartitionDiagnostics",
     "GaussianPartitionObjectives",
     "GaussianPosterior",
@@ -141,6 +154,7 @@ __all__ = [
     "TemperatureSchedule",
     "Tile",
     "TreeContrastLayout",
+    "TransportedProductSpaceTransition",
     "VariableKSearchConfig",
     "VariableKSearchRun",
     "apply_move",
@@ -182,5 +196,7 @@ __all__ = [
     "run_variable_k_dfs_search",
     "stochastic_local_search",
     "sum_coarsen_grid",
+    "swap_contrast_coordinate",
     "threshold_partition",
+    "transported_partition_metropolis_step",
 ]

--- a/openghg_inversions/basis/experimental/dyadic/transformed_product_space.py
+++ b/openghg_inversions/basis/experimental/dyadic/transformed_product_space.py
@@ -1,0 +1,525 @@
+"""Auxiliary-variable split/merge proposals for fixed dyadic product spaces.
+
+This module adds coefficient transport to the fixed-dimensional product-space
+kernel.  A local split or merge draws a replacement value for the affected
+permanent contrast coordinate and swaps the old value into the reverse
+auxiliary variable.  The Metropolis ratio includes both auxiliary densities,
+both structure-proposal probabilities, and the swap Jacobian.
+
+The accounting resembles a reversible-jump move, but the sampler is not
+trans-dimensional: every root/contrast coordinate remains in the augmented
+state under every partition.  The coordinate swap and the additive
+parent/children transform both have unit absolute Jacobian.  A packed active-
+only implementation would instead be genuine RJMCMC.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Protocol
+
+import numpy as np
+import numpy.typing as npt
+
+from .contrast import TreeContrastLayout
+from .product_space import (
+    LogAugmentedDensity,
+    PartitionMove,
+    ProductSpaceState,
+    _checked_log_density,
+    _frozen_vector,
+    enumerate_partition_neighbors,
+)
+from .proposals import MergeMove, SplitMove
+
+
+@dataclass(frozen=True, slots=True)
+class AdditiveCoefficientTransform:
+    """Mass-preserving map between one parent and two child coefficients.
+
+    The canonical contrast is ``left - right``.  ``left_mass`` and
+    ``right_mass`` may represent area, prior flux, or another declared positive
+    measure, but callers must use the same measure in both directions.
+
+    Attributes:
+        left_mass: Positive finite mass of the canonical left child.
+        right_mass: Positive finite mass of the canonical right child.
+    """
+
+    left_mass: float
+    right_mass: float
+
+    def __post_init__(self) -> None:
+        """Validate the two child masses."""
+        left_mass = _positive_scalar(self.left_mass, name="left_mass")
+        right_mass = _positive_scalar(self.right_mass, name="right_mass")
+        with np.errstate(over="ignore", invalid="ignore"):
+            total_mass = left_mass + right_mass
+        if not math.isfinite(total_mass):
+            raise ValueError("Combined child mass must be finite.")
+        object.__setattr__(self, "left_mass", left_mass)
+        object.__setattr__(
+            self,
+            "right_mass",
+            right_mass,
+        )
+
+    @property
+    def total_mass(self) -> float:
+        """Return the parent mass."""
+        return self.left_mass + self.right_mass
+
+    @property
+    def log_abs_jacobian(self) -> float:
+        """Return log absolute Jacobian for ``(parent, contrast) -> children``."""
+        return 0.0
+
+    def split(self, parent: float, contrast: float) -> tuple[float, float]:
+        """Map a parent common mode and contrast to ordered child values.
+
+        Args:
+            parent: Finite parent coefficient.
+            contrast: Finite canonical ``left - right`` contrast.
+
+        Returns:
+            Ordered ``(left, right)`` coefficients preserving weighted mass.
+        """
+        parent_value = _finite_scalar(parent, name="parent")
+        contrast_value = _finite_scalar(contrast, name="contrast")
+        left = parent_value + self.right_mass / self.total_mass * contrast_value
+        right = parent_value - self.left_mass / self.total_mass * contrast_value
+        return left, right
+
+    def merge(self, left: float, right: float) -> tuple[float, float]:
+        """Invert :meth:`split` and recover the parent and contrast.
+
+        Args:
+            left: Finite canonical left-child coefficient.
+            right: Finite canonical right-child coefficient.
+
+        Returns:
+            ``(parent, contrast)`` using the configured masses.
+        """
+        left_value = _finite_scalar(left, name="left")
+        right_value = _finite_scalar(right, name="right")
+        parent = (self.left_mass * left_value + self.right_mass * right_value) / self.total_mass
+        contrast = left_value - right_value
+        return parent, contrast
+
+
+class ContrastAuxiliaryProposal(Protocol):
+    """Proposal density for the contrast affected by a split or merge."""
+
+    def draw(
+        self,
+        state: ProductSpaceState,
+        move: PartitionMove,
+        coordinate_index: int,
+        rng: np.random.Generator,
+    ) -> float:
+        """Draw the contrast value placed in the proposed state."""
+        ...
+
+    def log_density(
+        self,
+        value: float,
+        state: ProductSpaceState,
+        move: PartitionMove,
+        coordinate_index: int,
+    ) -> float:
+        """Evaluate the normalized density used by :meth:`draw`."""
+        ...
+
+
+@dataclass(frozen=True, slots=True, eq=False)
+class GaussianContrastProposal:
+    """Independent Gaussian proposals for active and inactive contrasts.
+
+    A split draws from the active arrays because its destination activates the
+    affected contrast.  A merge draws from the inactive arrays because its
+    destination deactivates that contrast.  Means and variances use the
+    permanent contrast-coordinate order.
+
+    Attributes:
+        active_means: Mean used when a split activates each coordinate.
+        active_variances: Positive variance used for split proposals.
+        inactive_means: Mean used when a merge deactivates each coordinate.
+        inactive_variances: Positive variance used for merge proposals.
+    """
+
+    active_means: np.ndarray
+    active_variances: np.ndarray
+    inactive_means: np.ndarray
+    inactive_variances: np.ndarray
+
+    def __post_init__(self) -> None:
+        """Validate and freeze all Gaussian parameters."""
+        active_means = _frozen_vector(self.active_means, name="active_means")
+        inactive_means = _frozen_vector(self.inactive_means, name="inactive_means")
+        active_variances = _positive_vector(
+            self.active_variances,
+            name="active_variances",
+        )
+        inactive_variances = _positive_vector(
+            self.inactive_variances,
+            name="inactive_variances",
+        )
+        shapes = {
+            active_means.shape,
+            active_variances.shape,
+            inactive_means.shape,
+            inactive_variances.shape,
+        }
+        if len(shapes) != 1:
+            raise ValueError("Gaussian proposal arrays must have the same shape.")
+        object.__setattr__(self, "active_means", active_means)
+        object.__setattr__(self, "active_variances", active_variances)
+        object.__setattr__(self, "inactive_means", inactive_means)
+        object.__setattr__(self, "inactive_variances", inactive_variances)
+
+    @classmethod
+    def centered(
+        cls,
+        active_variances: npt.ArrayLike,
+        inactive_variances: npt.ArrayLike,
+    ) -> GaussianContrastProposal:
+        """Construct zero-mean active and inactive Gaussian proposals.
+
+        Args:
+            active_variances: Positive permanent-coordinate variances for splits.
+            inactive_variances: Positive permanent-coordinate variances for merges.
+
+        Returns:
+            Proposal with zero means and copied read-only parameter arrays.
+        """
+        active = _positive_vector(active_variances, name="active_variances")
+        inactive = _positive_vector(inactive_variances, name="inactive_variances")
+        if active.shape != inactive.shape:
+            raise ValueError("active and inactive variances must have the same shape.")
+        zeros = np.zeros(active.shape, dtype=float)
+        return cls(zeros, active, zeros, inactive)
+
+    def draw(
+        self,
+        state: ProductSpaceState,
+        move: PartitionMove,
+        coordinate_index: int,
+        rng: np.random.Generator,
+    ) -> float:
+        """Draw one destination-aware Gaussian contrast value."""
+        del state
+        if not isinstance(rng, np.random.Generator):
+            raise TypeError("rng must be a numpy.random.Generator.")
+        mean, variance = self._parameters(move, coordinate_index)
+        return float(rng.normal(mean, math.sqrt(variance)))
+
+    def log_density(
+        self,
+        value: float,
+        state: ProductSpaceState,
+        move: PartitionMove,
+        coordinate_index: int,
+    ) -> float:
+        """Evaluate one normalized destination-aware Gaussian density."""
+        del state
+        sample = _finite_scalar(value, name="value")
+        mean, variance = self._parameters(move, coordinate_index)
+        return -0.5 * (math.log(2.0 * math.pi * variance) + (sample - mean) ** 2 / variance)
+
+    def _parameters(self, move: PartitionMove, coordinate_index: int) -> tuple[float, float]:
+        """Return mean and variance for the destination status of a move."""
+        if isinstance(coordinate_index, bool) or not isinstance(coordinate_index, int):
+            raise TypeError("coordinate_index must be an integer.")
+        if coordinate_index < 0 or coordinate_index >= self.active_means.size:
+            raise IndexError("coordinate_index lies outside the proposal arrays.")
+        if isinstance(move, SplitMove):
+            return (
+                float(self.active_means[coordinate_index]),
+                float(self.active_variances[coordinate_index]),
+            )
+        if isinstance(move, MergeMove):
+            return (
+                float(self.inactive_means[coordinate_index]),
+                float(self.inactive_variances[coordinate_index]),
+            )
+        raise TypeError("move must be a SplitMove or MergeMove.")
+
+
+@dataclass(frozen=True, slots=True, eq=False)
+class ContrastSwap:
+    """Result of swapping one permanent contrast with an auxiliary value."""
+
+    coordinates: np.ndarray
+    reverse_auxiliary: float
+    log_abs_jacobian: float = 0.0
+
+    def __post_init__(self) -> None:
+        """Freeze coordinates and validate scalar diagnostics."""
+        object.__setattr__(
+            self,
+            "coordinates",
+            _frozen_vector(self.coordinates, name="coordinates"),
+        )
+        object.__setattr__(
+            self,
+            "reverse_auxiliary",
+            _finite_scalar(self.reverse_auxiliary, name="reverse_auxiliary"),
+        )
+        object.__setattr__(
+            self,
+            "log_abs_jacobian",
+            _finite_scalar(self.log_abs_jacobian, name="log_abs_jacobian"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class TransportedProductSpaceTransition:
+    """Diagnostic record for one auxiliary-variable partition transition."""
+
+    state: ProductSpaceState
+    candidate: ProductSpaceState
+    move: PartitionMove | None
+    accepted: bool
+    coordinate_index: int | None
+    forward_auxiliary: float | None
+    reverse_auxiliary: float | None
+    current_log_density: float
+    candidate_log_density: float
+    log_partition_q_forward: float
+    log_partition_q_reverse: float
+    log_auxiliary_q_forward: float
+    log_auxiliary_q_reverse: float
+    log_abs_jacobian: float
+    log_acceptance_ratio: float
+
+
+def swap_contrast_coordinate(
+    coordinates: npt.ArrayLike,
+    coordinate_index: int,
+    forward_auxiliary: float,
+) -> ContrastSwap:
+    """Swap a permanent coordinate with a forward auxiliary value.
+
+    Applying this function again to the returned coordinates with
+    ``reverse_auxiliary`` exactly restores the source.  The swap matrix has
+    determinant ``-1`` and therefore unit absolute Jacobian.
+
+    Args:
+        coordinates: Finite permanent root/contrast vector.
+        coordinate_index: Coordinate replaced by the auxiliary value.
+        forward_auxiliary: Finite value drawn for the proposed state.
+
+    Returns:
+        Proposed coordinates, reverse auxiliary, and zero log-Jacobian.
+    """
+    values = _frozen_vector(coordinates, name="coordinates")
+    if isinstance(coordinate_index, bool) or not isinstance(coordinate_index, int):
+        raise TypeError("coordinate_index must be an integer.")
+    if coordinate_index < 0 or coordinate_index >= values.size:
+        raise IndexError("coordinate_index lies outside coordinates.")
+    auxiliary = _finite_scalar(forward_auxiliary, name="forward_auxiliary")
+    proposed = values.copy()
+    reverse_auxiliary = float(proposed[coordinate_index])
+    proposed[coordinate_index] = auxiliary
+    return ContrastSwap(proposed, reverse_auxiliary, 0.0)
+
+
+def transported_partition_metropolis_step(
+    layout: TreeContrastLayout,
+    current: ProductSpaceState,
+    *,
+    log_density: LogAugmentedDensity,
+    auxiliary_proposal: ContrastAuxiliaryProposal,
+    rng: np.random.Generator,
+) -> TransportedProductSpaceTransition:
+    """Apply an exact split/merge move with an affected-contrast proposal.
+
+    Args:
+        layout: Permanent contrast layout and dyadic tree.
+        current: Current fixed-dimensional augmented state.
+        log_density: Complete normalized augmented target density.
+        auxiliary_proposal: Normalized proposal used for the destination
+            status of the affected contrast.
+        rng: Caller-owned NumPy random generator.
+
+    Returns:
+        Accepted state and complete target, proposal, auxiliary, and Jacobian
+        diagnostics.
+
+    Raises:
+        TypeError: If an interface or random generator is invalid.
+        ValueError: If dimensions or density values violate kernel invariants.
+    """
+    if not isinstance(layout, TreeContrastLayout):
+        raise TypeError("layout must be a TreeContrastLayout.")
+    if not isinstance(current, ProductSpaceState):
+        raise TypeError("current must be a ProductSpaceState.")
+    if current.inner_coordinates.shape != (layout.coordinate_count,):
+        raise ValueError("current inner coordinates do not match the contrast layout.")
+    if not callable(log_density):
+        raise TypeError("log_density must be callable.")
+    if not callable(getattr(auxiliary_proposal, "draw", None)) or not callable(
+        getattr(auxiliary_proposal, "log_density", None)
+    ):
+        raise TypeError("auxiliary_proposal must define draw and log_density methods.")
+    if not isinstance(rng, np.random.Generator):
+        raise TypeError("rng must be a numpy.random.Generator.")
+
+    current.partition.validate(layout.tree)
+    current_log_density = _checked_log_density(log_density(current), current=True)
+    neighbors = enumerate_partition_neighbors(layout.tree, current.partition)
+    if not neighbors:
+        return TransportedProductSpaceTransition(
+            state=current,
+            candidate=current,
+            move=None,
+            accepted=False,
+            coordinate_index=None,
+            forward_auxiliary=None,
+            reverse_auxiliary=None,
+            current_log_density=current_log_density,
+            candidate_log_density=current_log_density,
+            log_partition_q_forward=0.0,
+            log_partition_q_reverse=0.0,
+            log_auxiliary_q_forward=0.0,
+            log_auxiliary_q_reverse=0.0,
+            log_abs_jacobian=0.0,
+            log_acceptance_ratio=-math.inf,
+        )
+
+    neighbor = neighbors[int(rng.integers(len(neighbors)))]
+    coordinate_index = _coordinate_index(layout, neighbor.move)
+    forward_auxiliary = _finite_scalar(
+        auxiliary_proposal.draw(current, neighbor.move, coordinate_index, rng),
+        name="forward auxiliary draw",
+    )
+    swap = swap_contrast_coordinate(
+        current.inner_coordinates,
+        coordinate_index,
+        forward_auxiliary,
+    )
+    candidate = ProductSpaceState(
+        partition=neighbor.partition,
+        inner_coordinates=swap.coordinates,
+        outer_coefficients=current.outer_coefficients,
+    )
+    candidate_log_density = _checked_log_density(log_density(candidate), current=False)
+    reverse_neighbors = enumerate_partition_neighbors(layout.tree, candidate.partition)
+    reverse = next(
+        (item for item in reverse_neighbors if item.partition == current.partition),
+        None,
+    )
+    if reverse is None:  # pragma: no cover - protects future proposal extensions.
+        raise ValueError("Proposed partition has no reverse split-or-merge move.")
+    reverse_index = _coordinate_index(layout, reverse.move)
+    if reverse_index != coordinate_index:  # pragma: no cover - tree invariant.
+        raise ValueError("Forward and reverse moves must affect the same contrast coordinate.")
+
+    log_auxiliary_q_forward = _checked_auxiliary_log_density(
+        auxiliary_proposal.log_density(
+            forward_auxiliary,
+            current,
+            neighbor.move,
+            coordinate_index,
+        ),
+        forward=True,
+    )
+    log_auxiliary_q_reverse = _checked_auxiliary_log_density(
+        auxiliary_proposal.log_density(
+            swap.reverse_auxiliary,
+            candidate,
+            reverse.move,
+            coordinate_index,
+        ),
+        forward=False,
+    )
+    log_acceptance_ratio = (
+        candidate_log_density
+        - current_log_density
+        + reverse.log_q
+        - neighbor.log_q
+        + log_auxiliary_q_reverse
+        - log_auxiliary_q_forward
+        + swap.log_abs_jacobian
+    )
+    uniform = float(rng.random())
+    log_uniform = -math.inf if uniform == 0.0 else math.log(uniform)
+    accepted = bool(log_uniform < min(0.0, log_acceptance_ratio))
+    return TransportedProductSpaceTransition(
+        state=candidate if accepted else current,
+        candidate=candidate,
+        move=neighbor.move,
+        accepted=accepted,
+        coordinate_index=coordinate_index,
+        forward_auxiliary=forward_auxiliary,
+        reverse_auxiliary=swap.reverse_auxiliary,
+        current_log_density=current_log_density,
+        candidate_log_density=candidate_log_density,
+        log_partition_q_forward=neighbor.log_q,
+        log_partition_q_reverse=reverse.log_q,
+        log_auxiliary_q_forward=log_auxiliary_q_forward,
+        log_auxiliary_q_reverse=log_auxiliary_q_reverse,
+        log_abs_jacobian=swap.log_abs_jacobian,
+        log_acceptance_ratio=log_acceptance_ratio,
+    )
+
+
+def _coordinate_index(layout: TreeContrastLayout, move: PartitionMove) -> int:
+    """Return the permanent contrast index activated or deactivated by a move."""
+    if isinstance(move, SplitMove):
+        return layout.contrast_index(move.node_id)
+    if isinstance(move, MergeMove):
+        return layout.contrast_index(move.parent_id)
+    raise TypeError("move must be a SplitMove or MergeMove.")
+
+
+def _positive_vector(values: npt.ArrayLike, *, name: str) -> np.ndarray:
+    """Return a copied, read-only vector of positive finite values."""
+    result = _frozen_vector(values, name=name)
+    if np.any(result <= 0.0):
+        raise ValueError(f"{name} must contain only positive values.")
+    return result
+
+
+def _finite_scalar(value: float, *, name: str) -> float:
+    """Return one finite real scalar."""
+    source = np.asarray(value)
+    if source.shape != () or np.iscomplexobj(source):
+        raise ValueError(f"{name} must be a real scalar.")
+    result = float(source)
+    if not math.isfinite(result):
+        raise ValueError(f"{name} must be finite.")
+    return result
+
+
+def _positive_scalar(value: float, *, name: str) -> float:
+    """Return one positive finite real scalar."""
+    result = _finite_scalar(value, name=name)
+    if result <= 0.0:
+        raise ValueError(f"{name} must be positive.")
+    return result
+
+
+def _checked_auxiliary_log_density(value: float, *, forward: bool) -> float:
+    """Validate a proposal log density, allowing zero reverse density."""
+    try:
+        result = float(value)
+    except (TypeError, ValueError) as error:
+        raise ValueError("auxiliary log density must be a real scalar.") from error
+    if math.isnan(result) or result == math.inf or (forward and result == -math.inf):
+        if forward:
+            raise ValueError("forward auxiliary log density must be finite.")
+        raise ValueError("reverse auxiliary log density must be finite or negative infinity.")
+    return result
+
+
+__all__ = [
+    "AdditiveCoefficientTransform",
+    "ContrastAuxiliaryProposal",
+    "ContrastSwap",
+    "GaussianContrastProposal",
+    "TransportedProductSpaceTransition",
+    "swap_contrast_coordinate",
+    "transported_partition_metropolis_step",
+]

--- a/tests/basis/experimental/test_dyadic_transformed_product_space.py
+++ b/tests/basis/experimental/test_dyadic_transformed_product_space.py
@@ -1,0 +1,431 @@
+"""Tests for transported fixed-dimensional dyadic product-space updates."""
+
+import math
+from collections.abc import Callable
+
+import numpy as np
+import pytest
+
+from openghg_inversions.basis.experimental.dyadic.contrast import TreeContrastLayout
+from openghg_inversions.basis.experimental.dyadic.enumeration import enumerate_partitions
+from openghg_inversions.basis.experimental.dyadic.gaussian_product_space import (
+    GaussianProductSpaceTarget,
+)
+from openghg_inversions.basis.experimental.dyadic.product_space import ProductSpaceState
+from openghg_inversions.basis.experimental.dyadic.proposals import MergeMove, PairedMove, SplitMove
+from openghg_inversions.basis.experimental.dyadic.state import PartitionState
+from openghg_inversions.basis.experimental.dyadic.transformed_product_space import (
+    AdditiveCoefficientTransform,
+    GaussianContrastProposal,
+    swap_contrast_coordinate,
+    transported_partition_metropolis_step,
+)
+from openghg_inversions.basis.experimental.dyadic.tree import DyadicTree
+
+
+def _one_by_three_partitions() -> tuple[DyadicTree, tuple[PartitionState, ...]]:
+    """Return the asymmetric three-partition path for a one-by-three grid."""
+    tree = DyadicTree.from_shape((1, 3))
+    partitions = enumerate_partitions(tree)
+    assert len(partitions) == 3
+    return tree, partitions
+
+
+def _gaussian_target(
+    pseudo_prior_scale: float,
+) -> tuple[GaussianProductSpaceTarget, tuple[PartitionState, ...]]:
+    """Build a tiny Gaussian target with exactly enumerable partition masses."""
+    tree, partitions = _one_by_three_partitions()
+    log_uniform = -math.log(len(partitions))
+
+    def partition_log_prior(partition: PartitionState) -> float:
+        """Assign normalized uniform mass to each valid tiny-tree partition."""
+        assert partition in partitions
+        return log_uniform
+
+    target = GaussianProductSpaceTarget.from_grid(
+        observations=[1.8],
+        inner_grid_design=[[[1.0, 2.0, 3.0]]],
+        tree=tree,
+        observation_covariance=[[1.0]],
+        inactive_pseudo_prior_scale=pseudo_prior_scale,
+        outer_design=[[2.0]],
+        outer_prior_covariance=[[0.25]],
+        partition_log_prior=partition_log_prior,
+    )
+    return target, partitions
+
+
+def _finite_difference_jacobian(
+    function: Callable[[np.ndarray], np.ndarray],
+    point: np.ndarray,
+    step: float = 1e-6,
+) -> np.ndarray:
+    """Estimate a square Jacobian with centered finite differences."""
+    columns = []
+    for index in range(point.size):
+        offset = np.zeros_like(point)
+        offset[index] = step
+        columns.append((function(point + offset) - function(point - offset)) / (2.0 * step))
+    return np.column_stack(columns)
+
+
+def test_unequal_mass_additive_transform_round_trips_and_preserves_mass() -> None:
+    """An unequal-child split should preserve weighted mass and invert exactly."""
+    transform = AdditiveCoefficientTransform(left_mass=1.0, right_mass=2.0)
+
+    left, right = transform.split(parent=2.5, contrast=-1.2)
+    recovered_parent, recovered_contrast = transform.merge(left, right)
+
+    assert (left, right) == pytest.approx((1.7, 2.9))
+    assert recovered_parent == pytest.approx(2.5)
+    assert recovered_contrast == pytest.approx(-1.2)
+    assert transform.left_mass * left + transform.right_mass * right == pytest.approx(
+        transform.total_mass * 2.5
+    )
+
+
+def test_additive_transform_has_unit_finite_difference_jacobian() -> None:
+    """The parent/contrast-to-children map should have unit absolute determinant."""
+    transform = AdditiveCoefficientTransform(left_mass=1.25, right_mass=3.75)
+
+    def split(values: np.ndarray) -> np.ndarray:
+        """Return both child coefficients for finite-difference evaluation."""
+        return np.asarray(transform.split(float(values[0]), float(values[1])))
+
+    jacobian = _finite_difference_jacobian(split, np.array([0.8, -1.1]))
+
+    assert transform.log_abs_jacobian == 0.0
+    assert abs(np.linalg.det(jacobian)) == pytest.approx(1.0, abs=1e-9)
+    with pytest.raises(ValueError, match="Combined child mass"):
+        AdditiveCoefficientTransform(left_mass=1e308, right_mass=1e308)
+
+
+def test_coordinate_swap_round_trips_without_touching_other_coordinates() -> None:
+    """A second swap with the reverse auxiliary should restore the source vector."""
+    coordinates = np.array([0.3, -0.4, 1.7, 2.2])
+
+    forward = swap_contrast_coordinate(coordinates, 2, -3.5)
+    reverse = swap_contrast_coordinate(forward.coordinates, 2, forward.reverse_auxiliary)
+
+    np.testing.assert_array_equal(forward.coordinates, [0.3, -0.4, -3.5, 2.2])
+    np.testing.assert_array_equal(reverse.coordinates, coordinates)
+    assert forward.reverse_auxiliary == 1.7
+    assert reverse.reverse_auxiliary == -3.5
+    assert forward.log_abs_jacobian == reverse.log_abs_jacobian == 0.0
+    assert not forward.coordinates.flags.writeable
+    coordinates[:] = 99.0
+    np.testing.assert_array_equal(reverse.coordinates, [0.3, -0.4, 1.7, 2.2])
+
+
+def test_gaussian_proposal_uses_destination_active_and_inactive_laws() -> None:
+    """Splits should use active parameters while merges use inactive parameters."""
+    tree, (root, middle, _) = _one_by_three_partitions()
+    state = ProductSpaceState(root, np.zeros(3))
+    proposal = GaussianContrastProposal(
+        active_means=np.array([0.0, 1.5, 0.0]),
+        active_variances=np.array([1.0, 4.0, 1.0]),
+        inactive_means=np.array([0.0, -2.0, 0.0]),
+        inactive_variances=np.array([1.0, 0.25, 1.0]),
+    )
+    split = SplitMove(tree.root_id)
+    merge = MergeMove(tree.root_id)
+
+    split_draw = proposal.draw(state, split, 1, np.random.default_rng(12))
+    merge_draw = proposal.draw(
+        ProductSpaceState(middle, np.zeros(3)),
+        merge,
+        1,
+        np.random.default_rng(12),
+    )
+
+    expected_standard_normal = np.random.default_rng(12).normal()
+    assert split_draw == pytest.approx(1.5 + 2.0 * expected_standard_normal)
+    assert merge_draw == pytest.approx(-2.0 + 0.5 * expected_standard_normal)
+    assert proposal.log_density(1.5, state, split, 1) == pytest.approx(-0.5 * math.log(2.0 * math.pi * 4.0))
+    assert proposal.log_density(-2.0, state, merge, 1) == pytest.approx(-0.5 * math.log(2.0 * math.pi * 0.25))
+
+
+def test_gaussian_proposal_copies_parameters_and_validates_its_interface() -> None:
+    """Proposal parameters should be immutable and invalid calls should fail early."""
+    active = np.ones(3)
+    proposal = GaussianContrastProposal.centered(active, np.full(3, 2.0))
+    active[:] = 9.0
+
+    np.testing.assert_array_equal(proposal.active_variances, np.ones(3))
+    assert not proposal.active_variances.flags.writeable
+    with pytest.raises(ValueError, match="positive"):
+        GaussianContrastProposal.centered([1.0, 0.0], [1.0, 1.0])
+    with pytest.raises(ValueError, match="same shape"):
+        GaussianContrastProposal.centered([1.0], [1.0, 2.0])
+    with pytest.raises(IndexError, match="outside"):
+        proposal.log_density(0.0, _dummy_state(), SplitMove(0), 3)
+    with pytest.raises(TypeError, match="SplitMove or MergeMove"):
+        proposal.log_density(0.0, _dummy_state(), PairedMove(0, 1), 1)  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="numpy.random.Generator"):
+        proposal.draw(_dummy_state(), SplitMove(0), 1, object())  # type: ignore[arg-type]
+
+
+def _dummy_state() -> ProductSpaceState:
+    """Return a valid two-coordinate state for proposal interface checks."""
+    tree = DyadicTree.from_shape((1, 2))
+    return ProductSpaceState(PartitionState.root(tree), np.zeros(2))
+
+
+@pytest.mark.parametrize(
+    ("source_index", "seed"),
+    [(0, 7), (1, 0)],
+    ids=["split", "merge"],
+)
+def test_transported_split_merge_has_exact_mh_accounting(
+    source_index: int,
+    seed: int,
+) -> None:
+    """Both move directions should report exact target, partition, and auxiliary terms."""
+    tree, partitions = _one_by_three_partitions()
+    layout = TreeContrastLayout.from_tree(tree)
+    source = partitions[source_index]
+    current = ProductSpaceState(
+        source,
+        np.array([0.2, -0.8, 1.4]),
+        np.array([5.0, -2.0]),
+    )
+    proposal = GaussianContrastProposal(
+        active_means=np.array([0.0, 0.4, -0.2]),
+        active_variances=np.array([1.0, 1.7, 0.8]),
+        inactive_means=np.array([0.0, -0.6, 0.3]),
+        inactive_variances=np.array([1.0, 0.5, 2.1]),
+    )
+    target_logs = {partitions[0]: 0.0, partitions[1]: 4.0, partitions[2]: -3.0}
+
+    transition = transported_partition_metropolis_step(
+        layout,
+        current,
+        log_density=lambda state: target_logs[state.partition],
+        auxiliary_proposal=proposal,
+        rng=np.random.default_rng(seed),
+    )
+
+    assert transition.coordinate_index == 1
+    assert transition.forward_auxiliary is not None
+    assert transition.reverse_auxiliary is not None
+    assert transition.reverse_auxiliary == -0.8
+    assert isinstance(transition.move, (SplitMove, MergeMove))
+    reverse_move = transition.move.reverse()
+    forward_auxiliary_log_density = proposal.log_density(
+        transition.forward_auxiliary,
+        current,
+        transition.move,
+        transition.coordinate_index,
+    )
+    reverse_auxiliary_log_density = proposal.log_density(
+        transition.reverse_auxiliary,
+        transition.candidate,
+        reverse_move,
+        transition.coordinate_index,
+    )
+    expected = (
+        target_logs[transition.candidate.partition]
+        - target_logs[source]
+        + transition.log_partition_q_reverse
+        - transition.log_partition_q_forward
+        + reverse_auxiliary_log_density
+        - forward_auxiliary_log_density
+    )
+    assert transition.current_log_density == target_logs[source]
+    assert transition.candidate_log_density == target_logs[transition.candidate.partition]
+    assert transition.log_acceptance_ratio == pytest.approx(expected)
+    assert {transition.log_partition_q_forward, transition.log_partition_q_reverse} == {
+        0.0,
+        -math.log(2.0),
+    }
+    assert transition.log_auxiliary_q_forward == pytest.approx(forward_auxiliary_log_density)
+    assert transition.log_auxiliary_q_reverse == pytest.approx(reverse_auxiliary_log_density)
+    assert transition.log_abs_jacobian == 0.0
+    np.testing.assert_array_equal(transition.candidate.inner_coordinates[[0, 2]], [0.2, 1.4])
+    np.testing.assert_array_equal(transition.candidate.outer_coefficients, [5.0, -2.0])
+    assert not transition.candidate.inner_coordinates.flags.writeable
+    assert not transition.candidate.outer_coefficients.flags.writeable
+
+
+def test_transported_move_obeys_pointwise_detailed_balance() -> None:
+    """Paired source and destination fluxes should agree before integration."""
+    tree, partitions = _one_by_three_partitions()
+    layout = TreeContrastLayout.from_tree(tree)
+    current = ProductSpaceState(partitions[0], np.array([0.2, -0.8, 1.4]))
+    proposal = GaussianContrastProposal(
+        active_means=np.array([0.0, 0.4, -0.2]),
+        active_variances=np.array([1.0, 1.7, 0.8]),
+        inactive_means=np.array([0.0, -0.6, 0.3]),
+        inactive_variances=np.array([1.0, 0.5, 2.1]),
+    )
+    target_logs = {partitions[0]: -0.7, partitions[1]: 1.2, partitions[2]: -2.0}
+
+    transition = transported_partition_metropolis_step(
+        layout,
+        current,
+        log_density=lambda state: target_logs[state.partition],
+        auxiliary_proposal=proposal,
+        rng=np.random.default_rng(7),
+    )
+
+    forward_acceptance = min(1.0, math.exp(transition.log_acceptance_ratio))
+    reverse_acceptance = min(1.0, math.exp(-transition.log_acceptance_ratio))
+    forward_flux = (
+        math.exp(
+            transition.current_log_density
+            + transition.log_partition_q_forward
+            + transition.log_auxiliary_q_forward
+        )
+        * forward_acceptance
+    )
+    reverse_flux = (
+        math.exp(
+            transition.candidate_log_density
+            + transition.log_partition_q_reverse
+            + transition.log_auxiliary_q_reverse
+        )
+        * reverse_acceptance
+    )
+
+    assert forward_flux == pytest.approx(reverse_flux, rel=1e-12)
+
+
+def test_matched_gaussian_auxiliary_terms_cancel_changed_target_factors() -> None:
+    """Prior-matched split and merge proposals should cancel affected densities."""
+    target, partitions = _gaussian_target(pseudo_prior_scale=2.5)
+    proposal = GaussianContrastProposal.centered(
+        target.inner_prior_variances,
+        target.inactive_pseudo_prior_variances,
+    )
+    coordinate_index = target.contrast_layout.contrast_index(target.tree.root_id)
+    inactive_value = -0.8
+    active_value = 0.35
+    root_state = ProductSpaceState(partitions[0], np.array([0.2, inactive_value, 1.4]))
+    middle_state = ProductSpaceState(partitions[1], np.array([0.2, active_value, 1.4]))
+    split = SplitMove(target.tree.root_id)
+    merge = split.reverse()
+
+    active_proposal_log_density = proposal.log_density(
+        active_value,
+        root_state,
+        split,
+        coordinate_index,
+    )
+    inactive_proposal_log_density = proposal.log_density(
+        inactive_value,
+        middle_state,
+        merge,
+        coordinate_index,
+    )
+    active_variance = float(target.inner_prior_variances[coordinate_index])
+    inactive_variance = float(target.inactive_pseudo_prior_variances[coordinate_index])
+    active_target_log_density = -0.5 * (
+        math.log(2.0 * math.pi * active_variance) + active_value**2 / active_variance
+    )
+    inactive_target_log_density = -0.5 * (
+        math.log(2.0 * math.pi * inactive_variance) + inactive_value**2 / inactive_variance
+    )
+    changed_target_factor = active_target_log_density - inactive_target_log_density
+    auxiliary_correction = inactive_proposal_log_density - active_proposal_log_density
+
+    assert changed_target_factor + auxiliary_correction == pytest.approx(0.0, abs=1e-15)
+
+
+def test_transported_step_returns_an_isolated_tree_without_using_auxiliary() -> None:
+    """A one-cell tree should return unchanged without drawing an auxiliary."""
+    tree = DyadicTree.from_shape((1, 1))
+    layout = TreeContrastLayout.from_tree(tree)
+    current = ProductSpaceState(
+        PartitionState.root(tree),
+        np.array([0.2]),
+        np.array([1.0]),
+    )
+
+    transition = transported_partition_metropolis_step(
+        layout,
+        current,
+        log_density=lambda state: -1.25,
+        auxiliary_proposal=GaussianContrastProposal.centered([1.0], [2.0]),
+        rng=np.random.default_rng(4),
+    )
+
+    assert transition.state is current
+    assert transition.candidate is current
+    assert transition.move is None
+    assert not transition.accepted
+    assert transition.coordinate_index is None
+    assert transition.forward_auxiliary is None
+    assert transition.reverse_auxiliary is None
+    assert transition.log_acceptance_ratio == -math.inf
+
+
+def test_transported_step_rejects_invalid_public_interfaces() -> None:
+    """Kernel interface and dimensional errors should have explicit failures."""
+    tree = DyadicTree.from_shape((1, 2))
+    layout = TreeContrastLayout.from_tree(tree)
+    current = ProductSpaceState(PartitionState.root(tree), np.zeros(2))
+    proposal = GaussianContrastProposal.centered(np.ones(2), np.ones(2))
+    valid_arguments = {
+        "layout": layout,
+        "current": current,
+        "log_density": lambda state: 0.0,
+        "auxiliary_proposal": proposal,
+        "rng": np.random.default_rng(3),
+    }
+
+    for keyword, invalid, message in [
+        ("layout", object(), "layout"),
+        ("current", object(), "current"),
+        ("log_density", 1.0, "callable"),
+        ("auxiliary_proposal", object(), "draw and log_density"),
+        ("rng", object(), "numpy.random.Generator"),
+    ]:
+        arguments = dict(valid_arguments)
+        arguments[keyword] = invalid
+        with pytest.raises(TypeError, match=message):
+            transported_partition_metropolis_step(**arguments)  # type: ignore[arg-type]
+
+    wrong_size = ProductSpaceState(PartitionState.root(tree), np.zeros(1))
+    with pytest.raises(ValueError, match="do not match"):
+        transported_partition_metropolis_step(
+            layout,
+            wrong_size,
+            log_density=lambda state: 0.0,
+            auxiliary_proposal=proposal,
+            rng=np.random.default_rng(3),
+        )
+
+
+@pytest.mark.parametrize("pseudo_prior_scale", [0.45, 2.5])
+def test_conditional_and_transported_chain_matches_exact_partition_probabilities(
+    pseudo_prior_scale: float,
+) -> None:
+    """The transported tiny Gaussian chain should recover exact partition masses."""
+    target, partitions = _gaussian_target(pseudo_prior_scale)
+    expected = target.partition_probabilities(partitions)
+    proposal = GaussianContrastProposal.centered(
+        target.inner_prior_variances,
+        target.inactive_pseudo_prior_variances,
+    )
+    rng = np.random.default_rng(20260718)
+    state = target.draw_conditional_state(partitions[0], rng)
+    counts = {partition: 0 for partition in partitions}
+    draws = 10_000
+    burn_in = 1_000
+
+    for draw in range(draws):
+        state = target.draw_conditional_state(state.partition, rng)
+        state = transported_partition_metropolis_step(
+            target.contrast_layout,
+            state,
+            log_density=target.log_density,
+            auxiliary_proposal=proposal,
+            rng=rng,
+        ).state
+        if draw >= burn_in:
+            counts[state.partition] += 1
+
+    observed = np.array([counts[partition] for partition in partitions], dtype=float)
+    observed /= observed.sum()
+    np.testing.assert_allclose(observed, list(expected.values()), atol=0.05)


### PR DESCRIPTION
## Summary

- add the explicit mass-preserving additive map between a parent coefficient plus contrast and ordered child coefficients
- add a fixed-dimensional auxiliary-variable contrast swap with unit absolute Jacobian
- add active-on-split and inactive-on-merge Gaussian auxiliary proposals
- add a framework-independent split/merge MH kernel that records target, structure proposal, auxiliary proposal, and Jacobian terms separately
- verify pointwise detailed balance, prior/pseudo-prior cancellation, coordinate preservation, and exact tiny-tree partition frequencies

## Terminology

This is **transported product-space MH**, not trans-dimensional RJMCMC. Every permanent root/contrast coordinate remains in the augmented state. The Green-style auxiliary accounting is reusable for a future packed RJMCMC implementation, but no dimension changes in this PR.

## Scope

Experimental dyadic code only. This does not alter PyMC, RHIME, production basis algorithms, or public `openghg_inversions.basis` imports.

Stacked directly on #504, independently of #505 and #506. Theory and references are in #503.

## Verification

- focused transformed-kernel tests: 13 passed
- full experimental suite: 314 passed, one pre-existing environment binary-compatibility warning
- Ruff, Pyright, and targeted Mypy pass
- independent mathematical review completed with no remaining blockers