### PR TITLE
Expose state activity through RHIME model specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,10 +118,15 @@
   Models sample active states only but retain full ordered deterministic
   ``x``/``x_<sector>`` vectors, and flux-scaling prior parameters may now be
   scalar, full array-valued, or labelled xarray values. Programmatic model specs
-  can set per-sector activity, and sampled ``H_bc @ bc`` components can use the
-  same mechanism to fix some or all BC scaling states. Config-file syntax and
-  persisted activity-reason reports remain follow-up work; legacy
-  ``inferpymc`` remains single-sector and retains its full sampled state.
+  can set shared activity and per-sector overrides, and sampled ``H_bc @ bc``
+  components can use the same mechanism to fix some or all BC scaling states.
+  Config-file syntax and persisted activity-reason reports remain follow-up
+  work; legacy ``inferpymc`` remains single-sector and retains its full sampled
+  state. This API bridge addresses
+  [#509](https://github.com/openghg/openghg_inversions/issues/509), following the
+  state-contract context in
+  [#456](https://github.com/openghg/openghg_inversions/issues/456) and
+  [#493](https://github.com/openghg/openghg_inversions/issues/493).
 
 - Made retained `BasisFunctions` / `BasisOperator` metadata the primary basis
   contract for RHIME preparation and modern postprocessing outputs. Derived

--- a/docs/usage/rhime.rst
+++ b/docs/usage/rhime.rst
@@ -568,9 +568,11 @@ coordinate containing the value ``"outer"``:
 For multisector builders, use ``state_activity`` as a shared policy or
 ``sector_state_activities`` for sector-name overrides;
 ``StateActivity(active=False)`` freezes a complete sector. Programmatic
-prepared-input runs set the canonical per-sector policy with
-``SectorSpec(state_activity=...)``. RHIME config-file syntax and persisted
-activity-reason tables remain follow-up work.
+prepared-input runs may set a shared policy on ``RhimeModelSpec`` and use its
+``sector_state_activities`` mapping for overrides. The canonical per-sector
+policy is ``SectorSpec(state_activity=...)`` and takes precedence over that
+mapping. RHIME config-file syntax and persisted activity-reason tables remain
+follow-up work.
 Each prior dictionary in ``sector_priors`` supports the same scalar,
 full-state array, and labelled ``DataArray`` parameter forms; labelled values
 must match the selected sector's state coordinate exactly.

--- a/openghg_inversions/models/rhime.py
+++ b/openghg_inversions/models/rhime.py
@@ -127,6 +127,11 @@ class RhimeModelSpec:
             sampled BC graph without zero pruning. Supplying a policy opts into
             active/fixed BC construction; when all states are fixed, ``mu_bc``
             remains without a boundary-condition RV.
+        state_activity: Optional labelled active/fixed state policy shared by
+            flux sectors. The default retains exact-zero pruning.
+        sector_state_activities: Optional activity-policy overrides keyed by
+            sector name for multi-sector models. A policy stored directly on a
+            ``SectorSpec`` takes precedence over this compatibility mapping.
         builder_strategy: Public model-construction strategy. ``"concrete"``
             directly composes the default, readable reference model.
             ``"compiled"`` opts into the private semantic-plan compiler for
@@ -150,6 +155,8 @@ class RhimeModelSpec:
     offset_prior: dict[str, Any] | None = None
     offset_args: dict[str, Any] | None = None
     bc_state_activity: StateActivity | None = field(default=None, kw_only=True)
+    state_activity: StateActivity | None = field(default=None, kw_only=True)
+    sector_state_activities: dict[str, StateActivity] | None = field(default=None, kw_only=True)
     builder_strategy: RhimeBuilderStrategy = field(default="concrete", kw_only=True)
 
     def __post_init__(self) -> None:
@@ -497,11 +504,16 @@ def build_rhime_model_from_spec(inv_inputs: xr.Dataset, model_spec: RhimeModelSp
         anchor_time=model_spec.sigma_freq_anchor,
     )
     builder = build_rhime_model if model_spec.builder_strategy == "concrete" else _build_compiled_rhime_model
+    state_activity = model_spec.state_activity
+    if model_spec.sector_state_activities is not None:
+        state_activity = model_spec.sector_state_activities.get(sector.name, state_activity)
+    if sector.state_activity is not None:
+        state_activity = sector.state_activity
     return builder(
         inv_inputs,
         sigma_alignment=sigma_alignment,
         x_prior=dict(sector.x_prior),
-        state_activity=sector.state_activity,
+        state_activity=state_activity,
         bc_prior=model_spec.bc_prior,
         bc_state_activity=model_spec.bc_state_activity,
         sigma_prior=model_spec.sigma_prior,
@@ -754,6 +766,14 @@ def build_rhime_multisector_model_from_spec(
         if model_spec.builder_strategy == "concrete"
         else _build_compiled_rhime_multisector_model
     )
+    sector_state_activities = dict(model_spec.sector_state_activities or {})
+    sector_state_activities.update(
+        {
+            sector.name: sector.state_activity
+            for sector in model_spec.sectors
+            if sector.state_activity is not None
+        }
+    )
     return builder(
         inv_inputs,
         sigma_alignment=sigma_alignment,
@@ -761,11 +781,6 @@ def build_rhime_multisector_model_from_spec(
         sector_sources={sector.name: sector.flux_source for sector in model_spec.sectors},
         sector_variable_suffixes={sector.name: sector.variable_suffix for sector in model_spec.sectors},
         sector_priors={sector.name: dict(sector.x_prior) for sector in model_spec.sectors},
-        sector_state_activities={
-            sector.name: sector.state_activity
-            for sector in model_spec.sectors
-            if sector.state_activity is not None
-        },
         bc_prior=model_spec.bc_prior,
         bc_state_activity=model_spec.bc_state_activity,
         sigma_prior=model_spec.sigma_prior,
@@ -776,4 +791,6 @@ def build_rhime_multisector_model_from_spec(
         no_model_error=model_spec.no_model_error,
         offset_args=model_spec.offset_args,
         power=model_spec.power,
+        state_activity=model_spec.state_activity,
+        sector_state_activities=sector_state_activities or None,
     )

--- a/tests/models/test_state_activity.py
+++ b/tests/models/test_state_activity.py
@@ -12,13 +12,16 @@ import xarray as xr
 
 from openghg_inversions.models import (
     CoordRegistry,
+    RhimeModelSpec,
+    SectorSpec,
     StateActivity,
     active_prior_args,
     add_state_linear_component,
     attach_coord_registry,
-    build_rhime_model,
+    build_rhime_model_from_spec,
     build_rhime_multisector_model,
     detect_zero_sensitivity,
+    build_rhime_multisector_model_from_spec,
     resolve_state_activity,
 )
 from openghg_inversions.models.components import add_linear_component, resolve_model_variable
@@ -432,22 +435,74 @@ def test_state_linear_component_supports_zero_active_states() -> None:
     assert resolve_model_variable(model, "x") is model.named_vars["x"]
 
 
-def test_standard_rhime_uses_full_deterministic_x_and_active_prior() -> None:
-    """The standard builder prunes exact-zero H but preserves full ordered x."""
+def test_standard_rhime_spec_keeps_default_exact_zero_activity() -> None:
+    """The spec builder keeps exact-zero pruning and the full ordered state."""
     h = _sensitivity()
-    inputs = _model_inputs(h)
-    model = build_rhime_model(
-        inputs,
-        sigma_alignment=_sigma_alignment(inputs),
-        x_prior={"pdf": "normal", "mu": 1.0, "sigma": 0.2},
+    model_spec = RhimeModelSpec(
+        species="ch4",
+        domain="EUROPE",
+        sectors=(
+            SectorSpec(
+                name="total",
+                flux_source="total",
+                x_prior={"pdf": "normal", "mu": 1.0, "sigma": 0.2},
+                variable_suffix="total",
+            ),
+        ),
         use_bc=False,
         no_model_error=True,
+    )
+
+    model = build_rhime_model_from_spec(
+        _model_inputs(h),
+        model_spec,
     )
 
     assert {"x", "x_active", "x_is_active", "x_fixed_value", "mu"}.issubset(model.named_vars)
     assert model.named_vars["x_active"].eval().shape == (3,)
     np.testing.assert_array_equal(model.named_vars["x_is_active"].eval(), [True, False, True, True])
     assert model.named_vars["x"] not in model.free_RVs
+
+
+def test_standard_rhime_spec_honors_explicit_fixed_states_and_groups() -> None:
+    """A spec policy combines labelled state and group freezes."""
+    h = _sensitivity()
+    explicit = xr.DataArray(
+        [False, True, True, True],
+        dims="region",
+        coords={"region": ["inner-b", "outer-a", "zero", "inner-a"]},
+    )
+    fixed_value = xr.DataArray(
+        [4.0, 3.0, 2.0, 1.0],
+        dims="region",
+        coords={"region": ["inner-b", "outer-a", "zero", "inner-a"]},
+    )
+    model_spec = RhimeModelSpec(
+        species="ch4",
+        domain="EUROPE",
+        sectors=(
+            SectorSpec(
+                name="total",
+                flux_source="total",
+                x_prior={"pdf": "normal", "mu": 1.0, "sigma": 0.2},
+                variable_suffix="total",
+            ),
+        ),
+        use_bc=False,
+        no_model_error=True,
+        state_activity=StateActivity(
+            active=explicit,
+            fixed_value=fixed_value,
+            fixed_groups=("outer",),
+        ),
+    )
+
+    model = build_rhime_model_from_spec(_model_inputs(h), model_spec)
+
+    np.testing.assert_array_equal(model.named_vars["x_is_active"].eval(), [True, False, False, False])
+    assert model.named_vars["x_active"].eval().shape == (1,)
+    x_full = model.named_vars["x"].eval()
+    np.testing.assert_allclose(x_full[[1, 2, 3]], [2.0, 3.0, 4.0])
 
 
 def test_multisector_rhime_can_freeze_a_sector_and_use_array_priors() -> None:
@@ -483,3 +538,41 @@ def test_multisector_rhime_can_freeze_a_sector_and_use_array_priors() -> None:
     np.testing.assert_allclose(model.named_vars["x_ff"].eval(), np.ones(4))
     assert model.named_vars["x_ocean"].eval().shape == (4,)
     assert model.named_vars["mu"].eval().shape == (2,)
+
+
+def test_multisector_rhime_spec_honors_shared_and_per_sector_activity() -> None:
+    """A per-sector policy overrides the shared multisector policy."""
+    h = _sensitivity()
+    multi_h = xr.concat(
+        [h.expand_dims(source=["ff-source"]), (2.0 * h).expand_dims(source=["ocean-source"])],
+        dim="source",
+    )
+    model_spec = RhimeModelSpec(
+        species="ch4",
+        domain="EUROPE",
+        sectors=(
+            SectorSpec(
+                name="FF",
+                flux_source="ff-source",
+                x_prior={"pdf": "normal", "mu": 1.0, "sigma": 0.2},
+                variable_suffix="ff",
+            ),
+            SectorSpec(
+                name="ocean",
+                flux_source="ocean-source",
+                x_prior={"pdf": "normal", "mu": 1.0, "sigma": 0.3},
+                variable_suffix="ocean",
+            ),
+        ),
+        use_bc=False,
+        no_model_error=True,
+        state_activity=StateActivity(active=False, fixed_value=3.0),
+        sector_state_activities={"FF": StateActivity(active=False, fixed_value=2.0)},
+    )
+
+    model = build_rhime_multisector_model_from_spec(_model_inputs(multi_h), model_spec)
+
+    assert "x_ff_active" not in model.named_vars
+    np.testing.assert_allclose(model.named_vars["x_ff"].eval(), np.full(4, 2.0))
+    assert "x_ocean_active" not in model.named_vars
+    np.testing.assert_allclose(model.named_vars["x_ocean"].eval(), np.full(4, 3.0))

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -133,6 +133,20 @@ def builder_args(rhime_inv_inputs: xr.Dataset) -> dict:
     }
 
 
+def _assert_model_dot_matches_numpy(
+    model: pm.Model,
+    *,
+    output_name: str,
+    design_name: str,
+    state_name: str,
+) -> None:
+    """Compare compiled and NumPy matrix products at dtype-aware precision."""
+    actual = model[output_name].eval()
+    expected = model[design_name].get_value() @ model[state_name].eval()
+    tolerance = 100 * max(np.finfo(actual.dtype).eps, np.finfo(expected.dtype).eps)
+    np.testing.assert_allclose(actual, expected, rtol=tolerance, atol=tolerance)
+
+
 def _fake_basis_functions(*, artifact_source: str = "generated") -> BasisFunctions:
     """Build a minimal one-cell basis artifact for RHIME tests."""
     basis = xr.DataArray(
@@ -1575,10 +1589,17 @@ def test_concrete_and_compiled_models_support_all_fixed_flux_and_bc(
         assert "bc_active" not in model.named_vars
         np.testing.assert_allclose(model["x"].eval(), 2.0)
         np.testing.assert_allclose(model["bc"].eval(), 1.5)
-        np.testing.assert_allclose(model["mu"].eval(), model["hx"].get_value() @ model["x"].eval())
-        np.testing.assert_allclose(
-            model["mu_bc"].eval(),
-            model["hbc"].get_value() @ model["bc"].eval(),
+        _assert_model_dot_matches_numpy(
+            model,
+            output_name="mu",
+            design_name="hx",
+            state_name="x",
+        )
+        _assert_model_dot_matches_numpy(
+            model,
+            output_name="mu_bc",
+            design_name="hbc",
+            state_name="bc",
         )
 
 
@@ -1614,9 +1635,11 @@ def test_bc_activity_is_opt_in_and_restores_exact_zero_columns(
         assert list(registry.original_coords["bc_region_bc_active"]) == list(
             inv_inputs["H_bc"].indexes["bc_region"][1:]
         )
-        np.testing.assert_allclose(
-            model["mu_bc"].eval(),
-            model["hbc"].get_value() @ model["bc"].eval(),
+        _assert_model_dot_matches_numpy(
+            model,
+            output_name="mu_bc",
+            design_name="hbc",
+            state_name="bc",
         )
 
 

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -1722,17 +1722,26 @@ def test_direct_sector_spec_records_source_backing() -> None:
 
 def test_public_rhime_dataclasses_keep_existing_positional_order() -> None:
     """New default fields do not intercept existing positional construction."""
+    sector = SectorSpec(
+        name="FF",
+        flux_source="ff-inventory",
+        x_prior={"pdf": "normal", "mu": 1.0, "sigma": 0.2},
+        variable_suffix="ff",
+    )
     model_spec = RhimeModelSpec(
-        species="ch4",
-        domain="EUROPE",
-        sectors=(
-            SectorSpec(
-                name="FF",
-                flux_source="ff-inventory",
-                x_prior={"pdf": "normal", "mu": 1.0, "sigma": 0.2},
-                variable_suffix="ff",
-            ),
-        ),
+        "ch4",
+        "EUROPE",
+        (sector,),
+        True,
+        True,
+        False,
+        False,
+        False,
+        1.99,
+        None,
+        None,
+        None,
+        None,
     )
     output_spec = RhimeOutputSpec(output_format="none")
     run_spec = RhimeRunSpec(
@@ -1755,6 +1764,8 @@ def test_public_rhime_dataclasses_keep_existing_positional_order() -> None:
     )
 
     assert run_spec.split_by_sectors is True
+    assert model_spec.state_activity is None
+    assert model_spec.sector_state_activities is None
     assert not hasattr(run_spec, "sampler")
     assert not hasattr(run_spec, "sampling")
     assert result.output_metadata == output_metadata
@@ -2378,9 +2389,11 @@ def test_build_rhime_model_from_spec_dispatches_compiled_opt_in(
 def test_build_rhime_multisector_model_from_spec_preserves_sector_source_mapping(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Spec wrapper preserves source mappings and per-sector activity."""
+    """Spec wrapper preserves source mappings and activity precedence."""
     sentinel = cast(pm.Model, object())
     seen: dict[str, Any] = {}
+    shared_activity = StateActivity(fixed_value=3.0)
+    mapped_activity = StateActivity(active=False, fixed_value=2.0)
     ff_activity = StateActivity(fixed_groups=("outer",))
     bc_activity = StateActivity(active=False)
 
@@ -2414,6 +2427,8 @@ def test_build_rhime_multisector_model_from_spec_preserves_sector_source_mapping
             ),
         ),
         bc_state_activity=bc_activity,
+        state_activity=shared_activity,
+        sector_state_activities={"FF": mapped_activity, "ocean": mapped_activity},
     )
 
     model = build_rhime_multisector_model_from_spec(inv_inputs, model_spec)
@@ -2427,7 +2442,11 @@ def test_build_rhime_multisector_model_from_spec_preserves_sector_source_mapping
         "FF": {"pdf": "normal", "mu": 1.0, "sigma": 0.2},
         "ocean": {"pdf": "normal", "mu": 1.0, "sigma": 0.3},
     }
-    assert seen["kwargs"]["sector_state_activities"] == {"FF": ff_activity}
+    assert seen["kwargs"]["state_activity"] is shared_activity
+    assert seen["kwargs"]["sector_state_activities"] == {
+        "FF": ff_activity,
+        "ocean": mapped_activity,
+    }
     assert seen["kwargs"]["bc_state_activity"] is bc_activity
     assert isinstance(seen["kwargs"]["sigma_alignment"], SigmaAlignment)
 
@@ -5141,6 +5160,36 @@ def test_make_standard_output_bundle_returns_outputs_without_mutating_result() -
     assert "site_lons" not in bundle.inv_out.run_metadata
     assert bundle.outputs == {"inversion_output": bundle.inv_out}
     assert bundle.output_metadata == {"inversion_output_contract": "modern"}
+
+
+def test_output_bundle_serializes_state_activity_spec() -> None:
+    """Concrete per-sector policy dictionaries remain valid output metadata."""
+    _, output_spec, run_spec = _minimal_output_specs()
+    model_spec = RhimeModelSpec(
+        species="ch4",
+        domain="EUROPE",
+        sectors=run_spec.model.sectors,
+        sector_state_activities={"FF": StateActivity(active=False, fixed_value=2.0)},
+    )
+    prepared = RhimePreparedInputs(
+        inv_inputs=_minimal_output_inv_inputs(),
+        basis_functions=_fake_basis_functions(),
+        site_metadata=_prepared_site_metadata(),
+    )
+
+    bundle = rhime_outputs.make_standard_output_bundle(
+        output_spec=output_spec,
+        run_spec=run_spec,
+        model_spec=model_spec,
+        idata=_minimal_output_idata(),
+        prepared=prepared,
+        country_file=None,
+    )
+
+    assert bundle.inv_out is not None
+    policy = bundle.inv_out.model_metadata["sector_state_activities"]["FF"]
+    assert policy["active"] is False
+    assert policy["fixed_value"] == 2.0
 
 
 def test_make_multisector_output_bundle_returns_modern_inv_out() -> None:


### PR DESCRIPTION
* **Summary of changes**

Extends `RhimeModelSpec` with shared `state_activity` and top-level `sector_state_activities` compatibility fields, then forwards them through the standard and multisector spec-based builders.

The implementation is rebased onto the merged #513 design and current `devel`:

- `RhimeModelSpec.state_activity` supplies the shared policy.
- `RhimeModelSpec.sector_state_activities` supplies sector-name overrides.
- Canonical `SectorSpec.state_activity` values take precedence over the top-level mapping.
- Default exact-zero pruning and full-state reconstruction are preserved.
- Matrix-product assertions introduced with #513 now use dtype-aware tolerances so valid float32 PyTensor/NumPy reduction-order differences do not fail local compiler-backed tests.

Fields are keyword-only so existing positional construction remains compatible. Tests cover shared policy, per-sector precedence, public builders, positional compatibility, and output-bundle serialization.

Follow-up to #513 and advances #509.

* **Checks**

- [x] PR-specific Python 3.10/current-OpenGHG tox tests: 6 passed
- [x] Previously failing matrix-product tests pass against current OpenGHG and OpenGHG `devel`
- [x] Required full current-OpenGHG tox suite passed
- [x] Ruff / tox lint passed
- [x] OpenGHG 0.18 intentionally skipped locally because its import-time home-directory logging is unsuitable for this workflow
- [x] Documentation updated
- [x] CHANGELOG updated
- [x] No new requirements