### PR TITLE
Add labelled state activity and fixed contributions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,18 @@
   now share the same post-preparation execution path.
   [#509](https://github.com/openghg/openghg_inversions/issues/509)
 
+- Added a label-aware active/fixed state-vector contract to the modern RHIME
+  model builders. Exact-zero sensitivity columns are now fixed at scaling one
+  by default while every nonzero column remains active; explicit labelled
+  masks and ``basis_group`` freezes can retain other fixed states or sectors.
+  Models sample active states only but retain full ordered deterministic
+  ``x``/``x_<sector>`` vectors, and flux-scaling prior parameters may now be
+  scalar, full array-valued, or labelled xarray values. Programmatic model specs
+  can set per-sector activity, and sampled ``H_bc @ bc`` components can use the
+  same mechanism to fix some or all BC scaling states. Config-file syntax and
+  persisted activity-reason reports remain follow-up work; legacy
+  ``inferpymc`` remains single-sector and retains its full sampled state.
+
 - Made retained `BasisFunctions` / `BasisOperator` metadata the primary basis
   contract for RHIME preparation and modern postprocessing outputs. Derived
   flux, country, PARIS, and legacy-format products now record stable basis

--- a/docs/reference/openghg_inversions.models.rst
+++ b/docs/reference/openghg_inversions.models.rst
@@ -12,3 +12,4 @@ openghg\_inversions.models
    :maxdepth: 4
 
    openghg_inversions.models.rhime
+   openghg_inversions.models.state_activity

--- a/docs/reference/openghg_inversions.models.state_activity.rst
+++ b/docs/reference/openghg_inversions.models.state_activity.rst
@@ -1,0 +1,7 @@
+openghg\_inversions.models.state\_activity
+===========================================
+
+.. automodule:: openghg_inversions.models.state_activity
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/usage/rhime.rst
+++ b/docs/usage/rhime.rst
@@ -527,6 +527,70 @@ The exception changes split acceptance only: it does not reconnect, freeze,
 prune, or marginalize the resulting small region. A direct three-argument
 policy call has no target-region context and therefore remains strict.
 
+Active And Fixed States
+-----------------------
+
+The modern model builders sample only active flux-scaling states. Inactive
+columns are removed from the sampled vector and restored into the full ordered
+``x`` (or ``x_<sector>``) model variable before the forward calculation and
+postprocessing. By default, a sensitivity column is inactive only when every
+value in that column is exactly zero. No tolerance is applied, so a near-zero
+nonzero column remains active. Inactive multiplicative scaling states default
+to one.
+
+``StateActivity`` can also freeze labelled states, ``basis_group`` values, or a
+complete sector. Labelled masks and fixed values are aligned to the state
+coordinate rather than interpreted as numeric state ranges. Prior distribution
+parameters may likewise be scalars, full one-dimensional arrays, or labelled
+``DataArray`` objects. Given canonical ``inv_inputs``, the following example
+assumes that ``inv_inputs["H"]`` carries a state-aligned ``basis_group``
+coordinate containing the value ``"outer"``:
+
+.. code-block:: python
+
+   from openghg_inversions.models import StateActivity, build_rhime_model
+   from openghg_inversions.sigma import SigmaAlignment
+
+   state_policy = StateActivity(
+       fixed_groups=("outer",),
+       fixed_value=1.0,
+   )
+   sigma_alignment = SigmaAlignment.from_frequency(
+       inv_inputs["site_indicator"],
+   )
+   model = build_rhime_model(
+       inv_inputs,
+       sigma_alignment=sigma_alignment,
+       x_prior={"pdf": "normal", "mu": 1.0, "sigma": 0.5},
+       state_activity=state_policy,
+   )
+
+For multisector builders, use ``state_activity`` as a shared policy or
+``sector_state_activities`` for sector-name overrides;
+``StateActivity(active=False)`` freezes a complete sector. Programmatic
+prepared-input runs set the canonical per-sector policy with
+``SectorSpec(state_activity=...)``. RHIME config-file syntax and persisted
+activity-reason tables remain follow-up work.
+Each prior dictionary in ``sector_priors`` supports the same scalar,
+full-state array, and labelled ``DataArray`` parameter forms; labelled values
+must match the selected sector's state coordinate exactly.
+
+For low-level model construction, first inspect a labelled design with
+``detect_zero_sensitivity``, then combine the returned mask with a
+``StateActivity`` using ``resolve_state_activity``. State-vector graph helpers
+consume the resulting ``ResolvedStateActivity``; they do not inspect ``H`` or
+infer its output dimension.
+
+Boundary-condition scaling states can be handled the same way. Set
+``RhimeModelSpec(bc_state_activity=StateActivity(active=False))`` (or the
+equivalent low-level builder argument) to retain ``mu_bc = H_bc @ bc`` with a
+fixed ``bc`` vector and no boundary-condition random variable. This is distinct
+from supplying a standalone baseline time series, which belongs to a separate
+baseline component.
+
+The legacy single-sector ``inferpymc`` / ``fixedbasisMCMC`` compatibility path
+continues to sample its full flux state and does not gain multisector behavior.
+
 Output Formats
 --------------
 

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -28,6 +28,7 @@ from openghg_inversions.models import build_rhime_model  # noqa: E402
 from openghg_inversions.models.components import resolve_model_variable  # noqa: E402
 from openghg_inversions.models.coords import get_coord_registry, restore_inferencedata_coords  # noqa: E402
 from openghg_inversions.models.priors import PriorArgs  # noqa: E402
+from openghg_inversions.models.state_activity import StateActivity  # noqa: E402
 from openghg_inversions.inversion_inputs import _compact_integer_index  # noqa: E402
 from openghg_inversions.sigma import SigmaAlignment  # noqa: E402
 
@@ -161,6 +162,9 @@ def build_inferpymc_model(
         no_model_error=no_model_error,
         offset_args=offset_args,
         power=power,
+        # Keep fixedbasisMCMC/inferpymc's legacy single-sector state graph.
+        # Modern RHIME model specs opt into exact-zero pruning separately.
+        state_activity=StateActivity(prune_zero=False),
     )
 
 

--- a/openghg_inversions/models/__init__.py
+++ b/openghg_inversions/models/__init__.py
@@ -1,4 +1,12 @@
-"""Reusable model-building helpers for OpenGHG inversions."""
+"""Public model builders, coordinates, priors, and state-activity APIs.
+
+State activity separates design inspection with ``detect_zero_sensitivity``,
+policy resolution with ``resolve_state_activity``, and graph construction in
+the component helpers.
+
+Importing this package configures PyTensor before re-exporting the supported
+RHIME and reusable component entry points.
+"""
 
 # ruff: noqa: E402
 
@@ -8,11 +16,13 @@ configure_pytensor()
 
 from openghg_inversions.models.components import (
     LinearComponentResult,
+    StateLinearComponentResult,
     add_inferpymc_likelihood_component,
     add_linear_component,
     add_model_data,
     add_offset_component,
     add_sigma_component,
+    add_state_linear_component,
 )
 from openghg_inversions.models.coords import (
     CoordRegistry,
@@ -22,6 +32,13 @@ from openghg_inversions.models.coords import (
     restore_inferencedata_coords,
 )
 from openghg_inversions.models.priors import parse_prior
+from openghg_inversions.models.state_activity import (
+    ResolvedStateActivity,
+    StateActivity,
+    active_prior_args,
+    detect_zero_sensitivity,
+    resolve_state_activity,
+)
 from openghg_inversions.models.rhime import (
     DEFAULT_BC_PRIOR,
     DEFAULT_OFFSET_PRIOR,
@@ -45,15 +62,19 @@ __all__ = [
     "DEFAULT_X_PRIOR",
     "RhimeBuilderStrategy",
     "RhimeModelSpec",
+    "ResolvedStateActivity",
     "SectorSpec",
+    "StateActivity",
     "add_coords",
     "attach_coord_registry",
     "get_coord_registry",
     "restore_inferencedata_coords",
     "parse_prior",
     "LinearComponentResult",
+    "StateLinearComponentResult",
     "add_model_data",
     "add_linear_component",
+    "add_state_linear_component",
     "add_sigma_component",
     "add_offset_component",
     "add_inferpymc_likelihood_component",
@@ -62,4 +83,7 @@ __all__ = [
     "build_rhime_multisector_model",
     "build_rhime_multisector_model_from_spec",
     "safe_pymc_name",
+    "active_prior_args",
+    "detect_zero_sensitivity",
+    "resolve_state_activity",
 ]

--- a/openghg_inversions/models/_rhime_compiler.py
+++ b/openghg_inversions/models/_rhime_compiler.py
@@ -21,9 +21,14 @@ import pytensor.tensor as pt
 import xarray as xr
 from pytensor.tensor.variable import TensorVariable
 
-from openghg_inversions.models.components import add_model_data, get_model_latent
-from openghg_inversions.models.coords import CoordRegistry
-from openghg_inversions.models.priors import PriorArgs, parse_prior
+from openghg_inversions.models.components import add_model_data, add_state_vector
+from openghg_inversions.models.coords import attach_coord_registry, CoordRegistry
+from openghg_inversions.models.state_activity import (
+    ResolvedStateActivity,
+    StateActivity,
+    detect_zero_sensitivity,
+    resolve_state_activity,
+)
 
 
 @dataclass(frozen=True)
@@ -34,11 +39,13 @@ class _StatePlan:
         state_id: Stable semantic identifier for the state.
         variable_name: Backend variable name used for the state prior.
         prior_args: Prior metadata forwarded to the backend compiler.
+        state_activity: Optional active/fixed policy for the full state vector.
     """
 
     state_id: str
     variable_name: str
     prior_args: Mapping[str, Any]
+    state_activity: StateActivity | None = None
 
 
 @dataclass(frozen=True)
@@ -86,13 +93,14 @@ class _CompiledFlux:
     Args:
         mu: Total observation-space contribution.
         states: User-facing state tensors keyed by state ID.
-        latents: Effective backend latent tensors keyed by state ID.
+        latents: Effective backend latent tensors keyed by state ID. All-fixed
+            states map to ``None``.
         terms: Forward contribution tensors keyed by term ID.
     """
 
     mu: TensorVariable
     states: Mapping[str, TensorVariable]
-    latents: Mapping[str, TensorVariable]
+    latents: Mapping[str, TensorVariable | None]
     terms: Mapping[str, TensorVariable]
 
 
@@ -122,11 +130,50 @@ def _uses_reparameterized_lognormal(state: _StatePlan) -> bool:
     return pdf == "lognormal" and bool(state.prior_args.get("reparameterise", False))
 
 
-def _state_backend_names(state: _StatePlan) -> tuple[str, ...]:
-    """Return every backend name created by a state prior."""
-    if _uses_reparameterized_lognormal(state):
-        return (state.variable_name, f"{state.variable_name}_latent")
-    return (state.variable_name,)
+def _state_backend_names(
+    state: _StatePlan,
+    activity: ResolvedStateActivity,
+) -> tuple[str, ...]:
+    """Return every backend name created by a resolved state vector."""
+    if activity.n_active == activity.n_state:
+        if _uses_reparameterized_lognormal(state):
+            return (state.variable_name, f"{state.variable_name}_latent")
+        return (state.variable_name,)
+
+    names = [
+        state.variable_name,
+        f"{state.variable_name}_is_active",
+        f"{state.variable_name}_fixed_value",
+    ]
+    if activity.n_active:
+        names.append(f"{state.variable_name}_active")
+        if _uses_reparameterized_lognormal(state):
+            names.append(f"{state.variable_name}_active_latent")
+    return tuple(names)
+
+
+def _aggregate_state_design(
+    terms: list[_ForwardTermPlan],
+    *,
+    observation_dim: str,
+) -> xr.DataArray:
+    """Combine effective designs for exact-zero detection for one state.
+
+    A state is exactly insensitive only when every coefficient-scaled term is
+    zero for that state. Concatenation avoids cancellation between terms while
+    retaining the canonical state coordinates needed for labelled policies.
+
+    Args:
+        terms: Validated forward terms sharing one semantic state.
+        observation_dim: Common observation dimension.
+
+    Returns:
+        One labelled design containing every effective term column.
+    """
+    effective_designs = [term.design * term.coefficient for term in terms]
+    if len(effective_designs) == 1:
+        return effective_designs[0]
+    return xr.concat(effective_designs, dim=observation_dim)
 
 
 def _coords_for_dims(data: xr.DataArray, dims: tuple[str, ...]) -> dict[str, xr.DataArray]:
@@ -178,39 +225,41 @@ def _require_exact_layout(
 
 def _preflight_state_priors(
     plan: _FluxPlan,
-    terms_by_state: Mapping[str, list[_ForwardTermPlan]],
+    activities: Mapping[str, ResolvedStateActivity],
     registry: CoordRegistry,
 ) -> None:
     """Validate state prior metadata in isolated scratch models.
 
     Args:
         plan: Flux plan whose priors should be checked.
-        terms_by_state: Forward terms grouped by semantic state ID.
+        activities: Resolved activity contract keyed by semantic state ID.
         registry: Validated global coordinate registry for the term designs.
 
     Raises:
         ValueError: If a prior cannot be constructed with its state dimensions.
     """
     coords = {name: np.asarray(values).tolist() for name, values in registry.pymc_coords.items()}
-    with pm.Model(coords=coords, model=None):
+    with pm.Model(coords=coords, model=None) as model:
+        attach_coord_registry(model, CoordRegistry())
         for state in plan.states:
-            design = terms_by_state[state.state_id][0].design
-            state_dims = tuple(str(dim) for dim in design.dims if dim != plan.observation_dim)
             try:
-                parse_prior(
-                    state.variable_name,
-                    cast(PriorArgs, dict(state.prior_args)),
-                    dims=state_dims,
+                add_state_vector(
+                    activities[state.state_id],
+                    prior_args=dict(state.prior_args),
+                    var_name=state.variable_name,
                 )
             except (KeyError, TypeError, ValueError) as exc:
                 raise ValueError(f"Flux plan prior for state {state.state_id!r} is invalid.") from exc
 
 
-def _validate_flux_plan(plan: _FluxPlan) -> None:
+def _validate_flux_plan(plan: _FluxPlan) -> dict[str, ResolvedStateActivity]:
     """Validate a complete flux plan without mutating the active PyMC model.
 
     Args:
         plan: Ordered state and forward-term plan.
+
+    Returns:
+        Resolved state activities keyed by semantic state ID.
 
     Raises:
         TypeError: If a term design is not an xarray ``DataArray``.
@@ -247,16 +296,6 @@ def _validate_flux_plan(plan: _FluxPlan) -> None:
             "Flux total name collides with a term deterministic name; "
             "this is only valid for a single-term compatibility plan."
         )
-
-    backend_names = [name for state in plan.states for name in _state_backend_names(state)]
-    backend_names.extend(term.data_name for term in plan.terms)
-    backend_names.extend(
-        term.deterministic_name
-        for term in plan.terms
-        if not (compatible_single_term and term.deterministic_name == plan.total_name)
-    )
-    backend_names.append(plan.total_name)
-    _require_unique(backend_names, "backend names")
 
     registry = CoordRegistry()
     reference_observations: xr.DataArray | None = None
@@ -304,11 +343,37 @@ def _validate_flux_plan(plan: _FluxPlan) -> None:
                 raise ValueError(f"Flux terms for state {state_id!r} must have exact state dimensions.")
             _require_exact_layout(reference, term.design, state_dims, label="state")
 
-    _preflight_state_priors(plan, terms_by_state, registry)
+    activities = {
+        state.state_id: resolve_state_activity(
+            detect_zero_sensitivity(
+                _aggregate_state_design(
+                    terms_by_state[state.state_id],
+                    observation_dim=plan.observation_dim,
+                ),
+                output_dim=plan.observation_dim,
+            ),
+            state.state_activity,
+        )
+        for state in plan.states
+    }
+    backend_names = [
+        name for state in plan.states for name in _state_backend_names(state, activities[state.state_id])
+    ]
+    backend_names.extend(term.data_name for term in plan.terms)
+    backend_names.extend(
+        term.deterministic_name
+        for term in plan.terms
+        if not (compatible_single_term and term.deterministic_name == plan.total_name)
+    )
+    backend_names.append(plan.total_name)
+    _require_unique(backend_names, "backend names")
+
+    _preflight_state_priors(plan, activities, registry)
+    return activities
 
 
 def _compile_loop_sum(plan: _FluxPlan) -> _CompiledFlux:
-    """Compile a validated loop-sum plan into the active PyMC model.
+    """Validate and compile a loop-sum plan into the active PyMC model.
 
     Args:
         plan: Ordered state and forward-term plan.
@@ -320,10 +385,10 @@ def _compile_loop_sum(plan: _FluxPlan) -> _CompiledFlux:
         TypeError: If a term design is not an xarray ``DataArray``.
         ValueError: If the complete plan is invalid.
     """
-    _validate_flux_plan(plan)
+    activities = _validate_flux_plan(plan)
 
     state_tensors: dict[str, TensorVariable] = {}
-    latent_tensors: dict[str, TensorVariable] = {}
+    latent_tensors: dict[str, TensorVariable | None] = {}
     term_tensors: dict[str, TensorVariable] = {}
     ordered_outputs: list[TensorVariable] = []
     state_by_id = {state.state_id: state for state in plan.states}
@@ -333,14 +398,13 @@ def _compile_loop_sum(plan: _FluxPlan) -> _CompiledFlux:
         data = add_model_data(design, term.data_name)
         if term.state_id not in state_tensors:
             state = state_by_id[term.state_id]
-            state_dims = tuple(str(dim) for dim in design.dims if dim != plan.observation_dim)
-            user_facing = parse_prior(
-                state.variable_name,
-                cast(PriorArgs, dict(state.prior_args)),
-                dims=state_dims,
+            state_vector = add_state_vector(
+                activities[state.state_id],
+                prior_args=dict(state.prior_args),
+                var_name=state.variable_name,
             )
-            state_tensors[state.state_id] = user_facing
-            latent_tensors[state.state_id] = get_model_latent(user_facing, state.variable_name)
+            state_tensors[state.state_id] = state_vector.state
+            latent_tensors[state.state_id] = state_vector.latent
 
         output = pt.dot(data, state_tensors[term.state_id])
         if term.coefficient != 1.0:

--- a/openghg_inversions/models/_rhime_flux.py
+++ b/openghg_inversions/models/_rhime_flux.py
@@ -1,10 +1,17 @@
-"""Resolve RHIME flux declarations for concrete builders and compiler plans."""
+"""Normalize RHIME flux declarations for concrete builders and compiler plans.
+
+Semantic sector names remain separate from OpenGHG source labels and backend
+variable suffixes. Rectangular shared-basis and gathered source-specific layouts
+use the same entry points. Priors follow per-sector, shared, then default
+precedence; activity follows per-sector override, then shared policy. Scientific
+labels are resolved before backend namespacing and graph mutation.
+"""
 
 from __future__ import annotations
 
 import re
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any
 
 import pandas as pd
@@ -15,6 +22,12 @@ from openghg_inversions.models._rhime_compiler import (
     _FluxPlan,
     _ForwardTermPlan,
     _StatePlan,
+)
+from openghg_inversions.models.state_activity import (
+    StateActivity,
+    active_prior_args,
+    detect_zero_sensitivity,
+    resolve_state_activity,
 )
 
 
@@ -36,6 +49,7 @@ class _ResolvedSectorComponent:
     variable_suffix: str
     design: xr.DataArray
     prior_args: Mapping[str, Any]
+    state_activity: StateActivity
 
 
 def safe_pymc_name(value: str) -> str:
@@ -205,6 +219,7 @@ def _select_sector_design(
     source: str,
     variable_suffix: str,
     observation_dim: str = "nmeasure",
+    namespace_state_dim: bool = True,
 ) -> xr.DataArray:
     """Select one source design from rectangular or gathered sensitivity."""
     available_sources = _prepared_sources(design, observation_dim=observation_dim)
@@ -241,11 +256,76 @@ def _select_sector_design(
         ragged_dim=ragged_levels[0],
         stack_dim=state_dim,
     )
-    return selected.rename({state_dim: f"{state_dim}_{variable_suffix}"})
+    if namespace_state_dim:
+        return selected.rename({state_dim: f"{state_dim}_{variable_suffix}"})
+    return selected
 
 
-def _normalize_standard_flux_plan(inv_inputs: xr.Dataset, x_prior: Mapping[str, Any]) -> _FluxPlan:
-    """Normalize the standard flux component into a one-state linear plan."""
+def _namespace_sector_state_coords(
+    design: xr.DataArray,
+    *,
+    variable_suffix: str,
+    observation_dim: str = "nmeasure",
+    namespace_state_dim: bool = False,
+) -> xr.DataArray:
+    """Namespace sector-local auxiliary coordinates for backend registration.
+
+    Semantic policies are resolved before this transformation so a shared
+    policy can continue to refer to scientific coordinate names such as
+    ``basis_group``. Auxiliary coordinates attached exclusively to the state
+    dimension receive the sector suffix. Gathered layouts also namespace the
+    state dimension so sectors with different lengths can coexist.
+
+    Args:
+        design: Selected two-dimensional sector sensitivity.
+        variable_suffix: Validated backend suffix for the sector.
+        observation_dim: Name of the shared observation dimension.
+        namespace_state_dim: Whether to suffix the state dimension itself.
+
+    Returns:
+        Design with sector-local auxiliary coordinate names namespaced.
+
+    Raises:
+        ValueError: If a generated coordinate name already exists.
+    """
+    state_dims = {str(dim) for dim in design.dims if dim != observation_dim}
+    rename: dict[str, str] = {}
+    if namespace_state_dim:
+        rename.update({dim: f"{dim}_{variable_suffix}" for dim in state_dims})
+    for name, coord in design.coords.items():
+        coord_name = str(name)
+        if coord_name in design.dims or not coord.dims:
+            continue
+        if set(map(str, coord.dims)).issubset(state_dims):
+            namespaced = f"{coord_name}_{variable_suffix}"
+            if namespaced in design.coords and namespaced != coord_name:
+                raise ValueError(
+                    f"Cannot namespace sector coordinate {coord_name!r}: "
+                    f"coordinate {namespaced!r} already exists."
+                )
+            rename[coord_name] = namespaced
+    return design.rename(rename)
+
+
+def _normalize_standard_flux_plan(
+    inv_inputs: xr.Dataset,
+    x_prior: Mapping[str, Any],
+    *,
+    state_activity: StateActivity | None = None,
+) -> _FluxPlan:
+    """Normalize the standard flux component into a one-state linear plan.
+
+    Args:
+        inv_inputs: Canonical inputs containing the required ``H`` design.
+        x_prior: Flux-scaling prior specification.
+        state_activity: Optional activity policy, resolved during compilation.
+
+    Returns:
+        A single-state, single-forward-term compiler plan.
+
+    Raises:
+        KeyError: If ``inv_inputs`` does not contain ``H``.
+    """
     state_id = "flux"
     return _FluxPlan(
         states=(
@@ -253,6 +333,7 @@ def _normalize_standard_flux_plan(inv_inputs: xr.Dataset, x_prior: Mapping[str, 
                 state_id=state_id,
                 variable_name="x",
                 prior_args=x_prior,
+                state_activity=state_activity,
             ),
         ),
         terms=(
@@ -275,6 +356,8 @@ def _resolve_multisector_components(
     sector_priors: Mapping[str, Mapping[str, Any]] | None,
     x_prior: Mapping[str, Any] | None,
     default_x_prior: Mapping[str, Any],
+    state_activity: StateActivity | None = None,
+    sector_state_activities: Mapping[str, StateActivity] | None = None,
 ) -> tuple[_ResolvedSectorComponent, ...]:
     """Resolve multisector designs and priors independently of graph construction.
 
@@ -302,6 +385,9 @@ def _resolve_multisector_components(
             are absent.
         default_x_prior: Final shared prior used when neither explicit prior
             option is supplied.
+        state_activity: Optional activity policy shared by every sector.
+        sector_state_activities: Optional activity-policy overrides keyed by
+            semantic sector name.
 
     Returns:
         Ordered resolved components containing each sector identity, selected
@@ -324,6 +410,11 @@ def _resolve_multisector_components(
                 f"unused sector prior key(s): {unused_priors!r}."
             )
 
+    sector_state_activities = dict(sector_state_activities or {})
+    unknown_activity_sectors = sorted(set(sector_state_activities) - set(sector_names))
+    if unknown_activity_sectors:
+        raise ValueError(f"State activity supplied for unknown sector(s) {unknown_activity_sectors!r}.")
+
     components = []
     for binding in sector_bindings:
         if sector_priors is not None:
@@ -332,18 +423,47 @@ def _resolve_multisector_components(
             prior = x_prior
         else:
             prior = default_x_prior
+        gathered_layout = "source" not in inv_inputs["H"].dims
+        design = _select_sector_design(
+            inv_inputs["H"],
+            sector=binding.name,
+            source=binding.flux_source,
+            variable_suffix=binding.variable_suffix,
+            namespace_state_dim=False,
+        )
+        semantic_policy = sector_state_activities.get(binding.name, state_activity)
+        resolved_activity = resolve_state_activity(
+            detect_zero_sensitivity(design),
+            semantic_policy,
+        )
+        all_active = replace(
+            resolved_activity,
+            active=xr.ones_like(resolved_activity.active, dtype=bool),
+        )
+        normalized_prior = active_prior_args(dict(prior), all_active)
+        backend_design = _namespace_sector_state_coords(
+            design,
+            variable_suffix=binding.variable_suffix,
+            namespace_state_dim=gathered_layout,
+        )
+        backend_state_dim = next(str(dim) for dim in backend_design.dims if dim != "nmeasure")
+        semantic_state_dim = resolved_activity.state_dim
+        rename_state = (
+            {semantic_state_dim: backend_state_dim} if semantic_state_dim != backend_state_dim else {}
+        )
+        resolved_policy = StateActivity(
+            active=resolved_activity.active.rename(rename_state),
+            fixed_value=resolved_activity.fixed_value.rename(rename_state),
+            prune_zero=False,
+        )
         components.append(
             _ResolvedSectorComponent(
                 name=binding.name,
                 flux_source=binding.flux_source,
                 variable_suffix=binding.variable_suffix,
-                design=_select_sector_design(
-                    inv_inputs["H"],
-                    sector=binding.name,
-                    source=binding.flux_source,
-                    variable_suffix=binding.variable_suffix,
-                ),
-                prior_args=dict(prior),
+                design=backend_design,
+                prior_args=normalized_prior,
+                state_activity=resolved_policy,
             )
         )
     return tuple(components)
@@ -356,8 +476,30 @@ def _normalize_multisector_flux_plan(
     sector_priors: Mapping[str, Mapping[str, Any]] | None,
     x_prior: Mapping[str, Any] | None,
     default_x_prior: Mapping[str, Any],
+    state_activity: StateActivity | None = None,
+    sector_state_activities: Mapping[str, StateActivity] | None = None,
 ) -> _FluxPlan:
-    """Normalize selected sector designs into separate state and term plans."""
+    """Normalize selected sector designs into separate state and term plans.
+
+    Per-sector priors and activity policies override shared equivalents;
+    gathered scientific labels are resolved before backend namespacing.
+
+    Args:
+        inv_inputs: Canonical source-resolved inversion inputs.
+        sector_bindings: Ordered validated sector/source/backend bindings.
+        sector_priors: Optional complete per-sector prior mapping.
+        x_prior: Optional prior shared by all sectors.
+        default_x_prior: Fallback prior when explicit priors are absent.
+        state_activity: Optional policy shared by all sectors.
+        sector_state_activities: Optional per-sector policy overrides.
+
+    Returns:
+        One compiler state and forward term per sector.
+
+    Raises:
+        KeyError: If required sensitivity input ``H`` is absent.
+        ValueError: If layouts or sector/prior/activity mappings are invalid.
+    """
     states: list[_StatePlan] = []
     terms: list[_ForwardTermPlan] = []
     components = _resolve_multisector_components(
@@ -366,6 +508,8 @@ def _normalize_multisector_flux_plan(
         sector_priors=sector_priors,
         x_prior=x_prior,
         default_x_prior=default_x_prior,
+        state_activity=state_activity,
+        sector_state_activities=sector_state_activities,
     )
     for component in components:
         states.append(
@@ -373,6 +517,7 @@ def _normalize_multisector_flux_plan(
                 state_id=component.name,
                 variable_name=f"x_{component.variable_suffix}",
                 prior_args=component.prior_args,
+                state_activity=component.state_activity,
             )
         )
         terms.append(

--- a/openghg_inversions/models/components.py
+++ b/openghg_inversions/models/components.py
@@ -6,8 +6,12 @@ own coordinate sanitization policy; coordinate handling lives in
 ``openghg_inversions.models.coords``.
 
 All component helpers operate inside an active PyMC model context.
+``add_state_vector`` consumes an already resolved activity contract;
+``add_state_linear_component`` performs design inspection and policy resolution
+before constructing that graph.
 
 Naming conventions:
+
 - ``data_name``: name for registered ``pm.Data``
 - ``var_name``: name for the latent random variable
 - ``output_name``: name for the aligned deterministic output
@@ -22,7 +26,7 @@ coordinates using shared helper logic based on
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import cast
+from typing import Any, cast
 
 import numpy as np
 import pandas as pd
@@ -34,6 +38,13 @@ from pytensor.tensor.variable import TensorVariable
 from openghg_inversions.inversion_inputs import make_freq_indicator
 from openghg_inversions.models.coords import add_coords
 from openghg_inversions.models.priors import parse_prior
+from openghg_inversions.models.state_activity import (
+    ResolvedStateActivity,
+    StateActivity,
+    active_prior_args,
+    detect_zero_sensitivity,
+    resolve_state_activity,
+)
 from openghg_inversions.sigma import SigmaAlignment
 
 
@@ -44,6 +55,43 @@ class LinearComponentResult:
     data: TensorVariable
     latent: TensorVariable
     output: TensorVariable
+
+
+@dataclass
+class StateVectorResult:
+    """Objects created by ``add_state_vector``.
+
+    Attributes:
+        latent: Effective sampled latent variable, or ``None`` when every
+            state is fixed.
+        state: Full ordered state vector, including fixed values.
+        activity: Resolved state-activity contract in canonical state order.
+    """
+
+    latent: TensorVariable | None
+    state: TensorVariable
+    activity: ResolvedStateActivity
+
+
+@dataclass
+class StateLinearComponentResult:
+    """Objects created by ``add_state_linear_component``.
+
+    Attributes:
+        data: Full sensitivity matrix registered with PyMC.
+        latent: Effective active-state latent variable, or ``None`` when no
+            states are active.
+        state: Full ordered state vector. This is the ordinary user-facing
+            prior when all states are active and a deterministic otherwise.
+        output: Forward-model contribution from active and fixed states.
+        activity: Resolved state-activity contract in canonical state order.
+    """
+
+    data: TensorVariable
+    latent: TensorVariable | None
+    state: TensorVariable
+    output: TensorVariable
+    activity: ResolvedStateActivity
 
 
 def get_model_latent(variable: TensorVariable, base_name: str) -> TensorVariable:
@@ -198,6 +246,198 @@ def add_linear_component(
     if compute_deterministic:
         output = pm.Deterministic(output_name, output, dims=output_dim)
     return LinearComponentResult(data=h, latent=latent, output=output)
+
+
+def _with_legacy_all_active_coord(
+    data: xr.DataArray,
+    state_activity: StateActivity | None,
+    *,
+    output_dim: str,
+) -> xr.DataArray:
+    """Supply a positional state coordinate for the legacy all-active policy.
+
+    Args:
+        data: Candidate sensitivity matrix.
+        state_activity: Optional activity policy.
+        output_dim: Observation/output dimension name.
+
+    Returns:
+        ``data`` unchanged, or with positional labels for its sole state axis.
+    """
+    state_dims = [str(dim) for dim in data.dims if dim != output_dim]
+    legacy_all_active = (
+        state_activity is not None
+        and not state_activity.prune_zero
+        and not state_activity.fixed_groups
+        and isinstance(state_activity.active, (bool, np.bool_))
+        and bool(state_activity.active)
+    )
+    if legacy_all_active and len(state_dims) == 1 and state_dims[0] not in data.coords:
+        state_dim = state_dims[0]
+        return data.assign_coords({state_dim: np.arange(data.sizes[state_dim])})
+    return data
+
+
+def add_state_vector(
+    activity: ResolvedStateActivity,
+    /,
+    prior_args: dict[str, Any],
+    var_name: str,
+) -> StateVectorResult:
+    """Construct an active/fixed state graph from a resolved activity contract.
+
+    When every state is active, this creates the same base prior graph as
+    ``add_linear_component``. Partial activity creates an active-only prior and
+    restores it into a full deterministic state vector. An all-fixed policy
+    creates no random variable and exposes the fixed values as the full
+    deterministic state.
+
+    Args:
+        activity: Resolved activity and state-coordinate contract. Linear
+            design inspection must be completed before calling this helper.
+        prior_args: Prior specification. Distribution parameters may be scalar,
+            full-state arrays, or labelled state ``DataArray`` objects.
+        var_name: Name of the full user-facing state vector.
+
+    Returns:
+        The effective latent, full state vector, and supplied activity.
+
+    Raises:
+        KeyError: If the prior specification omits a required parameter.
+        TypeError: If the prior specification contains an unsupported value.
+        ValueError: If state-valued prior parameters are invalid.
+
+    Notes:
+        This helper registers state variables and state coordinates, but it
+        does not inspect or register a linear design and does not construct a
+        forward-model output. The registered activity mask is immutable
+        build-time metadata in semantic terms; changing it with ``pm.set_data``
+        would not rebuild the latent state layout. Call this helper inside an
+        active ``pm.Model`` context.
+    """
+    state_dim = activity.state_dim
+    state_coord = activity.zero_sensitivity.coords[state_dim]
+    add_coords(activity.zero_sensitivity.coords, model_dims=(state_dim,))
+    parsed_prior_args = active_prior_args(prior_args, activity)
+
+    if activity.n_active == activity.n_state:
+        state = parse_prior(var_name, parsed_prior_args, dims=state_dim)
+        return StateVectorResult(
+            latent=get_model_latent(state, var_name),
+            state=state,
+            activity=activity,
+        )
+
+    add_model_data(
+        activity.active.rename(f"{var_name}_is_active"),
+        f"{var_name}_is_active",
+    )
+    fixed_value = add_model_data(
+        activity.fixed_value.rename(f"{var_name}_fixed_value"),
+        f"{var_name}_fixed_value",
+    )
+    active_indices = activity.active_indices
+    latent: TensorVariable | None = None
+    active_state: TensorVariable | None = None
+    if activity.n_active:
+        active_dim = f"{state_dim}_{var_name}_active"
+        active_index = state_coord.to_index()[active_indices]
+        if isinstance(active_index, pd.MultiIndex):
+            # Keep tuple labels without re-registering the MultiIndex level
+            # names already owned by the full state dimension.
+            active_coord = np.empty(activity.n_active, dtype=object)
+            active_coord[:] = active_index.tolist()
+        else:
+            active_coord = active_index.to_numpy()
+        add_coords({active_dim: active_coord})
+        active_state = parse_prior(
+            f"{var_name}_active",
+            parsed_prior_args,
+            dims=active_dim,
+        )
+        latent = get_model_latent(active_state, f"{var_name}_active")
+
+    full_state = fixed_value
+    if active_state is not None:
+        full_state = pt.set_subtensor(full_state[active_indices], active_state)
+    state = pm.Deterministic(var_name, full_state, dims=state_dim)
+    return StateVectorResult(latent=latent, state=state, activity=activity)
+
+
+def add_state_linear_component(
+    data: xr.DataArray,
+    /,
+    data_name: str,
+    prior_args: dict,
+    var_name: str,
+    output_name: str,
+    state_activity: StateActivity | None = None,
+    output_dim: str = "nmeasure",
+    compute_deterministic: bool = True,
+) -> StateLinearComponentResult:
+    """Add a linear component that samples only active labelled states.
+
+    The public ``var_name`` is always a full ordered vector. When every state
+    is active, it retains the ordinary prior graph produced by
+    ``add_linear_component``. Otherwise, active states are sampled in
+    ``{var_name}_active`` and restored with inactive fixed values into a full
+    deterministic state. The forward contribution is always ``H @ state``.
+
+    Args:
+        data: Finite sensitivity matrix containing ``output_dim`` and exactly
+            one other dimension with a unique labelled state coordinate. The
+            explicit legacy all-active policy may synthesize positional labels.
+        data_name: Name used when registering the full matrix as ``pm.Data``.
+        prior_args: Prior specification. Distribution parameters may be scalar,
+            full-state arrays, or labelled state ``DataArray`` objects.
+        var_name: Name of the full deterministic state vector.
+        output_name: Name for the aligned forward-model contribution.
+        state_activity: Optional active/fixed policy. The default prunes only
+            exactly-zero sensitivity columns and fixes them to one.
+        output_dim: Observation/output dimension name.
+        compute_deterministic: Whether to wrap the output in a named
+            ``pm.Deterministic``.
+
+    Returns:
+        Registered data, optional active latent, full state, output, and the
+        resolved activity contract.
+
+    Raises:
+        ValueError: If the sensitivity layout, state policy, labels, fixed
+            values, or state-valued prior parameters are invalid.
+
+    Notes:
+        This helper mutates the active ``pm.Model`` by registering coordinates,
+        the full design, state variables, and optionally the named output.
+    """
+    output_dim = str(output_dim)
+    data = _with_legacy_all_active_coord(
+        data.transpose(output_dim, ...),
+        state_activity,
+        output_dim=output_dim,
+    )
+    activity = resolve_state_activity(
+        detect_zero_sensitivity(data, output_dim=output_dim),
+        state_activity,
+    )
+    h_full = add_model_data(data, data_name)
+    vector = add_state_vector(
+        activity,
+        prior_args=prior_args,
+        var_name=var_name,
+    )
+
+    output = pt.dot(h_full, vector.state)
+    if compute_deterministic:
+        output = pm.Deterministic(output_name, output, dims=output_dim)
+
+    return StateLinearComponentResult(
+        data=h_full,
+        latent=vector.latent,
+        state=vector.state,
+        output=cast(TensorVariable, output),
+        activity=vector.activity,
+    )
 
 
 def add_sigma_component(
@@ -361,10 +601,10 @@ def add_inferpymc_likelihood_component(
     if no_model_error is True:
         mean_obs = np.nanmean(data["mf"].values)
         small_amount = pm.floatX(1e-12 * mean_obs)
-        eps = pt.maximum(pt.abs(error_data), small_amount)
+        eps = cast(Any, pt.maximum)(pt.abs(error_data), small_amount)
     else:
         power0 = parse_prior("power", power) if isinstance(power, dict) else power
-        eps = pt.maximum(
+        eps = cast(Any, pt.maximum)(
             pt.sqrt(error_data**2 + pt.pow(pollution_event_scaled_error, power0)),
             min_error_data,
         )

--- a/openghg_inversions/models/priors.py
+++ b/openghg_inversions/models/priors.py
@@ -1,41 +1,61 @@
-"""Reusable prior helpers for PyMC model construction."""
+"""Create reusable scalar or array-valued PyMC prior variables.
+
+``parse_prior`` registers continuous distributions on the active model;
+``lognormal_mu_sigma`` converts requested moments, including arrays. Optional
+lognormal reparameterization exposes ``<name>_latent`` and keeps ``<name>`` as
+the user-facing deterministic variable.
+"""
 
 from __future__ import annotations
 
-from typing import TypeAlias
+from typing import Any, TypeAlias
 
 import numpy as np
 import pymc as pm
 import pytensor.tensor as pt
 from pymc.distributions import continuous
-from pytensor.tensor import TensorVariable
+from pytensor.tensor.variable import TensorVariable
 
-PriorArgs: TypeAlias = dict[str, str | float | bool]
+PriorArgs: TypeAlias = dict[str, Any]
 
 
-def lognormal_mu_sigma(mean: float, stdev: float) -> tuple[float, float]:
+def lognormal_mu_sigma(
+    mean: float | np.ndarray,
+    stdev: float | np.ndarray,
+) -> tuple[float | np.ndarray, float | np.ndarray]:
     """Convert lognormal mean and stdev into PyMC's ``mu`` and ``sigma``.
 
     Args:
-        mean: Requested mean of the lognormal distribution.
-        stdev: Requested standard deviation of the lognormal distribution.
+        mean: Requested scalar or array-valued mean of the lognormal
+            distribution.
+        stdev: Requested scalar or array-valued standard deviation of the
+            lognormal distribution.
 
     Returns:
         A ``(mu, sigma)`` tuple suitable for ``pm.Lognormal``.
     """
-    var = np.log(1 + (stdev / mean) ** 2)
-    mu = np.log(mean) - 0.5 * var
+    mean_array = np.asarray(mean)
+    stdev_array = np.asarray(stdev)
+    var = np.log(1 + (stdev_array / mean_array) ** 2)
+    mu = np.log(mean_array) - 0.5 * var
     sigma = np.sqrt(var)
+    if mu.ndim == 0 and sigma.ndim == 0:
+        return float(mu), float(sigma)
     return mu, sigma
 
 
 def _update_log_normal_prior(prior_params: PriorArgs) -> None:
-    """Rewrite lognormal prior arguments in-place to use ``mu`` and ``sigma``."""
+    """Rewrite requested lognormal moments to PyMC parameters in place.
+
+    Args:
+        prior_params: Mutable mapping. When ``stdev`` is present, it and
+            optional ``mean`` are replaced by ``mu`` and ``sigma``.
+    """
     if "stdev" not in prior_params:
         return
 
-    stdev = float(prior_params["stdev"])
-    mean = float(prior_params.get("mean", 1.0))
+    stdev = prior_params["stdev"]
+    mean = prior_params.get("mean", 1.0)
     mu, sigma = lognormal_mu_sigma(mean, stdev)
     prior_params["mu"] = mu
     prior_params["sigma"] = sigma

--- a/openghg_inversions/models/rhime.py
+++ b/openghg_inversions/models/rhime.py
@@ -11,6 +11,10 @@ builder optimizes one component per sector, where each sector is normally backed
 by one OpenGHG flux ``source`` coordinate in ``inv_inputs["H"]``. When sector
 labels differ from OpenGHG source values, the builder selects data by source
 and names PyMC variables by sector.
+
+Modern flux builders fix exact-zero sensitivity columns to one by default and
+restore them into the full public state vector. Boundary-condition activity is
+opt-in: omitting its policy preserves the ordinary fully sampled BC graph.
 """
 
 from __future__ import annotations
@@ -39,9 +43,11 @@ from openghg_inversions.models.components import (
     add_inferpymc_likelihood_component,
     add_linear_component,
     add_offset_component,
+    add_state_linear_component,
 )
 from openghg_inversions.models.coords import CoordRegistry, attach_coord_registry
 from openghg_inversions.models.priors import PriorArgs
+from openghg_inversions.models.state_activity import StateActivity
 from openghg_inversions.sigma import SigmaAlignment
 
 DEFAULT_X_PRIOR: PriorArgs = {"pdf": "lognormal", "mean": 1.0, "stdev": 1.0, "reparameterise": True}
@@ -80,12 +86,16 @@ class SectorSpec:
         x_prior: Prior specification for this sector's flux scaling factors.
         variable_suffix: PyMC-safe suffix used in multi-sector model variable
             names. Standard single-sector RHIME uses plain ``x``/``mu`` names.
+        state_activity: Optional labelled active/fixed policy for this sector's
+            flux-scaling states. ``None`` still applies the default flux policy,
+            fixing exactly-zero sensitivity columns to one.
     """
 
     name: str
     flux_source: str
     x_prior: dict[str, Any]
     variable_suffix: str
+    state_activity: StateActivity | None = field(default=None, kw_only=True)
 
 
 @dataclass(frozen=True)
@@ -112,6 +122,11 @@ class RhimeModelSpec:
         sigma_prior: Prior specification for model-error terms.
         offset_prior: Prior specification for optional offsets.
         offset_args: Extra keyword arguments forwarded to the offset component.
+        bc_state_activity: Optional active/fixed policy for the boundary-
+            condition scaling vector. ``None`` preserves the ordinary fully
+            sampled BC graph without zero pruning. Supplying a policy opts into
+            active/fixed BC construction; when all states are fixed, ``mu_bc``
+            remains without a boundary-condition RV.
         builder_strategy: Public model-construction strategy. ``"concrete"``
             directly composes the default, readable reference model.
             ``"compiled"`` opts into the private semantic-plan compiler for
@@ -134,6 +149,7 @@ class RhimeModelSpec:
     sigma_prior: dict[str, Any] | None = None
     offset_prior: dict[str, Any] | None = None
     offset_args: dict[str, Any] | None = None
+    bc_state_activity: StateActivity | None = field(default=None, kw_only=True)
     builder_strategy: RhimeBuilderStrategy = field(default="concrete", kw_only=True)
 
     def __post_init__(self) -> None:
@@ -169,6 +185,7 @@ def _add_rhime_observation_components(
     offset_prior: dict,
     add_offset: bool,
     use_bc: bool,
+    bc_state_activity: StateActivity | None,
     pollution_events_from_obs: bool,
     no_model_error: bool,
     offset_args: dict | None,
@@ -185,6 +202,8 @@ def _add_rhime_observation_components(
         offset_prior: Prepared optional offset prior.
         add_offset: Whether to add an offset component.
         use_bc: Whether to add a boundary-condition component.
+        bc_state_activity: Optional active/fixed policy for boundary-condition
+            scaling states.
         pollution_events_from_obs: Whether error scaling uses observations.
         no_model_error: Whether to suppress explicit model error.
         offset_args: Extra offset-component arguments.
@@ -195,15 +214,27 @@ def _add_rhime_observation_components(
     if use_bc:
         if "H_bc" not in inv_inputs:
             raise ValueError("If `use_bc` is True, `inv_inputs` must contain `H_bc`.")
-        bc_component = add_linear_component(
-            inv_inputs["H_bc"],
-            data_name="hbc",
-            prior_args=bc_prior,
-            var_name="bc",
-            output_name="mu_bc",
-            output_dim="nmeasure",
-            compute_deterministic=True,
-        )
+        if bc_state_activity is None:
+            bc_component = add_linear_component(
+                inv_inputs["H_bc"],
+                data_name="hbc",
+                prior_args=bc_prior,
+                var_name="bc",
+                output_name="mu_bc",
+                output_dim="nmeasure",
+                compute_deterministic=True,
+            )
+        else:
+            bc_component = add_state_linear_component(
+                inv_inputs["H_bc"],
+                data_name="hbc",
+                prior_args=bc_prior,
+                var_name="bc",
+                output_name="mu_bc",
+                output_dim="nmeasure",
+                compute_deterministic=True,
+                state_activity=bc_state_activity,
+            )
         mu_bc = bc_component.output
 
     offset = None
@@ -240,6 +271,7 @@ def _assemble_compiled_rhime_model(
     offset_prior: dict,
     add_offset: bool,
     use_bc: bool,
+    bc_state_activity: StateActivity | None,
     pollution_events_from_obs: bool,
     no_model_error: bool,
     offset_args: dict | None,
@@ -256,6 +288,8 @@ def _assemble_compiled_rhime_model(
         offset_prior: Prepared optional offset prior.
         add_offset: Whether to add an offset component.
         use_bc: Whether to add a boundary-condition component.
+        bc_state_activity: Optional active/fixed policy for boundary-condition
+            scaling states.
         pollution_events_from_obs: Whether error scaling uses observations.
         no_model_error: Whether to suppress explicit model error.
         offset_args: Extra offset-component arguments.
@@ -276,6 +310,7 @@ def _assemble_compiled_rhime_model(
             offset_prior=offset_prior,
             add_offset=add_offset,
             use_bc=use_bc,
+            bc_state_activity=bc_state_activity,
             pollution_events_from_obs=pollution_events_from_obs,
             no_model_error=no_model_error,
             offset_args=offset_args,
@@ -299,6 +334,8 @@ def build_rhime_model(
     no_model_error: bool = False,
     offset_args: dict | None = None,
     power: dict | float = 1.99,
+    state_activity: StateActivity | None = None,
+    bc_state_activity: StateActivity | None = None,
 ) -> pm.Model:
     """Build the standard single-sector RHIME model.
 
@@ -317,9 +354,20 @@ def build_rhime_model(
         no_model_error: Whether to suppress the explicit model-error term.
         offset_args: Extra keyword arguments forwarded to the offset component.
         power: Exponent or prior specification used in likelihood error scaling.
+        state_activity: Optional labelled active/fixed state policy. By
+            default, only exactly-zero ``H`` columns are fixed to one; every
+            nonzero column remains active.
+        bc_state_activity: Optional active/fixed policy for ``H_bc`` scaling
+            states. Omit it to preserve the standard fully sampled BC graph
+            without automatic zero-column pruning.
 
     Returns:
         Built PyMC model.
+
+    Raises:
+        KeyError: If required sensitivity inputs are absent.
+        ValueError: If the state layout, activity policy, labels, fixed values,
+            or state-valued prior parameters are invalid.
     """
     x_prior, bc_prior, sigma_prior, offset_prior = _prepare_builder_priors(
         x_prior=x_prior,
@@ -330,7 +378,7 @@ def build_rhime_model(
 
     with pm.Model() as model:
         attach_coord_registry(model, CoordRegistry())
-        flux_component = add_linear_component(
+        flux_component = add_state_linear_component(
             inv_inputs["H"],
             data_name="hx",
             prior_args=x_prior,
@@ -338,6 +386,7 @@ def build_rhime_model(
             output_name="mu",
             output_dim="nmeasure",
             compute_deterministic=True,
+            state_activity=state_activity,
         )
         _add_rhime_observation_components(
             inv_inputs,
@@ -348,6 +397,7 @@ def build_rhime_model(
             offset_prior=offset_prior,
             add_offset=add_offset,
             use_bc=use_bc,
+            bc_state_activity=bc_state_activity,
             pollution_events_from_obs=pollution_events_from_obs,
             no_model_error=no_model_error,
             offset_args=offset_args,
@@ -371,6 +421,8 @@ def _build_compiled_rhime_model(
     no_model_error: bool = False,
     offset_args: dict | None = None,
     power: dict | float = 1.99,
+    state_activity: StateActivity | None = None,
+    bc_state_activity: StateActivity | None = None,
 ) -> pm.Model:
     """Build the standard RHIME model through the opt-in flux compiler.
 
@@ -390,6 +442,8 @@ def _build_compiled_rhime_model(
         no_model_error: Whether to suppress the explicit model-error term.
         offset_args: Extra keyword arguments forwarded to the offset component.
         power: Exponent or prior specification used in likelihood error scaling.
+        state_activity: Optional labelled active/fixed flux-state policy.
+        bc_state_activity: Optional labelled active/fixed BC-state policy.
 
     Returns:
         Built PyMC model.
@@ -400,7 +454,7 @@ def _build_compiled_rhime_model(
         sigma_prior=sigma_prior,
         offset_prior=offset_prior,
     )
-    flux_plan = _normalize_standard_flux_plan(inv_inputs, x_prior)
+    flux_plan = _normalize_standard_flux_plan(inv_inputs, x_prior, state_activity=state_activity)
     return _assemble_compiled_rhime_model(
         inv_inputs,
         flux_plan=flux_plan,
@@ -410,6 +464,7 @@ def _build_compiled_rhime_model(
         offset_prior=offset_prior,
         add_offset=add_offset,
         use_bc=use_bc,
+        bc_state_activity=bc_state_activity,
         pollution_events_from_obs=pollution_events_from_obs,
         no_model_error=no_model_error,
         offset_args=offset_args,
@@ -446,7 +501,9 @@ def build_rhime_model_from_spec(inv_inputs: xr.Dataset, model_spec: RhimeModelSp
         inv_inputs,
         sigma_alignment=sigma_alignment,
         x_prior=dict(sector.x_prior),
+        state_activity=sector.state_activity,
         bc_prior=model_spec.bc_prior,
+        bc_state_activity=model_spec.bc_state_activity,
         sigma_prior=model_spec.sigma_prior,
         offset_prior=model_spec.offset_prior,
         add_offset=model_spec.add_offset,
@@ -476,6 +533,9 @@ def build_rhime_multisector_model(
     no_model_error: bool = False,
     offset_args: dict | None = None,
     power: dict | float = 1.99,
+    state_activity: StateActivity | None = None,
+    sector_state_activities: Mapping[str, StateActivity] | None = None,
+    bc_state_activity: StateActivity | None = None,
 ) -> pm.Model:
     """Build the first shared-basis multi-sector RHIME model.
 
@@ -511,9 +571,22 @@ def build_rhime_multisector_model(
         no_model_error: Whether to suppress explicit model-error terms.
         offset_args: Extra keyword arguments forwarded to the offset component.
         power: Exponent or prior specification used in likelihood error scaling.
+        state_activity: Policy shared by sectors without an explicit override.
+            When omitted, exactly-zero sensitivity columns are fixed to one.
+        sector_state_activities: Optional activity-policy overrides keyed by
+            sector name. Overrides win over ``state_activity``; missing sectors
+            use the shared policy. Unknown keys are rejected. An all-false
+            policy freezes a complete sector.
+        bc_state_activity: Optional active/fixed policy for ``H_bc`` scaling
+            states. Omit it to preserve the standard fully sampled BC graph.
 
     Returns:
         Built PyMC model.
+
+    Raises:
+        KeyError: If required sensitivity inputs are absent.
+        ValueError: If sector/source/prior/activity mappings or state layouts,
+            labels, fixed values, or state-valued prior parameters are invalid.
     """
     sector_bindings = _resolve_sector_bindings(
         inv_inputs,
@@ -527,16 +600,17 @@ def build_rhime_multisector_model(
         sector_priors=sector_priors,
         x_prior=x_prior,
         default_x_prior=DEFAULT_X_PRIOR,
+        state_activity=state_activity,
+        sector_state_activities=sector_state_activities,
     )
     bc_prior = dict(DEFAULT_BC_PRIOR if bc_prior is None else bc_prior)
     sigma_prior = dict(DEFAULT_SIGMA_PRIOR if sigma_prior is None else sigma_prior)
     offset_prior = dict(DEFAULT_OFFSET_PRIOR if offset_prior is None else offset_prior)
-
     with pm.Model() as model:
         attach_coord_registry(model, CoordRegistry())
         sector_outputs = []
         for component in sector_components:
-            linear_component = add_linear_component(
+            linear_component = add_state_linear_component(
                 component.design,
                 data_name=f"hx_{component.variable_suffix}",
                 prior_args=dict(component.prior_args),
@@ -544,6 +618,7 @@ def build_rhime_multisector_model(
                 output_name=f"mu_{component.variable_suffix}",
                 output_dim="nmeasure",
                 compute_deterministic=True,
+                state_activity=component.state_activity,
             )
             sector_outputs.append(linear_component.output)
 
@@ -561,6 +636,7 @@ def build_rhime_multisector_model(
             offset_prior=offset_prior,
             add_offset=add_offset,
             use_bc=use_bc,
+            bc_state_activity=bc_state_activity,
             pollution_events_from_obs=pollution_events_from_obs,
             no_model_error=no_model_error,
             offset_args=offset_args,
@@ -588,6 +664,9 @@ def _build_compiled_rhime_multisector_model(
     no_model_error: bool = False,
     offset_args: dict | None = None,
     power: dict | float = 1.99,
+    state_activity: StateActivity | None = None,
+    sector_state_activities: Mapping[str, StateActivity] | None = None,
+    bc_state_activity: StateActivity | None = None,
 ) -> pm.Model:
     """Build multisector RHIME through the opt-in flux compiler.
 
@@ -608,6 +687,9 @@ def _build_compiled_rhime_multisector_model(
         no_model_error: Whether to suppress explicit model-error terms.
         offset_args: Extra keyword arguments forwarded to the offset component.
         power: Exponent or prior specification used in likelihood error scaling.
+        state_activity: Optional activity policy shared by all flux sectors.
+        sector_state_activities: Optional activity overrides keyed by sector.
+        bc_state_activity: Optional active/fixed policy for BC scaling states.
 
     Returns:
         Built PyMC model.
@@ -624,6 +706,8 @@ def _build_compiled_rhime_multisector_model(
         sector_priors=sector_priors,
         x_prior=x_prior,
         default_x_prior=DEFAULT_X_PRIOR,
+        state_activity=state_activity,
+        sector_state_activities=sector_state_activities,
     )
     bc_prior = dict(DEFAULT_BC_PRIOR if bc_prior is None else bc_prior)
     sigma_prior = dict(DEFAULT_SIGMA_PRIOR if sigma_prior is None else sigma_prior)
@@ -637,6 +721,7 @@ def _build_compiled_rhime_multisector_model(
         offset_prior=offset_prior,
         add_offset=add_offset,
         use_bc=use_bc,
+        bc_state_activity=bc_state_activity,
         pollution_events_from_obs=pollution_events_from_obs,
         no_model_error=no_model_error,
         offset_args=offset_args,
@@ -676,7 +761,13 @@ def build_rhime_multisector_model_from_spec(
         sector_sources={sector.name: sector.flux_source for sector in model_spec.sectors},
         sector_variable_suffixes={sector.name: sector.variable_suffix for sector in model_spec.sectors},
         sector_priors={sector.name: dict(sector.x_prior) for sector in model_spec.sectors},
+        sector_state_activities={
+            sector.name: sector.state_activity
+            for sector in model_spec.sectors
+            if sector.state_activity is not None
+        },
         bc_prior=model_spec.bc_prior,
+        bc_state_activity=model_spec.bc_state_activity,
         sigma_prior=model_spec.sigma_prior,
         offset_prior=model_spec.offset_prior,
         add_offset=model_spec.add_offset,

--- a/openghg_inversions/models/state_activity.py
+++ b/openghg_inversions/models/state_activity.py
@@ -1,0 +1,518 @@
+"""Label-aware active/fixed state-vector policies for linear inversion models.
+
+This module separates state selection from PyMC graph construction. A
+``StateActivity`` policy can combine exact-zero sensitivity pruning with an
+explicit labelled activity mask and fixed ``basis_group`` labels. Detection
+follows the state coordinate order on the supplied sensitivity matrix, and
+resolution follows the resulting labelled mask; integer label ranges are never
+inferred.
+
+Inactive states remain part of the public state vector and use labelled or
+scalar fixed values. The default fixed value is one, which preserves the prior
+forward-model contribution of a multiplicative flux-scaling state.
+
+``detect_zero_sensitivity`` validates a linear design and reduces it to a
+labelled state mask. ``resolve_state_activity`` combines that mask with a
+policy to produce the canonical ``ResolvedStateActivity``;
+``active_prior_args`` then aligns and subsets state-valued prior parameters.
+Finite checks, exact-zero reductions, and state-vector alignment are explicit
+eager-compute boundaries for lazy or Dask-backed inputs during model building.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, cast
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+
+#: Strictly boolean scalar, positional mask, or labelled mask.
+ActivityValue = bool | np.ndarray | xr.DataArray
+#: Numeric scalar, positional vector, or labelled vector for inactive states.
+FixedValue = float | int | np.ndarray | xr.DataArray
+
+
+@dataclass(frozen=True)
+class StateActivity:
+    """Describe which states are sampled and how inactive states are fixed.
+
+    Args:
+        active: Boolean scalar, positional one-dimensional mask in canonical
+            state order, or labelled one-dimensional mask. A labelled mask is
+            aligned to the canonical state coordinate carried by the
+            zero-sensitivity mask, so its input order need not match the
+            canonical order. Set this to ``False`` to freeze a whole component
+            or sector.
+        fixed_value: Scalar or one-dimensional state-aligned values used for
+            inactive states. Multiplicative scaling states default to one.
+        fixed_groups: ``basis_group`` labels to freeze. Group selection is by
+            coordinate value, never by state-number ranges.
+        group_coord: Name of the state coordinate containing group labels.
+        prune_zero: Whether states marked exactly zero by prior design
+            inspection are made inactive. No tolerance is applied; every
+            nonzero finite column remains active by default.
+
+    Explicit ``active`` masks, fixed groups, and exact-zero pruning are
+    combined with logical AND. This permits one policy to represent zero-H
+    pruning, frozen states, frozen groups, or an entirely frozen sector.
+    """
+
+    active: ActivityValue = True
+    fixed_value: FixedValue = 1.0
+    fixed_groups: tuple[str, ...] = ()
+    group_coord: str = "basis_group"
+    prune_zero: bool = True
+
+
+@dataclass(frozen=True)
+class ResolvedStateActivity:
+    """A state-activity policy aligned to one detected linear design.
+
+    Attributes:
+        state_dim: Canonical state dimension name from the detection mask.
+        active: Boolean mask in canonical state order.
+        fixed_value: Fixed values in canonical state order.
+        zero_sensitivity: Labelled mask identifying exactly-zero design
+            columns and carrying the state coordinates used for graph
+            construction.
+    """
+
+    state_dim: str
+    active: xr.DataArray
+    fixed_value: xr.DataArray
+    zero_sensitivity: xr.DataArray
+
+    @property
+    def n_state(self) -> int:
+        """Return the full state-vector length."""
+        return int(self.active.sizes[self.state_dim])
+
+    @property
+    def n_active(self) -> int:
+        """Return the number of sampled states."""
+        return int(self.active.sum().compute().item())
+
+    @property
+    def active_indices(self) -> np.ndarray:
+        """Return positional indices of active states in canonical order."""
+        return np.flatnonzero(_materialize_1d(self.active, name="active", dtype=bool))
+
+    @property
+    def fixed_indices(self) -> np.ndarray:
+        """Return positional indices of inactive states in canonical order."""
+        return np.flatnonzero(~_materialize_1d(self.active, name="active", dtype=bool))
+
+
+def _state_dim(sensitivity: xr.DataArray, output_dim: str) -> str:
+    """Return the sole non-output dimension of a linear sensitivity matrix.
+
+    Args:
+        sensitivity: Candidate linear sensitivity matrix.
+        output_dim: Name of its observation/output dimension.
+
+    Returns:
+        The single state-dimension name.
+
+    Raises:
+        ValueError: If the matrix does not have exactly one non-output dimension.
+    """
+    state_dims = [str(dim) for dim in sensitivity.dims if dim != output_dim]
+    if len(state_dims) != 1:
+        raise ValueError(
+            "State activity requires a linear sensitivity matrix with exactly "
+            f"one non-output dimension; found {state_dims!r}."
+        )
+    return state_dims[0]
+
+
+def detect_zero_sensitivity(
+    sensitivity: xr.DataArray,
+    *,
+    output_dim: str = "nmeasure",
+) -> xr.DataArray:
+    """Return the labelled mask of exactly-zero sensitivity columns.
+
+    Args:
+        sensitivity: Finite two-dimensional linear design containing
+            ``output_dim`` and one uniquely labelled state dimension.
+        output_dim: Name of the observation/output dimension.
+
+    Returns:
+        A materialized boolean mask over the state dimension. State labels and
+        auxiliary state coordinates are retained from ``sensitivity``.
+
+    Raises:
+        ValueError: If ``sensitivity`` is not a finite two-dimensional design
+            with the required output dimension and unique state labels.
+
+    Notes:
+        Finite validation and exact-zero reduction materialize lazy design data
+        during model construction.
+    """
+    output_dim = str(output_dim)
+    if sensitivity.ndim != 2 or output_dim not in sensitivity.dims:
+        raise ValueError(
+            "State activity requires a two-dimensional linear sensitivity matrix "
+            f"containing output dimension {output_dim!r}; found dimensions {sensitivity.dims!r}."
+        )
+
+    state_dim = _state_dim(sensitivity, output_dim)
+    matrix = sensitivity.transpose(output_dim, state_dim)
+    _require_unique_state_coord(matrix, state_dim)
+
+    try:
+        finite_mask = cast(xr.DataArray, np.isfinite(matrix))
+    except TypeError as exc:
+        raise ValueError("Sensitivity must contain numeric values.") from exc
+    if not bool(finite_mask.all().compute().item()):
+        raise ValueError("Sensitivity must contain only finite values.")
+
+    return (matrix == 0).all(dim=output_dim).compute().rename("zero_sensitivity")
+
+
+def _materialize_1d(
+    value: xr.DataArray,
+    *,
+    name: str,
+    dtype: Any = None,
+) -> np.ndarray:
+    """Compute a one-dimensional array and return its NumPy representation.
+
+    Args:
+        value: Scalar or one-dimensional xarray value to materialize.
+        name: User-facing value name included in validation errors.
+        dtype: Optional NumPy dtype for the result.
+
+    Returns:
+        A materialized one-dimensional NumPy array. Scalar input is represented
+        by a length-one array.
+
+    Raises:
+        ValueError: If ``value`` has more than one dimension.
+    """
+    if value.ndim > 1:
+        raise ValueError(f"{name} must be scalar or one-dimensional; found shape {value.shape!r}.")
+    return np.asarray(value.compute().to_numpy(), dtype=dtype).reshape(-1)
+
+
+def _require_unique_state_coord(sensitivity: xr.DataArray, state_dim: str) -> pd.Index:
+    """Return a present, one-dimensional, unique canonical state index.
+
+    Args:
+        sensitivity: Labelled array containing the state coordinate.
+        state_dim: Canonical state-dimension name.
+
+    Returns:
+        The validated state index.
+
+    Raises:
+        ValueError: If the coordinate is absent, not state-only, or not unique.
+    """
+    if state_dim not in sensitivity.coords:
+        raise ValueError(f"Sensitivity must have labelled {state_dim!r} coordinates.")
+    state_coord = sensitivity.coords[state_dim]
+    if state_coord.dims != (state_dim,):
+        raise ValueError(f"State coordinate {state_dim!r} must be indexed only by {state_dim!r}.")
+    state_index = state_coord.to_index()
+    if not state_index.is_unique:
+        raise ValueError(f"Sensitivity {state_dim!r} coordinates must be unique.")
+    return state_index
+
+
+def _require_same_state_labels(
+    value: xr.DataArray,
+    *,
+    canonical_index: pd.Index,
+    state_dim: str,
+    name: str,
+) -> None:
+    """Validate that a labelled value defines exactly the canonical states.
+
+    Args:
+        value: Labelled state value to validate.
+        canonical_index: Required state labels.
+        state_dim: Canonical state-dimension name.
+        name: User-facing value name for validation errors.
+
+    Raises:
+        ValueError: If supplied labels are duplicate, missing, or additional.
+    """
+    value_index = value.coords[state_dim].to_index()
+    if not value_index.is_unique:
+        raise ValueError(f"{name} {state_dim!r} coordinates must be unique.")
+    same_labels = (
+        len(value_index) == len(canonical_index)
+        and bool(canonical_index.isin(value_index).all())
+        and bool(value_index.isin(canonical_index).all())
+    )
+    if not same_labels:
+        raise ValueError(f"{name} labels must match the canonical {state_dim!r} coordinate exactly.")
+
+
+def _require_finite(values: np.ndarray, *, name: str) -> None:
+    """Reject non-numeric, NaN, or infinite array values.
+
+    Args:
+        values: Numeric array to validate.
+        name: User-facing value name for validation errors.
+
+    Raises:
+        ValueError: If values are non-numeric or non-finite.
+    """
+    try:
+        finite = np.isfinite(values)
+    except TypeError as exc:
+        raise ValueError(f"{name} must contain numeric values.") from exc
+    if not bool(finite.all()):
+        raise ValueError(f"{name} must contain only finite values.")
+
+
+def _require_boolean(values: xr.DataArray, *, name: str) -> None:
+    """Require a strictly boolean aligned state value.
+
+    Args:
+        values: Aligned value to validate without coercion.
+        name: User-facing value name for validation errors.
+
+    Raises:
+        ValueError: If the value dtype is not boolean.
+    """
+    if np.asarray(values.to_numpy()).dtype != np.dtype(bool):
+        raise ValueError(f"{name} must contain only boolean values.")
+
+
+def _align_state_value(
+    value: ActivityValue | FixedValue,
+    *,
+    sensitivity: xr.DataArray,
+    state_dim: str,
+    name: str,
+    dtype: Any,
+) -> xr.DataArray:
+    """Broadcast or label-align and materialize a canonical state value.
+
+    Args:
+        value: Scalar, positional vector, or labelled state vector.
+        sensitivity: Labelled array providing canonical state labels and
+            length.
+        state_dim: Canonical state-dimension name.
+        name: User-facing value name for validation errors.
+        dtype: Optional NumPy dtype used after alignment.
+
+    Returns:
+        Materialized one-dimensional data in canonical state order.
+
+    Raises:
+        ValueError: If shape, dimensions, or labels do not match the state.
+    """
+    state_coord = sensitivity.coords[state_dim]
+    canonical_index = _require_unique_state_coord(sensitivity, state_dim)
+    state_size = sensitivity.sizes[state_dim]
+
+    if isinstance(value, xr.DataArray):
+        if value.ndim == 0:
+            scalar = value.compute().item()
+            values = np.full(state_size, scalar, dtype=dtype)
+        else:
+            if value.dims != (state_dim,):
+                raise ValueError(
+                    f"{name} must be scalar or have only the {state_dim!r} dimension; "
+                    f"found dimensions {value.dims!r}."
+                )
+            if state_dim not in value.coords:
+                raise ValueError(f"{name} must have labelled {state_dim!r} coordinates.")
+            _require_same_state_labels(
+                value,
+                canonical_index=canonical_index,
+                state_dim=state_dim,
+                name=name,
+            )
+            aligned = value.sel({state_dim: state_coord})
+            values = _materialize_1d(aligned, name=name, dtype=dtype)
+    else:
+        array = np.asarray(value)
+        if array.ndim == 0:
+            values = np.full(state_size, array.item(), dtype=dtype)
+        elif array.ndim == 1 and array.size == state_size:
+            values = np.asarray(array, dtype=dtype)
+        else:
+            raise ValueError(
+                f"{name} must be scalar or a one-dimensional array of length {state_size}; "
+                f"found shape {array.shape!r}."
+            )
+
+    return xr.DataArray(
+        values,
+        dims=(state_dim,),
+        coords={state_dim: state_coord},
+        name=name,
+    )
+
+
+def resolve_state_activity(
+    zero_sensitivity: xr.DataArray,
+    policy: StateActivity | None = None,
+) -> ResolvedStateActivity:
+    """Resolve an active/fixed policy against a labelled zero-state mask.
+
+    Args:
+        zero_sensitivity: One-dimensional, strictly boolean mask identifying
+            exactly-zero design columns. It must have a unique labelled state
+            coordinate and may carry auxiliary state coordinates used by the
+            policy.
+        policy: Optional activity policy. When omitted, exact-zero columns are
+            pruned and all other states are active with inactive value one.
+
+    Returns:
+        A policy aligned to the mask's canonical state coordinate.
+
+    Raises:
+        ValueError: If the zero mask is not one-dimensional, boolean, and
+            uniquely labelled; supplied arrays cannot be aligned; or requested
+            group metadata is absent or not state-aligned.
+
+    Notes:
+        Policy vectors are materialized during model construction. Use
+        ``detect_zero_sensitivity`` to validate and reduce a linear design
+        before calling this function.
+    """
+    policy = policy or StateActivity()
+    if zero_sensitivity.ndim != 1:
+        raise ValueError(
+            f"zero_sensitivity must be one-dimensional; found dimensions {zero_sensitivity.dims!r}."
+        )
+    state_dim = str(zero_sensitivity.dims[0])
+    _require_unique_state_coord(zero_sensitivity, state_dim)
+    _require_boolean(zero_sensitivity, name="zero_sensitivity")
+    zero_sensitivity = zero_sensitivity.compute().rename("zero_sensitivity")
+
+    explicit_active = _align_state_value(
+        policy.active,
+        sensitivity=zero_sensitivity,
+        state_dim=state_dim,
+        name="active",
+        dtype=None,
+    )
+    _require_boolean(explicit_active, name="active")
+    fixed_value = _align_state_value(
+        policy.fixed_value,
+        sensitivity=zero_sensitivity,
+        state_dim=state_dim,
+        name="fixed_value",
+        dtype=float,
+    )
+    _require_finite(_materialize_1d(fixed_value, name="fixed_value"), name="fixed_value")
+
+    active = explicit_active
+    if policy.prune_zero:
+        active = active & ~zero_sensitivity
+
+    if policy.fixed_groups:
+        if policy.group_coord not in zero_sensitivity.coords:
+            raise ValueError(f"Cannot freeze groups: sensitivity has no {policy.group_coord!r} coordinate.")
+        groups = zero_sensitivity.coords[policy.group_coord]
+        if groups.dims != (state_dim,):
+            raise ValueError(
+                f"Group coordinate {policy.group_coord!r} must be indexed only by {state_dim!r}."
+            )
+        group_values = _materialize_1d(groups, name=policy.group_coord)
+        available_groups = {str(value) for value in group_values.tolist()}
+        missing_groups = sorted(set(policy.fixed_groups) - available_groups)
+        if missing_groups:
+            raise ValueError(
+                f"Fixed group label(s) {missing_groups!r} are absent from {policy.group_coord!r}."
+            )
+        group_is_fixed = xr.DataArray(
+            np.isin(group_values.astype(str), policy.fixed_groups),
+            dims=(state_dim,),
+            coords={state_dim: zero_sensitivity.coords[state_dim]},
+        )
+        active = active & ~group_is_fixed
+
+    return ResolvedStateActivity(
+        state_dim=state_dim,
+        active=active.rename("active"),
+        fixed_value=fixed_value,
+        zero_sensitivity=zero_sensitivity,
+    )
+
+
+def active_prior_args(
+    prior_args: dict[str, Any],
+    activity: ResolvedStateActivity,
+) -> dict[str, Any]:
+    """Return prior arguments sliced to active states in canonical order.
+
+    Scalar parameters are retained. One-dimensional NumPy state parameters are
+    interpreted in canonical order and must describe the full state vector.
+    Labelled xarray parameters are first aligned by the canonical state
+    coordinate and then subset, allowing input label order to differ safely.
+    Array-backed parameters are materialized at this model-building boundary.
+    The support arrays of an ``Interpolated`` prior are preserved rather than
+    interpreted as state-valued parameters.
+
+    Args:
+        prior_args: PyMC prior specification.
+        activity: Resolved activity contract in canonical state order.
+
+    Returns:
+        A copy of ``prior_args`` containing scalar or active-state parameters.
+
+    Raises:
+        ValueError: If an array-valued distribution parameter is not scalar or
+            full-state one-dimensional data.
+    """
+    result: dict[str, Any] = {}
+    active_indices = activity.active_indices
+    canonical_coord = activity.active.coords[activity.state_dim]
+    pdf = str(prior_args.get("pdf", "")).lower()
+
+    for name, value in prior_args.items():
+        if name in {"pdf", "reparameterise"}:
+            result[name] = value
+            continue
+        if pdf == "interpolated" and name in {"x_points", "pdf_points"}:
+            support = value.compute().to_numpy() if isinstance(value, xr.DataArray) else np.asarray(value)
+            _require_finite(support, name=f"Prior parameter {name!r}")
+            result[name] = support
+            continue
+        if isinstance(value, xr.DataArray):
+            if value.ndim == 0:
+                scalar = value.compute().item()
+                scalar_array = np.asarray(scalar)
+                if np.issubdtype(scalar_array.dtype, np.number):
+                    _require_finite(scalar_array, name=f"Prior parameter {name!r}")
+                result[name] = scalar
+                continue
+            aligned = _align_state_value(
+                value,
+                sensitivity=xr.DataArray(
+                    np.empty(activity.n_state),
+                    dims=(activity.state_dim,),
+                    coords={activity.state_dim: canonical_coord},
+                ).expand_dims(nmeasure=[0]),
+                state_dim=activity.state_dim,
+                name=f"prior parameter {name!r}",
+                dtype=None,
+            )
+            aligned_values = _materialize_1d(aligned, name=f"Prior parameter {name!r}")
+            _require_finite(aligned_values, name=f"Prior parameter {name!r}")
+            result[name] = aligned_values[active_indices]
+            continue
+
+        array = np.asarray(value)
+        if array.ndim == 0:
+            result[name] = value
+        elif array.ndim == 1 and array.size == activity.n_state:
+            _require_finite(array, name=f"Prior parameter {name!r}")
+            result[name] = array[active_indices]
+        else:
+            raise ValueError(
+                f"Prior parameter {name!r} must be scalar or a one-dimensional full-state "
+                f"array of length {activity.n_state}; found shape {array.shape!r}."
+            )
+
+    return result

--- a/openghg_inversions/rhime/outputs.py
+++ b/openghg_inversions/rhime/outputs.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any, cast
 
 import arviz as az
+import numpy as np
 import xarray as xr
 
 from openghg_inversions._timing import timed
@@ -26,6 +27,40 @@ class RhimeOutputBundle:
     inv_out: InversionOutput | None = None
     outputs: dict[str, Any] = field(default_factory=dict)
     output_metadata: dict[str, Any] = field(default_factory=dict)
+
+
+def _structured_metadata(value: Any) -> Any:
+    """Convert array-backed spec values to lossless JSON-compatible metadata.
+
+    Args:
+        value: Nested metadata value, possibly backed by NumPy or xarray.
+
+    Returns:
+        Scalars and recursively structured dictionaries/lists. DataArrays keep
+        explicit dimensions, dimension coordinates, and values.
+    """
+    if isinstance(value, xr.DataArray):
+        materialized = value.compute()
+        return {
+            "dims": [str(dim) for dim in materialized.dims],
+            "coords": {
+                str(dim): _structured_metadata(materialized.coords[dim].to_numpy())
+                for dim in materialized.dims
+                if dim in materialized.coords
+            },
+            "values": _structured_metadata(materialized.to_numpy()),
+        }
+    if isinstance(value, np.ndarray):
+        if value.ndim == 0:
+            return _structured_metadata(value.item())
+        return [_structured_metadata(item) for item in value.tolist()]
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, dict):
+        return {str(key): _structured_metadata(item) for key, item in value.items()}
+    if isinstance(value, tuple | list):
+        return [_structured_metadata(item) for item in value]
+    return value
 
 
 def _resolve_output_path(
@@ -144,7 +179,7 @@ def _make_inversion_output(
             "basis_artifact_source": prepared.basis_artifact_source,
             "basis_artifact_path": prepared.basis_artifact_path,
         },
-        model_metadata=asdict(model_spec),
+        model_metadata=cast(dict[str, Any], _structured_metadata(asdict(model_spec))),
         output_metadata={
             "output_format": output_spec.output_format,
             "output_path": output_spec.output_path,

--- a/tests/models/test_priors.py
+++ b/tests/models/test_priors.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pymc as pm
 import pytest
+import xarray as xr
+from pymc.distributions import continuous
 
 from openghg_inversions.models.priors import lognormal_mu_sigma, parse_prior
 
@@ -12,6 +14,15 @@ def test_lognormal_mu_sigma_matches_requested_moments() -> None:
     expected_stdev = np.sqrt((np.exp(sigma**2) - 1) * np.exp(2 * mu + sigma**2))
     assert np.isclose(expected_mean, 2.0)
     assert np.isclose(expected_stdev, 0.5)
+
+
+def test_lognormal_mu_sigma_supports_array_parameters() -> None:
+    """Check lognormal moment conversion works elementwise for state arrays."""
+    mean = np.array([1.0, 2.0])
+    stdev = np.array([0.2, 0.5])
+    mu, sigma = lognormal_mu_sigma(mean, stdev)
+
+    np.testing.assert_allclose(np.exp(mu + 0.5 * sigma**2), mean)
 
 
 def test_parse_prior_reparameterised_lognormal_uses_latent_name() -> None:
@@ -33,3 +44,20 @@ def test_parse_prior_rejects_unknown_distribution() -> None:
     with pm.Model():
         with pytest.raises(ValueError, match="continuous distribution"):
             parse_prior("bad", {"pdf": "definitely_not_real"})
+
+
+def test_parse_prior_does_not_globally_strip_xarray_labels(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Leave labelled parameters intact for state-aware callers to process explicitly."""
+    labelled_mu = xr.DataArray([1.0, 2.0], dims="region", coords={"region": ["a", "b"]})
+    captured: dict[str, object] = {}
+
+    def fake_normal(name: str, **kwargs: object) -> object:
+        """Capture arguments that parse_prior forwards to the distribution."""
+        captured["name"] = name
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(continuous, "Normal", fake_normal)
+    parse_prior("x", {"pdf": "normal", "mu": labelled_mu, "sigma": 0.2})
+
+    assert captured["mu"] is labelled_mu

--- a/tests/models/test_state_activity.py
+++ b/tests/models/test_state_activity.py
@@ -1,0 +1,485 @@
+"""Tests for labelled active/fixed state-vector model construction."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import dask.array as da
+import numpy as np
+import pymc as pm
+import pytest
+import xarray as xr
+
+from openghg_inversions.models import (
+    CoordRegistry,
+    StateActivity,
+    active_prior_args,
+    add_state_linear_component,
+    attach_coord_registry,
+    build_rhime_model,
+    build_rhime_multisector_model,
+    detect_zero_sensitivity,
+    resolve_state_activity,
+)
+from openghg_inversions.models.components import add_linear_component, resolve_model_variable
+from openghg_inversions.models.components import add_state_vector
+from openghg_inversions.sigma import SigmaAlignment
+
+
+def _sensitivity() -> xr.DataArray:
+    """Return labelled sensitivity with exact-zero and near-zero columns."""
+    return xr.DataArray(
+        [
+            [1.0, 0.0, 2.0, 1.0e-12],
+            [3.0, 0.0, 4.0, -1.0e-12],
+        ],
+        dims=("nmeasure", "region"),
+        coords={
+            "nmeasure": [0, 1],
+            "region": ["inner-a", "zero", "outer-a", "inner-b"],
+            "basis_group": ("region", ["inner", "inner", "outer", "inner"]),
+        },
+        name="H",
+    )
+
+
+def _model_inputs(h: xr.DataArray) -> xr.Dataset:
+    """Return the minimal complete dataset needed by RHIME model builders."""
+    nmeasure = h.sizes["nmeasure"]
+    return xr.Dataset(
+        {
+            "H": h,
+            "mf": ("nmeasure", np.full(nmeasure, 2.0)),
+            "mf_error": ("nmeasure", np.full(nmeasure, 0.1)),
+            "min_error": ("nmeasure", np.zeros(nmeasure)),
+            "site_indicator": ("nmeasure", np.zeros(nmeasure, dtype=int)),
+            "sigma_freq_index": ("nmeasure", np.zeros(nmeasure, dtype=int)),
+        }
+    )
+
+
+def _sigma_alignment(inputs: xr.Dataset) -> SigmaAlignment:
+    """Return prepared sigma alignment for the minimal builder inputs."""
+    return SigmaAlignment.from_indices(inputs["site_indicator"], inputs["sigma_freq_index"])
+
+
+def test_detect_zero_sensitivity_validates_and_retains_state_metadata() -> None:
+    """Reduce the design to a labelled mask without dropping group metadata."""
+    zero_sensitivity = detect_zero_sensitivity(_sensitivity())
+
+    np.testing.assert_array_equal(zero_sensitivity, [False, True, False, False])
+    assert zero_sensitivity.dims == ("region",)
+    np.testing.assert_array_equal(zero_sensitivity["basis_group"], ["inner", "inner", "outer", "inner"])
+
+
+def test_detect_zero_sensitivity_requires_a_two_dimensional_output_design() -> None:
+    """Reject extra axes and designs lacking the declared output dimension."""
+    with pytest.raises(ValueError, match="two-dimensional"):
+        detect_zero_sensitivity(_sensitivity().expand_dims(extra=[0]))
+    with pytest.raises(ValueError, match="output dimension 'nmeasure'"):
+        detect_zero_sensitivity(_sensitivity().rename(nmeasure="observation"))
+
+
+def test_detect_zero_sensitivity_accepts_a_named_output_dimension() -> None:
+    """Detect zero columns when the caller declares a non-default output axis."""
+    design = _sensitivity().rename(nmeasure="observation")
+
+    zero_sensitivity = detect_zero_sensitivity(design, output_dim="observation")
+
+    np.testing.assert_array_equal(zero_sensitivity, [False, True, False, False])
+    assert zero_sensitivity.dims == ("region",)
+
+
+def test_resolve_state_activity_combines_labels_groups_and_exact_zero() -> None:
+    """Resolve masks by labels while retaining nonzero values of any magnitude."""
+    h = _sensitivity()
+    explicit = xr.DataArray(
+        [True, False, True, True],
+        dims="region",
+        coords={"region": ["inner-b", "outer-a", "zero", "inner-a"]},
+    )
+
+    resolved = resolve_state_activity(
+        detect_zero_sensitivity(h),
+        StateActivity(active=explicit, fixed_groups=("outer",)),
+    )
+
+    np.testing.assert_array_equal(resolved.zero_sensitivity, [False, True, False, False])
+    np.testing.assert_array_equal(resolved.active, [True, False, False, True])
+    assert resolved.n_active == 2
+    np.testing.assert_array_equal(resolved.active_indices, [0, 3])
+
+
+def test_active_prior_args_aligns_labelled_and_array_parameters() -> None:
+    """Subset labelled and positional full-state prior arrays to active order."""
+    h = _sensitivity()
+    resolved = resolve_state_activity(
+        detect_zero_sensitivity(h),
+        StateActivity(fixed_groups=("outer",)),
+    )
+    labelled_mu = xr.DataArray(
+        [40.0, 30.0, 20.0, 10.0],
+        dims="region",
+        coords={"region": ["inner-b", "outer-a", "zero", "inner-a"]},
+    )
+
+    prior = active_prior_args(
+        {
+            "pdf": "normal",
+            "mu": labelled_mu,
+            "sigma": np.array([1.0, 2.0, 3.0, 4.0]),
+        },
+        resolved,
+    )
+
+    np.testing.assert_array_equal(prior["mu"], [10.0, 40.0])
+    np.testing.assert_array_equal(prior["sigma"], [1.0, 4.0])
+
+
+def test_state_activity_materializes_dask_backed_reductions_and_vectors() -> None:
+    """Materialize lazy detection, policy resolution, and prior slicing."""
+    h = _sensitivity().chunk({"nmeasure": 1, "region": 2})
+    active = xr.DataArray(
+        da.from_array([True, True, False, True], chunks="auto"),
+        dims="region",
+        coords={"region": h.region},
+    )
+    fixed = xr.DataArray(
+        da.from_array([1.0, 2.0, 3.0, 4.0], chunks="auto"),
+        dims="region",
+        coords={"region": h.region},
+    )
+    resolved = resolve_state_activity(
+        detect_zero_sensitivity(h),
+        StateActivity(active=active, fixed_value=fixed),
+    )
+    lazy_mu = xr.DataArray(
+        da.from_array([10.0, 20.0, 30.0, 40.0], chunks="auto"),
+        dims="region",
+        coords={"region": h.region},
+    )
+
+    prior = active_prior_args(
+        {"pdf": "normal", "mu": lazy_mu, "sigma": xr.DataArray(0.5)},
+        resolved,
+    )
+
+    assert resolved.n_active == 2
+    np.testing.assert_array_equal(resolved.active_indices, [0, 3])
+    np.testing.assert_array_equal(prior["mu"], [10.0, 40.0])
+    assert prior["sigma"] == 0.5
+
+
+@pytest.mark.parametrize("labels", [["inner-a", "zero", "outer-a", "outer-a"], None])
+def test_detect_zero_sensitivity_rejects_invalid_canonical_labels(labels: list[str] | None) -> None:
+    """Require a present and unique canonical state coordinate during detection."""
+    h = _sensitivity()
+    if labels is None:
+        h = h.drop_indexes("region").drop_vars("region")
+    else:
+        h = h.assign_coords(region=labels)
+
+    with pytest.raises(ValueError, match="labelled|unique"):
+        detect_zero_sensitivity(h)
+
+
+@pytest.mark.parametrize(
+    "labels",
+    [
+        ["inner-a", "zero", "outer-a", "outer-a"],
+        ["inner-a", "zero", "outer-a", "unexpected"],
+    ],
+)
+def test_resolve_state_activity_rejects_duplicate_or_misaligned_policy_labels(
+    labels: list[str],
+) -> None:
+    """Reject duplicate, missing, or extra labels on state-aligned policy values."""
+    active = xr.DataArray([True] * 4, dims="region", coords={"region": labels})
+
+    with pytest.raises(ValueError, match="unique|match the canonical"):
+        resolve_state_activity(
+            detect_zero_sensitivity(_sensitivity()),
+            StateActivity(active=active),
+        )
+
+
+@pytest.mark.parametrize(
+    "active",
+    [1, 0.0, np.nan, "False", np.array([1, 0, 1, 0])],
+)
+def test_resolve_state_activity_rejects_non_boolean_active_values(
+    active: object,
+) -> None:
+    """Do not silently coerce numbers, missing values, or strings to activity."""
+    with pytest.raises(ValueError, match="active.*boolean"):
+        resolve_state_activity(
+            detect_zero_sensitivity(_sensitivity()),
+            StateActivity(active=cast(Any, active)),
+        )
+
+
+def test_resolve_state_activity_requires_a_boolean_zero_mask() -> None:
+    """Reject numeric inputs at the resolved-policy boundary."""
+    zero_sensitivity = detect_zero_sensitivity(_sensitivity()).astype(int)
+
+    with pytest.raises(ValueError, match="zero_sensitivity.*boolean"):
+        resolve_state_activity(zero_sensitivity)
+
+
+@pytest.mark.parametrize("bad_value", [np.nan, np.inf, -np.inf])
+def test_resolve_state_activity_rejects_nonfinite_sensitivity_and_fixed_values(
+    bad_value: float,
+) -> None:
+    """Reject every non-finite sensitivity or fixed-state value."""
+    h = _sensitivity().copy()
+    h[0, 0] = bad_value
+    with pytest.raises(ValueError, match="Sensitivity.*finite"):
+        detect_zero_sensitivity(h)
+
+    fixed = np.ones(h.sizes["region"])
+    fixed[1] = bad_value
+    with pytest.raises(ValueError, match="fixed_value.*finite"):
+        resolve_state_activity(
+            detect_zero_sensitivity(_sensitivity()),
+            StateActivity(fixed_value=fixed),
+        )
+
+
+@pytest.mark.parametrize("prior_kind", ["numpy", "xarray"])
+def test_active_prior_args_rejects_nonfinite_full_state_arrays(prior_kind: str) -> None:
+    """Reject non-finite positional and labelled full-state prior parameters."""
+    values = np.array([1.0, np.nan, 3.0, 4.0])
+    value: np.ndarray | xr.DataArray
+    if prior_kind == "xarray":
+        value = xr.DataArray(values, dims="region", coords={"region": _sensitivity().region})
+    else:
+        value = values
+    resolved = resolve_state_activity(detect_zero_sensitivity(_sensitivity()))
+
+    with pytest.raises(ValueError, match="Prior parameter 'mu'.*finite"):
+        active_prior_args({"pdf": "normal", "mu": value}, resolved)
+
+
+def test_state_linear_component_preserves_full_forward_identity() -> None:
+    """Full H/state multiplication equals active plus fixed contributions."""
+    h = _sensitivity()
+    fixed_value = xr.DataArray(
+        [4.0, 3.0, 2.0, 1.0],
+        dims="region",
+        coords={"region": ["inner-b", "outer-a", "zero", "inner-a"]},
+    )
+
+    registry = CoordRegistry()
+    with pm.Model() as model:
+        attach_coord_registry(model, registry)
+        result = add_state_linear_component(
+            h,
+            data_name="hx",
+            prior_args={"pdf": "normal", "mu": 2.0, "sigma": 0.1},
+            var_name="x",
+            output_name="mu",
+            state_activity=StateActivity(
+                fixed_value=fixed_value,
+                fixed_groups=("outer",),
+            ),
+        )
+
+    x_full, mu, x_active = pm.draw(
+        [result.state, result.output, model.named_vars["x_active"]],
+        random_seed=42,
+    )
+    active = result.activity.active_indices
+    fixed = result.activity.fixed_indices
+    expected_split = (
+        h.values[:, active] @ x_active + h.values[:, fixed] @ fixed_value.sel(region=h.region).values[fixed]
+    )
+
+    np.testing.assert_allclose(h.values @ x_full, mu)
+    np.testing.assert_allclose(expected_split, mu)
+    np.testing.assert_array_equal(model.named_vars["x_is_active"].eval(), [True, False, False, True])
+    assert model.named_vars["x"].name == "x"
+    assert model.named_vars["x_active"] in model.free_RVs
+    assert list(registry.original_coords["region_x_active"]) == ["inner-a", "inner-b"]
+
+
+def test_add_state_vector_registers_full_state_coord_in_a_fresh_model() -> None:
+    """Construct a state graph from a resolved contract and register its coordinate."""
+    activity = resolve_state_activity(
+        detect_zero_sensitivity(_sensitivity()),
+        StateActivity(prune_zero=False),
+    )
+    with pm.Model() as model:
+        result = add_state_vector(
+            activity,
+            prior_args={"pdf": "normal", "mu": 1.0, "sigma": 0.1},
+            var_name="x",
+        )
+
+    assert result.state in model.free_RVs
+    assert model.coords["region"] == (0, 1, 2, 3)
+
+
+def test_state_linear_component_preserves_legacy_graph_when_all_states_are_active() -> None:
+    """Use the ordinary base prior graph when state pruning changes nothing."""
+    h = _sensitivity().drop_sel(region="zero")
+    prior = {"pdf": "normal", "mu": 1.0, "sigma": 0.2}
+
+    with pm.Model() as linear_model:
+        attach_coord_registry(linear_model, CoordRegistry())
+        linear_result = add_linear_component(
+            h,
+            data_name="hx",
+            prior_args=prior,
+            var_name="x",
+            output_name="mu",
+        )
+    with pm.Model() as state_model:
+        attach_coord_registry(state_model, CoordRegistry())
+        state_result = add_state_linear_component(
+            h,
+            data_name="hx",
+            prior_args=prior,
+            var_name="x",
+            output_name="mu",
+        )
+
+    assert set(state_model.named_vars) == set(linear_model.named_vars) == {"hx", "x", "mu"}
+    assert [rv.name for rv in state_model.free_RVs] == [rv.name for rv in linear_model.free_RVs] == ["x"]
+    assert state_result.state is state_model.named_vars["x"]
+    assert state_result.latent is state_model.named_vars["x"]
+    assert linear_result.latent is linear_model.named_vars["x"]
+
+
+def test_state_linear_component_full_activity_preserves_reparameterised_names() -> None:
+    """Keep the legacy base and latent names for a fully active lognormal state."""
+    h = _sensitivity().drop_sel(region="zero")
+    with pm.Model() as model:
+        attach_coord_registry(model, CoordRegistry())
+        result = add_state_linear_component(
+            h,
+            data_name="hx",
+            prior_args={
+                "pdf": "lognormal",
+                "mean": 1.0,
+                "stdev": 0.2,
+                "reparameterise": True,
+            },
+            var_name="x",
+            output_name="mu",
+        )
+
+    assert set(model.named_vars) == {"hx", "x_latent", "x", "mu"}
+    assert [rv.name for rv in model.free_RVs] == ["x_latent"]
+    assert result.state is model.named_vars["x"]
+    assert result.latent is model.named_vars["x_latent"]
+
+
+def test_state_linear_component_restores_removed_states_in_canonical_order() -> None:
+    """Restoring active and fixed partitions reproduces the full state and output."""
+    h = _sensitivity()
+    fixed = xr.DataArray(
+        [11.0, 12.0, 13.0, 14.0],
+        dims="region",
+        coords={"region": h.region},
+    )
+    with pm.Model() as model:
+        attach_coord_registry(model, CoordRegistry())
+        result = add_state_linear_component(
+            h,
+            data_name="hx",
+            prior_args={"pdf": "normal", "mu": 2.0, "sigma": 0.1},
+            var_name="x",
+            output_name="mu",
+            state_activity=StateActivity(
+                active=np.array([True, False, True, False]),
+                fixed_value=fixed,
+            ),
+        )
+
+    full_state, active_state, output = pm.draw(
+        [result.state, model.named_vars["x_active"], result.output],
+        random_seed=42,
+    )
+    restored = fixed.to_numpy().copy()
+    restored[result.activity.active_indices] = active_state
+
+    np.testing.assert_allclose(full_state, restored)
+    np.testing.assert_allclose(output, h.to_numpy() @ restored)
+
+
+def test_state_linear_component_supports_zero_active_states() -> None:
+    """An all-fixed component creates no active prior and retains its full state."""
+    h = _sensitivity()
+    policy = StateActivity(active=False, fixed_value=2.5)
+
+    with pm.Model() as model:
+        attach_coord_registry(model, CoordRegistry())
+        result = add_state_linear_component(
+            h,
+            data_name="hx",
+            prior_args={"pdf": "normal", "mu": 1.0, "sigma": 1.0},
+            var_name="x",
+            output_name="mu",
+            state_activity=policy,
+        )
+
+    x_full, mu = pm.draw([result.state, result.output], random_seed=42)
+    np.testing.assert_allclose(x_full, np.full(h.sizes["region"], 2.5))
+    np.testing.assert_allclose(mu, h.values @ x_full)
+    assert result.latent is None
+    assert "x_active" not in model.named_vars
+    assert not any(rv.name and rv.name.startswith("x") for rv in model.free_RVs)
+    assert resolve_model_variable(model, "x") is model.named_vars["x"]
+
+
+def test_standard_rhime_uses_full_deterministic_x_and_active_prior() -> None:
+    """The standard builder prunes exact-zero H but preserves full ordered x."""
+    h = _sensitivity()
+    inputs = _model_inputs(h)
+    model = build_rhime_model(
+        inputs,
+        sigma_alignment=_sigma_alignment(inputs),
+        x_prior={"pdf": "normal", "mu": 1.0, "sigma": 0.2},
+        use_bc=False,
+        no_model_error=True,
+    )
+
+    assert {"x", "x_active", "x_is_active", "x_fixed_value", "mu"}.issubset(model.named_vars)
+    assert model.named_vars["x_active"].eval().shape == (3,)
+    np.testing.assert_array_equal(model.named_vars["x_is_active"].eval(), [True, False, True, True])
+    assert model.named_vars["x"] not in model.free_RVs
+
+
+def test_multisector_rhime_can_freeze_a_sector_and_use_array_priors() -> None:
+    """Per-sector policies can freeze all states while other sectors sample arrays."""
+    h = _sensitivity()
+    multi_h = xr.concat(
+        [h.expand_dims(source=["ff-source"]), (2.0 * h).expand_dims(source=["ocean-source"])],
+        dim="source",
+    )
+    inputs = _model_inputs(multi_h)
+    ocean_mu = xr.DataArray(
+        [1.4, 1.3, 1.2, 1.1],
+        dims="region",
+        coords={"region": ["inner-b", "outer-a", "zero", "inner-a"]},
+    )
+
+    model = build_rhime_multisector_model(
+        inputs,
+        sigma_alignment=_sigma_alignment(inputs),
+        sectors=["FF", "ocean"],
+        sector_sources={"FF": "ff-source", "ocean": "ocean-source"},
+        sector_priors={
+            "FF": {"pdf": "normal", "mu": 1.0, "sigma": 0.2},
+            "ocean": {"pdf": "normal", "mu": ocean_mu, "sigma": 0.3},
+        },
+        sector_state_activities={"FF": StateActivity(active=False)},
+        use_bc=False,
+        no_model_error=True,
+    )
+
+    assert "x_ff_active" not in model.named_vars
+    assert "x_ocean_active" in model.named_vars
+    np.testing.assert_allclose(model.named_vars["x_ff"].eval(), np.ones(4))
+    assert model.named_vars["x_ocean"].eval().shape == (4,)
+    assert model.named_vars["mu"].eval().shape == (2,)

--- a/tests/test_inferpymc.py
+++ b/tests/test_inferpymc.py
@@ -301,6 +301,31 @@ def test_inferpymc_preserves_legacy_compatibility_outputs(inv_inputs: xr.Dataset
     assert "step2" in result
 
 
+def test_inferpymc_pymc_sampler_runs_without_boundary_conditions(
+    inv_inputs: xr.Dataset,
+    model_args: dict,
+) -> None:
+    """The single-sector legacy sampler never constructs an empty BC step."""
+    args = dict(model_args)
+    args["use_bc"] = False
+
+    result = inferpymc(
+        inv_inputs=inv_inputs,
+        nit=1,
+        burn=0,
+        tune=0,
+        nchain=1,
+        verbose=False,
+        sampler_kwargs={"random_seed": 124, "compute_convergence_checks": False},
+        **args,
+    )
+
+    assert "bc" not in result["model"].named_vars
+    assert result["model"]["x"] in result["model"].free_RVs
+    assert "step1" in result
+    assert "step2" in result
+
+
 def test_inferpymc_forwards_numpyro_sampler_without_pymc_step(
     inv_inputs: xr.Dataset, model_args: dict, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -359,6 +384,43 @@ def test_build_inferpymc_model_contains_expected_variables(inv_inputs: xr.Datase
         "y",
     }
     assert expected_named_vars.issubset(model.named_vars)
+
+
+def test_build_inferpymc_model_keeps_zero_h_states_in_single_sector_graph(
+    inv_inputs: xr.Dataset,
+    model_args: dict,
+) -> None:
+    """The legacy single-sector adapter does not adopt modern state pruning."""
+    inputs = inv_inputs.copy()
+    sensitivity = inputs["H"].copy()
+    sensitivity[{"region": 0}] = 0.0
+    inputs["H"] = sensitivity
+
+    model = build_inferpymc_model(inputs, **model_args)
+
+    assert model.named_vars["x"] in model.free_RVs
+    assert model.named_vars_to_dims["x"] == ("region",)
+    assert "x_active" not in model.named_vars
+
+
+def test_build_inferpymc_model_preserves_unlabelled_interpolated_prior(
+    inv_inputs: xr.Dataset,
+    model_args: dict,
+) -> None:
+    """Legacy all-active mode accepts positional H and distribution support arrays."""
+    inputs = inv_inputs.drop_indexes("region").drop_vars("region")
+    args = dict(model_args)
+    args["xprior"] = {
+        "pdf": "interpolated",
+        "x_points": np.array([0.0, 0.5, 1.0, 2.0, 4.0]),
+        "pdf_points": np.array([0.0, 0.5, 1.0, 0.5, 0.0]),
+    }
+
+    model = build_inferpymc_model(inputs, **args)
+
+    assert model["x"] in model.free_RVs
+    assert "x_active" not in model.named_vars
+    assert len(model.coords["region"]) == inputs.sizes["region"]
 
 
 def test_build_inferpymc_model_with_offset_args_adds_offset_terms(

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -40,6 +40,7 @@ from openghg_inversions.flux_sanitization import (
 from openghg_inversions.inversion_data import RhimePreparedInputs, prepare_rhime_inputs
 from openghg_inversions.inversion_inputs import make_inv_inputs
 from openghg_inversions.models import (
+    StateActivity,
     build_rhime_model,
     build_rhime_model_from_spec,
     build_rhime_multisector_model,
@@ -833,6 +834,42 @@ def test_compile_loop_sum_preserves_term_order_independent_of_state_order() -> N
     assert list(compiled.terms) == ["a1", "b1", "a2"]
 
 
+def test_compile_loop_sum_resolves_zero_activity_across_shared_state_terms() -> None:
+    """A shared state is pruned only when every effective term column is zero."""
+    coords = {"region": ["first", "second", "zero"], "nmeasure": [0, 1]}
+    plan = _FluxPlan(
+        states=(_StatePlan("shared", "x_shared", {"pdf": "normal", "mu": 1.0, "sigma": 0.2}),),
+        terms=(
+            _ForwardTermPlan(
+                "first",
+                "shared",
+                xr.DataArray(
+                    [[1.0, 2.0], [0.0, 0.0], [0.0, 0.0]], dims=("region", "nmeasure"), coords=coords
+                ),
+                "h_first",
+                "mu_first",
+            ),
+            _ForwardTermPlan(
+                "second",
+                "shared",
+                xr.DataArray(
+                    [[0.0, 0.0], [3.0, 4.0], [0.0, 0.0]], dims=("region", "nmeasure"), coords=coords
+                ),
+                "h_second",
+                "mu_second",
+            ),
+        ),
+    )
+
+    with pm.Model() as model:
+        attach_coord_registry(model, CoordRegistry())
+        compiled = _compile_loop_sum(plan)
+
+    np.testing.assert_array_equal(model["x_shared_is_active"].eval(), [True, True, False])
+    assert model["x_shared_active"].eval().shape == (2,)
+    assert compiled.latents["shared"] is model["x_shared_active"]
+
+
 def test_build_rhime_model_contains_expected_variables(
     rhime_inv_inputs: xr.Dataset, builder_args: dict
 ) -> None:
@@ -973,15 +1010,42 @@ def test_concrete_and_compiled_multisector_models_accept_gathered_ragged_states(
         coords={
             **xr.Coordinates.from_pandas_multiindex(state_index, "state"),
             "nmeasure": multisector_inv_inputs.coords["nmeasure"],
+            "basis_group": ("state", ["fixed", "active", "fixed", "active", "active"]),
         },
+    )
+    ff_active = xr.DataArray(
+        [False, True],
+        dims="state",
+        coords={"state": ["south", "north"]},
+    )
+    ff_fixed = xr.DataArray(
+        [2.0, 3.0],
+        dims="state",
+        coords={"state": ["south", "north"]},
     )
 
     kwargs = {
         "sectors": ["FF", "ocean"],
         "sector_sources": {"FF": "ff-inventory", "ocean": "ocean-inventory"},
         "sector_priors": {
-            "FF": {"pdf": "normal", "mu": 1.0, "sigma": 0.2},
+            "FF": {
+                "pdf": "uniform",
+                "lower": xr.DataArray(
+                    [20.0, 10.0],
+                    dims="state",
+                    coords={"state": ["south", "north"]},
+                ),
+                "upper": xr.DataArray(
+                    [21.0, 11.0],
+                    dims="state",
+                    coords={"state": ["south", "north"]},
+                ),
+            },
             "ocean": {"pdf": "normal", "mu": 1.0, "sigma": 0.3},
+        },
+        "sector_state_activities": {
+            "FF": StateActivity(active=ff_active, fixed_value=ff_fixed),
+            "ocean": StateActivity(fixed_groups=("fixed",)),
         },
         **builder_args,
     }
@@ -1015,8 +1079,26 @@ def test_concrete_and_compiled_multisector_models_accept_gathered_ragged_states(
         assert list(registry.original_coords["state_ff"]) == ff_labels
         assert list(registry.original_coords["state_ocean"]) == ocean_labels
         assert registry.original_coords["nmeasure"].equals(inv_inputs.indexes["nmeasure"])
+        np.testing.assert_array_equal(registry.auxiliary_coords["basis_group_ff"], ["fixed", "active"])
+        np.testing.assert_array_equal(
+            registry.auxiliary_coords["basis_group_ocean"],
+            ["fixed", "active", "active"],
+        )
+        assert list(registry.original_coords["state_ff_x_ff_active"]) == ["north"]
+        assert list(registry.original_coords["state_ocean_x_ocean_active"]) == [
+            "pacific",
+            "indian",
+        ]
 
-    var_names = ["x_ff", "mu_ff", "x_ocean", "mu_ocean", "mu"]
+    var_names = [
+        "x_ff_active",
+        "x_ff",
+        "mu_ff",
+        "x_ocean_active",
+        "x_ocean",
+        "mu_ocean",
+        "mu",
+    ]
     with model:
         concrete_prior = pm.sample_prior_predictive(
             draws=2,
@@ -1042,6 +1124,10 @@ def test_concrete_and_compiled_multisector_models_accept_gathered_ragged_states(
     xr.testing.assert_allclose(concrete_dataset, compiled_dataset)
     assert list(concrete_dataset["state_ff"].values) == ff_labels
     assert list(concrete_dataset["state_ocean"].values) == ocean_labels
+    assert list(concrete_dataset["state_ff_x_ff_active"].values) == ["north"]
+    assert list(concrete_dataset["state_ocean_x_ocean_active"].values) == ["pacific", "indian"]
+    assert np.all((concrete_dataset["x_ff_active"] >= 10.0) & (concrete_dataset["x_ff_active"] <= 11.0))
+    np.testing.assert_allclose(concrete_dataset["x_ff"].sel(state_ff="south"), 2.0)
     assert concrete_dataset.indexes["nmeasure"].equals(inv_inputs.indexes["nmeasure"])
     xr.testing.assert_allclose(
         concrete_dataset["mu"],
@@ -1390,6 +1476,135 @@ def test_concrete_and_compiled_standard_models_are_equivalent(
         concrete_dataset["mu"],
         expected_mu.transpose(*concrete_dataset["mu"].dims).rename("mu"),
     )
+
+
+def test_concrete_and_compiled_standard_models_prune_exact_zero_states(
+    rhime_inv_inputs: xr.Dataset,
+    builder_args: dict,
+) -> None:
+    """Concrete and compiled graphs retain full state around an active prior."""
+    inv_inputs = rhime_inv_inputs.copy(deep=True)
+    first_region = inv_inputs["H"].coords["region"][0]
+    inv_inputs["H"].loc[{"region": first_region}] = 0.0
+    kwargs = {
+        **builder_args,
+        "use_bc": False,
+        "no_model_error": True,
+        "state_activity": StateActivity(),
+    }
+
+    concrete = build_rhime_model(inv_inputs, **kwargs)
+    compiled = rhime_models_module._build_compiled_rhime_model(inv_inputs, **kwargs)
+
+    assert set(concrete.named_vars) == set(compiled.named_vars)
+    assert concrete.named_vars_to_dims == compiled.named_vars_to_dims
+    np.testing.assert_array_equal(
+        concrete["x_is_active"].eval(),
+        compiled["x_is_active"].eval(),
+    )
+    assert not bool(concrete["x_is_active"].eval()[0])
+    assert concrete["x_active"] in concrete.free_RVs
+    assert compiled["x_active"] in compiled.free_RVs
+    with concrete:
+        concrete_prior = pm.sample_prior_predictive(
+            draws=2,
+            var_names=["x_active", "x", "mu"],
+            random_seed=417,
+        )
+    with compiled:
+        compiled_prior = pm.sample_prior_predictive(
+            draws=2,
+            var_names=["x_active", "x", "mu"],
+            random_seed=417,
+        )
+    xr.testing.assert_allclose(
+        cast(Any, concrete_prior).prior,
+        cast(Any, compiled_prior).prior,
+    )
+
+
+def test_concrete_and_compiled_models_support_all_fixed_flux_and_bc(
+    rhime_inv_inputs: xr.Dataset,
+    builder_args: dict,
+) -> None:
+    """All-fixed flux and BC states retain full deterministic contributions."""
+    kwargs = {
+        **builder_args,
+        "no_model_error": True,
+        "state_activity": StateActivity(active=False, fixed_value=2.0),
+        "bc_state_activity": StateActivity(active=False, fixed_value=1.5),
+    }
+
+    concrete = build_rhime_model(rhime_inv_inputs, **kwargs)
+    compiled = rhime_models_module._build_compiled_rhime_model(rhime_inv_inputs, **kwargs)
+
+    assert set(concrete.named_vars) == set(compiled.named_vars)
+    assert concrete.named_vars_to_dims == compiled.named_vars_to_dims
+    for model in (concrete, compiled):
+        assert model["x"] not in model.free_RVs
+        assert model["bc"] not in model.free_RVs
+        assert "x_active" not in model.named_vars
+        assert "bc_active" not in model.named_vars
+        np.testing.assert_allclose(model["x"].eval(), 2.0)
+        np.testing.assert_allclose(model["bc"].eval(), 1.5)
+        np.testing.assert_allclose(model["mu"].eval(), model["hx"].get_value() @ model["x"].eval())
+        np.testing.assert_allclose(
+            model["mu_bc"].eval(),
+            model["hbc"].get_value() @ model["bc"].eval(),
+        )
+
+
+def test_bc_activity_is_opt_in_and_restores_exact_zero_columns(
+    rhime_inv_inputs: xr.Dataset,
+    builder_args: dict,
+) -> None:
+    """Explicit BC activity prunes zero columns while omission keeps the old graph."""
+    inv_inputs = rhime_inv_inputs.copy(deep=True)
+    first_region = inv_inputs["H_bc"].coords["bc_region"][0]
+    inv_inputs["H_bc"].loc[{"bc_region": first_region}] = 0.0
+    kwargs = {**builder_args, "no_model_error": True}
+
+    default_model = build_rhime_model(inv_inputs, **kwargs)
+    assert default_model["bc"] in default_model.free_RVs
+    assert "bc_active" not in default_model.named_vars
+    assert "bc_is_active" not in default_model.named_vars
+
+    for model in (
+        build_rhime_model(inv_inputs, bc_state_activity=StateActivity(), **kwargs),
+        rhime_models_module._build_compiled_rhime_model(
+            inv_inputs,
+            bc_state_activity=StateActivity(),
+            **kwargs,
+        ),
+    ):
+        assert model["bc_active"] in model.free_RVs
+        assert model["bc"] not in model.free_RVs
+        assert not bool(model["bc_is_active"].eval()[0])
+        assert model["bc"].eval()[0] == 1.0
+        registry = models.get_coord_registry(model)
+        assert registry is not None
+        assert list(registry.original_coords["bc_region_bc_active"]) == list(
+            inv_inputs["H_bc"].indexes["bc_region"][1:]
+        )
+        np.testing.assert_allclose(
+            model["mu_bc"].eval(),
+            model["hbc"].get_value() @ model["bc"].eval(),
+        )
+
+
+def test_compiled_multisector_model_rejects_unknown_state_activity_sector(
+    multisector_inv_inputs: xr.Dataset,
+    builder_args: dict,
+) -> None:
+    """Compiler normalization rejects activity overrides for absent sectors."""
+    with pytest.raises(ValueError, match="unknown sector.*missing"):
+        rhime_models_module._build_compiled_rhime_multisector_model(
+            multisector_inv_inputs,
+            sectors=["FF", "ocean"],
+            sector_sources={"FF": "total-ukghg-edgar7", "ocean": "sector-2"},
+            sector_state_activities={"missing": StateActivity(active=False)},
+            **builder_args,
+        )
 
 
 def test_concrete_and_compiled_multisector_models_are_equivalent(
@@ -2030,9 +2245,11 @@ def test_rhime_normalises_legacy_output_format_aliases(
 def test_build_rhime_model_from_spec_forwards_single_sector_prior(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Forward the sector prior and construct prepared sigma alignment."""
+    """Forward sector activity and priors and construct sigma alignment."""
     sentinel = cast(pm.Model, object())
     seen: dict[str, Any] = {}
+    flux_activity = StateActivity(fixed_groups=("outer",))
+    bc_activity = StateActivity(active=False)
 
     def fake_build_rhime_model(inv_inputs: xr.Dataset, **kwargs: Any) -> pm.Model:
         seen["inv_inputs"] = inv_inputs
@@ -2050,9 +2267,11 @@ def test_build_rhime_model_from_spec_forwards_single_sector_prior(
                 flux_source="ff-inventory",
                 x_prior={"pdf": "normal", "mu": 1.0, "sigma": 0.2},
                 variable_suffix="ff",
+                state_activity=flux_activity,
             ),
         ),
         bc_prior={"pdf": "normal", "mu": 1.0, "sigma": 0.1},
+        bc_state_activity=bc_activity,
         sigma_per_site=False,
         sigma_freq="8D",
         sigma_freq_anchor="2019-01-01",
@@ -2064,6 +2283,8 @@ def test_build_rhime_model_from_spec_forwards_single_sector_prior(
     assert seen["inv_inputs"] is inv_inputs
     assert seen["kwargs"]["x_prior"] == {"pdf": "normal", "mu": 1.0, "sigma": 0.2}
     assert seen["kwargs"]["bc_prior"] == {"pdf": "normal", "mu": 1.0, "sigma": 0.1}
+    assert seen["kwargs"]["state_activity"] is flux_activity
+    assert seen["kwargs"]["bc_state_activity"] is bc_activity
     alignment = seen["kwargs"]["sigma_alignment"]
     assert isinstance(alignment, SigmaAlignment)
     assert alignment.nsite == 1
@@ -2129,9 +2350,11 @@ def test_build_rhime_model_from_spec_dispatches_compiled_opt_in(
 def test_build_rhime_multisector_model_from_spec_preserves_sector_source_mapping(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Spec wrapper keeps sector labels separate from OpenGHG source values."""
+    """Spec wrapper preserves source mappings and per-sector activity."""
     sentinel = cast(pm.Model, object())
     seen: dict[str, Any] = {}
+    ff_activity = StateActivity(fixed_groups=("outer",))
+    bc_activity = StateActivity(active=False)
 
     def fake_build_rhime_multisector_model(inv_inputs: xr.Dataset, **kwargs: Any) -> pm.Model:
         seen["inv_inputs"] = inv_inputs
@@ -2153,6 +2376,7 @@ def test_build_rhime_multisector_model_from_spec_preserves_sector_source_mapping
                 flux_source="ff-inventory",
                 x_prior={"pdf": "normal", "mu": 1.0, "sigma": 0.2},
                 variable_suffix="ff",
+                state_activity=ff_activity,
             ),
             SectorSpec(
                 name="ocean",
@@ -2161,6 +2385,7 @@ def test_build_rhime_multisector_model_from_spec_preserves_sector_source_mapping
                 variable_suffix="ocean",
             ),
         ),
+        bc_state_activity=bc_activity,
     )
 
     model = build_rhime_multisector_model_from_spec(inv_inputs, model_spec)
@@ -2174,6 +2399,8 @@ def test_build_rhime_multisector_model_from_spec_preserves_sector_source_mapping
         "FF": {"pdf": "normal", "mu": 1.0, "sigma": 0.2},
         "ocean": {"pdf": "normal", "mu": 1.0, "sigma": 0.3},
     }
+    assert seen["kwargs"]["sector_state_activities"] == {"FF": ff_activity}
+    assert seen["kwargs"]["bc_state_activity"] is bc_activity
     assert isinstance(seen["kwargs"]["sigma_alignment"], SigmaAlignment)
 
 
@@ -4958,10 +5185,24 @@ def test_make_multisector_output_bundle_builds_latest_paris_flux(
 def test_modern_inversion_output_save_load_roundtrip(tmp_path: Path) -> None:
     """Modern output preserves January annual flux metadata for a June run."""
     model_spec, output_spec, _ = _minimal_output_specs()
+    sector = model_spec.sectors[0]
+    flux_activity = StateActivity(
+        active=xr.DataArray([False], dims="region", coords={"region": ["r0"]}),
+        fixed_value=np.array([1.25]),
+    )
     model_spec = RhimeModelSpec(
         species=model_spec.species,
         domain=model_spec.domain,
-        sectors=model_spec.sectors,
+        sectors=(
+            SectorSpec(
+                name=sector.name,
+                flux_source=sector.flux_source,
+                x_prior=sector.x_prior,
+                variable_suffix=sector.variable_suffix,
+                state_activity=flux_activity,
+            ),
+        ),
+        bc_state_activity=StateActivity(active=False, fixed_value=np.array(0.75)),
         builder_strategy="compiled",
     )
     run_spec = RhimeRunSpec(
@@ -5010,6 +5251,15 @@ def test_modern_inversion_output_save_load_roundtrip(tmp_path: Path) -> None:
     assert reloaded.provenance["basis_representation"] == "operator-backed"
     assert reloaded.output_metadata["output_format"] == "inv_out"
     assert reloaded.model_metadata["builder_strategy"] == "compiled"
+    saved_activity = reloaded.model_metadata["sectors"][0]["state_activity"]
+    assert saved_activity["active"] == {
+        "dims": ["region"],
+        "coords": {"region": ["r0"]},
+        "values": [False],
+    }
+    assert saved_activity["fixed_value"] == [1.25]
+    assert reloaded.model_metadata["bc_state_activity"]["active"] is False
+    assert reloaded.model_metadata["bc_state_activity"]["fixed_value"] == 0.75
     assert reloaded.trace.attrs["burn"] == 1000
     assert cast(Any, reloaded.trace).posterior.attrs["burn"] == 1000
     xr.testing.assert_identical(reloaded.inv_inputs, prepared.inv_inputs)


### PR DESCRIPTION
## Summary of changes

- Add public labelled `StateActivity` / `ResolvedStateActivity` contracts.
- Prune exact-zero H columns by default while keeping every nonzero column,
  including near-zero columns, active.
- Sample only adjustable states and reconstruct the full ordered deterministic
  `x` / `x_<sector>` with inactive fixed values (default scaling one).
- Use the same active/fixed mechanism for explicit states, `basis_group`
  labels, and whole-sector freezing.
- Accept scalar, array-valued, and coordinate-labelled prior parameters while
  preserving existing scalar and per-sector shorthand APIs.

This is one model-contract slice under #509. It does not add high-level
configuration syntax, serialization of activity diagnostics, or grouped flux
outputs.

## Numerical contract

The implementation preserves the canonical full-state forward model:

```text
H_full @ x_full = H_active @ x_active + H_fixed @ fixed_value
```

Existing postprocessing continues to receive full `x` / `x_<sector>` trace
variables even when the free latent vector is reduced.

## Validation

- Full `uv run tox -p --parallel-no-spinner`: passed for current, previous,
  and development OpenGHG environments, plus lint.
- Focused state/prior tests: `21 passed`.
- Focused RHIME builder tests: `7 passed`.
- InferPyMC compatibility tests: `15 passed`.
- Ruff check and format check: passed.
- Scoped Pyright: `0 errors`.
- Independent correctness/API review: no blockers.

## Please check if the PR fulfills these requirements

- [ ] Closes #509 — this PR implements part of the umbrella sequence.
- [x] Tests added and passing.
- [x] Documentation and tutorials updated/added.
- [x] Added an entry to `CHANGELOG.md`.
- [x] No new requirements are needed.
