### PR TITLE
Run RHIME from prepared inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@
   and uncertainty statistics are calculated, then cast at the template
   boundary, keeping posterior stdev and covariance calculations consistent.
 
+- Added `run_rhime_from_prepared_inputs` so modern standard and multisector
+  RHIME models can run from an existing `RhimePreparedInputs` object without
+  repeating OpenGHG-backed data preparation. Existing `run_rhime` entry points
+  now share the same post-preparation execution path.
+  [#509](https://github.com/openghg/openghg_inversions/issues/509)
+
 - Made retained `BasisFunctions` / `BasisOperator` metadata the primary basis
   contract for RHIME preparation and modern postprocessing outputs. Derived
   flux, country, PARIS, and legacy-format products now record stable basis

--- a/docs/usage/rhime.rst
+++ b/docs/usage/rhime.rst
@@ -79,6 +79,63 @@ Python API
        },
    )
 
+Running Prepared Inputs
+-----------------------
+
+Advanced workflows can prepare canonical RHIME inputs separately from data
+acquisition and run them without repeating OpenGHG-backed preparation. Supply
+the retained ``RhimePreparedInputs`` together with the existing public run,
+model, output, and sampler specifications:
+
+.. code-block:: python
+
+   from openghg_inversions.models import RhimeModelSpec, SectorSpec
+   from openghg_inversions.rhime import (
+       RhimeOutputSpec,
+       RhimeRunSpec,
+       RhimeSampler,
+       run_rhime_from_prepared_inputs,
+   )
+
+   # Produced by prepare_rhime_inputs or by another source adapter that
+   # satisfies the same canonical contract.
+   prepared = prepare_inputs_elsewhere()
+   model_spec = RhimeModelSpec(
+       species="ch4",
+       domain="EUROPE",
+       sectors=(
+           SectorSpec(
+               name="total",
+               flux_source="total-ukghg-edgar7",
+               x_prior={"pdf": "lognormal", "mean": 1.0, "stdev": 1.0},
+               variable_suffix="total",
+           ),
+       ),
+   )
+   run_spec = RhimeRunSpec(
+       start_date="2019-01-01",
+       end_date="2019-01-02",
+       sites=prepared.sites,
+       averaging_period=prepared.averaging_period,
+       model=model_spec,
+       output=RhimeOutputSpec(output_format="none"),
+       split_by_sectors=False,
+   )
+   result = run_rhime_from_prepared_inputs(
+       prepared_inputs=prepared,
+       run_spec=run_spec,
+       sampler=RhimeSampler(draws=1000, tune=1000, chains=4),
+   )
+
+The prepared object is trusted canonical input: it must already contain the
+observation, error, sensitivity, and optional boundary-condition variables
+required by the selected model. A multisector run requires a ``source``
+dimension on ``prepared.inv_inputs["H"]`` and
+``run_spec.split_by_sectors=True``; a single-sector run requires neither. The
+sector count, prepared ``H`` layout, layout flag, and output settings are
+validated before model construction or sampling. Output side effects are still
+controlled by ``RhimeOutputSpec``.
+
 Config Files
 ------------
 

--- a/openghg_inversions/rhime/__init__.py
+++ b/openghg_inversions/rhime/__init__.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 from openghg_inversions.models.rhime import RhimeModelSpec, SectorSpec
 
 from .params import params_from_config, resolve_flux_sources
-from .runner import RhimeResult, run_rhime, run_rhime_multisector
+from .runner import (
+    RhimeResult,
+    run_rhime,
+    run_rhime_from_prepared_inputs,
+    run_rhime_multisector,
+)
 from .sampling import RhimeSampler
 from .specs import RhimeOutputSpec, RhimeRunSpec
 
@@ -19,5 +24,6 @@ __all__ = [
     "params_from_config",
     "resolve_flux_sources",
     "run_rhime",
+    "run_rhime_from_prepared_inputs",
     "run_rhime_multisector",
 ]

--- a/openghg_inversions/rhime/runner.py
+++ b/openghg_inversions/rhime/runner.py
@@ -3,6 +3,8 @@
 This module accepts Python keyword arguments or RHIME ``.ini`` files,
 normalizes legacy spelling into the modern spec vocabulary, prepares inversion
 inputs, builds a PyMC model, samples it, and writes requested outputs.
+``run_rhime_from_prepared_inputs`` starts at the same post-preparation boundary
+for callers that already hold canonical inputs and retained basis metadata.
 
 Terminology used by the RHIME API:
 
@@ -45,7 +47,13 @@ from openghg_inversions.rhime.outputs import (
 from . import params as rhime_params
 from .params import params_from_config, resolve_flux_sources
 from .sampling import RhimeSampler
-from .specs import RhimeOutputSpec, RhimeRunSpec
+from .specs import (
+    RhimeOutputSpec,
+    RhimeRunSpec,
+    validate_output_filename_convention,
+    validate_output_format,
+    validate_output_path_settings,
+)
 from openghg_inversions.inversion_data import (
     RhimePreparedInputs,
     prepare_rhime_inputs,
@@ -68,6 +76,7 @@ __all__ = [
     "params_from_config",
     "resolve_flux_sources",
     "run_rhime",
+    "run_rhime_from_prepared_inputs",
     "run_rhime_multisector",
 ]
 
@@ -136,29 +145,15 @@ def _run_spec_with_prepared_inputs(
     )
 
 
-def _run_common(
+def _execute_prepared_rhime(
     *,
+    prepared: RhimePreparedInputs,
+    run_spec: RhimeRunSpec,
+    sampler: RhimeSampler,
     multisector: bool,
-    params: dict[str, Any],
 ) -> RhimeResult:
-    """Run the shared RHIME pipeline after public wrapper/config normalization."""
-    timing_start = timer_start()
-    setup = _make_rhime_runner_setup(params=params, multisector=multisector)
-    log_timing("rhime.runner_setup", timer_seconds(timing_start), multisector=multisector)
-
-    timing_start = timer_start()
-    prepared = prepare_rhime_inputs(**setup.data_args)
-    log_timing(
-        "rhime.prepare_inputs",
-        timer_seconds(timing_start),
-        multisector=multisector,
-        nmeasure=prepared.inv_inputs.sizes.get("nmeasure"),
-        sites=len(prepared.sites),
-        regions=prepared.inv_inputs.sizes.get("region"),
-        sources=prepared.inv_inputs.sizes.get("source"),
-        basis_source=prepared.basis_artifact_source,
-    )
-    run_spec = _run_spec_with_prepared_inputs(setup.run_spec, prepared)
+    """Build, sample, and produce outputs from prepared RHIME inputs."""
+    run_spec = _run_spec_with_prepared_inputs(run_spec, prepared)
 
     build_and_sample_start = timer_start()
     timing_start = timer_start()
@@ -169,15 +164,15 @@ def _run_common(
     log_timing("rhime.model_build", timer_seconds(timing_start), multisector=multisector)
 
     timing_start = timer_start()
-    idata = setup.sampler.sample(model)
+    idata = sampler.sample(model)
     log_timing(
         "rhime.sampler_total",
         timer_seconds(timing_start),
-        draws=setup.sampler.draws,
-        burn=setup.sampler.burn,
-        tune=setup.sampler.tune,
-        chains=setup.sampler.chains,
-        nuts_sampler=setup.sampler.nuts_sampler,
+        draws=sampler.draws,
+        burn=sampler.burn,
+        tune=sampler.tune,
+        chains=sampler.chains,
+        nuts_sampler=sampler.nuts_sampler,
     )
     result = RhimeResult(
         run_spec=run_spec,
@@ -185,7 +180,7 @@ def _run_common(
         output_spec=run_spec.output,
         inv_inputs=prepared.inv_inputs,
         idata=idata,
-        sampler=setup.sampler,
+        sampler=sampler,
         model=model,
         basis_functions=prepared.basis_functions,
         output_metadata={"build_and_sample_seconds": timer_seconds(build_and_sample_start)},
@@ -209,7 +204,7 @@ def _run_common(
             idata=idata,
             prepared=prepared,
             country_file=run_spec.output.country_file,
-            sampler=setup.sampler,
+            sampler=sampler,
         )
     log_timing(
         "rhime.output_bundle_total",
@@ -220,6 +215,103 @@ def _run_common(
     _apply_output_bundle(result, output_bundle)
 
     return result
+
+
+def _run_common(
+    *,
+    multisector: bool,
+    params: dict[str, Any],
+) -> RhimeResult:
+    """Run the shared RHIME pipeline after public wrapper/config normalization."""
+    timing_start = timer_start()
+    setup = _make_rhime_runner_setup(params=params, multisector=multisector)
+    log_timing("rhime.runner_setup", timer_seconds(timing_start), multisector=multisector)
+
+    timing_start = timer_start()
+    prepared = prepare_rhime_inputs(**setup.data_args)
+    log_timing(
+        "rhime.prepare_inputs",
+        timer_seconds(timing_start),
+        multisector=multisector,
+        nmeasure=prepared.inv_inputs.sizes.get("nmeasure"),
+        sites=len(prepared.sites),
+        regions=prepared.inv_inputs.sizes.get("region"),
+        sources=prepared.inv_inputs.sizes.get("source"),
+        basis_source=prepared.basis_artifact_source,
+    )
+    return _execute_prepared_rhime(
+        prepared=prepared,
+        run_spec=setup.run_spec,
+        sampler=setup.sampler,
+        multisector=multisector,
+    )
+
+
+def run_rhime_from_prepared_inputs(
+    *,
+    prepared_inputs: RhimePreparedInputs,
+    run_spec: RhimeRunSpec,
+    sampler: RhimeSampler | None = None,
+) -> RhimeResult:
+    """Run RHIME directly from previously prepared inversion inputs.
+
+    This entry point bypasses RHIME configuration normalization and OpenGHG
+    data preparation. A model with one sector uses the standard builder; a
+    model with two or more sectors uses the multi-sector builder. The prepared
+    ``H`` source layout, run-spec layout flag, model sector count, and output
+    settings are validated before model construction or sampling.
+
+    Args:
+        prepared_inputs: Canonical inversion inputs and retained preparation
+            metadata to consume directly.
+        run_spec: Model, output, and run metadata for the inversion. Retained
+            sites and averaging periods are replaced with values from
+            ``prepared_inputs``.
+        sampler: Sampling settings to use. Defaults to a new ``RhimeSampler``.
+
+    Returns:
+        Modern RHIME result containing the built model, sampled trace, and
+        requested outputs.
+
+    Raises:
+        ValueError: If the model specification contains no sectors, the sector
+            count, prepared ``H`` layout, and prepared-data layout flag
+            disagree, or output settings are invalid.
+    """
+    sector_count = len(run_spec.model.sectors)
+    if sector_count < 1:
+        raise ValueError(f"`run_spec.model.sectors` must contain at least one sector; found {sector_count}.")
+    multisector = sector_count > 1
+    prepared_is_multisector = "source" in prepared_inputs.inv_inputs["H"].dims
+    if run_spec.split_by_sectors is not prepared_is_multisector:
+        raise ValueError(
+            "`run_spec.split_by_sectors` must agree with the prepared `H` layout: "
+            f"split_by_sectors={run_spec.split_by_sectors}, "
+            f"source dimension present={prepared_is_multisector}."
+        )
+    if run_spec.split_by_sectors is not multisector:
+        raise ValueError(
+            "`run_spec.split_by_sectors` must agree with the model sector count: "
+            f"found {sector_count} sector(s) and split_by_sectors={run_spec.split_by_sectors}."
+        )
+
+    output_spec = run_spec.output
+    validate_output_format(output_spec.output_format)
+    validate_output_filename_convention(output_spec.output_filename_convention)
+    validate_output_path_settings(
+        output_format=output_spec.output_format,
+        output_path=output_spec.output_path,
+        save_trace=output_spec.save_trace,
+        save_inversion_output=output_spec.save_inversion_output,
+        multisector=multisector,
+    )
+
+    return _execute_prepared_rhime(
+        prepared=prepared_inputs,
+        run_spec=run_spec,
+        sampler=RhimeSampler() if sampler is None else sampler,
+        multisector=multisector,
+    )
 
 
 def run_rhime(

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -63,6 +63,7 @@ from openghg_inversions.rhime import (
     params_from_config,
     resolve_flux_sources,
     run_rhime,
+    run_rhime_from_prepared_inputs,
     run_rhime_multisector,
 )
 
@@ -627,6 +628,354 @@ def test_public_rhime_dataclasses_keep_existing_positional_order() -> None:
     assert not hasattr(run_spec, "sampling")
     assert result.output_metadata == output_metadata
     assert result.sampler == RhimeSampler()
+
+
+@pytest.mark.parametrize("sector_count", [1, 2])
+def test_run_rhime_from_prepared_inputs_routes_without_preparation(
+    monkeypatch: pytest.MonkeyPatch,
+    sector_count: int,
+) -> None:
+    """Prepared runs bypass preparation and select the builder from sector count."""
+    model_spec, output_spec, run_spec = _minimal_output_specs(output_format="none")
+    sectors = model_spec.sectors
+    if sector_count == 2:
+        sectors += (
+            SectorSpec(
+                name="Ocean",
+                flux_source="ocean-inventory",
+                x_prior={"pdf": "normal", "mu": 1.0, "sigma": 0.2},
+                variable_suffix="ocean",
+            ),
+        )
+    model_spec = RhimeModelSpec(
+        species=model_spec.species,
+        domain=model_spec.domain,
+        sectors=sectors,
+    )
+    run_spec = RhimeRunSpec(
+        run_spec.start_date,
+        run_spec.end_date,
+        ("STALE",),
+        ("24h",),
+        model_spec,
+        output_spec,
+        split_by_sectors=sector_count > 1,
+    )
+    inv_inputs = _minimal_output_inv_inputs()
+    if sector_count == 2:
+        inv_inputs["H"] = xr.concat(
+            [inv_inputs["H"].expand_dims(source=[sector.flux_source]) for sector in model_spec.sectors],
+            dim="source",
+        )
+    prepared = RhimePreparedInputs(
+        inv_inputs=inv_inputs,
+        basis_functions=_fake_basis_functions(),
+        sites=("TAC",),
+        averaging_period=("1h",),
+        basis_artifact_source="generated",
+    )
+    sampler = RhimeSampler(draws=7, sample_prior_predictive=False, sample_posterior_predictive=False)
+    built_model = pm.Model()
+    builder_calls: list[str] = []
+    output_calls: list[str] = []
+
+    def fail_prepare(**kwargs: Any) -> None:
+        raise AssertionError("prepared runs must not call prepare_rhime_inputs")
+
+    def fail_setup(**kwargs: Any) -> None:
+        raise AssertionError("prepared runs must not normalize runner parameters")
+
+    def fail_config(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("prepared runs must not normalize config parameters")
+
+    def build_standard(inv_inputs: xr.Dataset, spec: RhimeModelSpec) -> pm.Model:
+        builder_calls.append("standard")
+        return built_model
+
+    def build_multisector(inv_inputs: xr.Dataset, spec: RhimeModelSpec) -> pm.Model:
+        builder_calls.append("multisector")
+        return built_model
+
+    def fake_sample(self: RhimeSampler, model: pm.Model) -> az.InferenceData:
+        assert self is sampler
+        assert model is built_model
+        return _minimal_output_idata()
+
+    def make_standard_outputs(**kwargs: Any) -> rhime_outputs.RhimeOutputBundle:
+        output_calls.append("standard")
+        return rhime_outputs.RhimeOutputBundle()
+
+    def make_multisector_outputs(**kwargs: Any) -> rhime_outputs.RhimeOutputBundle:
+        output_calls.append("multisector")
+        return rhime_outputs.RhimeOutputBundle()
+
+    monkeypatch.setattr(rhime_module, "prepare_rhime_inputs", fail_prepare)
+    monkeypatch.setattr(rhime_module, "_make_rhime_runner_setup", fail_setup)
+    monkeypatch.setattr(rhime_module, "params_from_config", fail_config)
+    monkeypatch.setattr(rhime_module, "build_rhime_model_from_spec", build_standard)
+    monkeypatch.setattr(rhime_module, "build_rhime_multisector_model_from_spec", build_multisector)
+    monkeypatch.setattr(RhimeSampler, "sample", fake_sample)
+    monkeypatch.setattr(rhime_module, "make_standard_output_bundle", make_standard_outputs)
+    monkeypatch.setattr(rhime_module, "make_multisector_output_bundle", make_multisector_outputs)
+
+    result = run_rhime_from_prepared_inputs(
+        prepared_inputs=prepared,
+        run_spec=run_spec,
+        sampler=sampler,
+    )
+
+    expected_route = "standard" if sector_count == 1 else "multisector"
+    assert builder_calls == [expected_route]
+    assert output_calls == [expected_route]
+    assert result.sampler is sampler
+    assert result.run_spec.sites == prepared.sites
+    assert result.run_spec.averaging_period == prepared.averaging_period
+    assert result.run_spec.split_by_sectors is (sector_count > 1)
+
+
+@pytest.mark.parametrize(
+    ("sector_count", "split_by_sectors"),
+    [(1, True), (2, False)],
+)
+def test_run_rhime_from_prepared_inputs_rejects_layout_mode_mismatch_before_execution(
+    monkeypatch: pytest.MonkeyPatch,
+    sector_count: int,
+    split_by_sectors: bool,
+) -> None:
+    """Prepared runs reject disagreement between sector count and data layout."""
+    model_spec, output_spec, run_spec = _minimal_output_specs(output_format="none")
+    sectors = model_spec.sectors
+    if sector_count == 2:
+        sectors += (
+            SectorSpec(
+                name="Ocean",
+                flux_source="ocean-inventory",
+                x_prior={"pdf": "normal", "mu": 1.0, "sigma": 0.2},
+                variable_suffix="ocean",
+            ),
+        )
+    run_spec = RhimeRunSpec(
+        run_spec.start_date,
+        run_spec.end_date,
+        run_spec.sites,
+        run_spec.averaging_period,
+        RhimeModelSpec(species=model_spec.species, domain=model_spec.domain, sectors=sectors),
+        output_spec,
+        split_by_sectors=split_by_sectors,
+    )
+    inv_inputs = _minimal_output_inv_inputs()
+    if split_by_sectors:
+        inv_inputs["H"] = inv_inputs["H"].expand_dims(source=[sectors[0].flux_source])
+    prepared = RhimePreparedInputs(
+        inv_inputs=inv_inputs,
+        basis_functions=_fake_basis_functions(),
+        sites=("TAC",),
+        averaging_period=("1h",),
+        basis_artifact_source="generated",
+    )
+
+    def fail_execution(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("layout validation must precede model building and sampling")
+
+    monkeypatch.setattr(rhime_module, "build_rhime_model_from_spec", fail_execution)
+    monkeypatch.setattr(rhime_module, "build_rhime_multisector_model_from_spec", fail_execution)
+    monkeypatch.setattr(RhimeSampler, "sample", fail_execution)
+
+    with pytest.raises(ValueError, match="split_by_sectors.*must agree"):
+        run_rhime_from_prepared_inputs(prepared_inputs=prepared, run_spec=run_spec)
+
+
+@pytest.mark.parametrize("sector_count", [1, 2])
+def test_run_rhime_from_prepared_inputs_rejects_flag_h_layout_mismatch_before_execution(
+    monkeypatch: pytest.MonkeyPatch,
+    sector_count: int,
+) -> None:
+    """Prepared runs reject a layout flag that disagrees with H dimensions."""
+    model_spec, output_spec, run_spec = _minimal_output_specs(output_format="none")
+    sectors = model_spec.sectors
+    if sector_count == 2:
+        sectors += (
+            SectorSpec(
+                name="Ocean",
+                flux_source="ocean-inventory",
+                x_prior={"pdf": "normal", "mu": 1.0, "sigma": 0.2},
+                variable_suffix="ocean",
+            ),
+        )
+    model_spec = RhimeModelSpec(
+        species=model_spec.species,
+        domain=model_spec.domain,
+        sectors=sectors,
+    )
+    multisector = sector_count > 1
+    run_spec = RhimeRunSpec(
+        run_spec.start_date,
+        run_spec.end_date,
+        run_spec.sites,
+        run_spec.averaging_period,
+        model_spec,
+        output_spec,
+        split_by_sectors=multisector,
+    )
+    inv_inputs = _minimal_output_inv_inputs()
+    if not multisector:
+        inv_inputs["H"] = inv_inputs["H"].expand_dims(source=[sectors[0].flux_source])
+    prepared = RhimePreparedInputs(
+        inv_inputs=inv_inputs,
+        basis_functions=_fake_basis_functions(),
+        sites=("TAC",),
+        averaging_period=("1h",),
+        basis_artifact_source="generated",
+    )
+
+    def fail_execution(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("H layout validation must precede model building and sampling")
+
+    monkeypatch.setattr(rhime_module, "build_rhime_model_from_spec", fail_execution)
+    monkeypatch.setattr(rhime_module, "build_rhime_multisector_model_from_spec", fail_execution)
+    monkeypatch.setattr(RhimeSampler, "sample", fail_execution)
+
+    with pytest.raises(ValueError, match="split_by_sectors.*prepared `H` layout"):
+        run_rhime_from_prepared_inputs(prepared_inputs=prepared, run_spec=run_spec)
+
+
+def test_run_rhime_from_prepared_inputs_defaults_sampler_and_skips_none_output_writes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Prepared standard runs default the sampler and write nothing for none output."""
+    model_spec, _, run_spec = _minimal_output_specs(output_format="none")
+    output_spec = RhimeOutputSpec(
+        output_format="none",
+        output_path=str(tmp_path),
+        output_name="prepared",
+        save_trace=True,
+        save_inversion_output=True,
+    )
+    run_spec = RhimeRunSpec(
+        run_spec.start_date,
+        run_spec.end_date,
+        run_spec.sites,
+        run_spec.averaging_period,
+        model_spec,
+        output_spec,
+    )
+    prepared = RhimePreparedInputs(
+        inv_inputs=_minimal_output_inv_inputs(),
+        basis_functions=_fake_basis_functions(),
+        sites=("TAC",),
+        averaging_period=("1h",),
+        basis_artifact_source="generated",
+    )
+    built_model = pm.Model()
+    sampled_with: list[RhimeSampler] = []
+
+    def fake_sample(self: RhimeSampler, model: pm.Model) -> az.InferenceData:
+        sampled_with.append(self)
+        assert model is built_model
+        return _minimal_output_idata()
+
+    monkeypatch.setattr(rhime_module, "build_rhime_model_from_spec", lambda *args: built_model)
+    monkeypatch.setattr(RhimeSampler, "sample", fake_sample)
+
+    result = run_rhime_from_prepared_inputs(prepared_inputs=prepared, run_spec=run_spec)
+
+    assert len(sampled_with) == 1
+    assert sampled_with[0] is result.sampler
+    assert result.sampler == RhimeSampler()
+    assert result.outputs == {}
+    assert result.inv_out is None
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.parametrize(
+    ("case", "expected_error"),
+    [
+        ("default_without_path", "output_path.*required"),
+        ("multisector_legacy", "legacy.*supports only single-sector"),
+    ],
+)
+def test_run_rhime_from_prepared_inputs_validates_output_before_execution(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    case: str,
+    expected_error: str,
+) -> None:
+    """Prepared runs apply existing output validation before build or sample."""
+    model_spec, _, run_spec = _minimal_output_specs(output_format="none")
+    sectors = model_spec.sectors
+    if case == "multisector_legacy":
+        sectors += (
+            SectorSpec(
+                name="Ocean",
+                flux_source="ocean-inventory",
+                x_prior={"pdf": "normal", "mu": 1.0, "sigma": 0.2},
+                variable_suffix="ocean",
+            ),
+        )
+        output_spec = RhimeOutputSpec(output_format="legacy", output_path=str(tmp_path))
+    else:
+        output_spec = RhimeOutputSpec()
+    run_spec = RhimeRunSpec(
+        run_spec.start_date,
+        run_spec.end_date,
+        run_spec.sites,
+        run_spec.averaging_period,
+        RhimeModelSpec(species=model_spec.species, domain=model_spec.domain, sectors=sectors),
+        output_spec,
+        split_by_sectors=len(sectors) > 1,
+    )
+    inv_inputs = _minimal_output_inv_inputs()
+    if len(sectors) > 1:
+        inv_inputs["H"] = xr.concat(
+            [inv_inputs["H"].expand_dims(source=[sector.flux_source]) for sector in sectors],
+            dim="source",
+        )
+    prepared = RhimePreparedInputs(
+        inv_inputs=inv_inputs,
+        basis_functions=_fake_basis_functions(),
+        sites=("TAC",),
+        averaging_period=("1h",),
+        basis_artifact_source="generated",
+    )
+
+    def fail_execution(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("output validation must precede model building and sampling")
+
+    monkeypatch.setattr(rhime_module, "build_rhime_model_from_spec", fail_execution)
+    monkeypatch.setattr(rhime_module, "build_rhime_multisector_model_from_spec", fail_execution)
+    monkeypatch.setattr(RhimeSampler, "sample", fail_execution)
+
+    with pytest.raises(ValueError, match=expected_error):
+        run_rhime_from_prepared_inputs(prepared_inputs=prepared, run_spec=run_spec)
+
+
+def test_run_rhime_from_prepared_inputs_rejects_empty_model() -> None:
+    """Prepared runs reject model specifications without a sector."""
+    model_spec, output_spec, run_spec = _minimal_output_specs(output_format="none")
+    run_spec = RhimeRunSpec(
+        run_spec.start_date,
+        run_spec.end_date,
+        run_spec.sites,
+        run_spec.averaging_period,
+        RhimeModelSpec(species=model_spec.species, domain=model_spec.domain, sectors=()),
+        output_spec,
+    )
+    prepared = RhimePreparedInputs(
+        inv_inputs=_minimal_output_inv_inputs(),
+        basis_functions=_fake_basis_functions(),
+        sites=("TAC",),
+        averaging_period=("1h",),
+        basis_artifact_source="generated",
+    )
+
+    with pytest.raises(ValueError, match="must contain at least one sector; found 0"):
+        run_rhime_from_prepared_inputs(prepared_inputs=prepared, run_spec=run_spec)
+
+
+def test_run_rhime_from_prepared_inputs_is_publicly_reexported() -> None:
+    """The prepared-input runner is available from the public RHIME package."""
+    assert rhime_public.run_rhime_from_prepared_inputs is run_rhime_from_prepared_inputs
 
 
 def test_unreleased_sampling_compatibility_shims_are_absent() -> None:


### PR DESCRIPTION
## Summary of changes

- Add public `run_rhime_from_prepared_inputs(...)` execution from an existing
  `RhimePreparedInputs`, `RhimeRunSpec`, and optional `RhimeSampler`.
- Reuse one shared post-preparation executor from the existing standard and
  multisector runners, leaving their OpenGHG preparation behavior unchanged.
- Fail before model building or sampling when the prepared `H` source layout,
  `split_by_sectors`, model sector count, or output settings disagree.
- Document the direct prepared-input API and add an unreleased changelog entry.

This is the first execution seam in #509. It deliberately does not add
prepared-input serialization, cached `fp_x_flux` preparation, baseline-series
ingress, or model/output contract changes. PR #472 is now merged; this branch
is rebased onto its merge commit (`81f6da1`) and the prepared-input executor
uses the same sector-aware PARIS output path.

## Validation

- Post-#472 `uv run tox -p --parallel-no-spinner`: passed for current,
  previous, and development OpenGHG environments, plus lint.
- Post-#472 `uv run pytest tests/test_rhime.py -q`: `116 passed`.
- Focused prepared-input tests: `12 passed`.
- Ruff check and format checks: passed.
- Pyright on changed package modules: `0 errors`, `0 warnings`.
- Independent correctness and architecture reviews: no remaining blockers.
- A strict Sphinx build reached and parsed the updated usage page, but the
  checkout still reports 151 existing import/reference warnings, including an
  environment mismatch where autodoc resolves modules from a sibling checkout.

## Please check if the PR fulfills these requirements

- [ ] Closes #509 — this PR is one checklist item under the umbrella issue.
- [x] Tests added and passing.
- [x] Documentation and tutorials updated/added.
- [x] Added an entry to `CHANGELOG.md`.
- [x] No new requirements are needed.
