### PR TITLE
Keep RHIME likelihood error components separate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ## Code changes
 
+- Added modern RHIME likelihood support for fixed aggregation-error covariance
+  supplied after input preparation: exact dense, low-rank-plus-diagonal, and
+  independent diagonal representations. Structured likelihoods retain the
+  observed ``y`` variable and predictive sampling, preserve the total-marginal
+  minimum-error floor, and leave legacy HBMCMC paths unchanged. Derived basic,
+  PARIS, and legacy products reject these inputs pending representation-neutral
+  postprocessing reconstruction. [PR #516](https://github.com/openghg/openghg_inversions/pull/516)
+
 - Added coordinate-preserving loaders and a weights-first region-constrained
   fixed-outer adapter. Packaged InTEM and raw country/land-sea class maps are
   normalized to the weights grid, outer classes retain one target each, and

--- a/docs/usage/rhime.rst
+++ b/docs/usage/rhime.rst
@@ -165,6 +165,37 @@ multisector layout. The sector count, prepared ``H`` layout, layout flag, and
 output settings are validated before model construction or sampling. Output
 side effects are still controlled by ``RhimeOutputSpec``.
 
+Aggregation-error covariance
+-----------------------------
+
+Modern RHIME can add fixed aggregation error to the observation covariance
+without changing the raw ``mf_error`` values. Attach these arrays only after
+observation filtering, averaging, global site gathering, and basis projection,
+so both covariance axes match the final ``nmeasure`` ordering. Prepared inputs
+may contain one of:
+
+* ``aggregation_error_covariance(nmeasure, nmeasure_cov)`` for the exact dense
+  covariance;
+* ``low_rank_factor(nmeasure, agg_rank)`` together with
+  ``diagonal_residual_variance(nmeasure)`` for a low-rank-plus-diagonal
+  approximation;
+* ``aggregation_error_sd(nmeasure)`` for an independent diagonal
+  approximation or diagnostic.
+
+Dense and low-rank forms are the primary representations. If a matching
+``aggregation_error_sd`` diagnostic is present beside either one, RHIME
+validates it against the structured covariance diagonal but does not replace
+the structured likelihood with it. ``aggregation_error_mode="auto"`` selects
+the available structured form first; set ``"dense"``, ``"low_rank"``,
+``"diagonal"``, or ``"none"`` for an explicit comparison run.
+
+The minimum-error setting remains a floor on total marginal standard
+deviation, including aggregation error, while off-diagonal covariance is left
+unchanged. Legacy HBMCMC model and replay paths are not extended. Until the
+derived-error reconstruction follow-up lands, aggregation-error runs support
+``output_format="inv_out"`` and ``"none"``; ``"basic"``, ``"paris"``, and
+``"legacy"`` are rejected rather than producing lossy error fields.
+
 Model Construction
 ------------------
 

--- a/openghg_inversions/config/templates/rhime_template.ini
+++ b/openghg_inversions/config/templates/rhime_template.ini
@@ -71,6 +71,8 @@ min_error = 0.0
 fix_basis_outer_regions = False
 ; Use "compiled" to opt into the experimental semantic-plan compiler.
 builder_strategy = "concrete"
+; Select "dense", "low_rank", or "diagonal" to override prepared-input auto-detection.
+aggregation_error_mode = "auto"
 ; "lazy" records and applies zero-fill lazily; "count" computes exact non-finite flux counts once.
 flux_non_finite_check = "lazy"
 use_bc = True

--- a/openghg_inversions/models/__init__.py
+++ b/openghg_inversions/models/__init__.py
@@ -53,6 +53,8 @@ from openghg_inversions.models.rhime import (
     build_rhime_multisector_model_from_spec,
     safe_pymc_name,
 )
+from openghg_inversions.models.rhime_likelihood import add_rhime_likelihood_component
+from openghg_inversions.observation_error import AggregationErrorMode
 
 __all__ = [
     "CoordRegistry",
@@ -60,6 +62,7 @@ __all__ = [
     "DEFAULT_OFFSET_PRIOR",
     "DEFAULT_SIGMA_PRIOR",
     "DEFAULT_X_PRIOR",
+    "AggregationErrorMode",
     "RhimeBuilderStrategy",
     "RhimeModelSpec",
     "ResolvedStateActivity",
@@ -78,6 +81,7 @@ __all__ = [
     "add_sigma_component",
     "add_offset_component",
     "add_inferpymc_likelihood_component",
+    "add_rhime_likelihood_component",
     "build_rhime_model",
     "build_rhime_model_from_spec",
     "build_rhime_multisector_model",

--- a/openghg_inversions/models/likelihoods.py
+++ b/openghg_inversions/models/likelihoods.py
@@ -1,0 +1,120 @@
+"""Observation likelihoods for diagonal and structured covariance."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import cast
+
+import numpy as np
+import pymc as pm
+import pytensor.tensor as pt
+from pytensor.tensor.variable import TensorVariable
+
+from openghg_inversions.observation_error import AggregationError
+
+
+def _low_rank_gaussian_logp(
+    value: TensorVariable,
+    mean: TensorVariable,
+    factor: TensorVariable,
+    diagonal_variance: TensorVariable,
+) -> TensorVariable:
+    """Normalized Gaussian log-density using the Woodbury identity."""
+    inverse_sqrt_diagonal = pt.reciprocal(pt.sqrt(diagonal_variance))
+    whitened_residual = (value - mean) * inverse_sqrt_diagonal
+    whitened_factor = factor * inverse_sqrt_diagonal[:, None]
+    core = pt.eye(factor.shape[1], dtype=whitened_factor.dtype) + pt.dot(
+        whitened_factor.T,
+        whitened_factor,
+    )
+    cholesky = pt.linalg.cholesky(core)
+    projected = pt.dot(whitened_factor.T, whitened_residual)
+    latent_mode = pt.linalg.solve(
+        cholesky.T,
+        pt.linalg.solve(cholesky, projected),
+    )
+    # This augmented-residual form avoids subtracting two large, nearly equal
+    # quadratic terms when the retained low-rank variance is large.
+    conditional_residual = whitened_residual - pt.dot(whitened_factor, latent_mode)
+    quadratic = pt.dot(conditional_residual, conditional_residual) + pt.dot(
+        latent_mode,
+        latent_mode,
+    )
+    logdet = pt.sum(pt.log(diagonal_variance)) + pm.floatX(2.0) * pt.sum(
+        pt.log(pt.diagonal(cholesky))
+    )
+    normalizing_constant = value.shape[0] * pm.floatX(np.log(2.0 * np.pi))
+    return -pm.floatX(0.5) * (normalizing_constant + logdet + quadratic)
+
+
+def _low_rank_gaussian_random(
+    mean: np.ndarray,
+    factor: np.ndarray,
+    diagonal_variance: np.ndarray,
+    rng: np.random.Generator | None = None,
+    size: int | Sequence[int] | None = None,
+) -> np.ndarray:
+    """Draw from a low-rank-plus-diagonal Gaussian."""
+    rng = np.random.default_rng() if rng is None else rng
+    sample_shape = () if size is None else (size,) if isinstance(size, int) else tuple(size)
+    rank_noise = rng.normal(size=(*sample_shape, factor.shape[1]))
+    diagonal_noise = rng.normal(size=(*sample_shape, mean.shape[-1]))
+    correlated = np.einsum("...r,nr->...n", rank_noise, factor)
+    return mean + correlated + np.sqrt(diagonal_variance) * diagonal_noise
+
+
+def add_gaussian_observation_likelihood(
+    *,
+    observed: TensorVariable,
+    mean: TensorVariable,
+    independent_variance: TensorVariable,
+    aggregation_error: AggregationError,
+    output_dim: str,
+) -> TensorVariable:
+    """Add ``y`` with the selected fixed aggregation-error covariance."""
+    if aggregation_error.mode in ("none", "diagonal"):
+        variance = independent_variance
+        if aggregation_error.mode == "diagonal":
+            assert aggregation_error.diagonal_variance is not None
+            variance = variance + pt.as_tensor_variable(
+                pm.floatX(np.asarray(aggregation_error.diagonal_variance.values))
+            )
+        return cast(
+            TensorVariable,
+            pm.Normal("y", mu=mean, sigma=pt.sqrt(variance), observed=observed, dims=output_dim),
+        )
+
+    if aggregation_error.mode == "dense":
+        assert aggregation_error.covariance is not None
+        covariance = pt.as_tensor_variable(pm.floatX(np.asarray(aggregation_error.covariance.values)))
+        return cast(
+            TensorVariable,
+            pm.MvNormal(
+                "y",
+                mu=mean,
+                cov=covariance + pt.diag(independent_variance),
+                observed=observed,
+                dims=output_dim,
+            ),
+        )
+
+    assert aggregation_error.factor is not None
+    assert aggregation_error.diagonal_variance is not None
+    factor = pt.as_tensor_variable(pm.floatX(np.asarray(aggregation_error.factor.values)))
+    diagonal = independent_variance + pt.as_tensor_variable(
+        pm.floatX(np.asarray(aggregation_error.diagonal_variance.values))
+    )
+    return cast(
+        TensorVariable,
+        pm.CustomDist(
+            "y",
+            mean,
+            factor,
+            diagonal,
+            logp=_low_rank_gaussian_logp,
+            random=_low_rank_gaussian_random,
+            signature="(n),(n,r),(n)->(n)",
+            observed=observed,
+            dims=output_dim,
+        ),
+    )

--- a/openghg_inversions/models/rhime.py
+++ b/openghg_inversions/models/rhime.py
@@ -40,14 +40,15 @@ from openghg_inversions.models._rhime_flux import (
     safe_pymc_name as _safe_pymc_name,
 )
 from openghg_inversions.models.components import (
-    add_inferpymc_likelihood_component,
     add_linear_component,
     add_offset_component,
     add_state_linear_component,
 )
 from openghg_inversions.models.coords import CoordRegistry, attach_coord_registry
 from openghg_inversions.models.priors import PriorArgs
+from openghg_inversions.models.rhime_likelihood import add_rhime_likelihood_component
 from openghg_inversions.models.state_activity import StateActivity
+from openghg_inversions.observation_error import AggregationErrorMode
 from openghg_inversions.sigma import SigmaAlignment
 
 DEFAULT_X_PRIOR: PriorArgs = {"pdf": "lognormal", "mean": 1.0, "stdev": 1.0, "reparameterise": True}
@@ -117,6 +118,8 @@ class RhimeModelSpec:
         pollution_events_from_obs: Whether model error scales with observed
             enhancements instead of modelled enhancements.
         no_model_error: Whether explicit model-error terms are disabled.
+        aggregation_error_mode: Fixed aggregation-error covariance
+            representation. ``"auto"`` selects from prepared inputs.
         power: Exponent or prior specification used in likelihood error scaling.
         bc_prior: Prior specification for boundary-condition scaling factors.
         sigma_prior: Prior specification for model-error terms.
@@ -149,6 +152,7 @@ class RhimeModelSpec:
     add_offset: bool = False
     pollution_events_from_obs: bool = False
     no_model_error: bool = False
+    aggregation_error_mode: AggregationErrorMode = field(default="auto", kw_only=True)
     power: dict[str, Any] | float = 1.99
     bc_prior: dict[str, Any] | None = None
     sigma_prior: dict[str, Any] | None = None
@@ -164,6 +168,11 @@ class RhimeModelSpec:
         if self.builder_strategy not in ("concrete", "compiled"):
             raise ValueError(
                 f"`builder_strategy` must be either 'concrete' or 'compiled'; got {self.builder_strategy!r}."
+            )
+        if self.aggregation_error_mode not in ("auto", "none", "dense", "low_rank", "diagonal"):
+            raise ValueError(
+                "`aggregation_error_mode` must be one of 'auto', 'none', 'dense', "
+                f"'low_rank', or 'diagonal'; got {self.aggregation_error_mode!r}."
             )
 
 
@@ -195,6 +204,7 @@ def _add_rhime_observation_components(
     bc_state_activity: StateActivity | None,
     pollution_events_from_obs: bool,
     no_model_error: bool,
+    aggregation_error_mode: AggregationErrorMode,
     offset_args: dict | None,
     power: dict | float,
 ) -> None:
@@ -213,6 +223,7 @@ def _add_rhime_observation_components(
             scaling states.
         pollution_events_from_obs: Whether error scaling uses observations.
         no_model_error: Whether to suppress explicit model error.
+        aggregation_error_mode: Aggregation-error representation to use.
         offset_args: Extra offset-component arguments.
         power: Likelihood error-scaling exponent or prior.
 
@@ -254,7 +265,7 @@ def _add_rhime_observation_components(
             **(offset_args or {}),
         )
 
-    add_inferpymc_likelihood_component(
+    add_rhime_likelihood_component(
         inv_inputs,
         mu=mu,
         mu_bc=mu_bc,
@@ -264,6 +275,7 @@ def _add_rhime_observation_components(
         power=power,
         pollution_events_from_obs=pollution_events_from_obs,
         no_model_error=no_model_error,
+        aggregation_error_mode=aggregation_error_mode,
         output_dim="nmeasure",
     )
 
@@ -281,6 +293,7 @@ def _assemble_compiled_rhime_model(
     bc_state_activity: StateActivity | None,
     pollution_events_from_obs: bool,
     no_model_error: bool,
+    aggregation_error_mode: AggregationErrorMode,
     offset_args: dict | None,
     power: dict | float,
 ) -> pm.Model:
@@ -299,6 +312,7 @@ def _assemble_compiled_rhime_model(
             scaling states.
         pollution_events_from_obs: Whether error scaling uses observations.
         no_model_error: Whether to suppress explicit model error.
+        aggregation_error_mode: Aggregation-error representation to use.
         offset_args: Extra offset-component arguments.
         power: Likelihood error-scaling exponent or prior.
 
@@ -320,6 +334,7 @@ def _assemble_compiled_rhime_model(
             bc_state_activity=bc_state_activity,
             pollution_events_from_obs=pollution_events_from_obs,
             no_model_error=no_model_error,
+            aggregation_error_mode=aggregation_error_mode,
             offset_args=offset_args,
             power=power,
         )
@@ -339,6 +354,7 @@ def build_rhime_model(
     use_bc: bool = True,
     pollution_events_from_obs: bool = False,
     no_model_error: bool = False,
+    aggregation_error_mode: AggregationErrorMode = "auto",
     offset_args: dict | None = None,
     power: dict | float = 1.99,
     state_activity: StateActivity | None = None,
@@ -359,6 +375,7 @@ def build_rhime_model(
         pollution_events_from_obs: Whether to derive pollution-event scaling
             from observations rather than modelled concentrations.
         no_model_error: Whether to suppress the explicit model-error term.
+        aggregation_error_mode: Aggregation-error representation to use.
         offset_args: Extra keyword arguments forwarded to the offset component.
         power: Exponent or prior specification used in likelihood error scaling.
         state_activity: Optional labelled active/fixed state policy. By
@@ -407,6 +424,7 @@ def build_rhime_model(
             bc_state_activity=bc_state_activity,
             pollution_events_from_obs=pollution_events_from_obs,
             no_model_error=no_model_error,
+            aggregation_error_mode=aggregation_error_mode,
             offset_args=offset_args,
             power=power,
         )
@@ -426,6 +444,7 @@ def _build_compiled_rhime_model(
     use_bc: bool = True,
     pollution_events_from_obs: bool = False,
     no_model_error: bool = False,
+    aggregation_error_mode: AggregationErrorMode = "auto",
     offset_args: dict | None = None,
     power: dict | float = 1.99,
     state_activity: StateActivity | None = None,
@@ -447,6 +466,7 @@ def _build_compiled_rhime_model(
         use_bc: Whether to include boundary-condition terms.
         pollution_events_from_obs: Whether pollution scaling uses observations.
         no_model_error: Whether to suppress the explicit model-error term.
+        aggregation_error_mode: Aggregation-error representation to use.
         offset_args: Extra keyword arguments forwarded to the offset component.
         power: Exponent or prior specification used in likelihood error scaling.
         state_activity: Optional labelled active/fixed flux-state policy.
@@ -474,6 +494,7 @@ def _build_compiled_rhime_model(
         bc_state_activity=bc_state_activity,
         pollution_events_from_obs=pollution_events_from_obs,
         no_model_error=no_model_error,
+        aggregation_error_mode=aggregation_error_mode,
         offset_args=offset_args,
         power=power,
     )
@@ -522,6 +543,7 @@ def build_rhime_model_from_spec(inv_inputs: xr.Dataset, model_spec: RhimeModelSp
         use_bc=model_spec.use_bc,
         pollution_events_from_obs=model_spec.pollution_events_from_obs,
         no_model_error=model_spec.no_model_error,
+        aggregation_error_mode=model_spec.aggregation_error_mode,
         offset_args=model_spec.offset_args,
         power=model_spec.power,
     )
@@ -543,6 +565,7 @@ def build_rhime_multisector_model(
     use_bc: bool = True,
     pollution_events_from_obs: bool = False,
     no_model_error: bool = False,
+    aggregation_error_mode: AggregationErrorMode = "auto",
     offset_args: dict | None = None,
     power: dict | float = 1.99,
     state_activity: StateActivity | None = None,
@@ -581,6 +604,7 @@ def build_rhime_multisector_model(
         pollution_events_from_obs: Whether to derive pollution-event scaling
             from observations rather than modelled concentrations.
         no_model_error: Whether to suppress explicit model-error terms.
+        aggregation_error_mode: Aggregation-error representation to use.
         offset_args: Extra keyword arguments forwarded to the offset component.
         power: Exponent or prior specification used in likelihood error scaling.
         state_activity: Policy shared by sectors without an explicit override.
@@ -651,6 +675,7 @@ def build_rhime_multisector_model(
             bc_state_activity=bc_state_activity,
             pollution_events_from_obs=pollution_events_from_obs,
             no_model_error=no_model_error,
+            aggregation_error_mode=aggregation_error_mode,
             offset_args=offset_args,
             power=power,
         )
@@ -674,6 +699,7 @@ def _build_compiled_rhime_multisector_model(
     use_bc: bool = True,
     pollution_events_from_obs: bool = False,
     no_model_error: bool = False,
+    aggregation_error_mode: AggregationErrorMode = "auto",
     offset_args: dict | None = None,
     power: dict | float = 1.99,
     state_activity: StateActivity | None = None,
@@ -697,6 +723,7 @@ def _build_compiled_rhime_multisector_model(
         use_bc: Whether to include boundary-condition terms.
         pollution_events_from_obs: Whether pollution scaling uses observations.
         no_model_error: Whether to suppress explicit model-error terms.
+        aggregation_error_mode: Aggregation-error representation to use.
         offset_args: Extra keyword arguments forwarded to the offset component.
         power: Exponent or prior specification used in likelihood error scaling.
         state_activity: Optional activity policy shared by all flux sectors.
@@ -736,6 +763,7 @@ def _build_compiled_rhime_multisector_model(
         bc_state_activity=bc_state_activity,
         pollution_events_from_obs=pollution_events_from_obs,
         no_model_error=no_model_error,
+        aggregation_error_mode=aggregation_error_mode,
         offset_args=offset_args,
         power=power,
     )
@@ -789,6 +817,7 @@ def build_rhime_multisector_model_from_spec(
         use_bc=model_spec.use_bc,
         pollution_events_from_obs=model_spec.pollution_events_from_obs,
         no_model_error=model_spec.no_model_error,
+        aggregation_error_mode=model_spec.aggregation_error_mode,
         offset_args=model_spec.offset_args,
         power=model_spec.power,
         state_activity=model_spec.state_activity,

--- a/openghg_inversions/models/rhime_likelihood.py
+++ b/openghg_inversions/models/rhime_likelihood.py
@@ -1,0 +1,94 @@
+"""Modern RHIME likelihood assembly with fixed aggregation covariance."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import numpy as np
+import pymc as pm
+import pytensor.tensor as pt
+import xarray as xr
+from pytensor.tensor.variable import TensorVariable
+
+from openghg_inversions.models.components import add_model_data, add_sigma_component
+from openghg_inversions.models.likelihoods import add_gaussian_observation_likelihood
+from openghg_inversions.models.priors import parse_prior
+from openghg_inversions.observation_error import (
+    AggregationErrorMode,
+    resolve_aggregation_error,
+    validate_observation_error_inputs,
+)
+from openghg_inversions.sigma import SigmaAlignment
+
+
+def add_rhime_likelihood_component(
+    data: xr.Dataset,
+    /,
+    mu: TensorVariable,
+    mu_bc: TensorVariable | None,
+    sigprior: dict,
+    sigma_alignment: SigmaAlignment,
+    offset: TensorVariable | None = None,
+    power: dict | float = 1.99,
+    pollution_events_from_obs: bool = False,
+    no_model_error: bool = False,
+    aggregation_error_mode: AggregationErrorMode = "auto",
+    output_dim: str = "nmeasure",
+) -> TensorVariable:
+    """Add the modern RHIME observation model.
+
+    Aggregation covariance is fixed prepared-input data. ``mf_error`` remains
+    the raw observation-error standard deviation, and inferred model variance
+    remains an independent diagonal contribution.
+    """
+    validate_observation_error_inputs(data, output_dim=output_dim)
+    aggregation_error = resolve_aggregation_error(
+        data,
+        aggregation_error_mode,
+        output_dim=output_dim,
+    )
+    y_data = add_model_data(data["mf"].transpose(output_dim), "Y")
+    error_data = add_model_data(data["mf_error"].transpose(output_dim), "error")
+    min_error_data = add_model_data(data["min_error"].transpose(output_dim), "min_error")
+
+    sigma = add_sigma_component(sigma_alignment, prior_args=sigprior)
+    if pollution_events_from_obs:
+        pollution_event = pt.abs(y_data - mu_bc) if mu_bc is not None else pt.abs(y_data) + 1e-6 * pt.mean(y_data)
+    else:
+        pollution_event = pt.abs(mu)
+
+    if no_model_error:
+        mean_obs = np.nanmean(data["mf"].values)
+        small_amount = pm.floatX(1e-12 * mean_obs)
+        independent_variance = cast(Any, pt.maximum)(error_data**2, small_amount**2)
+    else:
+        power0 = parse_prior("power", power) if isinstance(power, dict) else power
+        model_error_variance = pt.pow(pollution_event * sigma, power0)
+        raw_independent_variance = error_data**2 + model_error_variance
+        aggregation_marginal_variance = pt.as_tensor_variable(
+            pm.floatX(aggregation_error.marginal_variance)
+        )
+        floor_extra = cast(Any, pt.maximum)(
+            min_error_data**2 - raw_independent_variance - aggregation_marginal_variance,
+            0.0,
+        )
+        independent_variance = raw_independent_variance + floor_extra
+
+    total_mu = mu
+    if mu_bc is not None:
+        total_mu = total_mu + mu_bc
+    if offset is not None:
+        total_mu = total_mu + offset
+
+    total_marginal_variance = independent_variance + pt.as_tensor_variable(
+        pm.floatX(aggregation_error.marginal_variance)
+    )
+    epsilon = pm.Deterministic("epsilon", pt.sqrt(total_marginal_variance), dims=output_dim)
+    add_gaussian_observation_likelihood(
+        observed=y_data,
+        mean=total_mu,
+        independent_variance=independent_variance,
+        aggregation_error=aggregation_error,
+        output_dim=output_dim,
+    )
+    return epsilon

--- a/openghg_inversions/observation_error.py
+++ b/openghg_inversions/observation_error.py
@@ -1,0 +1,225 @@
+"""Backend-neutral aggregation-error covariance contracts.
+
+Aggregation error is fixed input data, separate from measurement error and
+the inferred RHIME model-error term.  Prepared inversion inputs may represent
+it exactly as a dense covariance, efficiently as a low-rank-plus-diagonal
+covariance, or diagnostically as independent standard deviations.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, TypeAlias
+
+import numpy as np
+import xarray as xr
+
+AggregationErrorMode: TypeAlias = Literal["auto", "none", "dense", "low_rank", "diagonal"]
+
+AGGREGATION_ERROR_SD = "aggregation_error_sd"
+AGGREGATION_ERROR_COVARIANCE = "aggregation_error_covariance"
+LOW_RANK_FACTOR = "low_rank_factor"
+DIAGONAL_RESIDUAL_VARIANCE = "diagonal_residual_variance"
+
+
+@dataclass(frozen=True)
+class AggregationError:
+    """Validated aggregation-error representation selected for a likelihood."""
+
+    mode: Literal["none", "dense", "low_rank", "diagonal"]
+    marginal_variance: np.ndarray
+    covariance: xr.DataArray | None = None
+    factor: xr.DataArray | None = None
+    diagonal_variance: xr.DataArray | None = None
+
+
+def _numeric_finite(name: str, array: xr.DataArray) -> np.ndarray:
+    values = np.asarray(array.values)
+    if not np.issubdtype(values.dtype, np.number):
+        raise ValueError(f"Aggregation-error input {name!r} must be numeric.")
+    if not np.isfinite(values).all():
+        raise ValueError(f"Aggregation-error input {name!r} must contain only finite values.")
+    return values
+
+
+def _validate_vector(
+    data: xr.Dataset,
+    name: str,
+    *,
+    output_dim: str,
+    nonnegative: bool = True,
+) -> tuple[xr.DataArray, np.ndarray]:
+    array = data[name]
+    if array.dims != (output_dim,):
+        raise ValueError(
+            f"Aggregation-error input {name!r} must have dims ({output_dim!r},); "
+            f"got {array.dims!r}."
+        )
+    if array.sizes[output_dim] != data.sizes[output_dim]:
+        raise ValueError(f"Aggregation-error input {name!r} is not observation-aligned.")
+    values = _numeric_finite(name, array)
+    if nonnegative and (values < 0).any():
+        raise ValueError(f"Aggregation-error input {name!r} must contain only non-negative values.")
+    return array, values
+
+
+def validate_observation_error_inputs(
+    data: xr.Dataset,
+    *,
+    output_dim: str = "nmeasure",
+) -> None:
+    """Validate observations and independent diagonal error inputs."""
+    if "mf" not in data:
+        raise ValueError("Canonical inversion inputs must contain 'mf'.")
+    if data["mf"].dims != (output_dim,):
+        raise ValueError(
+            f"Canonical inversion input 'mf' must have dims ({output_dim!r},); got {data['mf'].dims!r}."
+        )
+    missing = [name for name in ("mf_error", "min_error") if name not in data]
+    if missing:
+        raise ValueError(f"Canonical inversion inputs are missing error component(s): {missing!r}.")
+    for name in ("mf_error", "min_error"):
+        _validate_vector(data, name, output_dim=output_dim)
+
+
+def _select_mode(data: xr.Dataset, requested: AggregationErrorMode) -> Literal[
+    "none", "dense", "low_rank", "diagonal"
+]:
+    if requested not in ("auto", "none", "dense", "low_rank", "diagonal"):
+        raise ValueError(
+            "`aggregation_error_mode` must be one of 'auto', 'none', 'dense', "
+            f"'low_rank', or 'diagonal'; got {requested!r}."
+        )
+    if requested != "auto":
+        return requested
+
+    dense = AGGREGATION_ERROR_COVARIANCE in data
+    low_rank = LOW_RANK_FACTOR in data or DIAGONAL_RESIDUAL_VARIANCE in data
+    if dense and low_rank:
+        raise ValueError(
+            "Prepared inputs contain both dense and low-rank aggregation-error covariance; "
+            "set `aggregation_error_mode` explicitly."
+        )
+    if dense:
+        return "dense"
+    if low_rank:
+        return "low_rank"
+    if AGGREGATION_ERROR_SD in data:
+        return "diagonal"
+    return "none"
+
+
+def resolve_aggregation_error(
+    data: xr.Dataset,
+    mode: AggregationErrorMode = "auto",
+    *,
+    output_dim: str = "nmeasure",
+    covariance_dim: str = "nmeasure_cov",
+) -> AggregationError:
+    """Validate and select an aggregation-error covariance representation.
+
+    In ``"auto"`` mode, a structured representation takes precedence over
+    ``aggregation_error_sd`` because that vector is commonly retained as a
+    marginal diagnostic beside the exact covariance.  Supplying both dense and
+    low-rank forms is ambiguous and therefore requires an explicit selection.
+    """
+    if output_dim not in data.dims:
+        raise ValueError(f"Prepared inputs have no observation dimension {output_dim!r}.")
+    selected = _select_mode(data, mode)
+    nmeasure = data.sizes[output_dim]
+
+    if selected == "none":
+        return AggregationError(mode="none", marginal_variance=np.zeros(nmeasure))
+
+    if selected == "diagonal":
+        if AGGREGATION_ERROR_SD not in data:
+            raise ValueError(
+                f"Diagonal aggregation error requires {AGGREGATION_ERROR_SD!r} in prepared inputs."
+            )
+        standard_deviation, values = _validate_vector(
+            data, AGGREGATION_ERROR_SD, output_dim=output_dim
+        )
+        return AggregationError(
+            mode="diagonal",
+            marginal_variance=values**2,
+            diagonal_variance=standard_deviation**2,
+        )
+
+    if selected == "dense":
+        if AGGREGATION_ERROR_COVARIANCE not in data:
+            raise ValueError(
+                f"Dense aggregation error requires {AGGREGATION_ERROR_COVARIANCE!r} in prepared inputs."
+            )
+        covariance = data[AGGREGATION_ERROR_COVARIANCE]
+        if covariance.dims != (output_dim, covariance_dim):
+            raise ValueError(
+                f"Aggregation-error input {AGGREGATION_ERROR_COVARIANCE!r} must have dims "
+                f"({output_dim!r}, {covariance_dim!r}); got {covariance.dims!r}."
+            )
+        if covariance.shape != (nmeasure, nmeasure):
+            raise ValueError(
+                f"Aggregation-error input {AGGREGATION_ERROR_COVARIANCE!r} must be square and "
+                f"match {output_dim!r}; got shape {covariance.shape!r}."
+            )
+        values = _numeric_finite(AGGREGATION_ERROR_COVARIANCE, covariance)
+        scale = max(float(np.max(np.abs(values))), 1.0)
+        tolerance = 1e-10 * scale
+        if not np.allclose(values, values.T, rtol=1e-10, atol=tolerance):
+            raise ValueError(f"Aggregation-error input {AGGREGATION_ERROR_COVARIANCE!r} must be symmetric.")
+        if float(np.linalg.eigvalsh(values).min()) < -tolerance:
+            raise ValueError(
+                f"Aggregation-error input {AGGREGATION_ERROR_COVARIANCE!r} must be positive semidefinite."
+            )
+        marginal_variance = np.diag(values).copy()
+        _validate_marginal_sd(data, marginal_variance, output_dim=output_dim)
+        return AggregationError(
+            mode="dense",
+            marginal_variance=marginal_variance,
+            covariance=covariance,
+        )
+
+    missing = [
+        name for name in (LOW_RANK_FACTOR, DIAGONAL_RESIDUAL_VARIANCE) if name not in data
+    ]
+    if missing:
+        raise ValueError(f"Low-rank aggregation error is missing input(s): {missing!r}.")
+    factor = data[LOW_RANK_FACTOR]
+    if factor.ndim != 2 or factor.dims[0] != output_dim:
+        raise ValueError(
+            f"Aggregation-error input {LOW_RANK_FACTOR!r} must be a two-dimensional array "
+            f"whose first dimension is {output_dim!r}; got {factor.dims!r}."
+        )
+    if factor.sizes[output_dim] != nmeasure:
+        raise ValueError(f"Aggregation-error input {LOW_RANK_FACTOR!r} is not observation-aligned.")
+    if factor.shape[1] < 1:
+        raise ValueError(f"Aggregation-error input {LOW_RANK_FACTOR!r} must contain at least one rank column.")
+    factor_values = _numeric_finite(LOW_RANK_FACTOR, factor)
+    diagonal, diagonal_values = _validate_vector(
+        data, DIAGONAL_RESIDUAL_VARIANCE, output_dim=output_dim
+    )
+    marginal_variance = np.sum(factor_values**2, axis=1) + diagonal_values
+    _validate_marginal_sd(data, marginal_variance, output_dim=output_dim)
+    return AggregationError(
+        mode="low_rank",
+        marginal_variance=marginal_variance,
+        factor=factor,
+        diagonal_variance=diagonal,
+    )
+
+
+def _validate_marginal_sd(
+    data: xr.Dataset,
+    marginal_variance: np.ndarray,
+    *,
+    output_dim: str,
+) -> None:
+    """Validate an optional marginal-SD diagnostic beside structured input."""
+    if AGGREGATION_ERROR_SD not in data:
+        return
+    _, values = _validate_vector(data, AGGREGATION_ERROR_SD, output_dim=output_dim)
+    expected = np.sqrt(marginal_variance)
+    if not np.allclose(values, expected, rtol=1e-6, atol=1e-12):
+        raise ValueError(
+            f"Aggregation-error diagnostic {AGGREGATION_ERROR_SD!r} must equal the square root "
+            "of the selected covariance diagonal."
+        )

--- a/openghg_inversions/rhime/params.py
+++ b/openghg_inversions/rhime/params.py
@@ -18,6 +18,7 @@ from typing import Any, cast
 from openghg_inversions.config import config
 from openghg_inversions.model_error import normalise_min_error_options
 from openghg_inversions.models import (
+    AggregationErrorMode,
     DEFAULT_X_PRIOR,
     RhimeBuilderStrategy,
     RhimeModelSpec,
@@ -389,6 +390,7 @@ def validate_supported_params(params: Mapping[str, Any], *, data_params: set[str
         "sigma_per_site",
         "sigma_freq",
         "builder_strategy",
+        "aggregation_error_mode",
     }
     supported = data_params | runner_params | required_run_params()
     unsupported = sorted(set(params) - supported)
@@ -460,6 +462,7 @@ def _make_model_spec(
     power: dict[str, Any] | float,
     offset_args: dict[str, Any] | None,
     builder_strategy: RhimeBuilderStrategy,
+    aggregation_error_mode: AggregationErrorMode,
 ) -> RhimeModelSpec:
     """Create a lightweight model spec from normalized run parameters."""
     default_x_prior = DEFAULT_X_PRIOR.copy() if x_prior is None else x_prior.copy()
@@ -516,6 +519,7 @@ def _make_model_spec(
         offset_prior=offset_prior,
         offset_args=offset_args,
         builder_strategy=builder_strategy,
+        aggregation_error_mode=aggregation_error_mode,
     )
 
 
@@ -574,6 +578,10 @@ def make_rhime_runner_setup(
         RhimeBuilderStrategy,
         remaining.pop("builder_strategy", "concrete"),
     )
+    aggregation_error_mode = cast(
+        AggregationErrorMode,
+        remaining.pop("aggregation_error_mode", "auto"),
+    )
 
     sampler = RhimeSampler(
         draws=remaining.pop("draws", 1000),
@@ -622,6 +630,7 @@ def make_rhime_runner_setup(
         power=power,
         offset_args=offset_args,
         builder_strategy=builder_strategy,
+        aggregation_error_mode=aggregation_error_mode,
     )
     run_spec = RhimeRunSpec(
         start_date=start_date,

--- a/openghg_inversions/rhime/runner.py
+++ b/openghg_inversions/rhime/runner.py
@@ -66,6 +66,7 @@ from openghg_inversions.models import (
     build_rhime_multisector_model_from_spec,
 )
 from openghg_inversions.models._rhime_flux import _select_sector_design
+from openghg_inversions.observation_error import resolve_aggregation_error
 from openghg_inversions.postprocessing.inversion_output import InversionOutput
 
 __all__ = [
@@ -369,6 +370,20 @@ def run_rhime_from_prepared_inputs(
 
     output_spec = run_spec.output
     validate_output_format(output_spec.output_format)
+    aggregation_error = resolve_aggregation_error(
+        prepared_inputs.inv_inputs,
+        run_spec.model.aggregation_error_mode,
+    )
+    if aggregation_error.mode != "none" and output_spec.output_format in {
+        "basic",
+        "paris",
+        "legacy",
+    }:
+        raise ValueError(
+            "RHIME aggregation-error covariance is not yet supported by derived "
+            f"output_format={output_spec.output_format!r}; use 'inv_out' or 'none' until "
+            "the postprocessing reconstruction follow-up lands."
+        )
     validate_output_filename_convention(output_spec.output_filename_convention)
     validate_output_path_settings(
         output_format=output_spec.output_format,

--- a/tests/models/test_likelihoods.py
+++ b/tests/models/test_likelihoods.py
@@ -1,0 +1,145 @@
+from typing import Any, cast
+
+import numpy as np
+import pymc as pm
+import pytest
+import xarray as xr
+from scipy.stats import multivariate_normal
+
+from openghg_inversions.models.coords import CoordRegistry, attach_coord_registry
+from openghg_inversions.models.likelihoods import add_gaussian_observation_likelihood
+from openghg_inversions.models.rhime_likelihood import add_rhime_likelihood_component
+from openghg_inversions.observation_error import resolve_aggregation_error
+from openghg_inversions.sigma import SigmaAlignment
+
+
+def _base_data() -> xr.Dataset:
+    return xr.Dataset(
+        {
+            "mf": ("nmeasure", [1.0, 2.0, 3.0]),
+            "mf_error": ("nmeasure", [0.2, 0.3, 0.4]),
+            "min_error": ("nmeasure", [0.0, 0.0, 0.0]),
+            "site_indicator": ("nmeasure", [0, 0, 0]),
+        },
+        coords={"nmeasure": np.arange(3)},
+    )
+
+
+def _low_rank_data() -> tuple[xr.Dataset, np.ndarray]:
+    data = _base_data()
+    factor = np.array([[0.5, 0.0], [0.2, 0.3], [0.0, 0.2]])
+    residual = np.array([0.25, 0.27, 0.26])
+    data["low_rank_factor"] = (("nmeasure", "agg_rank"), factor)
+    data["diagonal_residual_variance"] = ("nmeasure", residual)
+    return data, factor @ factor.T + np.diag(residual)
+
+
+def _fixed_likelihood_model(data: xr.Dataset) -> pm.Model:
+    aggregation_error = resolve_aggregation_error(data)
+    with pm.Model(coords={"nmeasure": np.arange(3)}) as model:
+        observed = pm.Data("Y", pm.floatX(data["mf"].values), dims="nmeasure")
+        mean = pm.Data("mean", pm.floatX(np.array([0.8, 1.7, 2.9])), dims="nmeasure")
+        independent_variance = pm.Data(
+            "independent_variance",
+            pm.floatX(data["mf_error"].values**2),
+            dims="nmeasure",
+        )
+        add_gaussian_observation_likelihood(
+            observed=observed,
+            mean=mean,
+            independent_variance=independent_variance,
+            aggregation_error=aggregation_error,
+            output_dim="nmeasure",
+        )
+    return model
+
+
+def test_low_rank_logp_matches_dense_gaussian() -> None:
+    low_rank_data, covariance = _low_rank_data()
+    dense_data = _base_data()
+    dense_data["aggregation_error_covariance"] = (
+        ("nmeasure", "nmeasure_cov"),
+        covariance,
+    )
+    low_rank_model = _fixed_likelihood_model(low_rank_data)
+    dense_model = _fixed_likelihood_model(dense_data)
+    expected = multivariate_normal.logpdf(
+        low_rank_data["mf"].values,
+        mean=np.array([0.8, 1.7, 2.9]),
+        cov=covariance + np.diag(low_rank_data["mf_error"].values**2),
+    )
+
+    low_rank_logp = float(low_rank_model.compile_logp()(low_rank_model.initial_point()))
+    dense_logp = float(dense_model.compile_logp()(dense_model.initial_point()))
+
+    assert low_rank_logp == pytest.approx(expected, rel=1e-6)
+    assert low_rank_logp == pytest.approx(dense_logp, rel=1e-6)
+
+
+def test_low_rank_likelihood_retains_observed_y_and_predictive_sampling() -> None:
+    data, _ = _low_rank_data()
+    model = _fixed_likelihood_model(data)
+
+    with model:
+        predictive = pm.sample_prior_predictive(draws=2, var_names=["y"])
+
+    assert [rv.name for rv in model.observed_RVs] == ["y"]
+    assert predictive.prior_predictive["y"].shape == (1, 2, 3)
+
+
+@pytest.mark.parametrize("mode", ["diagonal", "dense", "low_rank"])
+def test_min_error_is_a_floor_on_total_marginal_sd(mode: str) -> None:
+    data = _base_data()
+    data["min_error"] = ("nmeasure", np.full(3, 2.0))
+    aggregation_variance = np.array([0.5, 0.6, 0.7])
+    if mode == "diagonal":
+        data["aggregation_error_sd"] = ("nmeasure", np.sqrt(aggregation_variance))
+    elif mode == "dense":
+        data["aggregation_error_covariance"] = (
+            ("nmeasure", "nmeasure_cov"),
+            np.diag(aggregation_variance),
+        )
+    else:
+        data["low_rank_factor"] = (("nmeasure", "agg_rank"), np.zeros((3, 1)))
+        data["diagonal_residual_variance"] = ("nmeasure", aggregation_variance)
+
+    sigma_alignment = SigmaAlignment.from_frequency(
+        data["site_indicator"], frequency=None, per_site=False
+    )
+    with pm.Model(coords={"nmeasure": np.arange(3)}) as model:
+        attach_coord_registry(model, CoordRegistry())
+        mu = pm.Data("mu_input", np.ones(3), dims="nmeasure")
+        add_rhime_likelihood_component(
+            data,
+            mu=mu,
+            mu_bc=None,
+            sigprior={"pdf": "uniform", "lower": 0.5, "upper": 0.5001},
+            sigma_alignment=sigma_alignment,
+            aggregation_error_mode=cast(Any, mode),
+        )
+
+    np.testing.assert_allclose(model.named_vars["epsilon"].eval(), 2.0)
+    assert "model_error" not in model.named_vars
+
+
+def test_no_model_error_ignores_floor_but_includes_structured_marginal() -> None:
+    data, covariance = _low_rank_data()
+    data["min_error"] = ("nmeasure", np.full(3, 20.0))
+    sigma_alignment = SigmaAlignment.from_frequency(
+        data["site_indicator"], frequency=None, per_site=False
+    )
+    with pm.Model(coords={"nmeasure": np.arange(3)}) as model:
+        attach_coord_registry(model, CoordRegistry())
+        mu = pm.Data("mu_input", np.ones(3), dims="nmeasure")
+        add_rhime_likelihood_component(
+            data,
+            mu=mu,
+            mu_bc=None,
+            sigprior={"pdf": "uniform", "lower": 0.1, "upper": 1.0},
+            sigma_alignment=sigma_alignment,
+            no_model_error=True,
+        )
+
+    expected = np.sqrt(data["mf_error"].values**2 + np.diag(covariance))
+    np.testing.assert_allclose(model.named_vars["epsilon"].eval(), expected)
+    assert "model_error" not in model.named_vars

--- a/tests/test_inversion_inputs.py
+++ b/tests/test_inversion_inputs.py
@@ -452,6 +452,23 @@ def test_make_inv_inputs_rejects_mismatched_state_dimension_names() -> None:
         make_inv_inputs(fp_data=fp_data, sites=["AAA", "BBB"], min_error=0.0)
 
 
+def test_make_inv_inputs_retains_separate_aggregation_error_component() -> None:
+    """Canonical inputs retain aggregation error without modifying raw mf_error."""
+    fp_data = {
+        "AAA": _make_minimal_fp_site(mf_base=10.0, include_inlet_height=False),
+        "BBB": _make_minimal_fp_site(mf_base=20.0, include_inlet_height=False),
+    }
+    for site, aggregation_error in (("AAA", [0.3, 0.4]), ("BBB", [0.5, 0.6])):
+        fp_data[site]["aggregation_error_sd"] = ("time", aggregation_error)
+    raw_errors = np.concatenate([fp_data[site]["mf_error"].values for site in ("AAA", "BBB")])
+
+    result = make_inv_inputs(fp_data=fp_data, sites=["AAA", "BBB"], min_error=0.2)
+
+    np.testing.assert_allclose(result["mf_error"].values, raw_errors)
+    np.testing.assert_allclose(result["aggregation_error_sd"].values, [0.3, 0.4, 0.5, 0.6])
+    np.testing.assert_allclose(result["min_error"].values, 0.2)
+
+
 def test_make_inv_inputs_raises_if_required_var_would_be_dropped():
     """`make_inv_inputs` should still fail clearly if a required var is not shared."""
     fp_data = {

--- a/tests/test_observation_error.py
+++ b/tests/test_observation_error.py
@@ -1,0 +1,97 @@
+import numpy as np
+import pytest
+import xarray as xr
+
+from openghg_inversions.models import RhimeModelSpec
+from openghg_inversions.observation_error import resolve_aggregation_error
+
+
+def _inputs() -> xr.Dataset:
+    return xr.Dataset(coords={"nmeasure": np.arange(3)})
+
+
+def test_dense_covariance_is_primary_over_matching_sd_diagnostic() -> None:
+    covariance = np.array([[2.0, 0.4, 0.0], [0.4, 1.0, 0.2], [0.0, 0.2, 0.5]])
+    data = _inputs()
+    data["aggregation_error_covariance"] = (("nmeasure", "nmeasure_cov"), covariance)
+    data["aggregation_error_sd"] = ("nmeasure", np.sqrt(np.diag(covariance)))
+
+    result = resolve_aggregation_error(data)
+
+    assert result.mode == "dense"
+    np.testing.assert_allclose(result.marginal_variance, np.diag(covariance))
+
+
+def test_low_rank_covariance_uses_factor_and_residual_diagonal() -> None:
+    factor = np.array([[1.0, 0.0], [0.5, 0.25], [0.0, 0.5]])
+    residual = np.array([0.2, 0.3, 0.4])
+    data = _inputs()
+    data["low_rank_factor"] = (("nmeasure", "agg_rank"), factor)
+    data["diagonal_residual_variance"] = ("nmeasure", residual)
+
+    result = resolve_aggregation_error(data)
+
+    assert result.mode == "low_rank"
+    np.testing.assert_allclose(result.marginal_variance, np.sum(factor**2, axis=1) + residual)
+
+
+def test_auto_rejects_two_structured_representations() -> None:
+    data = _inputs()
+    data["aggregation_error_covariance"] = (
+        ("nmeasure", "nmeasure_cov"),
+        np.eye(3),
+    )
+    data["low_rank_factor"] = (("nmeasure", "agg_rank"), np.ones((3, 1)))
+    data["diagonal_residual_variance"] = ("nmeasure", np.ones(3))
+
+    with pytest.raises(ValueError, match="both dense and low-rank"):
+        resolve_aggregation_error(data)
+
+
+@pytest.mark.parametrize(
+    ("covariance", "match"),
+    [
+        (np.array([[1.0, 0.2], [0.1, 1.0]]), "symmetric"),
+        (np.array([[1.0, 2.0], [2.0, 1.0]]), "positive semidefinite"),
+    ],
+)
+def test_dense_covariance_validation(covariance: np.ndarray, match: str) -> None:
+    data = xr.Dataset(
+        {"aggregation_error_covariance": (("nmeasure", "nmeasure_cov"), covariance)},
+        coords={"nmeasure": np.arange(2)},
+    )
+
+    with pytest.raises(ValueError, match=match):
+        resolve_aggregation_error(data)
+
+
+def test_structured_covariance_rejects_inconsistent_sd_diagnostic() -> None:
+    data = _inputs()
+    data["aggregation_error_covariance"] = (
+        ("nmeasure", "nmeasure_cov"),
+        np.eye(3),
+    )
+    data["aggregation_error_sd"] = ("nmeasure", np.full(3, 2.0))
+
+    with pytest.raises(ValueError, match="diagnostic.*square root"):
+        resolve_aggregation_error(data)
+
+
+def test_explicit_none_ignores_available_diagnostic() -> None:
+    data = _inputs()
+    data["aggregation_error_sd"] = ("nmeasure", np.ones(3))
+
+    result = resolve_aggregation_error(data, "none")
+
+    assert result.mode == "none"
+    np.testing.assert_array_equal(result.marginal_variance, np.zeros(3))
+
+
+def test_model_spec_rejects_unknown_aggregation_error_mode() -> None:
+    with pytest.raises(ValueError, match="aggregation_error_mode.*dense.*low_rank"):
+        RhimeModelSpec(
+            species="ch4",
+            domain="EUROPE",
+            sectors=(),
+            aggregation_error_mode="factorized",  # type: ignore[arg-type]
+        )

--- a/tests/test_prepared_inputs_serialisation.py
+++ b/tests/test_prepared_inputs_serialisation.py
@@ -102,6 +102,70 @@ def _prepared_inputs(
     )
 
 
+@pytest.mark.parametrize("suffix", [".nc", ".zarr"])
+@pytest.mark.parametrize("representation", ["dense", "low_rank"])
+def test_structured_aggregation_error_survives_prepared_input_round_trip(
+    tmp_path: Path,
+    suffix: str,
+    representation: str,
+) -> None:
+    prepared = _prepared_inputs()
+    inv_inputs = prepared.inv_inputs.copy()
+    covariance = np.array([[0.5, 0.1], [0.1, 0.4]])
+    if representation == "dense":
+        inv_inputs["aggregation_error_covariance"] = (
+            ("nmeasure", "nmeasure_cov"),
+            covariance,
+        )
+    else:
+        factor = np.array([[0.5], [0.2]])
+        inv_inputs["low_rank_factor"] = (("nmeasure", "agg_rank"), factor)
+        inv_inputs["diagonal_residual_variance"] = (
+            "nmeasure",
+            np.diag(covariance) - np.sum(factor**2, axis=1),
+        )
+    structured = RhimePreparedInputs(
+        inv_inputs=inv_inputs,
+        basis_functions=prepared.basis_functions,
+        site_metadata=prepared.site_metadata,
+    )
+    path = tmp_path / f"structured-{representation}{suffix}"
+
+    structured.save(path)
+    loaded = RhimePreparedInputs.load(path)
+
+    xr.testing.assert_identical(loaded.inv_inputs, structured.inv_inputs)
+
+
+def test_derived_outputs_reject_aggregation_error_until_reconstruction_lands() -> None:
+    prepared = _prepared_inputs()
+    prepared.inv_inputs["aggregation_error_sd"] = ("nmeasure", [0.2, 0.3])
+    model_spec = RhimeModelSpec(
+        species="ch4",
+        domain="EUROPE",
+        sectors=(
+            SectorSpec(
+                name="total",
+                flux_source="total",
+                x_prior={"pdf": "normal", "mu": 1.0, "sigma": 0.2},
+                variable_suffix="total",
+            ),
+        ),
+        use_bc=False,
+    )
+    run_spec = RhimeRunSpec(
+        start_date="2019-01-01",
+        end_date="2019-01-02",
+        sites=prepared.sites,
+        averaging_period=prepared.averaging_period,
+        model=model_spec,
+        output=RhimeOutputSpec(output_format="basic", save_inversion_output=False),
+    )
+
+    with pytest.raises(ValueError, match="aggregation-error covariance.*output_format='basic'"):
+        run_rhime_from_prepared_inputs(prepared_inputs=prepared, run_spec=run_spec)
+
+
 def _multisource_prepared_inputs() -> RhimePreparedInputs:
     """Build prepared inputs whose retained basis has source order B, A."""
     coords = {"lat": [51.0], "lon": [-2.0, -1.0]}


### PR DESCRIPTION
## Summary of changes

- Preserve raw `mf_error`, optional diagonal `aggregation_error_sd`,
  `min_error`, inferred `model_error`, and total `epsilon` as distinct values.
- Validate aligned finite nonnegative aggregation SDs and combine independent
  diagonal terms exactly once at the likelihood boundary.
- Propagate averaged aggregation SD as `sqrt(sum(sd**2)) / n` rather than an
  arithmetic mean.
- Keep generic inversion outputs component-aware while explicitly omitting the
  internal aggregation field from fixed PARIS v03/v04 concentration schemas.
- Preserve aggregation error, floors, PEFO mode, no-model-error mode, and
  nondefault power through backward-compatible legacy save/replay, including
  repeated replay generations.
- Avoid misreporting floor-clipped residual variance as inferred model error.

This is the diagonal error-contract slice tracked by #509 and #493. Full
aggregation covariance remains out of scope.

## Validation

- Focused model/input/resampling tests: `20 passed`.
- Legacy/current postprocessing tests: `10 passed`.
- Standard/multisector/save-load/PARIS tests: `5 passed`.
- Final replay, legacy-writer, and floor-masking review selection: `9 passed`.
- Ruff check and format check: passed.
- Scoped Pyright on modern output/runner paths: `0 errors`.
- Independent correctness rereview: no remaining blockers.
- Full tox matrix (current, previous, and development OpenGHG plus lint): passed.

## Please check if the PR fulfills these requirements

- [ ] Closes #509 or #493 — this PR implements the diagonal error slice only.
- [x] Tests added and passing.
- [x] Documentation and tutorials updated/added.
- [x] Added an entry to `CHANGELOG.md`.
- [x] No new requirements are needed.