### PR TITLE
Fix dtype bug #517

### DIFF
--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -751,8 +751,8 @@ def inferpymc_postprocessouts(
         bfds = fp_data[".basis"]
 
     # Calculate mean  and mode posterior scale map and flux field
-    scalemap_mu = np.zeros_like(bfds.values)
-    scalemap_mode = np.zeros_like(bfds.values)
+    scalemap_mu = np.zeros_like(bfds.values, dtype=float)
+    scalemap_mode = np.zeros_like(bfds.values, dtype=float)
 
     for npm in nparam:
         scalemap_mu[bfds.values == (npm + 1)] = np.mean(xouts[:, npm])


### PR DESCRIPTION
Incorrect dtype int for scalemap_mu and scalemap_mode. Both these scaling maps should have dtype float. Added bug fix.

- [ ] Closes #517
- [ ] Tests added and passing
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry to the `CHANGELOG.md` file
- [ ] Added any new requirements to `requirements.txt`
