### PR TITLE
Preserve missing draws in multisector totals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ## Code changes
 
+- Preserved all-sector-missing draws when constructing multisector spatial and
+  country totals, and promoted country covariance accumulation to float64 before
+  PARIS template casting. Trace-group merging now explicitly retains its outer
+  draw alignment, and totals require a value from every sector so a structural
+  zero cannot hide a different sector's padded draw. This prevents padded draws
+  from being interpreted as zero flux, keeps total posterior variance consistent
+  with the full within-country sector covariance matrix, and preserves the
+  contract under future xarray defaults.
 
 - Made retained `BasisFunctions` / `BasisOperator` metadata the primary basis
   contract for RHIME preparation and modern postprocessing outputs. Derived

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,14 @@
 ## Code changes
 
 - Reset retained posterior draw labels after burn-in before attaching predictive
-  groups, and record the discarded burn count in trace metadata. Trace-group
-  merging still explicitly retains outer alignment for genuinely unequal
-  external groups, while multisector totals require a value from every sector so
-  padded draws cannot be interpreted as zero flux. PARIS country-sector samples
-  are now promoted to float64 before totals and uncertainty statistics are
-  calculated, then cast at the template boundary, keeping total posterior
-  variance consistent with the full within-country sector covariance matrix.
+  groups in both modern RHIME and fixed-basis sampling, and preserve the
+  discarded burn count through trace and `InversionOutput` round trips.
+  Trace-group merging still explicitly retains outer alignment for genuinely
+  unequal external groups, while multisector totals require a value from every
+  sector so padded draws cannot be interpreted as zero flux. Single- and
+  multisector PARIS country samples are now promoted to float64 before totals
+  and uncertainty statistics are calculated, then cast at the template
+  boundary, keeping posterior stdev and covariance calculations consistent.
 
 - Made retained `BasisFunctions` / `BasisOperator` metadata the primary basis
   contract for RHIME preparation and modern postprocessing outputs. Derived

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,14 @@
 
 ## Code changes
 
-- Preserved all-sector-missing draws when constructing multisector spatial and
-  country totals, and promoted country covariance accumulation to float64 before
-  PARIS template casting. Trace-group merging now explicitly retains its outer
-  draw alignment, and totals require a value from every sector so a structural
-  zero cannot hide a different sector's padded draw. This prevents padded draws
-  from being interpreted as zero flux, keeps total posterior variance consistent
-  with the full within-country sector covariance matrix, and preserves the
-  contract under future xarray defaults.
+- Reset retained posterior draw labels after burn-in before attaching predictive
+  groups, and record the discarded burn count in trace metadata. Trace-group
+  merging still explicitly retains outer alignment for genuinely unequal
+  external groups, while multisector totals require a value from every sector so
+  padded draws cannot be interpreted as zero flux. PARIS country-sector samples
+  are now promoted to float64 before totals and uncertainty statistics are
+  calculated, then cast at the template boundary, keeping total posterior
+  variance consistent with the full within-country sector covariance matrix.
 
 - Made retained `BasisFunctions` / `BasisOperator` metadata the primary basis
   contract for RHIME preparation and modern postprocessing outputs. Derived

--- a/openghg_inversions/_sampling.py
+++ b/openghg_inversions/_sampling.py
@@ -1,0 +1,41 @@
+"""Shared normalization helpers for retained ArviZ sampling results.
+
+This module contains sampler-independent operations applied after burn slicing
+and before predictive groups are attached. Keeping this boundary neutral lets
+the modern RHIME and fixed-basis compatibility samplers share identical draw
+coordinate and metadata behavior.
+
+``_reset_retained_draws`` mutates the supplied ``InferenceData``: every
+draw-bearing dataset is relabelled with consecutive zero-based draws, ``burn``
+is recorded on the root and those groups, and groups without a draw dimension
+are unchanged.
+"""
+
+from __future__ import annotations
+
+import arviz as az
+import numpy as np
+import xarray as xr
+
+
+def _reset_retained_draws(idata: az.InferenceData, *, burn: int) -> az.InferenceData:
+    """Relabel retained draws and preserve the discarded burn-in count.
+
+    Args:
+        idata: Inference data whose draw-bearing groups are relabelled in place.
+        burn: Number of discarded burn-in draws to record in metadata.
+
+    Returns:
+        The mutated inference data, with each draw coordinate reset to
+        consecutive zero-based integers and burn stored on the root and
+        draw-bearing groups.
+    """
+    idata.attrs["burn"] = burn
+    for group_name in idata.groups():
+        group = getattr(idata, group_name)
+        if not isinstance(group, xr.Dataset) or "draw" not in group.dims:
+            continue
+        group = group.assign_coords(draw=np.arange(group.sizes["draw"]))
+        group.attrs["burn"] = burn
+        setattr(idata, group_name, group)
+    return idata

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -154,7 +154,7 @@ def _canonicalize_fixedbasis_trace(trace: object, basis_functions: BasisFunction
         }
         renamed_groups[group] = ds.rename(applicable) if applicable else ds.copy()
 
-    return cast(Any, az.InferenceData)(**renamed_groups)
+    return cast(Any, az.InferenceData)(attrs=dict(trace.attrs), **renamed_groups)
 
 
 def _inv_inputs_from_rerun_arrays(
@@ -479,7 +479,8 @@ def _handle_core_output_artifacts(context: _OutputContext) -> None:
         trace = context.mcmc_results["trace"]
         if isinstance(trace, az.InferenceData):
             trace = cast(Any, az.InferenceData)(
-                **{group: _reset_serialisation_multiindexes(trace[group]) for group in trace.groups()}
+                attrs=dict(trace.attrs),
+                **{group: _reset_serialisation_multiindexes(trace[group]) for group in trace.groups()},
             )
         trace.to_netcdf(str(trace_path), engine="netcdf4", compress=True)
 

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -4,7 +4,7 @@ import re
 import getpass
 import warnings
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 
@@ -21,6 +21,7 @@ from scipy import stats  # noqa: E402
 
 from openghg_inversions import convert  # noqa: E402
 from openghg_inversions import utils  # noqa: E402
+from openghg_inversions._sampling import _reset_retained_draws  # noqa: E402
 from openghg_inversions.hbmcmc.hbmcmc_output import define_output_filename  # noqa: E402
 from openghg_inversions.config.version import code_version  # noqa: E402
 from openghg_inversions.models import build_rhime_model  # noqa: E402
@@ -214,7 +215,8 @@ def sample(
 
     Args:
         model: Built PyMC model to sample from.
-        draws: Number of posterior draws to keep per chain.
+        draws: Number of posterior draws requested per chain before burn
+            slicing.
         tune: Number of tuning draws passed to ``pm.sample``.
         chains: Number of MCMC chains to run.
         burn: Number of posterior draws to discard from the returned
@@ -230,7 +232,9 @@ def sample(
 
     Returns:
         Burn-sliced ``InferenceData`` for the requested model, optionally
-        extended with predictive groups.
+        extended with predictive groups. Retained draw coordinates are reset
+        to consecutive zero-based integers, and ``burn`` is stored on the root
+        and draw-bearing group attributes.
     """
     sample_kwargs = dict(kwargs)
     sample_kwargs.pop("return_inferencedata", None)
@@ -248,6 +252,7 @@ def sample(
         )
 
     burned_trace = raw_trace.isel(draw=slice(burn, None))
+    burned_trace = _reset_retained_draws(cast(az.InferenceData, burned_trace), burn=burn)
     burned_trace = extend_inferencedata_predictive(
         burned_trace,
         model=model,
@@ -291,7 +296,8 @@ def _rename_trace_for_legacy_inferpymc(trace: az.InferenceData) -> az.InferenceD
 
     Returns:
         A copied ``InferenceData`` whose groups use the legacy inferpymc
-        dimension names where required.
+        dimension names where required. Root and group attributes are
+        preserved.
     """
     rename_map = {"region": "nx", "bc_region": "nbc"}
     renamed_groups: dict[str, xr.Dataset] = {}
@@ -301,7 +307,7 @@ def _rename_trace_for_legacy_inferpymc(trace: az.InferenceData) -> az.InferenceD
         applicable = {old: new for old, new in rename_map.items() if old in ds.dims or old in ds.coords}
         renamed_groups[group] = ds.rename(applicable) if applicable else ds.copy()
 
-    return az.InferenceData(**renamed_groups)
+    return cast(Any, az.InferenceData)(attrs=dict(trace.attrs), **renamed_groups)
 
 
 def _adapt_legacy_inferpymc_results(

--- a/openghg_inversions/postprocessing/inversion_output.py
+++ b/openghg_inversions/postprocessing/inversion_output.py
@@ -115,16 +115,38 @@ def _open_datatree_loaded(file_path: str | Path) -> xr.DataTree:
 
 
 def _inferencedata_to_datatree(idata: az.InferenceData) -> xr.DataTree:
-    """Convert an ArviZ InferenceData object to a DataTree."""
+    """Convert inference data to a serialization-safe data tree.
+
+    Args:
+        idata: Inference data whose root attributes and groups should be
+            retained. Group MultiIndexes are expanded before serialization.
+
+    Returns:
+        A data tree whose root contains ``idata.attrs`` and whose children
+        contain the serialization-safe inference-data groups.
+    """
     return xr.DataTree.from_dict(
-        {group: _reset_serialisation_multiindexes(idata[group]) for group in idata.groups()}
+        {
+            "/": xr.Dataset(attrs=dict(idata.attrs)),
+            **{group: _reset_serialisation_multiindexes(idata[group]) for group in idata.groups()},
+        }
     )
 
 
 def _inferencedata_from_datatree(dt: xr.DataTree) -> az.InferenceData:
-    """Convert a DataTree of InferenceData groups back to ArviZ InferenceData."""
+    """Restore inference data from a serialized data tree.
+
+    Args:
+        dt: Data tree whose root attributes and child groups represent an
+            ``InferenceData`` object.
+
+    Returns:
+        Reconstructed inference data with root attributes preserved and group
+        MultiIndexes restored.
+    """
     return cast(Any, az.InferenceData)(
-        **{group: _restore_serialisation_multiindexes(child.to_dataset()) for group, child in dt.items()}
+        attrs=dict(dt.attrs),
+        **{group: _restore_serialisation_multiindexes(child.to_dataset()) for group, child in dt.items()},
     )
 
 

--- a/openghg_inversions/postprocessing/inversion_output.py
+++ b/openghg_inversions/postprocessing/inversion_output.py
@@ -279,7 +279,7 @@ def convert_idata_to_dataset(
             if "chain" in trace.dims:
                 trace = trace.isel(chain=0, drop=True)
             traces.append(trace)
-    return xr.merge(traces)
+    return xr.merge(traces, join="outer")
 
 
 def _add_attributes_to_trace_dataset(trace_ds: xr.Dataset, obs_units: str, obs_longname: str) -> None:

--- a/openghg_inversions/postprocessing/make_outputs.py
+++ b/openghg_inversions/postprocessing/make_outputs.py
@@ -377,7 +377,7 @@ def _multisector_flux_trace_parts(
             for sector, dataset in zip(sectors, sector_flux_traces, strict=True)
         ],
         dim="sector",
-    ).sum("sector")
+    ).sum("sector", min_count=len(sectors))
     return sectors, sector_flux_traces, total_flux_trace
 
 
@@ -485,7 +485,7 @@ def make_multisector_country_trace_outputs(
             for sector, trace in zip(sectors, sector_country_traces, strict=True)
         ],
         dim="sector",
-    ).sum("sector")
+    ).sum("sector", min_count=len(sectors))
     result = xr.merge([total_country_trace, *sector_country_traces])
     for name in result.data_vars:
         result[name].attrs["units"] = "g/yr"

--- a/openghg_inversions/postprocessing/make_paris_outputs.py
+++ b/openghg_inversions/postprocessing/make_paris_outputs.py
@@ -912,18 +912,32 @@ def _multisector_country_trace_kg(
         ValueError: If required multisector metadata is missing or retained
             basis, flux, and country grids cannot be aligned.
     """
-    country_trace = make_multisector_country_trace_outputs(inv_out, countries) * 1e-3
-    rename = {
-        "country_total_prior": "country_prior",
-        "country_total_posterior": "country_posterior",
-    }
+    projected_trace = make_multisector_country_trace_outputs(inv_out, countries)
+    rename = {}
     for variable_suffix, sector_name in sector_name_by_suffix.items():
         for when in ("prior", "posterior"):
             source_name = f"country_{variable_suffix}_{when}"
-            if source_name in country_trace:
+            if source_name in projected_trace:
                 rename[source_name] = f"country_{sector_name}_{when}"
 
-    result = country_trace[list(rename)].rename(rename)
+    # Promote only the projected country samples. PARIS country uncertainty
+    # statistics and totals then share one aligned float64 sector intermediate,
+    # while the much larger spatial draw arrays keep their original dtype.
+    sector_trace = projected_trace[list(rename)].rename(rename).astype(np.float64) * 1e-3
+    result = sector_trace.copy(deep=False)
+    for when in ("prior", "posterior"):
+        sector_variables = [
+            f"country_{sector_name}_{when}"
+            for sector_name in sector_name_by_suffix.values()
+            if f"country_{sector_name}_{when}" in sector_trace
+        ]
+        result[f"country_{when}"] = xr.concat(
+            [sector_trace[name] for name in sector_variables],
+            dim="sector",
+        ).sum("sector", min_count=len(sector_name_by_suffix))
+
+    result = result[["country_prior", "country_posterior", *sector_trace.data_vars]]
+    result.attrs = dict(projected_trace.attrs)
     for name in result.data_vars:
         result[name].attrs["units"] = "kg/yr"
     return result

--- a/openghg_inversions/postprocessing/make_paris_outputs.py
+++ b/openghg_inversions/postprocessing/make_paris_outputs.py
@@ -943,6 +943,31 @@ def _multisector_country_trace_kg(
     return result
 
 
+def _single_sector_country_trace_kg(
+    inv_out: InversionOutput,
+    countries: Countries,
+) -> xr.Dataset:
+    """Return a float64 single-sector country trace in kilograms per year.
+
+    Args:
+        inv_out: Single-sector inversion output.
+        countries: Country masks and cell areas used for country projection.
+
+    Returns:
+        Projected prior and posterior country traces promoted to float64 before
+        conversion from grams to kilograms per year. Dimensions, coordinates,
+        and dataset attributes are preserved, and every output variable has
+        ``units="kg/yr"``; variables typically have dimensions
+        ``(flux_time, country, draw)``.
+    """
+    projected_trace = countries.get_country_trace(inv_out=inv_out)
+    result = projected_trace.astype(np.float64) * 1e-3
+    result.attrs = dict(projected_trace.attrs)
+    for name in result.data_vars:
+        result[name].attrs["units"] = "kg/yr"
+    return result
+
+
 def _latest_country_outputs(
     inv_out: InversionOutput,
     countries: Countries,
@@ -960,27 +985,26 @@ def _latest_country_outputs(
         stats_args: Additional arguments passed to ``calculate_stats``.
         sector_name_by_suffix: Optional mapping from RHIME sector suffixes to
             normalized PARIS sector names.
-        multisector_country_trace: Optional precomputed multisector country
-            trace in kilograms per year.
+        multisector_country_trace: Optional precomputed single- or multisector
+            country trace in kilograms per year. The historical parameter name
+            is retained for compatibility.
 
     Returns:
         Country statistics in kilograms per year, with ``country`` and
         ``flux_time`` dimensions and total plus per-sector variables where
         applicable.
     """
-    if inv_out.is_multisector:
-        country_trace = multisector_country_trace
-        if country_trace is None:
-            country_trace = _multisector_country_trace_kg(
+    country_trace = multisector_country_trace
+    if country_trace is None:
+        country_trace = (
+            _multisector_country_trace_kg(
                 inv_out,
                 countries,
                 sector_name_by_suffix or _paris_sector_name_by_suffix(inv_out),
             )
-        country_stats_args = dict(stats_args)
-        country_stats_args["stats"] = stats
-        return calculate_stats(country_trace, **country_stats_args)
-
-    country_trace = countries.get_country_trace(inv_out=inv_out) * 1e-3
+            if inv_out.is_multisector
+            else _single_sector_country_trace_kg(inv_out, countries)
+        )
     country_stats_args = dict(stats_args)
     country_stats_args["stats"] = stats
     return calculate_stats(country_trace, **country_stats_args)
@@ -1004,25 +1028,26 @@ def _country_posterior_covariance_kg(
         inv_out: Single- or multisector inversion output.
         countries: Country masks and cell areas used for the country projection.
         flux_frequency: Frequency used to select output flux intervals.
-        multisector_country_trace: Optional precomputed multisector country trace
-            in kilograms per year.
+        multisector_country_trace: Optional precomputed single- or multisector
+            country trace in kilograms per year. The historical parameter name
+            is retained for compatibility.
 
     Returns:
         Population covariance for each flux interval with dimensions ordered as
         time, first country, and second country, in kg2 yr-2.
     """
-    if inv_out.is_multisector:
-        country_trace = multisector_country_trace
-        if country_trace is None:
-            country_trace = _multisector_country_trace_kg(
+    country_trace = multisector_country_trace
+    if country_trace is None:
+        country_trace = (
+            _multisector_country_trace_kg(
                 inv_out,
                 countries,
                 _paris_sector_name_by_suffix(inv_out),
             )
-        posterior = country_trace["country_posterior"]
-    else:
-        country_trace = countries.get_country_trace(inv_out=inv_out)
-        posterior = country_trace["country_posterior"] * 1e-3
+            if inv_out.is_multisector
+            else _single_sector_country_trace_kg(inv_out, countries)
+        )
+    posterior = country_trace["country_posterior"]
     flux_period = _flux_frequency_to_offset(flux_frequency)
     flux_times = list(pd.to_datetime(posterior.flux_time.values))
     _, _, valid_indices = _flux_interval_midpoints_and_bounds(
@@ -1411,14 +1436,14 @@ def paris_flux_output_latest(
         domain=domain,
         country_selections=country_selections,
     )
-    multisector_country_trace = (
+    country_trace = (
         _multisector_country_trace_kg(
             inv_out,
             countries,
             sector_name_by_suffix,
         )
         if inv_out.is_multisector
-        else None
+        else _single_sector_country_trace_kg(inv_out, countries)
     )
     country_outs = _latest_country_outputs(
         inv_out,
@@ -1426,7 +1451,7 @@ def paris_flux_output_latest(
         stats=stats,
         stats_args=stats_args,
         sector_name_by_suffix=sector_name_by_suffix,
-        multisector_country_trace=multisector_country_trace,
+        multisector_country_trace=country_trace,
     )
     country_fraction = countries.matrix.as_numpy().rename("country_fraction")
     cell_area = countries.area_grid.as_numpy().rename("cell_area")
@@ -1434,7 +1459,7 @@ def paris_flux_output_latest(
         inv_out,
         countries=countries,
         flux_frequency=flux_frequency,
-        multisector_country_trace=multisector_country_trace,
+        multisector_country_trace=country_trace,
     )
     sector_covariances, sector_cross_covariance = (
         _sector_country_posterior_covariances_kg(
@@ -1442,7 +1467,7 @@ def paris_flux_output_latest(
             countries=countries,
             flux_frequency=flux_frequency,
             sector_name_by_suffix=sector_name_by_suffix,
-            multisector_country_trace=multisector_country_trace,
+            multisector_country_trace=country_trace,
         )
         if inv_out.is_multisector
         else ({}, None)

--- a/openghg_inversions/postprocessing/make_paris_outputs.py
+++ b/openghg_inversions/postprocessing/make_paris_outputs.py
@@ -1019,9 +1019,12 @@ def _country_posterior_covariance_kg(
     )
 
     posterior = posterior.isel(flux_time=valid_indices).dropna("draw", how="all")
-    values = posterior.transpose("flux_time", "country", "draw").values
+    values = np.asarray(
+        posterior.transpose("flux_time", "country", "draw").values,
+        dtype=np.float64,
+    )
     if values.shape[2] == 0:
-        return np.full((values.shape[0], values.shape[1], values.shape[1]), np.nan, dtype="float32")
+        return np.full((values.shape[0], values.shape[1], values.shape[1]), np.nan, dtype=np.float64)
 
     centered = values - values.mean(axis=2, keepdims=True)
     return np.einsum("tcd,ted->tce", centered, centered) / values.shape[2]
@@ -1082,9 +1085,13 @@ def _sector_country_posterior_covariances_kg(
     ]
     sector_covariances = {}
     for sector_name, posterior in zip(sector_names, sector_posteriors, strict=True):
-        values = posterior.values
+        values = np.asarray(posterior.values, dtype=np.float64)
         if values.shape[2] == 0:
-            covariance = np.full((values.shape[0], values.shape[1], values.shape[1]), np.nan, dtype="float32")
+            covariance = np.full(
+                (values.shape[0], values.shape[1], values.shape[1]),
+                np.nan,
+                dtype=np.float64,
+            )
         else:
             centered = values - values.mean(axis=2, keepdims=True)
             covariance = np.einsum("tcd,ted->tce", centered, centered) / values.shape[2]
@@ -1097,12 +1104,15 @@ def _sector_country_posterior_covariances_kg(
         ],
         dim="sector",
     )
-    values = posterior_by_sector.transpose("flux_time", "country", "sector", "draw").values
+    values = np.asarray(
+        posterior_by_sector.transpose("flux_time", "country", "sector", "draw").values,
+        dtype=np.float64,
+    )
     if values.shape[3] == 0:
         sector_cross_covariance = np.full(
             (values.shape[0], values.shape[1], values.shape[2], values.shape[2]),
             np.nan,
-            dtype="float32",
+            dtype=np.float64,
         )
     else:
         centered = values - values.mean(axis=3, keepdims=True)

--- a/openghg_inversions/postprocessing/make_paris_outputs.py
+++ b/openghg_inversions/postprocessing/make_paris_outputs.py
@@ -920,9 +920,11 @@ def _multisector_country_trace_kg(
             if source_name in projected_trace:
                 rename[source_name] = f"country_{sector_name}_{when}"
 
-    # Promote only the projected country samples. PARIS country uncertainty
-    # statistics and totals then share one aligned float64 sector intermediate,
-    # while the much larger spatial draw arrays keep their original dtype.
+    # Float32 aggregation can incur significant round-off error in high-magnitude
+    # country totals and uncertainty statistics, so promote the projected country
+    # samples before calculating them. Keeping the promotion at country level lets
+    # these calculations share one aligned float64 sector intermediate while the
+    # much larger spatial draw arrays retain their original dtype.
     sector_trace = projected_trace[list(rename)].rename(rename).astype(np.float64) * 1e-3
     result = sector_trace.copy(deep=False)
     for when in ("prior", "posterior"):

--- a/openghg_inversions/rhime/outputs.py
+++ b/openghg_inversions/rhime/outputs.py
@@ -85,10 +85,23 @@ def _define_derived_output_filename(
 
 
 def _save_inferencedata(idata: az.InferenceData, path: str | Path) -> None:
-    """Save InferenceData, preferring the h5netcdf backend with fallbacks."""
+    """Save inference data while preserving metadata and serializable coords.
+
+    Root and group attributes are preserved while group MultiIndexes are reset
+    on a serialization copy. The h5netcdf, ArviZ-default, and netcdf4 backends
+    are attempted in that order.
+
+    Args:
+        idata: Inference data to serialize.
+        path: Destination NetCDF path.
+
+    Raises:
+        RuntimeError: If every supported NetCDF backend fails.
+    """
     if isinstance(idata, az.InferenceData):
         idata = cast(Any, az.InferenceData)(
-            **{group: _reset_serialisation_multiindexes(idata[group]) for group in idata.groups()}
+            attrs=dict(idata.attrs),
+            **{group: _reset_serialisation_multiindexes(idata[group]) for group in idata.groups()},
         )
 
     failures = []

--- a/openghg_inversions/rhime/sampling.py
+++ b/openghg_inversions/rhime/sampling.py
@@ -11,6 +11,7 @@ import pymc as pm
 import xarray as xr
 
 from openghg_inversions._timing import log_timing, timer_seconds, timer_start
+from openghg_inversions._sampling import _reset_retained_draws as _shared_reset_retained_draws
 from openghg_inversions.models.coords import get_coord_registry, restore_inferencedata_coords
 
 NutsSampler = Literal["pymc", "nutpie", "numpyro", "blackjax"]
@@ -86,15 +87,7 @@ def _reset_retained_draws(trace: az.InferenceData, *, burn: int) -> az.Inference
         consecutive zero-based integers and ``burn`` stored on the trace and
         draw-bearing groups.
     """
-    trace.attrs["burn"] = burn
-    for group_name in trace.groups():
-        group = getattr(trace, group_name)
-        if not isinstance(group, xr.Dataset) or "draw" not in group.dims:
-            continue
-        group = group.assign_coords(draw=np.arange(group.sizes["draw"]))
-        group.attrs["burn"] = burn
-        setattr(trace, group_name, group)
-    return trace
+    return _shared_reset_retained_draws(trace, burn=burn)
 
 
 class RhimeSampler:

--- a/openghg_inversions/rhime/sampling.py
+++ b/openghg_inversions/rhime/sampling.py
@@ -74,6 +74,29 @@ def _log_sample_stats(trace: az.InferenceData, *, label: str) -> None:
         log_timing(label, 0.0, **fields)
 
 
+def _reset_retained_draws(trace: az.InferenceData, *, burn: int) -> az.InferenceData:
+    """Relabel retained draws and preserve the discarded burn-in count.
+
+    Args:
+        trace: Inference data whose draw-bearing groups are relabelled in place.
+        burn: Number of discarded burn-in draws to record in metadata.
+
+    Returns:
+        The mutated inference data, with each draw coordinate reset to
+        consecutive zero-based integers and ``burn`` stored on the trace and
+        draw-bearing groups.
+    """
+    trace.attrs["burn"] = burn
+    for group_name in trace.groups():
+        group = getattr(trace, group_name)
+        if not isinstance(group, xr.Dataset) or "draw" not in group.dims:
+            continue
+        group = group.assign_coords(draw=np.arange(group.sizes["draw"]))
+        group.attrs["burn"] = burn
+        setattr(trace, group_name, group)
+    return trace
+
+
 class RhimeSampler:
     """PyMC sampler configuration and execution for RHIME models.
 
@@ -207,6 +230,7 @@ class RhimeSampler:
 
         timing_start = timer_start()
         trace = cast(az.InferenceData, raw_trace.isel(draw=slice(self.burn, None)))
+        trace = _reset_retained_draws(trace, burn=self.burn)
         log_timing("rhime.sampler.burn_slicing", timer_seconds(timing_start), burn=self.burn)
 
         trace = self._extend_predictive(trace, model=model)

--- a/tests/postprocessing/test_make_outputs.py
+++ b/tests/postprocessing/test_make_outputs.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Callable
+from typing import Any, Callable, cast
 
 import numpy as np
 import pytest
@@ -113,6 +113,115 @@ def test_multisector_flux_trace_materialization_is_optional(
 
     assert not isinstance(lazy_trace["flux_total_posterior"].data, np.ndarray)
     assert isinstance(materialized_trace["flux_total_posterior"].data, np.ndarray)
+
+
+def test_multisector_flux_total_preserves_all_missing_draws(
+    multisector_postprocessing_inv_out: Callable[..., InversionOutput],
+) -> None:
+    """Sector totals keep padding from unequal trace-group draw counts missing."""
+    inv_out = multisector_postprocessing_inv_out()
+    inference_data = cast(Any, inv_out.trace)
+    prior = inference_data.prior
+    extra_prior_draw = prior.isel(draw=[0]).assign_coords(draw=[prior.sizes["draw"]])
+    inference_data.prior = xr.concat([prior, extra_prior_draw], dim="draw")
+
+    trace = make_multisector_flux_trace_outputs(
+        inv_out,
+        report_flux_on_inversion_grid=False,
+    )
+
+    sector_total = trace["flux_ff_posterior"] + trace["flux_ocean_posterior"]
+    xr.testing.assert_allclose(trace["flux_total_posterior"], sector_total)
+    assert trace["flux_total_posterior"].isel(draw=-1).isnull().all()
+
+
+def test_multisector_flux_total_requires_each_sector_per_draw(
+    monkeypatch: pytest.MonkeyPatch,
+    multisector_postprocessing_inv_out: Callable[..., InversionOutput],
+) -> None:
+    """A structural zero does not hide another sector's padded missing draw."""
+    inv_out = multisector_postprocessing_inv_out()
+
+    def sector_trace(
+        output: InversionOutput,
+        sector: make_outputs.OutputSector,
+        *,
+        report_flux_on_inversion_grid: bool,
+    ) -> xr.Dataset:
+        del output, report_flux_on_inversion_grid
+        values = (
+            np.asarray([0.0, 0.0, 0.0])
+            if sector.variable_suffix == "ff"
+            else np.asarray([1.0, 2.0, np.nan])
+        )
+        return xr.Dataset({f"flux_{sector.variable_suffix}_posterior": ("draw", values)})
+
+    monkeypatch.setattr(make_outputs, "_sector_flux_trace_dataset", sector_trace)
+
+    trace = make_multisector_flux_trace_outputs(inv_out)
+
+    np.testing.assert_allclose(trace["flux_total_posterior"].isel(draw=slice(0, 2)), [1.0, 2.0])
+    assert trace["flux_total_posterior"].isel(draw=-1).isnull()
+
+
+def test_multisector_country_total_requires_each_sector_per_draw(
+    monkeypatch: pytest.MonkeyPatch,
+    multisector_postprocessing_inv_out: Callable[..., InversionOutput],
+) -> None:
+    """Country totals also reject draws missing any sector contribution."""
+    inv_out = multisector_postprocessing_inv_out()
+    countries = object.__new__(Countries)
+    countries.matrix = xr.DataArray(
+        [[[1.0]]],
+        dims=("country", "lat", "lon"),
+        coords={"country": ["GBR"], "lat": [0.0], "lon": [0.0]},
+    )
+    countries.area_grid = xr.DataArray(
+        [[1.0]],
+        dims=("lat", "lon"),
+        coords={"lat": [0.0], "lon": [0.0]},
+    )
+
+    def scale_trace(
+        output: InversionOutput,
+        sector: make_outputs.OutputSector,
+    ) -> xr.Dataset:
+        del output
+        values = (
+            np.asarray([0.0, 0.0, 0.0])
+            if sector.variable_suffix == "ff"
+            else np.asarray([1.0, 2.0, np.nan])
+        )
+        return xr.Dataset({"x_posterior": ("draw", values)})
+
+    def project_country_trace(
+        species: str,
+        trace: xr.Dataset,
+        x_to_country: xr.DataArray,
+    ) -> xr.Dataset:
+        del species, x_to_country
+        return trace.expand_dims(country=["GBR"], flux_time=[np.datetime64("2019-01-01")])
+
+    monkeypatch.setattr(make_outputs, "_sector_scale_trace", scale_trace)
+    monkeypatch.setattr(
+        make_outputs,
+        "_sector_basis_functions",
+        lambda *args: inv_out.basis_functions,
+    )
+    monkeypatch.setattr(
+        make_outputs,
+        "make_x_to_country_matrix",
+        lambda *args, **kwargs: xr.DataArray([1.0]),
+    )
+    monkeypatch.setattr(Countries, "_get_country_trace", staticmethod(project_country_trace))
+
+    trace = make_multisector_country_trace_outputs(inv_out, countries)
+
+    np.testing.assert_allclose(
+        trace["country_total_posterior"].isel(draw=slice(0, 2)).squeeze(),
+        [1.0, 2.0],
+    )
+    assert trace["country_total_posterior"].isel(draw=-1).isnull().all()
 
 
 def test_multisector_country_traces_project_basis_regions_before_scaling(

--- a/tests/postprocessing/test_make_paris_outputs.py
+++ b/tests/postprocessing/test_make_paris_outputs.py
@@ -18,7 +18,9 @@ from openghg_inversions.postprocessing.inversion_output import InversionOutput
 from openghg_inversions.postprocessing.make_paris_outputs import (
     PARIS_LATEST_COUNTRIES,
     _country_posterior_covariance_kg,
+    _latest_country_outputs,
     _latest_paris_countries,
+    _multisector_country_trace_kg,
     _paris_sector_name_by_suffix,
     _sector_country_posterior_covariances_kg,
     paris_flux_output,
@@ -264,28 +266,51 @@ def test_latest_paris_flux_output_processes_multisector_sectors(
 
 
 def test_multisector_country_covariance_promotes_float32_traces(
+    monkeypatch: pytest.MonkeyPatch,
     multisector_postprocessing_inv_out: Callable[..., InversionOutput],
 ) -> None:
-    """Country covariance centers high-magnitude float32 samples in float64."""
+    """Country totals promote sectors before aggregation and covariance statistics."""
     inv_out = multisector_postprocessing_inv_out()
     ff = np.asarray([1.0e12, 1.0002e12, 9.999e11, 1.0003e12], dtype=np.float32)
     ocean = np.asarray([8.0e11, 7.998e11, 8.0015e11, 7.9975e11], dtype=np.float32)
-    total = ff + ocean
+    rounded_total = ff + ocean
     coords = {
         "flux_time": [np.datetime64("2019-01-01")],
         "country": ["GBR"],
         "draw": np.arange(ff.size),
     }
-    country_trace = xr.Dataset(
-        {
-            "country_posterior": (("flux_time", "country", "draw"), total[None, None, :]),
-            "country_ff_posterior": (("flux_time", "country", "draw"), ff[None, None, :]),
-            "country_ocean_posterior": (
-                ("flux_time", "country", "draw"),
-                ocean[None, None, :],
-            ),
-        },
-        coords=coords,
+    raw_country_trace = xr.Dataset(coords=coords)
+    for when in ("prior", "posterior"):
+        raw_country_trace[f"country_total_{when}"] = (
+            ("flux_time", "country", "draw"),
+            rounded_total[None, None, :],
+        )
+        raw_country_trace[f"country_ff_{when}"] = (
+            ("flux_time", "country", "draw"),
+            ff[None, None, :],
+        )
+        raw_country_trace[f"country_ocean_{when}"] = (
+            ("flux_time", "country", "draw"),
+            ocean[None, None, :],
+        )
+
+    monkeypatch.setattr(
+        make_paris_outputs,
+        "make_multisector_country_trace_outputs",
+        lambda output, countries: raw_country_trace,
+    )
+    country_trace = _multisector_country_trace_kg(
+        inv_out,
+        countries=cast(Countries, None),
+        sector_name_by_suffix={"ff": "ff", "ocean": "ocean"},
+    )
+    country_stats = _latest_country_outputs(
+        inv_out,
+        countries=cast(Countries, None),
+        stats=["stdev"],
+        stats_args={},
+        sector_name_by_suffix={"ff": "ff", "ocean": "ocean"},
+        multisector_country_trace=country_trace,
     )
 
     total_covariance = _country_posterior_covariance_kg(
@@ -306,11 +331,24 @@ def test_multisector_country_covariance_promotes_float32_traces(
     assert all(covariance.dtype == np.dtype("float64") for covariance in sector_covariances.values())
     assert cross_covariance is not None
     assert cross_covariance.dtype == np.dtype("float64")
-    np.testing.assert_allclose(total_covariance[0, 0, 0], np.var(total.astype(np.float64)))
-    sector_values = np.stack([ff, ocean]).astype(np.float64)
+    sector_values = np.stack([ff, ocean]).astype(np.float64) * 1e-3
+    expected_total = sector_values.sum(axis=0)
+    rounded_total_kg = rounded_total.astype(np.float64) * 1e-3
+    assert not np.array_equal(expected_total, rounded_total_kg)
+    np.testing.assert_array_equal(
+        country_trace["country_posterior"].values[0, 0],
+        expected_total,
+    )
+    expected_variance = np.var(expected_total)
+    np.testing.assert_allclose(
+        country_stats["country_posterior_stdev"].values[0, 0] ** 2,
+        expected_variance,
+    )
+    np.testing.assert_allclose(total_covariance[0, 0, 0], expected_variance)
     centered = sector_values - sector_values.mean(axis=1, keepdims=True)
     expected_cross_covariance = centered @ centered.T / sector_values.shape[1]
     np.testing.assert_allclose(cross_covariance[0, 0], expected_cross_covariance)
+    np.testing.assert_allclose(cross_covariance[0, 0].sum(), expected_variance)
 
 
 def test_latest_paris_flux_output_renames_overlapping_sector_suffixes_exactly(

--- a/tests/postprocessing/test_make_paris_outputs.py
+++ b/tests/postprocessing/test_make_paris_outputs.py
@@ -23,6 +23,7 @@ from openghg_inversions.postprocessing.make_paris_outputs import (
     _multisector_country_trace_kg,
     _paris_sector_name_by_suffix,
     _sector_country_posterior_covariances_kg,
+    _single_sector_country_trace_kg,
     paris_flux_output,
 )
 
@@ -349,6 +350,63 @@ def test_multisector_country_covariance_promotes_float32_traces(
     expected_cross_covariance = centered @ centered.T / sector_values.shape[1]
     np.testing.assert_allclose(cross_covariance[0, 0], expected_cross_covariance)
     np.testing.assert_allclose(cross_covariance[0, 0].sum(), expected_variance)
+
+
+def test_single_sector_country_statistics_promote_before_unit_conversion(
+    multisector_postprocessing_inv_out: Callable[..., InversionOutput],
+) -> None:
+    """Single-sector country stdev and covariance share one promoted trace."""
+    inv_out = multisector_postprocessing_inv_out()
+    inv_out.run_metadata["split_by_sectors"] = False
+    samples = np.asarray([1.0e12, 1.0002e12, 9.999e11, 1.0003e12], dtype=np.float32)
+    raw_country_trace = xr.Dataset(
+        {
+            "country_prior": (("flux_time", "country", "draw"), samples[None, None, :]),
+            "country_posterior": (("flux_time", "country", "draw"), samples[None, None, :]),
+        },
+        coords={
+            "flux_time": [np.datetime64("2019-01-01")],
+            "country": ["GBR"],
+            "draw": np.arange(samples.size),
+        },
+    )
+
+    class FakeCountries:
+        """Provide the fixed projected country trace used by this regression test."""
+
+        def get_country_trace(self, inv_out: InversionOutput) -> xr.Dataset:
+            """Return high-magnitude projected samples without further conversion."""
+            return raw_country_trace
+
+    countries = cast(Countries, FakeCountries())
+    country_trace = _single_sector_country_trace_kg(inv_out, countries)
+    country_stats = _latest_country_outputs(
+        inv_out,
+        countries=countries,
+        stats=["stdev"],
+        stats_args={},
+        multisector_country_trace=country_trace,
+    )
+    covariance = _country_posterior_covariance_kg(
+        inv_out,
+        countries=countries,
+        flux_frequency="yearly",
+        multisector_country_trace=country_trace,
+    )
+
+    expected_samples = samples.astype(np.float64) * 1e-3
+    float32_scaled_samples = (samples * np.float32(1e-3)).astype(np.float64)
+    assert not np.array_equal(expected_samples, float32_scaled_samples)
+    assert country_trace["country_posterior"].dtype == np.dtype("float64")
+    np.testing.assert_array_equal(
+        country_trace["country_posterior"].values[0, 0],
+        expected_samples,
+    )
+    expected_variance = np.var(expected_samples)
+    stdev_squared = country_stats["country_posterior_stdev"].values[0, 0] ** 2
+    np.testing.assert_allclose(stdev_squared, expected_variance)
+    np.testing.assert_allclose(covariance[0, 0, 0], expected_variance)
+    np.testing.assert_allclose(covariance[0, 0, 0], stdev_squared)
 
 
 def test_latest_paris_flux_output_renames_overlapping_sector_suffixes_exactly(

--- a/tests/postprocessing/test_make_paris_outputs.py
+++ b/tests/postprocessing/test_make_paris_outputs.py
@@ -17,8 +17,10 @@ from openghg_inversions.postprocessing.countries import Countries
 from openghg_inversions.postprocessing.inversion_output import InversionOutput
 from openghg_inversions.postprocessing.make_paris_outputs import (
     PARIS_LATEST_COUNTRIES,
+    _country_posterior_covariance_kg,
     _latest_paris_countries,
     _paris_sector_name_by_suffix,
+    _sector_country_posterior_covariances_kg,
     paris_flux_output,
 )
 
@@ -261,6 +263,56 @@ def test_latest_paris_flux_output_processes_multisector_sectors(
             np.testing.assert_allclose(actual.values, expected.values, rtol=1e-6)
 
 
+def test_multisector_country_covariance_promotes_float32_traces(
+    multisector_postprocessing_inv_out: Callable[..., InversionOutput],
+) -> None:
+    """Country covariance centers high-magnitude float32 samples in float64."""
+    inv_out = multisector_postprocessing_inv_out()
+    ff = np.asarray([1.0e12, 1.0002e12, 9.999e11, 1.0003e12], dtype=np.float32)
+    ocean = np.asarray([8.0e11, 7.998e11, 8.0015e11, 7.9975e11], dtype=np.float32)
+    total = ff + ocean
+    coords = {
+        "flux_time": [np.datetime64("2019-01-01")],
+        "country": ["GBR"],
+        "draw": np.arange(ff.size),
+    }
+    country_trace = xr.Dataset(
+        {
+            "country_posterior": (("flux_time", "country", "draw"), total[None, None, :]),
+            "country_ff_posterior": (("flux_time", "country", "draw"), ff[None, None, :]),
+            "country_ocean_posterior": (
+                ("flux_time", "country", "draw"),
+                ocean[None, None, :],
+            ),
+        },
+        coords=coords,
+    )
+
+    total_covariance = _country_posterior_covariance_kg(
+        inv_out,
+        countries=cast(Countries, None),
+        flux_frequency="yearly",
+        multisector_country_trace=country_trace,
+    )
+    sector_covariances, cross_covariance = _sector_country_posterior_covariances_kg(
+        inv_out,
+        countries=cast(Countries, None),
+        flux_frequency="yearly",
+        sector_name_by_suffix={"ff": "ff", "ocean": "ocean"},
+        multisector_country_trace=country_trace,
+    )
+
+    assert total_covariance.dtype == np.dtype("float64")
+    assert all(covariance.dtype == np.dtype("float64") for covariance in sector_covariances.values())
+    assert cross_covariance is not None
+    assert cross_covariance.dtype == np.dtype("float64")
+    np.testing.assert_allclose(total_covariance[0, 0, 0], np.var(total.astype(np.float64)))
+    sector_values = np.stack([ff, ocean]).astype(np.float64)
+    centered = sector_values - sector_values.mean(axis=1, keepdims=True)
+    expected_cross_covariance = centered @ centered.T / sector_values.shape[1]
+    np.testing.assert_allclose(cross_covariance[0, 0], expected_cross_covariance)
+
+
 def test_latest_paris_flux_output_renames_overlapping_sector_suffixes_exactly(
     europe_country_file: Path,
     fake_multisector_basis_functions_matching_country_grid: Callable[..., BasisFunctions],
@@ -330,6 +382,13 @@ def test_latest_paris_flux_output_renames_overlapping_sector_suffixes_exactly(
             rtol=1e-6,
         )
     assert np.isfinite(flux_outputs["covariance_flux_sectors_posterior_country"].values).all()
+    total_variance = np.diagonal(
+        flux_outputs["covariance_flux_total_posterior_country"].values,
+        axis1=1,
+        axis2=2,
+    )
+    sector_variance = flux_outputs["covariance_flux_sectors_posterior_country"].values.sum(axis=(2, 3))
+    np.testing.assert_allclose(total_variance, sector_variance, rtol=1e-6)
 
 
 def test_latest_paris_country_selection_defaults_to_domain_file(

--- a/tests/test_inferpymc.py
+++ b/tests/test_inferpymc.py
@@ -1,3 +1,5 @@
+from typing import Any, cast
+
 import arviz as az
 import numpy as np
 import pandas as pd
@@ -13,6 +15,7 @@ from openghg_inversions.hbmcmc.inversion_pymc import (
     sample,
 )
 from openghg_inversions.models.coords import restore_inferencedata_coords
+from openghg_inversions.postprocessing.inversion_output import convert_idata_to_dataset
 
 
 @pytest.fixture(scope="module")
@@ -122,6 +125,92 @@ def test_sample_accepts_plain_model_and_predictive_options(
     assert "prior" in modern_result
     assert "prior_predictive" in modern_result
     assert "posterior_predictive" in modern_result
+
+
+def test_sample_resets_burned_draws_before_extending_predictive_groups(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Legacy sampling aligns every retained and predictive group after burn-in."""
+    raw_trace = az.InferenceData(
+        posterior=xr.Dataset(
+            {"x": (("chain", "draw"), np.arange(6, dtype=float)[None, :])},
+            coords={"chain": [0], "draw": np.arange(6)},
+        ),
+        sample_stats=xr.Dataset(
+            {"diverging": (("chain", "draw"), np.zeros((1, 6), dtype=bool))},
+            coords={"chain": [0], "draw": np.arange(6)},
+        ),
+        log_likelihood=xr.Dataset(
+            {"y": (("chain", "draw"), np.zeros((1, 6)))},
+            coords={"chain": [0], "draw": np.arange(6)},
+        ),
+    )
+
+    def fake_sample(**kwargs: Any) -> az.InferenceData:
+        """Return a deterministic raw trace without running MCMC."""
+        return raw_trace
+
+    def fake_prior_predictive(draws: int, model: pm.Model) -> az.InferenceData:
+        """Return zero-based prior groups matching the retained draw count."""
+        coords = {"chain": [0], "draw": np.arange(draws)}
+        return az.InferenceData(
+            prior=xr.Dataset({"x": (("chain", "draw"), np.ones((1, draws)))}, coords=coords),
+            prior_predictive=xr.Dataset(
+                {"y": (("chain", "draw"), np.ones((1, draws)))},
+                coords=coords,
+            ),
+        )
+
+    def fake_posterior_predictive(
+        trace: az.InferenceData,
+        **kwargs: Any,
+    ) -> az.InferenceData:
+        """Return a zero-based posterior-predictive group for the retained trace."""
+        draws = cast(Any, trace).posterior.sizes["draw"]
+        return az.InferenceData(
+            posterior_predictive=xr.Dataset(
+                {"y": (("chain", "draw"), np.ones((1, draws)))},
+                coords={"chain": [0], "draw": np.arange(draws)},
+            )
+        )
+
+    monkeypatch.setattr(inversion_pymc_module.pm, "sample", fake_sample)
+    monkeypatch.setattr(inversion_pymc_module.pm, "sample_prior_predictive", fake_prior_predictive)
+    monkeypatch.setattr(
+        inversion_pymc_module.pm,
+        "sample_posterior_predictive",
+        fake_posterior_predictive,
+    )
+
+    result = cast(
+        Any,
+        sample(
+            pm.Model(),
+            draws=6,
+            burn=3,
+            tune=0,
+            chains=1,
+            sample_prior_predictive=True,
+            sample_posterior_predictive=["y"],
+        ),
+    )
+    merged = convert_idata_to_dataset(result)
+
+    expected_draws = np.arange(3)
+    for group_name in (
+        "posterior",
+        "sample_stats",
+        "log_likelihood",
+        "prior",
+        "prior_predictive",
+        "posterior_predictive",
+    ):
+        np.testing.assert_array_equal(result[group_name].draw.values, expected_draws)
+    assert result.attrs["burn"] == 3
+    assert result.posterior.attrs["burn"] == 3
+    assert merged.sizes["draw"] == 3
+    np.testing.assert_array_equal(merged.draw.values, expected_draws)
+    assert not merged.to_array().isnull().any()
 
 
 def test_sample_always_returns_inferencedata(
@@ -267,9 +356,7 @@ def test_build_inferpymc_model_with_offset_args_adds_offset_terms(
 
     model = build_inferpymc_model(inv_inputs, **args)
 
-    assert {"offset", "offset_latent", "offset_design", "offset_freq_indicator"}.issubset(
-        model.named_vars
-    )
+    assert {"offset", "offset_latent", "offset_design", "offset_freq_indicator"}.issubset(model.named_vars)
 
 
 def test_build_inferpymc_model_with_pollution_events_and_no_bc_builds_likelihood(

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -2356,7 +2356,7 @@ def test_make_multisector_output_bundle_builds_latest_paris_flux(
 
 
 def test_modern_inversion_output_save_load_roundtrip(tmp_path: Path) -> None:
-    """Modern RHIME InversionOutput preserves retained inputs, basis, and metadata."""
+    """Modern InversionOutput preserves trace burn metadata, inputs, and basis."""
     model_spec, output_spec, run_spec = _minimal_output_specs()
     basis_artifact_path = str(tmp_path / "unit-basis.nc")
     prepared = RhimePreparedInputs(
@@ -2369,11 +2369,14 @@ def test_modern_inversion_output_save_load_roundtrip(tmp_path: Path) -> None:
         basis_artifact_source="unit-test",
         basis_artifact_path=basis_artifact_path,
     )
+    idata = _minimal_output_idata()
+    idata.attrs["burn"] = 1000
+    cast(Any, idata).posterior.attrs["burn"] = 1000
     bundle = rhime_outputs.make_standard_output_bundle(
         output_spec=output_spec,
         run_spec=run_spec,
         model_spec=model_spec,
-        idata=_minimal_output_idata(),
+        idata=idata,
         prepared=prepared,
         country_file=None,
     )
@@ -2391,6 +2394,8 @@ def test_modern_inversion_output_save_load_roundtrip(tmp_path: Path) -> None:
     assert reloaded.basis_functions.basis_artifact_path == basis_artifact_path
     assert reloaded.provenance["basis_representation"] == "operator-backed"
     assert reloaded.output_metadata["output_format"] == "inv_out"
+    assert reloaded.trace.attrs["burn"] == 1000
+    assert cast(Any, reloaded.trace).posterior.attrs["burn"] == 1000
     xr.testing.assert_identical(reloaded.inv_inputs, prepared.inv_inputs)
     xr.testing.assert_identical(reloaded.basis_functions.flux, prepared.basis_functions.flux)
     xr.testing.assert_equal(
@@ -2902,6 +2907,7 @@ def test_latest_paris_output_processes_modern_output(europe_country_file: Path, 
     )
     assert "country_flux_total_posterior" not in flux_outputs
     assert flux_outputs["flux_total_posterior"].dtype == np.dtype("float32")
+    assert flux_outputs["stdev_flux_total_posterior_country"].dtype == np.dtype("float32")
     assert flux_outputs["covariance_flux_total_posterior_country"].dtype == np.dtype("float32")
     assert flux_outputs["time_bnds"].dtype == np.dtype("float64")
 
@@ -3150,8 +3156,8 @@ def test_save_inferencedata_falls_back_after_h5netcdf_failure(tmp_path: Path) ->
     ]
 
 
-def test_save_inferencedata_resets_multiindex_coords(tmp_path: Path) -> None:
-    """Standalone trace saving handles restored scientific measurement coordinates."""
+def test_save_inferencedata_preserves_burn_attrs_and_resets_multiindex_coords(tmp_path: Path) -> None:
+    """Standalone trace saving preserves burn metadata and serializable coordinates."""
     nmeasure_index = pd.MultiIndex.from_arrays(
         [["TAC"], pd.to_datetime(["2019-01-01"])],
         names=["site", "time"],
@@ -3166,10 +3172,16 @@ def test_save_inferencedata_resets_multiindex_coords(tmp_path: Path) -> None:
     )
     path = tmp_path / "trace.nc"
 
-    rhime_outputs._save_inferencedata(az.InferenceData(posterior_predictive=posterior_predictive), path)
+    idata = az.InferenceData(posterior_predictive=posterior_predictive)
+    idata.attrs["burn"] = 1000
+    cast(Any, idata).posterior_predictive.attrs["burn"] = 1000
+
+    rhime_outputs._save_inferencedata(idata, path)
     reloaded = az.from_netcdf(path)
 
     reloaded_posterior_predictive = cast(Any, reloaded).posterior_predictive
+    assert reloaded.attrs["burn"] == 1000
+    assert reloaded_posterior_predictive.attrs["burn"] == 1000
     assert "site" in reloaded_posterior_predictive.coords
     assert "time" in reloaded_posterior_predictive.coords
     assert not isinstance(reloaded_posterior_predictive.indexes.get("nmeasure"), pd.MultiIndex)

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -895,10 +895,15 @@ def test_rhime_sampler_runs_pymc_sampling_and_predictive_steps(
         def __init__(self) -> None:
             self.isel_kwargs: dict[str, Any] | None = None
             self.extensions: list[Any] = []
+            self.attrs: dict[str, Any] = {}
 
         def isel(self, **kwargs: Any) -> "FakeInferenceData":
             self.isel_kwargs = kwargs
             return self
+
+        def groups(self) -> list[str]:
+            """Return the fake InferenceData group names."""
+            return ["sample_stats"]
 
         def extend(self, other: Any) -> None:
             self.extensions.append(other)
@@ -975,6 +980,88 @@ def test_rhime_sampler_runs_pymc_sampling_and_predictive_steps(
     assert sample_stats_fields["divergences"] == 2
 
 
+def test_rhime_sampler_resets_retained_draws_before_extending_predictive_groups(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Equal-length predictive groups do not outer-align against burned draw labels."""
+    raw_trace = az.InferenceData(
+        posterior=xr.Dataset(
+            {"x": (("chain", "draw"), np.arange(2000, dtype=float)[None, :])},
+            coords={"chain": [0], "draw": np.arange(2000)},
+        ),
+        sample_stats=xr.Dataset(
+            {"diverging": (("chain", "draw"), np.zeros((1, 2000), dtype=bool))},
+            coords={"chain": [0], "draw": np.arange(2000)},
+        ),
+        log_likelihood=xr.Dataset(
+            {"y": (("chain", "draw"), np.zeros((1, 2000)))},
+            coords={"chain": [0], "draw": np.arange(2000)},
+        ),
+    )
+    predictive_draws: dict[str, np.ndarray] = {}
+
+    def fake_sample(**kwargs: Any) -> az.InferenceData:
+        """Return the unsliced sampling trace."""
+        return raw_trace
+
+    def fake_prior_predictive(draws: int, model: pm.Model) -> az.InferenceData:
+        """Build prior groups with zero-based draw labels."""
+        predictive_draws["prior"] = np.arange(draws)
+        return az.InferenceData(
+            prior=xr.Dataset(
+                {"x": (("chain", "draw"), np.ones((1, draws)))},
+                coords={"chain": [0], "draw": predictive_draws["prior"]},
+            ),
+            prior_predictive=xr.Dataset(
+                {"y": (("chain", "draw"), np.ones((1, draws)))},
+                coords={"chain": [0], "draw": predictive_draws["prior"]},
+            ),
+        )
+
+    def fake_posterior_predictive(trace: az.InferenceData, **kwargs: Any) -> az.InferenceData:
+        """Record and mirror the retained posterior draw labels."""
+        inference_data = cast(Any, trace)
+        predictive_draws["posterior_seen"] = inference_data.posterior.draw.values.copy()
+        draws = inference_data.posterior.sizes["draw"]
+        return az.InferenceData(
+            posterior_predictive=xr.Dataset(
+                {"y": (("chain", "draw"), np.ones((1, draws)))},
+                coords={"chain": [0], "draw": np.arange(draws)},
+            )
+        )
+
+    monkeypatch.setattr("openghg_inversions.rhime.sampling.pm.sample", fake_sample)
+    monkeypatch.setattr(
+        "openghg_inversions.rhime.sampling.pm.sample_prior_predictive",
+        fake_prior_predictive,
+    )
+    monkeypatch.setattr(
+        "openghg_inversions.rhime.sampling.pm.sample_posterior_predictive",
+        fake_posterior_predictive,
+    )
+    sampler = RhimeSampler(draws=2000, burn=1000, tune=0, chains=1)
+
+    result = sampler.sample(pm.Model())
+    inference_data = cast(Any, result)
+    trace_dataset = inversion_output_module.convert_idata_to_dataset(result)
+
+    expected_draws = np.arange(1000)
+    np.testing.assert_array_equal(inference_data.posterior.draw.values, expected_draws)
+    np.testing.assert_array_equal(inference_data.sample_stats.draw.values, expected_draws)
+    np.testing.assert_array_equal(inference_data.log_likelihood.draw.values, expected_draws)
+    np.testing.assert_array_equal(inference_data.prior.draw.values, expected_draws)
+    np.testing.assert_array_equal(inference_data.prior_predictive.draw.values, expected_draws)
+    np.testing.assert_array_equal(inference_data.posterior_predictive.draw.values, expected_draws)
+    np.testing.assert_array_equal(predictive_draws["prior"], expected_draws)
+    np.testing.assert_array_equal(predictive_draws["posterior_seen"], expected_draws)
+    assert trace_dataset.sizes["draw"] == 1000
+    np.testing.assert_array_equal(trace_dataset.draw.values, expected_draws)
+    assert not trace_dataset.to_array().isnull().any()
+    assert inference_data.attrs["burn"] == 1000
+    for group_name in ("posterior", "sample_stats", "log_likelihood"):
+        assert inference_data[group_name].attrs["burn"] == 1000
+
+
 def test_rhime_sampler_restores_registered_coords_after_predictive_steps(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -988,9 +1075,14 @@ def test_rhime_sampler_restores_registered_coords_after_predictive_steps(
 
         def __init__(self) -> None:
             self.extensions: list[str] = []
+            self.attrs: dict[str, Any] = {}
 
         def isel(self, **kwargs: Any) -> "FakeInferenceData":
             return self
+
+        def groups(self) -> list[str]:
+            """Return the fake InferenceData group names."""
+            return []
 
         def extend(self, other: str) -> None:
             self.extensions.append(other)


### PR DESCRIPTION
## Summary

Fixes multisector spatial and country reconstruction when burn slicing and predictive sampling produce equal-length ArviZ groups with different draw labels. With `draws=2000, burn=1000`, retained posterior groups previously kept labels `1000..1999` while the 1,000 prior-predictive samples used `0..999`; the downstream outer merge therefore created a padded 2,000-label union.

Both modern RHIME and fixed-basis sampling now reset retained draw coordinates to `0..n_retained-1` immediately after burn slicing and before predictive groups are attached. The explicit outer merge remains as a defensive fallback for genuinely unequal external groups, and multisector totals still require a value from every sector so structural zeroes cannot hide padded missing draws.

Latest-PARIS country processing promotes projected country samples to float64 before aggregation and uncertainty statistics for both single- and multisector inversions. Total and per-sector stdev/covariance therefore use the same promoted country-level inputs, while the much larger spatial draw arrays retain their original dtype and outputs are cast only at the template boundary.

The discarded burn count is recorded on the InferenceData root and draw-bearing groups and now survives standalone trace, InversionOutput/DataTree, and fixed-basis compatibility serialization paths.

## Validation

- Full `tests/test_inferpymc.py`: 16 passed
- Full `tests/postprocessing/test_make_paris_outputs.py`: 7 passed
- Focused RHIME sampling, serialization, and latest-PARIS checks: 6 passed
- Ruff check and format checks passed
- Targeted Pyright passed; legacy files retain unrelated baseline type errors
- Full tox matrix not run locally

Real-data evidence remains in #519. Test-inversions job `18115001` passed the strict latest-PARIS multisector validator end to end in 4:01; the test definition and validator are in openghg/test_inversions#12. Its six sampling divergences make that functional/output-contract evidence only and are unrelated to the draw-coordinate mismatch.

## Checklist

- [x] Closes #519
- [x] Regression and round-trip tests added and passing
- [x] Behavior documented in `CHANGELOG.md`
- [x] No new requirements