### PR TITLE
Add RHIME builder strategy seam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 ## Code changes
 
+- Added a shared RHIME flux-plan/compiler seam for standard and multisector
+  builders, and routed explicit sector-to-source mappings plus complete
+  per-sector priors through multisector preparation and model specifications.
+  Source-specific ragged state blocks remain gathered over
+  `(source, region_in_source)`, scalar source provenance remains single-sector,
+  and rectangular multisource adaptation is confined to the legacy
+  `fixedbasisMCMC` boundary.
+  [#402](https://github.com/openghg/openghg_inversions/issues/402),
+  [#403](https://github.com/openghg/openghg_inversions/issues/403),
+  [PR #529](https://github.com/openghg/openghg_inversions/pull/529)
+
 - Reset retained posterior draw labels after burn-in before attaching predictive
   groups in both modern RHIME and fixed-basis sampling, and preserve the
   discarded burn count through trace and `InversionOutput` round trips.

--- a/README.md
+++ b/README.md
@@ -214,8 +214,9 @@ RHIME terminology:
 - `species`: primary gas or tracer name used for object-store lookup and output naming.
 - `source`: OpenGHG metadata key used to retrieve flux data.
 - `flux_sources`: RHIME field containing requested OpenGHG flux `source` values.
-- `sector_sources`: optional mapping from RHIME sector names to OpenGHG flux `source` values.
-- `sector`: model component optimized separately, usually backed by one flux `source`.
+- `sector_sources`: optional one-to-one mapping from RHIME sector names to unique OpenGHG flux `source` values.
+- `sector_priors`: optional complete mapping from RHIME sector names to flux-scaling priors; omit it to use a shared `x_prior`.
+- `sector`: model component optimized separately, currently backed by one unique flux `source`.
 - `tracer`: additional species used to constrain the primary species through linked forward models.
 - `emissions_name`: legacy compatibility spelling only; use `flux_sources` in new RHIME configs.
 

--- a/docs/plans/issues_402_403_builder_strategy_design.md
+++ b/docs/plans/issues_402_403_builder_strategy_design.md
@@ -1,0 +1,442 @@
+# Issues 402/403 Builder Strategy Design Notes
+
+Date: 2026-06-09
+
+Status: design notes, not an implementation plan.
+
+## Scope
+
+These notes revisit:
+
+- [#402](https://github.com/openghg/openghg_inversions/issues/402):
+  multi-sector RHIME with shared-basis inputs and a builder-strategy seam.
+- [#403](https://github.com/openghg/openghg_inversions/issues/403):
+  route multiple flux sources and per-sector priors into RHIME inputs.
+- [#472](https://github.com/openghg/openghg_inversions/pull/472):
+  sector-level latest-PARIS flux outputs.
+
+They also check the design against milestone 10 high-resolution requirements
+([#407](https://github.com/openghg/openghg_inversions/issues/407),
+[#408](https://github.com/openghg/openghg_inversions/issues/408),
+[#409](https://github.com/openghg/openghg_inversions/issues/409),
+[#410](https://github.com/openghg/openghg_inversions/issues/410)) and
+milestone 11 tracer requirements
+([#411](https://github.com/openghg/openghg_inversions/issues/411),
+[#412](https://github.com/openghg/openghg_inversions/issues/412),
+[#413](https://github.com/openghg/openghg_inversions/issues/413)).
+
+The source checkout used for OpenGHG `ModelScenario` behavior is:
+
+```text
+~/Documents/openghg/openghg/analyse/_scenario.py
+```
+
+## Position
+
+The durable distinction is not "single-sector versus multi-sector". The
+durable distinction is how a set of named flux contributions is compiled into
+one or more modelled-observation vectors.
+
+Current RHIME already has the bones of one pattern:
+
+```text
+OpenGHG flux sources
+-> prepared sensitivities and prior fluxes
+-> named model contributions
+-> summed concentration mean
+-> shared BC / offset / error / likelihood
+-> product-specific outputs
+```
+
+On that framing:
+
+- `run_rhime` is one model contribution, currently restricted to one
+  `flux_source`.
+- `run_rhime_multisector` is multiple model contributions, currently one
+  contribution per `flux_source`, compiled with a loop-sum strategy.
+- A future single-sector multi-source inversion is one model contribution backed
+  by a group of input sources.
+- A future high-resolution model is multiple domain contributions, for example
+  outer plus inner, compiled into one total `mu`.
+- A future linked CO2/O2 model has one or more latent sector states feeding
+  multiple species or tracer forward models and likelihoods.
+
+That suggests a small "contribution plan" as the local bridge toward the
+semantic model representation. It can remain private and RHIME-specific for now,
+but it should use the same concepts that a later `SemanticModel` would use.
+
+## Current Coverage And Gaps
+
+### Issue 402
+
+Already mostly done:
+
+- `SectorSpec` and `RhimeModelSpec` exist and keep model metadata out of the
+  runner.
+- `build_rhime_multisector_model(...)` builds one `x_<suffix>` and
+  `mu_<suffix>` per sector and creates total deterministic `mu` as the sum of
+  sector contributions.
+- Per-sector priors are passed through to distinct latent variables.
+- Shared-basis multisector preparation carries source-resolved sensitivity data
+  in `H(..., source)`.
+- Source-specific/ragged basis operators already exist in the basis layer.
+
+Remaining design gap:
+
+- The builder strategy seam is not real yet. The loop is hard-coded in the
+  multisector builder, and the runner chooses separate builders with a
+  `multisector` boolean.
+- The current model metadata says "sector", but the prepared data coordinate is
+  still OpenGHG `source`. That is acceptable as a transitional layout, but it is
+  not a semantic sector model.
+- Non-shared basis support is partly present below the builder, but the current
+  RHIME builder still wants legacy padded source structure rather than a direct
+  gathered-state contribution layout.
+
+Minimum closure for #402 may not require a public strategy registry. It does
+require a place where the model builder first normalizes the model into ordered
+linear contributions, then applies a compilation shape such as loop-sum. The
+spec should continue to describe the math and labels, not whether PyMC uses a
+loop, a stacked design matrix, or some later PyTensor operation.
+
+### Issue 403
+
+Already mostly done:
+
+- New API/config surfaces prefer `flux_sources`.
+- `sector_sources` can map user-facing sector names to OpenGHG source names.
+- `sector_priors` accepts per-sector prior dictionaries.
+- Validation catches duplicate sanitized sector names, malformed sector priors,
+  and mismatched `sector_sources`.
+- `run_rhime_multisector` can retrieve multiple OpenGHG flux sources and prepare
+  source-resolved sensitivities.
+
+Remaining design gap:
+
+- `run_rhime` currently rejects multiple `flux_sources`, even though OpenGHG
+  `ModelScenario` has a coarse single-total multi-source behavior.
+- `sector_sources` currently enforces a one-to-one mapping between model sectors
+  and OpenGHG sources. That makes it mainly a renaming device when there is no
+  real grouping.
+- The canonical "sector" sensitivity is really source-resolved sensitivity. It
+  does not yet express one model sector backed by multiple source inputs.
+
+The important fresh constraint is that "multiple sources" and "multiple model
+states" are not the same thing.
+
+## ModelScenario Constraint
+
+OpenGHG `ModelScenario` already distinguishes two useful modes.
+
+With `split_by_sectors=False`, `combine_flux_sources(...)` takes one or more
+OpenGHG flux sources and combines them into one flux dataset. The downstream
+`fp_x_flux` has no `source` dimension. That is the old coarse behavior: many
+input sources, one modelled flux field, one possible state vector.
+
+With `split_by_sectors=True`, `calc_modelled_obs(...)` still computes the usual
+total `mf_mod` and `fp_x_flux`, then loops over each source to add
+`mf_mod_sectoral` and `fp_x_flux_sectoral` with a `source` dimension.
+
+This is a strong argument against using `source` and `sector` interchangeably.
+OpenGHG `source` is input provenance. A RHIME sector or contribution is a model
+grouping decision.
+
+It also means a single-sector multi-source RHIME path is not an exotic future
+feature. It is the behavior that the current `run_rhime` wrapper blocks at the
+parameter layer.
+
+## Builder Strategy As General Pattern
+
+The builder-strategy seam should sit behind the RHIME model-spec boundary, close
+to `models/rhime.py`.
+
+The runner should not grow a tree of special cases. Parameter parsing should not
+know whether the PyMC graph is a loop, a stacked dot product, or a shared-state
+projection. Data preparation should provide source-resolved or grouped
+sensitivities, but the builder should own how model contributions are compiled.
+
+A useful contribution record, conceptually, needs these roles:
+
+- model contribution id: stable model/component name, for example `ff`,
+  `ocean`, `outer`, or `inner`.
+- input source group: one or more OpenGHG `source` values that back the
+  contribution.
+- state space: shared basis region, source-specific gathered state, inner-domain
+  state, outer-domain state, or shared tracer-linked state.
+- prior policy: one prior for the contribution state, or a future policy for
+  source-specific subparts.
+- output labels: product-neutral labels for generic diagnostics.
+- links: optional typed dependencies, such as "this O2 forward map uses the CH4
+  fossil-fuel state with a conversion factor".
+
+This record is not necessarily a new public class today. It is the shape that
+keeps `run_rhime` and `run_rhime_multisector` from remaining separate model
+families.
+
+### Current Special Cases
+
+`run_rhime` can be viewed as:
+
+```text
+contribution total:
+    input source group = requested flux_sources
+    state = one optimized state
+    builder strategy = single linear contribution
+    aggregate mu = contribution mu
+```
+
+Today this is artificially limited to one source. Relaxing that limit would
+recover the `ModelScenario` coarse total behavior: multiple input sources, one
+state, one `mu`.
+
+`run_rhime_multisector` can be viewed as:
+
+```text
+contribution ff:
+    input source group = [ff-source]
+    state = x_ff
+    mu = H_ff @ x_ff
+
+contribution ocean:
+    input source group = [ocean-source]
+    state = x_ocean
+    mu = H_ocean @ x_ocean
+
+aggregate total:
+    mu = mu_ff + mu_ocean
+```
+
+This is the current loop-sum strategy. The same contribution list could later
+be lowered as a stacked design matrix if the state dimensions are compatible or
+can be represented with gathered state indices.
+
+### Future Special Cases
+
+Single-sector multi-source:
+
+```text
+contribution total:
+    input source group = [source_a, source_b, ...]
+    state = x_total
+    mu = H_grouped @ x_total
+```
+
+This is not equivalent to independently optimized sectors summed after the
+fact. It represents the assumption that one scale state applies to the grouped
+prior flux.
+
+Virtual total:
+
+```text
+aggregate total:
+    mu_total = sum(mu_contribution)
+    flux_total = sum(reconstructed_flux_contribution)
+```
+
+`total` should usually be a virtual aggregate, not an OpenGHG source and not a
+sampled sector state. A derived `x_total` is only meaningful under explicit
+conditions. For example, if all contributions share basis regions, an output
+could compute a flux-weighted total scale factor, but that is an output
+diagnostic rather than the latent variable sampled by the model.
+
+High-resolution inner/outer:
+
+```text
+contribution outer:
+    state = x_outer
+    mu = H_outer @ x_outer
+
+contribution inner:
+    state = x_inner
+    mu = H_inner @ x_inner
+
+aggregate total:
+    mu = mu_outer + mu_inner
+```
+
+This is structurally the same as multisector loop-sum, but the contribution
+identity is domain partition rather than emission sector. Milestone 10 asks for
+this distinction to survive into outputs, so flattening everything into a
+single anonymous state would be a step backward even if it samples correctly.
+
+Tracer linked-state:
+
+```text
+contribution ch4_ff_state:
+    state = x_ff
+
+forward co2:
+    mu_co2_ff = H_co2_ff @ x_ff
+
+forward o2:
+    mu_o2_ff = conversion_factor * H_o2_ff @ x_ff
+```
+
+This is why the builder seam should not be only "loop versus stacked dot". The
+larger abstraction is a contribution/state graph that can lower to PyMC in more
+than one shape.
+
+## Source, Sector, And Output Vocabulary
+
+The current names are close, but the responsibilities should be sharper.
+
+Recommended vocabulary:
+
+- `flux_source`: OpenGHG input/source coordinate used for object-store lookup
+  and data provenance.
+- `source_group`: one or more `flux_source` values backing a model
+  contribution.
+- `model_contribution`: an optimized model component, currently usually called
+  a sector.
+- `model_sector`: a contribution whose scientific meaning is an emission or
+  uptake sector.
+- `model_variable_suffix`: private PyMC/trace suffix used for variable names.
+- `output_sector_label`: product-neutral label for output diagnostics.
+- `paris_sector_code`: PARIS schema-safe label used in PARIS variable names and
+  the PARIS `sector` coordinate.
+- `virtual_total`: aggregate over contributions, not a real source.
+
+If the mapping is one-to-one and the names are identical, `sector_sources` adds
+little semantic value. It is just a renaming layer. That is acceptable as a
+transition, but the long-term model should not require users to invent a sector
+mapping when all they have is a list of OpenGHG sources.
+
+The first non-renaming case is likely:
+
+```text
+model sector "anthro":
+    source_group = ["ff-inventory", "industry-inventory", "waste-inventory"]
+```
+
+That removes the one-to-one mapping and makes the sector/source split worth
+having.
+
+## PR 472 Output Flow
+
+PR #472 is useful because it exercises the whole path from model-sector
+metadata to product variables.
+
+Good direction:
+
+- It adds per-sector latest-PARIS flux variables alongside total variables.
+- It keeps total flux outputs derived from reconstructed sector flux fields,
+  not from summed scale factors.
+- It adds a PARIS `sector` coordinate and sector country covariance diagnostics.
+
+Risk:
+
+- PARIS sector names are derived from `variable_suffix`. That suffix is
+  documented as the PyMC-safe model variable suffix, not as a product-facing
+  code. Changing a model variable suffix would therefore change public PARIS
+  variable names.
+- The PR adds a local sector metadata parser in `make_paris_outputs.py`, while
+  `make_outputs.py` already has `OutputSector` metadata resolution. That is a
+  duplication point.
+- The current flow becomes:
+
+```text
+OpenGHG source
+-> SectorSpec.name
+-> variable_suffix
+-> generic flux_<suffix> variables
+-> PARIS flux_<paris_name> variables
+```
+
+That is understandable for #405, but it will get harder when milestone 10 adds
+inner/outer outputs and milestone 11 adds species/tracer-aware outputs.
+
+The output boundary should name the stages explicitly:
+
+```text
+model identity
+-> product-neutral output label
+-> product-specific variable name
+```
+
+PARIS-specific sanitisation belongs in the PARIS adapter. It should not leak
+back into model variable names or model specs.
+
+## Alignment With The Semantic IR Plan
+
+The uploaded semantic IR plan argues for this pattern:
+
+```text
+TOML config
+-> semantic intermediate representation
+-> required-data / prepared-data layer
+-> backend-specific compilation
+-> PyMC graph / analytic model / visualization
+```
+
+#402 and #403 should not try to implement that whole architecture. They can,
+however, avoid choices that would fight it.
+
+Useful near-term alignment:
+
+- Treat the RHIME model spec as strategy-independent.
+- Treat `run_rhime` and `run_rhime_multisector` as convenience constructors for
+  contribution shapes, not fundamentally separate pipelines.
+- Keep source provenance separate from model contribution identity.
+- Keep virtual aggregates such as `total` out of the input-source coordinate.
+- Put product naming in output adapters, not in PyMC variable suffixes.
+- Think of the builder strategy as a small `CompilationPlan` precursor: a
+  recorded decision about how semantic contributions are lowered into a backend
+  graph.
+
+The near-term contribution plan is therefore a bridge:
+
+```text
+RhimeModelSpec
+-> contribution plan
+-> builder strategy
+-> PyMC model
+```
+
+A later semantic model can generalize the same path:
+
+```text
+SemanticModel
+-> prepared component data
+-> compilation plan
+-> backend model
+```
+
+## Practical Design Tests
+
+These are not an implementation checklist. They are useful questions to keep
+future edits honest.
+
+- Can a single run have multiple input `flux_sources` but one optimized model
+  contribution?
+- Can a model contribution be backed by more than one OpenGHG source?
+- Can `total` be present in outputs without being present as an OpenGHG source
+  or sampled sector?
+- Can the same contribution list be compiled as loop-sum or stacked-dot without
+  changing the model spec?
+- Can model variable suffixes change without changing PARIS variable names?
+- Can inner/outer domain identity survive both sampling and output?
+- Can one latent state contribute to both primary-species and tracer
+  likelihoods without duplicating the latent?
+
+If the answer to any of these is "no", the current design is probably encoding
+too much of the current shared-basis multisector implementation as permanent
+architecture.
+
+## Summary
+
+The current code likely contains most of the minimum needed to close the narrow
+parts of #402 and #403. The larger opportunity is to use those issues to stop
+treating `run_rhime` and `run_rhime_multisector` as separate model families.
+
+The better abstraction is:
+
+```text
+input sources are provenance
+model contributions are optimized state-bearing components
+builder strategies lower contributions into PyMC graphs
+virtual totals aggregate contributions
+output adapters own product names
+```
+
+That is small enough to fit the current milestones and compatible with the
+semantic IR direction.

--- a/docs/plans/issues_402_403_builder_strategy_design.md
+++ b/docs/plans/issues_402_403_builder_strategy_design.md
@@ -109,21 +109,24 @@ The current code already has most of the mathematical behavior:
 - Generic and PARIS postprocessing reconstruct sector fluxes and calculate
   physical totals from reconstructed fluxes rather than summed scale factors.
 
-The central acceptance item is still missing:
+The central acceptance item is now implemented, with some binary orchestration
+still visible at the runner boundary:
 
-- The loop implementation is hard-coded in
-  `build_rhime_multisector_model(...)`.
+- Standard and multisector declarations normalize into the same private
+  `_FluxPlan` representation before PyMC compilation.
 - Standard and multisector runners still select different builders and output
   paths through a `multisector` boolean.
 - `run_rhime_from_prepared_inputs(...)` is the correct new execution boundary,
   but it still requires model sector count, `split_by_sectors`, and the
   presence of `H.source` to encode the same binary mode.
-- The current builder consumes padded `H(region, nmeasure, source)` even though
-  the basis layer can represent ragged state spaces without padding.
+- Shared-basis sensitivity can remain `H(region, nmeasure, source)`;
+  source-specific bases remain gathered over
+  `(source, region_in_source)` and are selected into separate term designs
+  without padding.
 
-The conclusion is stronger than in the first note: #402 should remain open
-until a real internal compilation seam exists. A public strategy option is not
-required, but a private normalized linear-term boundary is.
+The private normalized linear-term boundary now exists. Remaining builder
+selection in the runner is orchestration around that common compiler, not a
+second mathematical implementation.
 
 ### Issue 403
 

--- a/docs/plans/issues_402_403_builder_strategy_design.md
+++ b/docs/plans/issues_402_403_builder_strategy_design.md
@@ -144,16 +144,16 @@ Important limitations and one correction:
   `ModelScenario` ability to combine several sources into one total prior flux.
 - Each `SectorSpec` contains exactly one `flux_source`. One optimized component
   cannot be backed by several sources.
-- `sector_sources` is not a strict one-to-one mapping. Multiple sectors may
-  point to the same source because validation compares sets of source values.
-  That can create separate, potentially non-identifiable states over the same
-  sensitivity. The actual invariant is "one source reference per sector", not
-  a bijection.
+- The narrow #403 implementation now treats `sector_sources` as one-to-one.
+  Duplicate source values are rejected because separate states over the same
+  sensitivity are generally non-identifiable. Broader cardinalities belong in
+  explicit component/state/term relations rather than this renaming adapter.
 - The canonical prepared coordinate is `source`, not `sector`. Renaming that
   coordinate to `sector` merely to satisfy the issue wording would make the
   architecture less clear.
-- Unknown or unused sector-prior keys should be treated deliberately rather
-  than silently becoming configuration debris.
+- `sector_priors`, when supplied, must contain exactly one prior for every
+  sector. Omitting it applies the shared `x_prior`; partial maps are rejected
+  rather than silently falling back after a typo.
 
 The original #403 acceptance criteria can be closed narrowly around the current
 one-source-per-sector case once its prepared-data contract and validation are

--- a/docs/plans/issues_402_403_builder_strategy_design.md
+++ b/docs/plans/issues_402_403_builder_strategy_design.md
@@ -1,10 +1,10 @@
 # Issues 402/403 Builder Strategy Design Notes
 
-Date: 2026-06-09
+Date: 2026-07-24
 
-Status: design notes, not an implementation plan.
+Status: second-pass architecture notes, not a formal implementation plan.
 
-## Scope
+## Scope And Evidence
 
 These notes revisit:
 
@@ -12,431 +12,964 @@ These notes revisit:
   multi-sector RHIME with shared-basis inputs and a builder-strategy seam.
 - [#403](https://github.com/openghg/openghg_inversions/issues/403):
   route multiple flux sources and per-sector priors into RHIME inputs.
-- [#472](https://github.com/openghg/openghg_inversions/pull/472):
-  sector-level latest-PARIS flux outputs.
 
-They also check the design against milestone 10 high-resolution requirements
-([#407](https://github.com/openghg/openghg_inversions/issues/407),
-[#408](https://github.com/openghg/openghg_inversions/issues/408),
-[#409](https://github.com/openghg/openghg_inversions/issues/409),
-[#410](https://github.com/openghg/openghg_inversions/issues/410)) and
-milestone 11 tracer requirements
-([#411](https://github.com/openghg/openghg_inversions/issues/411),
-[#412](https://github.com/openghg/openghg_inversions/issues/412),
-[#413](https://github.com/openghg/openghg_inversions/issues/413)).
+They treat the following work as additional constraints:
 
-The source checkout used for OpenGHG `ModelScenario` behavior is:
+- [#414](https://github.com/openghg/openghg_inversions/issues/414):
+  backend-neutral component preparation and deterministic reconstruction.
+- [#456](https://github.com/openghg/openghg_inversions/issues/456):
+  grouped state-vector layouts for layered and inner/outer bases.
+- [#509](https://github.com/openghg/openghg_inversions/issues/509):
+  source-neutral prepared inputs and grouped outputs.
+- [#407](https://github.com/openghg/openghg_inversions/issues/407) through
+  [#410](https://github.com/openghg/openghg_inversions/issues/410):
+  high-resolution inner/outer inputs, models, outputs, and extension guidance.
+- [#411](https://github.com/openghg/openghg_inversions/issues/411) through
+  [#413](https://github.com/openghg/openghg_inversions/issues/413):
+  linked primary-species/tracer specs, models, and outputs.
+
+Relevant merged work since the first version of this note:
+
+- [PR #472](https://github.com/openghg/openghg_inversions/pull/472)
+  merged sector-aware latest-PARIS flux outputs on 2026-07-20.
+- [PR #510](https://github.com/openghg/openghg_inversions/pull/510)
+  merged `run_rhime_from_prepared_inputs(...)` on 2026-07-22.
+- [PR #526](https://github.com/openghg/openghg_inversions/pull/526)
+  merged backend-neutral `SigmaAlignment` preparation and reconstruction on
+  2026-07-24.
+
+Draft PRs #513 through #516 are useful design evidence under #509, but they are
+not treated as merged behavior here.
+
+The OpenGHG `ModelScenario` source used for source-combination behavior is:
 
 ```text
 ~/Documents/openghg/openghg/analyse/_scenario.py
 ```
 
-## Position
+The local worktree snapshot predates some of the July merges. Statements about
+current `devel` after those merges were checked through GitHub; statements about
+the existing RHIME implementation were also checked against the local source.
 
-The durable distinction is not "single-sector versus multi-sector". The
-durable distinction is how a set of named flux contributions is compiled into
-one or more modelled-observation vectors.
+## Recommendation
 
-Current RHIME already has the bones of one pattern:
+Revise and split the earlier design.
+
+The first note correctly separated input sources, model grouping, builder
+strategy, virtual totals, and product names. Its weak point was the term
+"model contribution": it was asked to mean both a sampled state and its
+contribution to modelled observations.
+
+That works for current multisector RHIME because every sector has exactly one
+state and exactly one `mu_<sector>`. It fails for linked CO2/O2, where one state
+must feed several forward terms, and it obscures 6 km models, where inner and
+outer are usually state-space groups rather than emission sectors.
+
+The extensible semantic core is a small directed linear model:
 
 ```text
-OpenGHG flux sources
--> prepared sensitivities and prior fluxes
--> named model contributions
--> summed concentration mean
--> shared BC / offset / error / likelihood
--> product-specific outputs
+input source provenance
+-> physical flux components
+-> latent state blocks
+-> linear forward terms
+-> observation channels and likelihoods
+-> virtual aggregates and output views
 ```
 
-On that framing:
+Compilation decides how that model becomes a PyMC graph. It must not determine
+the scientific identities in the model.
 
-- `run_rhime` is one model contribution, currently restricted to one
-  `flux_source`.
-- `run_rhime_multisector` is multiple model contributions, currently one
-  contribution per `flux_source`, compiled with a loop-sum strategy.
-- A future single-sector multi-source inversion is one model contribution backed
-  by a group of input sources.
-- A future high-resolution model is multiple domain contributions, for example
-  outer plus inner, compiled into one total `mu`.
-- A future linked CO2/O2 model has one or more latent sector states feeding
-  multiple species or tracer forward models and likelihoods.
+For the narrow closure of #402 and #403, this does not require a public
+`SemanticModel`, a strategy registry, or a component-class framework. The
+smallest useful seam is:
 
-That suggests a small "contribution plan" as the local bridge toward the
-semantic model representation. It can remain private and RHIME-specific for now,
-but it should use the same concepts that a later `SemanticModel` would use.
+```text
+RhimeModelSpec + RhimePreparedInputs
+-> ordered backend-neutral linear model data
+-> private loop-sum PyMC compiler
+```
 
-## Current Coverage And Gaps
+That seam should align with #414 rather than introduce a second RHIME-specific
+component framework.
+
+## Current Status
 
 ### Issue 402
 
-Already mostly done:
+The current code already has most of the mathematical behavior:
 
-- `SectorSpec` and `RhimeModelSpec` exist and keep model metadata out of the
-  runner.
-- `build_rhime_multisector_model(...)` builds one `x_<suffix>` and
-  `mu_<suffix>` per sector and creates total deterministic `mu` as the sum of
-  sector contributions.
-- Per-sector priors are passed through to distinct latent variables.
-- Shared-basis multisector preparation carries source-resolved sensitivity data
-  in `H(..., source)`.
-- Source-specific/ragged basis operators already exist in the basis layer.
+- `SectorSpec` and `RhimeModelSpec` represent one or more optimized sectors.
+- The multisector builder creates one `x_<suffix>` and `mu_<suffix>` per
+  sector.
+- Total `mu` is the sum of sector contributions.
+- Per-sector priors produce separate latent variables.
+- Shared-basis preparation retains source-resolved `H`.
+- The basis layer can represent source-specific ragged states through
+  `MultiSourceBucketBasisOperator`.
+- Generic and PARIS postprocessing reconstruct sector fluxes and calculate
+  physical totals from reconstructed fluxes rather than summed scale factors.
 
-Remaining design gap:
+The central acceptance item is still missing:
 
-- The builder strategy seam is not real yet. The loop is hard-coded in the
-  multisector builder, and the runner chooses separate builders with a
-  `multisector` boolean.
-- The current model metadata says "sector", but the prepared data coordinate is
-  still OpenGHG `source`. That is acceptable as a transitional layout, but it is
-  not a semantic sector model.
-- Non-shared basis support is partly present below the builder, but the current
-  RHIME builder still wants legacy padded source structure rather than a direct
-  gathered-state contribution layout.
+- The loop implementation is hard-coded in
+  `build_rhime_multisector_model(...)`.
+- Standard and multisector runners still select different builders and output
+  paths through a `multisector` boolean.
+- `run_rhime_from_prepared_inputs(...)` is the correct new execution boundary,
+  but it still requires model sector count, `split_by_sectors`, and the
+  presence of `H.source` to encode the same binary mode.
+- The current builder consumes padded `H(region, nmeasure, source)` even though
+  the basis layer can represent ragged state spaces without padding.
 
-Minimum closure for #402 may not require a public strategy registry. It does
-require a place where the model builder first normalizes the model into ordered
-linear contributions, then applies a compilation shape such as loop-sum. The
-spec should continue to describe the math and labels, not whether PyMC uses a
-loop, a stacked design matrix, or some later PyTensor operation.
+The conclusion is stronger than in the first note: #402 should remain open
+until a real internal compilation seam exists. A public strategy option is not
+required, but a private normalized linear-term boundary is.
 
 ### Issue 403
 
-Already mostly done:
+The current code also implements most of the narrow routing behavior:
 
-- New API/config surfaces prefer `flux_sources`.
-- `sector_sources` can map user-facing sector names to OpenGHG source names.
-- `sector_priors` accepts per-sector prior dictionaries.
-- Validation catches duplicate sanitized sector names, malformed sector priors,
-  and mismatched `sector_sources`.
-- `run_rhime_multisector` can retrieve multiple OpenGHG flux sources and prepare
-  source-resolved sensitivities.
+- New config and API surfaces use `flux_sources`.
+- Multiple OpenGHG sources can be retrieved for multisector runs.
+- `sector_priors` supplies separate prior dictionaries.
+- `sector_sources` separates user-facing sector labels from OpenGHG source
+  names.
+- Source-resolved sensitivity input is available as `H(..., source)`.
+- Validation covers missing sources, malformed prior structures, and duplicate
+  sanitized PyMC names.
 
-Remaining design gap:
+Important limitations and one correction:
 
-- `run_rhime` currently rejects multiple `flux_sources`, even though OpenGHG
-  `ModelScenario` has a coarse single-total multi-source behavior.
-- `sector_sources` currently enforces a one-to-one mapping between model sectors
-  and OpenGHG sources. That makes it mainly a renaming device when there is no
-  real grouping.
-- The canonical "sector" sensitivity is really source-resolved sensitivity. It
-  does not yet express one model sector backed by multiple source inputs.
+- `run_rhime` still requires exactly one source, despite the lower-level
+  `ModelScenario` ability to combine several sources into one total prior flux.
+- Each `SectorSpec` contains exactly one `flux_source`. One optimized component
+  cannot be backed by several sources.
+- `sector_sources` is not a strict one-to-one mapping. Multiple sectors may
+  point to the same source because validation compares sets of source values.
+  That can create separate, potentially non-identifiable states over the same
+  sensitivity. The actual invariant is "one source reference per sector", not
+  a bijection.
+- The canonical prepared coordinate is `source`, not `sector`. Renaming that
+  coordinate to `sector` merely to satisfy the issue wording would make the
+  architecture less clear.
+- Unknown or unused sector-prior keys should be treated deliberately rather
+  than silently becoming configuration debris.
 
-The important fresh constraint is that "multiple sources" and "multiple model
-states" are not the same thing.
+The original #403 acceptance criteria can be closed narrowly around the current
+one-source-per-sector case once its prepared-data contract and validation are
+explicit. Grouped sources controlling one state are a distinct semantic
+feature and are better tracked explicitly than hidden inside a renaming map.
 
-## ModelScenario Constraint
+## Why "Contribution" Is Too Broad
 
-OpenGHG `ModelScenario` already distinguishes two useful modes.
+The relationships required by milestones 9 through 11 are not one-to-one.
 
-With `split_by_sectors=False`, `combine_flux_sources(...)` takes one or more
-OpenGHG flux sources and combines them into one flux dataset. The downstream
-`fp_x_flux` has no `source` dimension. That is the old coarse behavior: many
-input sources, one modelled flux field, one possible state vector.
+| Relationship | Current case | Future cardinality |
+|---|---|---|
+| Input source to physical component | Usually one source per sector | Several sources may form one component; one source may feed several diagnostic views |
+| Physical component to state block | One sector owns one state | A component may have inner and outer states or layered states |
+| State block to forward term | One state creates one `mu` | One state may feed CO2 and O2 terms or several source-resolved terms |
+| Observation channel to forward term | One channel receives all sectors | Each channel receives several terms, potentially from shared states |
+| Semantic identity to backend name | Same suffix used everywhere | Stable IDs, trace names, and product names must be separate |
+| Component to output view | One sector output | Sector, basis group, species, domain, and virtual totals may be different views |
 
-With `split_by_sectors=True`, `calc_modelled_obs(...)` still computes the usual
-total `mf_mod` and `fp_x_flux`, then loops over each source to add
-`mf_mod_sectoral` and `fp_x_flux_sectoral` with a `source` dimension.
+The word `contribution` is still useful for an observation-space term such as
+`H_ff @ x_ff`. It should not imply ownership of the state `x_ff`.
 
-This is a strong argument against using `source` and `sector` interchangeably.
-OpenGHG `source` is input provenance. A RHIME sector or contribution is a model
-grouping decision.
+## Proposed Vocabulary
 
-It also means a single-sector multi-source RHIME path is not an exotic future
-feature. It is the behavior that the current `run_rhime` wrapper blocks at the
-parameter layer.
+These are conceptual roles, not committed public class names.
 
-## Builder Strategy As General Pattern
+### Input source
 
-The builder-strategy seam should sit behind the RHIME model-spec boundary, close
-to `models/rhime.py`.
+An acquisition and provenance identity, normally an OpenGHG `source` value.
+It says where prior flux data came from. It does not say how many states are
+sampled.
 
-The runner should not grow a tree of special cases. Parameter parsing should not
-know whether the PyMC graph is a loop, a stacked dot product, or a shared-state
-projection. Data preparation should provide source-resolved or grouped
-sensitivities, but the builder should own how model contributions are compiled.
+### Source group
 
-A useful contribution record, conceptually, needs these roles:
+One or more input sources plus an explicit combination policy.
 
-- model contribution id: stable model/component name, for example `ff`,
-  `ocean`, `outer`, or `inner`.
-- input source group: one or more OpenGHG `source` values that back the
-  contribution.
-- state space: shared basis region, source-specific gathered state, inner-domain
-  state, outer-domain state, or shared tracer-linked state.
-- prior policy: one prior for the contribution state, or a future policy for
-  source-specific subparts.
-- output labels: product-neutral labels for generic diagnostics.
-- links: optional typed dependencies, such as "this O2 forward map uses the CH4
-  fossil-fuel state with a conversion factor".
+The policy matters. A tuple of names is insufficient because the model may
+mean:
 
-This record is not necessarily a new public class today. It is the shape that
-keeps `run_rhime` and `run_rhime_multisector` from remaining separate model
-families.
+- combine aligned prior fluxes before applying one scale state;
+- preserve source-resolved sensitivities but apply the same state to every
+  source term;
+- optimize every source independently;
+- use one source only for provenance or an output diagnostic.
 
-### Current Special Cases
+### Flux component
 
-`run_rhime` can be viewed as:
+A stable scientific or reporting identity such as `ff`, `ocean`, `biosphere`,
+or `anthro`. A sector is a flux component whose scientific meaning is an
+emission or uptake sector.
 
-```text
-contribution total:
-    input source group = requested flux_sources
-    state = one optimized state
-    builder strategy = single linear contribution
-    aggregate mu = contribution mu
-```
+A flux component need not own exactly one state.
 
-Today this is artificially limited to one source. Relaxing that limit would
-recover the `ModelScenario` coarse total behavior: multiple input sources, one
-state, one `mu`.
+### Basis group
 
-`run_rhime_multisector` can be viewed as:
+A state-space partition within a component, such as `default`, `outer`,
+`inner_6km`, a layer, a mask class, or another grouped basis partition.
 
-```text
-contribution ff:
-    input source group = [ff-source]
-    state = x_ff
-    mu = H_ff @ x_ff
+This follows the direction of #456 and #509: sector/source and basis group are
+orthogonal. Inner and outer should not be disguised as sectors simply because
+both produce additive terms in observation space.
 
-contribution ocean:
-    input source group = [ocean-source]
-    state = x_ocean
-    mu = H_ocean @ x_ocean
+### State block
 
-aggregate total:
-    mu = mu_ff + mu_ocean
-```
+One set of sampled or fixed degrees of freedom with:
 
-This is the current loop-sum strategy. The same contribution list could later
-be lowered as a stacked design matrix if the state dimensions are compatible or
-can be represented with gathered state indices.
+- a stable semantic ID;
+- a prior or fixed-state policy;
+- one state-space/basis reference;
+- optional component and basis-group labels;
+- activity and full-state reconstruction metadata.
 
-### Future Special Cases
+The gathered, padded, or separately named backend layout of a state block is a
+compilation choice, not its semantic identity.
 
-Single-sector multi-source:
+### Linear forward term
+
+A labelled map from one state block to one observation channel:
 
 ```text
-contribution total:
-    input source group = [source_a, source_b, ...]
-    state = x_total
-    mu = H_grouped @ x_total
+mu_term = coefficient_term * (H_term @ x_state)
 ```
 
-This is not equivalent to independently optimized sectors summed after the
-fact. It represents the assumption that one scale state applies to the grouped
-prior flux.
+The coefficient can carry a sign, oxidation ratio, unit conversion, or other
+declared transform. It may be fixed or have a prior, and it may be scalar or
+labelled over coordinates such as time, domain, component, or basis group.
+Non-scalar coefficients need an explicit preparation/alignment step analogous
+to `SigmaAlignment`; backend broadcasting is not a semantic alignment policy.
 
-Virtual total:
+If both the coefficient and `x_state` are sampled, the term is bilinear in the
+joint latent variables even though it remains linear in either one
+conditionally. The semantic representation should therefore preserve the
+coefficient as a separate relation rather than folding it irreversibly into
+`H_term`. The first #402 compiler only needs the current fixed-scalar case, but
+its internal term representation should use a neutral `coefficient` name and
+leave room for a fixed value, a prepared labelled value, or a prior-backed
+parameter. The term references prepared labelled data; it does not own or
+recreate the latent state.
+
+### Observation channel
+
+One observation and likelihood stream, for example CO2 or O2, with:
+
+- its own observation coordinate;
+- terms that sum into its modelled mean;
+- boundary-condition and fixed-baseline terms;
+- offset and error components;
+- likelihood configuration.
+
+CO2 and O2 observations must not be required to share one `nmeasure` axis.
+
+### Virtual aggregate
+
+A derived total or grouping over semantic objects. A virtual aggregate is not
+automatically an input source or sampled state.
+
+Examples:
+
+- `mu_total` is a sum of compatible observation-space terms.
+- `flux_total` is a sum, mosaic, or projection of reconstructed physical flux
+  fields.
+- a total uncertainty must include covariance cross terms.
+- `x_total` is generally undefined unless an explicit, scientifically valid
+  scale-factor reduction is declared.
+
+### Output view
+
+A product-neutral statement of what should be reconstructed or grouped, using
+stable semantic IDs and coordinates. Product adapters then map those views to
+generic, PARIS, or legacy variable names.
+
+### Compilation plan
+
+A record of backend-only decisions:
+
+- loop-sum versus fused or stacked linear algebra;
+- separate, gathered, active/fixed, or concatenated sampler layout;
+- concrete PyMC and model-data names;
+- retained versus reconstructable deterministics.
+
+It should record a decision, not redefine the semantic model.
+
+## Speculative Semantic Kernel
+
+A minimal future model can be described with four relations plus output views.
+Illustrative names:
 
 ```text
-aggregate total:
-    mu_total = sum(mu_contribution)
-    flux_total = sum(reconstructed_flux_contribution)
+FluxComponentSpec:
+    id
+    source_group
+    source_combination_policy
+    label
+
+StateBlockSpec:
+    id
+    component_id
+    basis_group
+    state_space_ref
+    prior_or_fixed_policy
+
+ObservationSpec:
+    id
+    species
+    likelihood_policy
+    nuisance_component_refs
+
+LinearTermSpec:
+    id
+    state_block_id
+    observation_id
+    prepared_design_ref
+    coefficient_ref
+
+CoefficientSpec:
+    id
+    value_or_prior_policy
+    coordinate_scope
+    alignment_policy
+    units
+    sign_and_direction
+
+OutputViewSpec:
+    id
+    selectors
+    aggregation_policy
+    product_neutral_label
 ```
 
-`total` should usually be a virtual aggregate, not an OpenGHG source and not a
-sampled sector state. A derived `x_total` is only meaningful under explicit
-conditions. For example, if all contributions share basis regions, an output
-could compute a flux-weighted total scale factor, but that is an output
-diagnostic rather than the latent variable sampled by the model.
+These relations contain no PyMC suffixes, state-vector slices, loop/stack
+choice, or PARIS codes.
 
-High-resolution inner/outer:
+This is deliberately smaller than an arbitrary component DAG. It represents
+all current and anticipated linear RHIME variants without committing #402 or
+#403 to a public semantic IR.
+
+## Two Preparation Levels
+
+PR #510 and issue #509 establish the first source-neutral execution boundary:
 
 ```text
-contribution outer:
-    state = x_outer
-    mu = H_outer @ x_outer
-
-contribution inner:
-    state = x_inner
-    mu = H_inner @ x_inner
-
-aggregate total:
-    mu = mu_outer + mu_inner
+source adapter
+-> RhimePreparedInputs
+-> model builder
+-> sampler
+-> output bundle
 ```
 
-This is structurally the same as multisector loop-sum, but the contribution
-identity is domain partition rather than emission sector. Milestone 10 asks for
-this distinction to survive into outputs, so flattening everything into a
-single anonymous state would be a step backward even if it samples correctly.
-
-Tracer linked-state:
+Issue #414 introduces a second, component-local preparation boundary:
 
 ```text
-contribution ch4_ff_state:
-    state = x_ff
-
-forward co2:
-    mu_co2_ff = H_co2_ff @ x_ff
-
-forward o2:
-    mu_o2_ff = conversion_factor * H_o2_ff @ x_ff
+canonical inversion inputs + component specification
+-> prepared component data
+-> backend adapter
+-> reconstruction
 ```
 
-This is why the builder seam should not be only "loop versus stacked dot". The
-larger abstraction is a contribution/state graph that can lower to PyMC in more
-than one shape.
-
-## Source, Sector, And Output Vocabulary
-
-The current names are close, but the responsibilities should be sharper.
-
-Recommended vocabulary:
-
-- `flux_source`: OpenGHG input/source coordinate used for object-store lookup
-  and data provenance.
-- `source_group`: one or more `flux_source` values backing a model
-  contribution.
-- `model_contribution`: an optimized model component, currently usually called
-  a sector.
-- `model_sector`: a contribution whose scientific meaning is an emission or
-  uptake sector.
-- `model_variable_suffix`: private PyMC/trace suffix used for variable names.
-- `output_sector_label`: product-neutral label for output diagnostics.
-- `paris_sector_code`: PARIS schema-safe label used in PARIS variable names and
-  the PARIS `sector` coordinate.
-- `virtual_total`: aggregate over contributions, not a real source.
-
-If the mapping is one-to-one and the names are identical, `sector_sources` adds
-little semantic value. It is just a renaming layer. That is acceptable as a
-transition, but the long-term model should not require users to invent a sector
-mapping when all they have is a list of OpenGHG sources.
-
-The first non-renaming case is likely:
+These fit together:
 
 ```text
-model sector "anthro":
-    source_group = ["ff-inventory", "industry-inventory", "waste-inventory"]
+source adapter
+-> RhimePreparedInputs
+-> semantic model normalization
+-> backend-neutral prepared linear model
+-> compilation plan
+-> PyMC graph
 ```
 
-That removes the one-to-one mapping and makes the sector/source split worth
-having.
+Conceptually, a prepared linear term needs:
 
-## PR 472 Output Flow
+```text
+term_id
+state_block_id
+observation_id
+design: H_term(nmeasure_for_channel, state_for_block)
+reconstruction and provenance metadata
+```
 
-PR #472 is useful because it exercises the whole path from model-sector
-metadata to product variables.
+A mapping of separately labelled terms is preferable to one universal xarray
+cube over species, sector, basis group, source, and state. A universal cube
+would create invalid Cartesian combinations and repeat the ragged-padding
+problem already visible in multisource bases.
 
-Good direction:
+`RhimePreparedInputs` remains the reusable run boundary. It should not have to
+encode the full semantic model solely through `H.source` and
+`split_by_sectors`.
 
-- It adds per-sector latest-PARIS flux variables alongside total variables.
-- It keeps total flux outputs derived from reconstructed sector flux fields,
-  not from summed scale factors.
-- It adds a PARIS `sector` coordinate and sector country covariance diagnostics.
+## Builder Strategy
 
-Risk:
+The builder seam should compile state blocks and forward terms, not sectors as
+indivisible objects.
 
-- PARIS sector names are derived from `variable_suffix`. That suffix is
-  documented as the PyMC-safe model variable suffix, not as a product-facing
-  code. Changing a model variable suffix would therefore change public PARIS
-  variable names.
-- The PR adds a local sector metadata parser in `make_paris_outputs.py`, while
-  `make_outputs.py` already has `OutputSector` metadata resolution. That is a
-  duplication point.
-- The current flow becomes:
+A compiler should:
+
+1. Create each semantic state block exactly once.
+2. Apply every prepared forward term that references that state.
+3. Sum terms by observation-channel ID.
+4. Attach channel-specific BC, fixed baseline, offset, error, and likelihood
+   components.
+5. Record state, term, data, and output-role mappings for reconstruction.
+
+The current `add_linear_component(...)` creates a prior/state and applies one
+design matrix in one operation. That is convenient for the current one-state to
+one-term cardinality, but linked tracers require state creation and linear
+application to be separable. The proposed linear seam in #414 is the right
+place to establish that separation.
+
+### Loop-sum
+
+The first compiler should preserve the current transparent behavior:
+
+```text
+for each state block:
+    create state once
+
+for each forward term:
+    apply H_term to referenced state
+
+for each observation channel:
+    mu_channel = sum(channel terms)
+```
+
+This is sufficient for #402. It is easy to validate against current
+deterministics and preserves per-term diagnostics.
+
+### Fuse terms sharing a state
+
+If several compatible terms reference the same state and observation channel:
+
+```text
+H_a @ x + H_b @ x
+-> (H_a + H_b) @ x
+```
+
+This is a valid optimization only after checking coordinates, units, state
+layout, and coefficient policies. Terms with independently sampled
+coefficients cannot in general be fused this way. The optimization is
+especially relevant to one-state
+multiple-source models.
+
+### Stack independent state blocks
+
+If terms target one observation channel but reference independent state
+blocks:
+
+```text
+H_a @ x_a + H_b @ x_b
+-> concat_state(H_a, H_b) @ concat(x_a, x_b)
+```
+
+The compilation plan must retain the block-to-state lookup needed for priors,
+posterior reconstruction, and outputs.
+
+### Multiple observation channels
+
+CO2/O2 can be lowered as separate loops, a block matrix, or another backend
+representation. The key invariant is that a shared state is created once.
+Stacking must not duplicate that state or accidentally apply its prior twice.
+
+No loop/stack choice needs to be public configuration today. An internal
+callable or compiler function, with the selected decision recorded in output
+metadata, is enough to satisfy the strategy seam.
+
+## Current Runners As Special Cases
+
+### `run_rhime`
+
+Current meaning:
+
+```text
+one input source
+-> one flux component
+-> one state block
+-> one forward term
+-> one observation channel
+```
+
+Future grouped-source meaning:
+
+```text
+several input sources
+-> one flux component
+-> one state block
+-> one or several source-resolved forward terms
+-> one observation channel
+```
+
+The semantic assumption is "one scale state controls the grouped prior flux",
+not "there happen to be several sectors with equal values".
+
+### `run_rhime_multisector`
+
+Current meaning:
+
+```text
+one source reference per sector
+-> one state block per sector
+-> one forward term per sector
+-> terms summed into one observation channel
+```
+
+The current loop-sum builder is one compiler for that semantic shape.
+
+### `run_rhime_from_prepared_inputs`
+
+PR #510 supplies the correct shared post-preparation executor. Its present
+validation still derives model mode from:
+
+- sector count;
+- `split_by_sectors`;
+- whether `H` has a `source` dimension.
+
+That is reasonable compatibility validation for current builders, but it
+cannot be the durable semantic rule. A one-state grouped-source model may keep
+source-resolved `H`; a 6 km model may have several state blocks without a
+source dimension; a tracer model has several channels while reusing states.
+
+The future executor should dispatch from the normalized model relation, while
+the current boolean remains a compatibility property of the two M9 wrappers.
+
+## Source Group Semantics And ModelScenario
+
+OpenGHG `ModelScenario` already provides one useful grouped-source behavior.
+
+With `split_by_sectors=False`, `combine_flux_sources(...)`:
+
+- aligns source flux datasets to the highest-frequency time coordinate;
+- forward-fills lower-frequency datasets;
+- sums the quantified datasets;
+- produces one total `fp_x_flux` without a `source` dimension.
+
+This is "combine before scaling": one state acts on the summed prior flux.
+
+With `split_by_sectors=True`, `calc_modelled_obs(...)` also computes
+source-resolved `fp_x_flux_sectoral(..., source)` while retaining total
+`fp_x_flux`.
+
+That gives two possible prepared forms for one-state multiple-source semantics:
+
+```text
+materialized grouped term:
+    H_group @ x
+
+source-resolved terms sharing one state:
+    H_source_a @ x + H_source_b @ x + ...
+```
+
+They are mathematically equivalent only when alignment, units, basis/state
+layout, masks, and fixed transforms are compatible. The source-resolved form
+retains better provenance and can support source-level diagnostic flux output;
+the compiler may still fuse it when valid.
+
+A future `source_group` therefore needs a declared combination policy and
+validation invariants. It must not be just `tuple[str, ...]`.
+
+## Speculative Model Shapes
+
+### Standard RHIME
+
+```text
+component[total]
+    sources = [inventory]
+
+state[total.default]
+    component = total
+    basis_group = default
+
+term[total_to_ch4]
+    state = total.default
+    observation = ch4
+    mu = H_total @ x_total
+
+observation[ch4]
+    mu = term[total_to_ch4]
+    likelihood = current RHIME likelihood
+```
+
+### One State Backed By Several Sources
+
+```text
+component[anthro]
+    sources = [ff, industry, waste]
+    combine = shared_state_source_terms
+
+state[anthro.default]
+
+term[ff_to_co2]       = H_ff @ x_anthro
+term[industry_to_co2] = H_industry @ x_anthro
+term[waste_to_co2]    = H_waste @ x_anthro
+
+observation[co2].mu = sum(anthro terms)
+```
+
+This preserves source-level reconstruction while sampling one state. A
+`combine_before_scaling` adapter may instead materialize `H_anthro`.
+
+### Shared-Basis Multisector
+
+```text
+state[ff.default]    -> term[ff_to_ch4]    --\
+state[ocean.default] -> term[ocean_to_ch4] ---+-> observation[ch4].mu
+state[bio.default]   -> term[bio_to_ch4]   --/
+```
+
+The states share a basis definition but remain independently sampled.
+
+### Non-shared Or Ragged Multisector
+
+```text
+state[ff.default](state_ff)
+    -> H_ff(nmeasure, state_ff)
+
+state[ocean.default](state_ocean)
+    -> H_ocean(nmeasure, state_ocean)
+```
+
+The builder does not need a padded
+`H(region, nmeasure, source)`. Each prepared term carries its own state
+dimension. A stacked compiler can create an explicit state layout later.
+
+The current gathered `(source, region_in_source)` basis representation is a
+valid storage or compiler layout, not the scientific meaning of the model.
+
+### 6 km Inner/Outer
+
+For one physical component:
+
+```text
+component[ff]
+
+state[ff.outer]
+    basis_group = outer
+    basis = B_outer
+
+state[ff.inner_6km]
+    basis_group = inner_6km
+    basis = B_inner
+
+term[ff_outer_to_co2] = H_outer @ x_ff_outer
+term[ff_inner_to_co2] = H_inner @ x_ff_inner
+
+observation[co2].mu = sum(outer, inner)
+```
+
+For multisector 6 km, state blocks may exist for selected
+`(flux_component, basis_group)` pairs. The representation should not force a
+dense sector x basis-group Cartesian product when some combinations do not
+exist.
+
+Observation-space addition does not define physical flux-output composition.
+Inner and outer outputs may require:
+
+- a complementary-mask sum;
+- an inner-over-outer mosaic;
+- projection to a common grid before summing;
+- separate native-grid products plus a coarser total.
+
+The chosen support and composition policy must be explicit to avoid overlap or
+double counting.
+
+### Linked CO2/O2
+
+```text
+state[ff.default] -------------------------------\
+    |                                             \
+    +-> term[ff_to_co2] = H_co2_ff @ x_ff          +-> observation[co2].mu
+    |
+    +-> term[ff_to_o2] = r_ff * H_o2_ff @ x_ff ----+-> observation[o2].mu
+
+state[bio.default]
+    +-> term[bio_to_co2] = H_co2_bio @ x_bio
+    +-> term[bio_to_o2] = r_bio * H_o2_bio @ x_bio
+```
+
+Each state exists once. Each observation channel has its own observations,
+boundary/fixed baseline, offset, error model, and likelihood.
+
+The conversion-factor relation must record:
+
+- fixed value or prior policy;
+- units;
+- direction of conversion;
+- sign convention;
+- component/sector scope;
+- coordinate scope, including time or domain dependence;
+- alignment and broadcasting policy.
+
+A sampled conversion coefficient that multiplies a sampled flux state makes
+that forward relation bilinear. This is representable without copying the flux
+state, but it is not part of the strictly linear compiler proposed for the
+narrow #402 closure.
+
+The state itself needs an explicit scientific meaning. It might be a
+dimensionless scaling of primary-species prior flux, a physical carbon flux, or
+another shared latent. Ratio placement and output reconstruction depend on that
+choice.
+
+### Combined Multisector, 6 km, CO2/O2
+
+The pressure-test model is:
+
+```text
+state[ff.outer]     -> CO2 and O2 terms
+state[ff.inner]     -> CO2 and O2 terms
+state[bio.outer]    -> CO2 and O2 terms
+state[bio.inner]    -> CO2 and O2 terms
+state[ocean.outer]  -> CO2 term, and O2 only if scientifically declared
+```
+
+This is still the same relation:
+
+- sectors are flux components;
+- inner/outer are basis groups;
+- states are sampled blocks;
+- CO2/O2 are observation channels;
+- edges are linear terms;
+- totals are output views.
+
+No new runner family is required by the semantic model.
+
+## Virtual Totals
+
+`total` should not be a magic sector.
+
+### Observation totals
+
+For each channel:
+
+```text
+mu_channel = sum(forward terms targeting channel)
+```
+
+This is always valid once dimensions and units are compatible.
+
+### Flux totals
+
+Reconstruct every physical flux component first, then apply an explicit output
+aggregation:
+
+```text
+flux_total = aggregate(reconstructed component/group fluxes)
+```
+
+For ordinary sectors on one grid, the aggregate is a sum. For inner/outer
+domains, it may be a mosaic or projection. For linked tracers, derived
+tracer-flux fields need their own unit and sign metadata.
+
+### Uncertainty totals
+
+Totals must retain covariance cross terms. PR #472 established this for
+between-sector country totals, and #509 correctly extends the requirement to
+sector x basis-group outputs.
+
+### State totals
+
+Scale factors do not have an unconditional total. If all states share an
+aligned basis and a product needs a total scale diagnostic, it must define a
+scientifically valid reduction such as a prior-flux-weighted scale. That is an
+output view, not a sampled `x_total`.
+
+## Output Identity And PR 472
+
+PR #472 is now merged and demonstrates the value of sector-aware
+reconstruction:
+
+- sector and total flux variables are emitted;
+- totals are reconstructed from physical flux fields;
+- sector country totals and covariance diagnostics are retained;
+- the PARIS `sector` coordinate is supported by the latest template.
+
+The naming concern from the first note remains real in current `devel`:
+
+- generic output resolves traces and variables through `variable_suffix`;
+- `_paris_sector_name_by_suffix(...)` derives PARIS sector codes from that
+  PyMC-safe suffix;
+- generic and PARIS modules each parse sector metadata into a local
+  `OutputSector` shape.
+
+This creates the chain:
 
 ```text
 OpenGHG source
 -> SectorSpec.name
 -> variable_suffix
--> generic flux_<suffix> variables
--> PARIS flux_<paris_name> variables
+-> generic output variable
+-> PARIS sector code
 ```
 
-That is understandable for #405, but it will get harder when milestone 10 adds
-inner/outer outputs and milestone 11 adds species/tracer-aware outputs.
+Issue #414 now explicitly states the stronger rule: dynamic sector names and
+variable roles should be carried explicitly and must not be inferred from
+sanitized variable suffixes.
 
-The output boundary should name the stages explicitly:
+A durable output boundary needs a serializable compilation/reconstruction
+manifest:
 
 ```text
-model identity
--> product-neutral output label
--> product-specific variable name
+semantic component/state/term IDs
+-> concrete trace and model-data names
+-> product-neutral output coordinates
+-> product-specific names
 ```
 
-PARIS-specific sanitisation belongs in the PARIS adapter. It should not leak
-back into model variable names or model specs.
+At minimum it should record:
 
-## Alignment With The Semantic IR Plan
+- state block ID to sampled variable name;
+- linear term ID to model-data and optional deterministic names;
+- flux component, basis group, observation/species, and source provenance;
+- virtual aggregate definitions;
+- reconstruction references and conversion factors;
+- stable product-neutral labels.
 
-The uploaded semantic IR plan argues for this pattern:
+`variable_suffix` can remain a backward-compatible backend naming device. Old
+artifacts can retain suffix-based fallback. New output identities should not
+depend on changing a PyMC variable name.
 
-```text
-TOML config
--> semantic intermediate representation
--> required-data / prepared-data layer
--> backend-specific compilation
--> PyMC graph / analytic model / visualization
-```
+PARIS should have one central mapping from product-neutral component identity
+to a recorded PARIS sector code. Sanitization can remain a fallback at the
+adapter boundary, but the resolved code should be stored and reused.
 
-#402 and #403 should not try to implement that whole architecture. They can,
-however, avoid choices that would fight it.
+## Alignment With Current Issues
 
-Useful near-term alignment:
+| Issue | Architectural ownership |
+|---|---|
+| #402 | Normalize current state/term relations and add the private linear compiler seam; preserve loop-sum behavior |
+| #403 | Route current source and prior shorthands into the normalized relation; document one-source-per-sector as a current limitation |
+| #414 | Prepare, apply, and reconstruct backend-neutral linear component data; define deterministic retention |
+| #456 | Define explicit grouped state layout and metadata without positional slice inference |
+| #509 | Own source-neutral adapters, prepared-input execution, state-group outputs, and separation of sampler layout from output accounting |
+| #407-#410 | Define inner/outer acquisition, supports, basis groups, composition, and extension guidance |
+| #411-#413 | Define shared-state multi-channel relations, conversion metadata, channel likelihoods, and tracer-aware outputs |
+| #415/#442 | Persist prepared data, reconstruction manifests, MultiIndexes, and run-bundle provenance |
+| #444 | Decide how generic variable roles are selected; this should consume explicit semantic roles rather than recreate suffix inference |
 
-- Treat the RHIME model spec as strategy-independent.
-- Treat `run_rhime` and `run_rhime_multisector` as convenience constructors for
-  contribution shapes, not fundamentally separate pipelines.
-- Keep source provenance separate from model contribution identity.
-- Keep virtual aggregates such as `total` out of the input-source coordinate.
-- Put product naming in output adapters, not in PyMC variable suffixes.
-- Think of the builder strategy as a small `CompilationPlan` precursor: a
-  recorded decision about how semantic contributions are lowered into a backend
-  graph.
+This division avoids having #402 implement a full semantic IR while still
+making it a useful precursor.
 
-The near-term contribution plan is therefore a bridge:
+## Narrow Closure Versus Future Design
 
-```text
-RhimeModelSpec
--> contribution plan
--> builder strategy
--> PyMC model
-```
+### Reasonable closure for #402
 
-A later semantic model can generalize the same path:
+The issue can close when:
 
-```text
-SemanticModel
--> prepared component data
--> compilation plan
--> backend model
-```
+- standard and multisector model specs normalize into backend-neutral prepared
+  linear terms;
+- one private compiler constructs the existing loop-sum graph;
+- the compiler creates each state once, sums terms by observation channel, and
+  records explicit roles;
+- `RhimeModelSpec` remains independent of compiler layout;
+- current trace names, priors, numerical behavior, and outputs remain
+  compatible;
+- the non-shared case is documented as separate state blocks/design matrices,
+  without requiring padded source cubes.
 
-## Practical Design Tests
+A public strategy parameter or stacked compiler is not required for closure.
+The seam must be real and testable, not only described.
 
-These are not an implementation checklist. They are useful questions to keep
-future edits honest.
+### Reasonable closure for #403
 
-- Can a single run have multiple input `flux_sources` but one optimized model
-  contribution?
-- Can a model contribution be backed by more than one OpenGHG source?
-- Can `total` be present in outputs without being present as an OpenGHG source
-  or sampled sector?
-- Can the same contribution list be compiled as loop-sum or stacked-dot without
-  changing the model spec?
-- Can model variable suffixes change without changing PARIS variable names?
-- Can inner/outer domain identity survive both sampling and output?
-- Can one latent state contribute to both primary-species and tracer
-  likelihoods without duplicating the latent?
+The narrow original issue can close around the one-source-per-sector case when:
 
-If the answer to any of these is "no", the current design is probably encoding
-too much of the current shared-basis multisector implementation as permanent
-architecture.
+- `H.source` is documented as input provenance rather than semantic sector
+  identity;
+- the sector-to-source relation and duplicate-source behavior are explicit;
+- sector-prior keys and missing/unused mappings are validated deliberately;
+- error messages identify both semantic sector and source;
+- source-resolved prepared inputs feed the normalized linear-term path.
+
+One-state grouped-source support should be tracked as an explicit follow-up
+unless #403 is deliberately broadened. Its semantic design is recorded here so
+the M9 implementation does not block it.
+
+## Invariants
+
+A future semantic or normalized model should enforce:
+
+- Stable semantic IDs are unique and serializable.
+- Every state, term, channel, source group, and output reference resolves.
+- Every state block is created at most once per model.
+- Every linear term references exactly one state and one observation channel.
+- A state may feed several terms and channels.
+- Terms summed in one channel have compatible observation coordinates and
+  units.
+- Source-group combination declares alignment, units, and combination policy.
+- Basis groups and state spaces are explicit; slices are not inferred from
+  position or numeric labels.
+- `total` is never an implicit source or latent state.
+- Physical flux aggregation declares sum, mosaic, masking, or projection
+  semantics.
+- Conversion coefficients declare fixed value or prior, units, sign,
+  direction, coordinate scope, and alignment policy.
+- Output identities do not depend on backend name sanitization.
+- Compilation choices are recorded but do not alter semantic meaning.
+
+## Pressure Tests
+
+The design is extensible only if these can be represented without adding a new
+runner family:
+
+- one OpenGHG source, one state, one channel;
+- several OpenGHG sources, one shared state, source-resolved diagnostics;
+- several sectors with independent priors on a shared basis;
+- sectors with different and ragged state spaces;
+- one sector with independent outer and inner state blocks;
+- selected sector x basis-group combinations without a dense Cartesian cube;
+- one state feeding CO2 and O2 channels with different observation indexes;
+- channel-specific BC, fixed baseline, offset, error, and likelihood terms;
+- fixed or inactive states that remain in full ordered output;
+- output grouping by sector, basis group, source provenance, and species;
+- total flux uncertainty including sector/group covariance cross terms;
+- renaming PyMC variables without changing generic or PARIS product identity.
+
+If one of these requires redefining `source`, inventing a fake sector, copying a
+latent state, or parsing a suffix, the design is still encoding current
+implementation details as model semantics.
+
+## Open Questions
+
+- Which grouped-source combination policies should be public, and which should
+  remain adapter-specific?
+- When sources differ in temporal coverage, grid, units, or basis, what
+  equivalence is required before their forward terms may share one state?
+- Is a flux component always a reporting identity, or can several components
+  intentionally share one state?
+- Are inner and outer supports complementary, overlapping, or nested, and how
+  is double counting prevented?
+- Which grid owns a physical total when inner and outer outputs have different
+  native resolutions?
+- What is the scientific meaning and unit of a shared CO2/O2 latent state?
+- Are oxidation coefficients fixed, or prior-backed; and may they vary by
+  sector, time, domain, or basis group?
+- Can nuisance states be shared across observation channels, or must sharing
+  always be explicit?
+- Should compiler strategy be selected automatically, injected for tests, or
+  only recorded after selection?
+- What is the smallest additive schema change that can persist explicit
+  state/term/output roles while preserving old `InversionOutput` artifacts?
 
 ## Summary
 
-The current code likely contains most of the minimum needed to close the narrow
-parts of #402 and #403. The larger opportunity is to use those issues to stop
-treating `run_rhime` and `run_rhime_multisector` as separate model families.
+The durable model is not "single-sector versus multisector", and it is not one
+generic state-bearing contribution object.
 
-The better abstraction is:
+It is:
 
 ```text
-input sources are provenance
-model contributions are optimized state-bearing components
-builder strategies lower contributions into PyMC graphs
-virtual totals aggregate contributions
-output adapters own product names
+sources identify provenance
+flux components identify physical/reporting meaning
+state blocks identify sampled degrees of freedom
+forward terms map states into observation channels
+channels own likelihood-local behavior
+virtual aggregates and output views define totals
+compilation plans choose backend graph shape
+product adapters own product names
 ```
 
-That is small enough to fit the current milestones and compatible with the
-semantic IR direction.
+M9 can lower this relation with the current loop-sum behavior. M10 adds explicit
+basis groups, supports, and multiple grids. M11 adds shared-state fan-out into
+multiple observation channels. These are extensions of one relational linear
+model, not separate RHIME model families.

--- a/docs/usage/concrete_rhime_model.rst
+++ b/docs/usage/concrete_rhime_model.rst
@@ -1,0 +1,393 @@
+Concrete RHIME Model
+====================
+
+.. note::
+
+   This is a draft description of the current RHIME PyMC model and its
+   customization boundary. Code under ``openghg_inversions.models._rhime_compiler``
+   is private implementation machinery, not a public model-definition API.
+
+This page makes the model graph behind :func:`run_rhime` and
+:func:`run_rhime_multisector` explicit. It has three purposes:
+
+* show the concrete statistical model and its PyMC names;
+* show how the standard model can be reconstructed from public component
+  helpers; and
+* pressure-test how a future likelihood or complete model extension could fit
+  without turning compiler internals into a researcher-facing API.
+
+The current builders
+--------------------
+
+Both public builders use the same construction stages:
+
+.. code-block:: text
+
+   RhimeModelSpec + canonical inversion inputs
+   -> private flux compilation plan
+   -> flux states and forward terms
+   -> total flux contribution, mu
+   -> boundary, offset, error, and likelihood components
+   -> PyMC model
+
+The private compiler currently covers only the linear flux part of one
+observation channel. Boundary conditions, optional offsets, the RHIME error
+model, and the observed distribution are added afterwards by the shared model
+assembler.
+
+Standard single-flux model
+--------------------------
+
+Let ``H`` be the flux sensitivity matrix with dimensions
+``(region, nmeasure)`` in canonical inversion inputs. The builder transposes it
+to observation-first order before registering it as PyMC data. The flux model
+is
+
+.. math::
+
+   x &\sim p_x, \\
+   \mu &= Hx.
+
+With the default prior, ``x`` is the physical deterministic transform of a
+standard-normal ``x_latent``:
+
+.. math::
+
+   x_{\mathrm{latent}} &\sim \mathcal{N}(0, 1), \\
+   x &= \exp(\mu_x + \sigma_x x_{\mathrm{latent}}).
+
+When boundary-condition scaling is enabled,
+
+.. math::
+
+   bc &\sim p_{bc}, \\
+   \mu_{bc} &= H_{bc}bc.
+
+An optional site or site-by-period offset contributes ``offset``. The mean of
+the observed distribution is therefore
+
+.. math::
+
+   \mu_{\mathrm{obs}} = \mu + \mu_{bc} + \mathrm{offset},
+
+where omitted components are left out of the sum.
+
+The default RHIME error model uses observation error, a minimum error, and an
+observation-aligned model-error scale ``sigma``. Unless
+``pollution_events_from_obs`` is selected,
+
+.. math::
+
+   \epsilon =
+   \max\left(
+     \sqrt{
+       \mathrm{error}^2 +
+       \left(\left|\mu\right|\sigma\right)^{\mathrm{power}}
+     },
+     \mathrm{min\_error}
+   \right).
+
+The current observed distribution is
+
+.. math::
+
+   y \sim \mathcal{N}(\mu_{\mathrm{obs}}, \epsilon).
+
+The default priors are:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 42 38
+
+   * - Quantity
+     - Prior
+     - PyMC variables
+   * - Flux scaling
+     - Lognormal with mean 1 and standard deviation 1, reparameterized
+     - ``x_latent`` and ``x``
+   * - Boundary scaling
+     - Truncated normal with mean 1, standard deviation 0.05, and lower bound 0
+     - ``bc``
+   * - Model error
+     - Uniform from 0.1 to 3
+     - ``sigma``
+   * - Optional offset
+     - Normal with mean 0 and standard deviation 1
+     - ``offset_latent`` and ``offset``
+
+The important default model-data and deterministic names are:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 24 30 46
+
+   * - Name
+     - Role
+     - Canonical input
+   * - ``hx``
+     - Flux design data
+     - ``H``
+   * - ``mu``
+     - Flux contribution
+     - ``hx @ x``
+   * - ``hbc``
+     - Boundary design data
+     - ``H_bc``
+   * - ``mu_bc``
+     - Boundary contribution
+     - ``hbc @ bc``
+   * - ``Y``
+     - Observed mole fraction data
+     - ``mf``
+   * - ``error``
+     - Observation error data
+     - ``mf_error``
+   * - ``min_error``
+     - Minimum error data
+     - ``min_error``
+   * - ``epsilon``
+     - Observation-aligned error scale
+     - RHIME error model
+   * - ``y``
+     - Observed random variable
+     - Normal likelihood
+
+Equivalent construction from public helpers
+-------------------------------------------
+
+The production builder routes the flux component through the private compiler
+so standard and multisector RHIME share one implementation. A researcher does
+not need to construct a private plan to write the equivalent concrete
+single-flux model. The following uses public component helpers:
+
+.. code-block:: python
+
+   import pymc as pm
+
+   from openghg_inversions.models import (
+       CoordRegistry,
+       add_inferpymc_likelihood_component,
+       add_linear_component,
+       attach_coord_registry,
+   )
+   from openghg_inversions.sigma import SigmaAlignment
+
+   x_prior = {
+       "pdf": "lognormal",
+       "mean": 1.0,
+       "stdev": 1.0,
+       "reparameterise": True,
+   }
+   bc_prior = {
+       "pdf": "truncatednormal",
+       "mu": 1.0,
+       "sigma": 0.05,
+       "lower": 0.0,
+   }
+   sigma_prior = {"pdf": "uniform", "lower": 0.1, "upper": 3.0}
+
+   sigma_alignment = SigmaAlignment.from_frequency(
+       inv_inputs["site_indicator"],
+       frequency=None,
+       per_site=True,
+   )
+
+   with pm.Model() as model:
+       attach_coord_registry(model, CoordRegistry())
+
+       flux = add_linear_component(
+           inv_inputs["H"],
+           data_name="hx",
+           prior_args=x_prior,
+           var_name="x",
+           output_name="mu",
+           output_dim="nmeasure",
+       )
+       boundary = add_linear_component(
+           inv_inputs["H_bc"],
+           data_name="hbc",
+           prior_args=bc_prior,
+           var_name="bc",
+           output_name="mu_bc",
+           output_dim="nmeasure",
+       )
+       add_inferpymc_likelihood_component(
+           inv_inputs,
+           mu=flux.output,
+           mu_bc=boundary.output,
+           sigprior=sigma_prior,
+           sigma_alignment=sigma_alignment,
+           output_dim="nmeasure",
+       )
+
+This example is deliberately concrete and editable. It is suitable when a
+model developer needs to change graph construction directly. It does not
+automatically participate in the complete ``run_rhime`` output pipeline; that
+pipeline still selects one of the built-in model builders.
+
+Multisector model
+-----------------
+
+For the current shared-basis multisector model, each sector has an independent
+state and forward contribution:
+
+.. math::
+
+   x_s &\sim p_s, \\
+   \mu_s &= H_s x_s, \\
+   \mu &= \sum_s \mu_s.
+
+If the normalized PyMC suffix for sector ``s`` is ``ff``, its variables are
+``x_ff`` and ``mu_ff`` and its design data is ``hx_ff``. Source values select
+the corresponding ``H`` slices; sector names provide model identities. They
+are not required to be the same strings.
+
+Every sector state and every reparameterization-generated latent must have a
+unique backend name. The compiler also checks that all sector contributions
+share an identical observation layout before summing them.
+
+Names and generated names
+-------------------------
+
+PyMC model variables currently share one flat effective namespace. A prior can
+create more names than the requested base name. In particular, a
+reparameterized lognormal requested as ``x_ff`` creates both ``x_ff`` and
+``x_ff_latent``.
+
+Both names should be treated as reserved for that prior. No data variable,
+other state, forward-term deterministic, or total should use either name. The
+current compiler enforces this rule within the flux compilation plan. The
+shared assembler still relies on conventional names for later boundary,
+offset, error, and likelihood components; there is not yet one allocator for
+the complete model namespace.
+
+Knowledge of the ``_latent`` suffix is also duplicated between the compiler
+and ``parse_prior``. A future pure prior-description helper should report all
+generated names before graph construction, leaving ``parse_prior`` responsible
+for creating them.
+
+Component-local namespacing is another possible way to guarantee uniqueness.
+An earlier model-configuration prototype used nested PyMC models to prefix
+internal variables by component. That made collisions difficult but also made
+the final trace names and graph construction less transparent. A future
+component namespace should therefore be explicit:
+
+* each component has a stable semantic ID;
+* local roles such as ``state``, ``design``, and ``contribution`` are unique
+  within that component;
+* one name allocator renders those identities into stable backend names; and
+* every generated companion name is reserved at the same time.
+
+This preserves the useful uniqueness guarantee without requiring nested PyMC
+models or making PyMC prefixes part of scientific model identity.
+
+Alternative likelihood thought experiment
+-----------------------------------------
+
+There is currently no likelihood option on ``RhimeModelSpec``. The private flux
+compiler stops at ``mu``, and the shared assembler always installs
+``add_inferpymc_likelihood_component``.
+
+A plausible first extension is an injected ``likelihood_builder`` on the
+direct Python model builder. It would replace the whole current observation
+component, including error construction and the observed distribution, rather
+than only replacing ``pm.Normal``:
+
+.. code-block:: python
+
+   from dataclasses import dataclass
+   from collections.abc import Mapping
+   from typing import Protocol
+
+   import pymc as pm
+   import xarray as xr
+   from pytensor.tensor.variable import TensorVariable
+
+   from openghg_inversions.sigma import SigmaAlignment
+
+
+   @dataclass(frozen=True)
+   class LikelihoodContext:
+       data: xr.Dataset
+       mu: TensorVariable
+       mu_bc: TensorVariable | None
+       offset: TensorVariable | None
+       sigma_alignment: SigmaAlignment
+       sigma_prior: Mapping[str, object]
+       power: Mapping[str, object] | float
+       pollution_events_from_obs: bool
+       no_model_error: bool
+       output_dim: str
+
+
+   @dataclass(frozen=True)
+   class LikelihoodResult:
+       observed: TensorVariable
+       prediction: TensorVariable
+       error_scale: TensorVariable | None
+
+
+   class LikelihoodBuilder(Protocol):
+       def __call__(self, context: LikelihoodContext) -> LikelihoodResult:
+           ...
+
+
+   def build_model(
+       inv_inputs: xr.Dataset,
+       *,
+       likelihood_builder: LikelihoodBuilder = build_default_rhime_likelihood,
+   ) -> pm.Model:
+       ...
+
+This is a design sketch, not current API. Passing a context object avoids a
+growing callback signature as observation models evolve. Returning explicit
+roles avoids requiring sampling and postprocessing to infer meaning from names
+such as ``y`` or ``epsilon``.
+
+Replacing the complete observation component is the cleanest initial contract
+because the current helper combines error construction and the observed
+distribution. If real alternatives differ only in distribution family, error
+construction could later be extracted as a smaller reusable component before
+introducing a second callback boundary.
+
+There are two useful levels of extension:
+
+``likelihood_builder``
+   Reuses the built-in flux, boundary, and offset assembly but replaces the
+   observation/error component. This is appropriate for a Student-t likelihood,
+   a different model-error policy, or another single-channel observation model.
+
+``model_builder``
+   Consumes canonical prepared inputs and returns a complete PyMC model plus a
+   serializable variable-role manifest. This is the broader boundary needed for
+   linked tracers, several observation channels, or models distributed by an
+   extension package.
+
+The direct Python API should establish these contracts before config or plugin
+discovery is added. ``RhimeModelSpec`` should remain serializable; arbitrary
+Python callables should not be embedded in it. If external model packages later
+need CLI or config selection, a plugin entry point can resolve a stable builder
+name to a complete model factory and record the package and builder identity in
+output provenance.
+
+Customization stability
+-----------------------
+
+The current customization levels are:
+
+Supported high-level options
+   Priors, boundary conditions, offsets, sigma alignment, and existing error
+   options supplied through the public RHIME builders and model spec.
+
+Supported low-level components
+   Public functions in ``openghg_inversions.models`` can be composed inside a
+   user-owned ``pm.Model`` as shown above.
+
+Private implementation
+   ``_FluxPlan``, ``_StatePlan``, ``_ForwardTermPlan``, and
+   ``_compile_loop_sum`` may change while the semantic model representation is
+   developed. They should not be imported by research scripts.
+
+Future extension API
+   Likelihood and complete model builders should be introduced only with
+   explicit input, naming, sampling, and output-role contracts.

--- a/docs/usage/concrete_rhime_model.rst
+++ b/docs/usage/concrete_rhime_model.rst
@@ -113,6 +113,12 @@ The default priors are:
      - Normal with mean 0 and standard deviation 1
      - ``offset_latent`` and ``offset``
 
+This table describes the Python builder default used when ``x_prior`` is
+omitted. The shipped RHIME config template instead supplies an explicit
+``x_prior`` without ``reparameterise=True``. That config therefore creates
+``x`` directly, without ``x_latent``. Add ``"reparameterise": True`` to the
+config prior to request the API-default parameterization shown here.
+
 The important default model-data and deterministic names are:
 
 .. list-table::

--- a/docs/usage/concrete_rhime_model.rst
+++ b/docs/usage/concrete_rhime_model.rst
@@ -8,13 +8,11 @@ Concrete RHIME Model
    is private implementation machinery, not a public model-definition API.
 
 This page makes the model graph behind :func:`run_rhime` and
-:func:`run_rhime_multisector` explicit. It has three purposes:
+:func:`run_rhime_multisector` explicit. It has two purposes:
 
 * show the concrete statistical model and its PyMC names;
 * show how the standard model can be reconstructed from public component
-  helpers; and
-* pressure-test how a future likelihood or complete model extension could fit
-  without turning compiler internals into a researcher-facing API.
+  helpers.
 
 The current builders
 --------------------
@@ -262,116 +260,28 @@ offset, error, and likelihood components; there is not yet one allocator for
 the complete model namespace.
 
 Knowledge of the ``_latent`` suffix is also duplicated between the compiler
-and ``parse_prior``. A future pure prior-description helper should report all
-generated names before graph construction, leaving ``parse_prior`` responsible
-for creating them.
+and ``parse_prior``. Generated-name reporting, whole-model allocation, and
+component namespaces are not implemented. They are tracked in
+`issue #532 <https://github.com/openghg/openghg_inversions/issues/532>`_.
 
-Component-local namespacing is another possible way to guarantee uniqueness.
-An earlier model-configuration prototype used nested PyMC models to prefix
-internal variables by component. That made collisions difficult but also made
-the final trace names and graph construction less transparent. A future
-component namespace should therefore be explicit:
-
-* each component has a stable semantic ID;
-* local roles such as ``state``, ``design``, and ``contribution`` are unique
-  within that component;
-* one name allocator renders those identities into stable backend names; and
-* every generated companion name is reserved at the same time.
-
-This preserves the useful uniqueness guarantee without requiring nested PyMC
-models or making PyMC prefixes part of scientific model identity.
-
-Alternative likelihood thought experiment
------------------------------------------
+Alternative models and likelihoods
+----------------------------------
 
 There is currently no likelihood option on ``RhimeModelSpec``. The private flux
 compiler stops at ``mu``, and the shared assembler always installs
-``add_inferpymc_likelihood_component``.
+``add_inferpymc_likelihood_component``. Likewise, the prepared-input runner
+selects one of the built-in standard or multisector model builders.
 
-A plausible first extension is an injected ``likelihood_builder`` on the
-direct Python model builder. It would replace the whole current observation
-component, including error construction and the observed distribution, rather
-than only replacing ``pm.Normal``:
+Public contracts for alternative likelihood builders, complete model builders,
+output roles, and possible later plugin discovery are not implemented. That
+design and its pressure tests are tracked in
+`issue #533 <https://github.com/openghg/openghg_inversions/issues/533>`_.
+The more general semantic model and observation-channel representation is
+tracked in
+`issue #528 <https://github.com/openghg/openghg_inversions/issues/528>`_.
 
-.. code-block:: python
-
-   from dataclasses import dataclass
-   from collections.abc import Mapping
-   from typing import Protocol
-
-   import pymc as pm
-   import xarray as xr
-   from pytensor.tensor.variable import TensorVariable
-
-   from openghg_inversions.sigma import SigmaAlignment
-
-
-   @dataclass(frozen=True)
-   class LikelihoodContext:
-       data: xr.Dataset
-       mu: TensorVariable
-       mu_bc: TensorVariable | None
-       offset: TensorVariable | None
-       sigma_alignment: SigmaAlignment
-       sigma_prior: Mapping[str, object]
-       power: Mapping[str, object] | float
-       pollution_events_from_obs: bool
-       no_model_error: bool
-       output_dim: str
-
-
-   @dataclass(frozen=True)
-   class LikelihoodResult:
-       observed: TensorVariable
-       prediction: TensorVariable
-       error_scale: TensorVariable | None
-
-
-   class LikelihoodBuilder(Protocol):
-       def __call__(self, context: LikelihoodContext) -> LikelihoodResult:
-           ...
-
-
-   def build_model(
-       inv_inputs: xr.Dataset,
-       *,
-       likelihood_builder: LikelihoodBuilder = build_default_rhime_likelihood,
-   ) -> pm.Model:
-       ...
-
-This is a design sketch, not current API. Passing a context object avoids a
-growing callback signature as observation models evolve. Returning explicit
-roles avoids requiring sampling and postprocessing to infer meaning from names
-such as ``y`` or ``epsilon``.
-
-Replacing the complete observation component is the cleanest initial contract
-because the current helper combines error construction and the observed
-distribution. If real alternatives differ only in distribution family, error
-construction could later be extracted as a smaller reusable component before
-introducing a second callback boundary.
-
-There are two useful levels of extension:
-
-``likelihood_builder``
-   Reuses the built-in flux, boundary, and offset assembly but replaces the
-   observation/error component. This is appropriate for a Student-t likelihood,
-   a different model-error policy, or another single-channel observation model.
-
-``model_builder``
-   Consumes canonical prepared inputs and returns a complete PyMC model plus a
-   serializable variable-role manifest. This is the broader boundary needed for
-   linked tracers, several observation channels, or models distributed by an
-   extension package.
-
-The direct Python API should establish these contracts before config or plugin
-discovery is added. ``RhimeModelSpec`` should remain serializable; arbitrary
-Python callables should not be embedded in it. If external model packages later
-need CLI or config selection, a plugin entry point can resolve a stable builder
-name to a complete model factory and record the package and builder identity in
-output provenance.
-
-Customization stability
------------------------
+Customization boundaries
+------------------------
 
 The current customization levels are:
 
@@ -387,7 +297,3 @@ Private implementation
    ``_FluxPlan``, ``_StatePlan``, ``_ForwardTermPlan``, and
    ``_compile_loop_sum`` may change while the semantic model representation is
    developed. They should not be imported by research scripts.
-
-Future extension API
-   Likelihood and complete model builders should be introduced only with
-   explicit input, naming, sampling, and output-role contracts.

--- a/docs/usage/rhime.rst
+++ b/docs/usage/rhime.rst
@@ -21,12 +21,19 @@ Terminology
 
 ``sector``
    Model component optimized separately in a multi-sector RHIME run. A sector
-   is usually backed by one flux ``source``.
+   is currently backed by one unique flux ``source``.
 
 ``sector_sources``
    Optional mapping from sector names to OpenGHG ``source`` values. Use this
    when sector labels such as ``FF`` or ``ocean`` differ from the source names
-   used to retrieve flux data.
+   used to retrieve flux data. The current multi-sector model requires a
+   one-to-one mapping: two independently optimized sectors cannot select the
+   same source.
+
+``sector_priors``
+   Optional mapping containing one flux-scaling prior for every sector. When
+   omitted, all sectors use the shared ``x_prior``. When supplied, missing and
+   unused sector keys are errors.
 
 ``tracer``
    Additional species used to constrain the primary species, normally with
@@ -78,6 +85,18 @@ Python API
            "ocean": {"pdf": "lognormal", "mean": 1.0, "stdev": 1.0},
        },
    )
+
+The canonical prepared sensitivity is ``H(region, nmeasure, source)``.
+``source`` remains the OpenGHG retrieval identity; sector names and priors live
+in the model specification and select ``H`` by source label. Source-coordinate
+order therefore does not determine sector routing. Prepared source-resolved
+sensitivities also carry ``source_region_count(source)`` so the current builder
+can reject padded source-specific state layouts explicitly.
+
+The current builder supports one distinct source and one independent state
+vector per sector. Source-specific bases must have compatible region counts.
+Ragged source-specific state blocks are rejected instead of being padded with
+unconstrained latent elements.
 
 Running Prepared Inputs
 -----------------------
@@ -166,7 +185,10 @@ New RHIME config files should use ``flux_sources``:
    output_name = "example"
 
 For multi-sector RHIME, use ``sector_sources`` when the optimized sector names
-are not the same strings as the OpenGHG source values.
+are not the same strings as the OpenGHG source values. Its values must match
+``flux_sources`` exactly and must be unique. If ``sector_priors`` is supplied,
+it must contain exactly the same sector keys as ``sector_sources``; otherwise
+omit it and use one shared ``x_prior``.
 
 .. code-block:: ini
 

--- a/docs/usage/rhime.rst
+++ b/docs/usage/rhime.rst
@@ -136,6 +136,13 @@ sector count, prepared ``H`` layout, layout flag, and output settings are
 validated before model construction or sampling. Output side effects are still
 controlled by ``RhimeOutputSpec``.
 
+Model Construction
+------------------
+
+The concrete PyMC graph, its variable names, an equivalent construction from
+public model components, and a draft custom-likelihood extension are described
+in :doc:`concrete_rhime_model`.
+
 Config Files
 ------------
 

--- a/docs/usage/rhime.rst
+++ b/docs/usage/rhime.rst
@@ -86,17 +86,21 @@ Python API
        },
    )
 
-The canonical prepared sensitivity is ``H(region, nmeasure, source)``.
+Shared-basis preparation uses ``H(region, nmeasure, source)``. When sources
+have different basis indexes, preparation instead keeps one gathered state
+dimension whose MultiIndex levels are ``(source, region_in_source)``. This is
+the same concat-gather representation used for ``nmeasure`` with
+``(site, time)`` levels: ragged values are concatenated rather than padded.
+Modern preparation preserves the state-dimension name supplied by the basis
+operator; it does not rename arbitrary state axes to ``region``.
+
 ``source`` remains the OpenGHG retrieval identity; sector names and priors live
 in the model specification and select ``H`` by source label. Source-coordinate
-order therefore does not determine sector routing. Prepared source-resolved
-sensitivities also carry ``source_region_count(source)`` so the current builder
-can reject padded source-specific state layouts explicitly.
-
-The current builder supports one distinct source and one independent state
-vector per sector. Source-specific bases must have compatible region counts.
-Ragged source-specific state blocks are rejected instead of being padded with
-unconstrained latent elements.
+order therefore does not determine sector routing. The current builder
+supports one distinct source and one independent state vector per sector.
+Rectangular legacy inputs may carry ``source_region_count(source)`` so padded
+layouts can be rejected; modern preparation does not create that compatibility
+metadata.
 
 Running Prepared Inputs
 -----------------------

--- a/docs/usage/rhime.rst
+++ b/docs/usage/rhime.rst
@@ -152,12 +152,15 @@ model, output, and sampler specifications:
 
 The prepared object is trusted canonical input: it must already contain the
 observation, error, sensitivity, and optional boundary-condition variables
-required by the selected model. A multisector run requires a ``source``
-dimension on ``prepared.inv_inputs["H"]`` and
-``run_spec.split_by_sectors=True``; a single-sector run requires neither. The
-sector count, prepared ``H`` layout, layout flag, and output settings are
-validated before model construction or sampling. Output side effects are still
-controlled by ``RhimeOutputSpec``.
+required by the selected model. A multisector run requires
+``run_spec.split_by_sectors=True`` and a source-resolved layout on
+``prepared.inv_inputs["H"]``. Shared-basis inputs may use a rectangular
+``source`` dimension. Source-specific, ragged state blocks use one gathered
+state dimension with a ``(source, region_in_source)`` MultiIndex. A scalar
+``source`` coordinate is provenance for a single-sector input, not a
+multisector layout. The sector count, prepared ``H`` layout, layout flag, and
+output settings are validated before model construction or sampling. Output
+side effects are still controlled by ``RhimeOutputSpec``.
 
 Model Construction
 ------------------

--- a/docs/usage/rhime.rst
+++ b/docs/usage/rhime.rst
@@ -140,8 +140,8 @@ Model Construction
 ------------------
 
 The concrete PyMC graph, its variable names, an equivalent construction from
-public model components, and a draft custom-likelihood extension are described
-in :doc:`concrete_rhime_model`.
+public model components, and links to tracked extension work are described in
+:doc:`concrete_rhime_model`.
 
 Config Files
 ------------

--- a/docs/usage/usage.rst
+++ b/docs/usage/usage.rst
@@ -8,3 +8,4 @@ Using OpenGHG Inversions
    installation
    getting_started
    rhime
+   concrete_rhime_model

--- a/openghg_inversions/array_ops.py
+++ b/openghg_inversions/array_ops.py
@@ -41,14 +41,14 @@ an xarray issue, which now is written in terms of ``force_align``.
 
 from __future__ import annotations
 
-from collections.abc import Hashable, Iterable, Mapping, Sequence
-from typing import Any, Literal, overload, TypeVar
 import warnings
+from collections.abc import Hashable, Iterable, Mapping, Sequence
+from typing import Any, Literal, TypeVar, overload
 
-from dask.array.core import Array as DaskArray
 import numpy as np
 import pandas as pd
 import xarray as xr
+from dask.array.core import Array as DaskArray
 from sparse import COO, SparseArray
 from xarray.core.common import DataWithCoords, is_chunked_array  # type: ignore
 
@@ -297,20 +297,24 @@ def concat_gather_data_arrays(
     stack_dim: str | None = None,
     **concat_kwargs,
 ) -> xr.DataArray:
-    """Concatenate DataArrays by gathering along ragged coordinate.
+    """Concatenate DataArrays by gathering along a ragged coordinate.
 
     For example, if the keys are site codes and the ragged dimension is time,
-    then the "stacked dimension" will be the usual `nmeasure` coordinate.
+    then the stacked dimension is the usual ``nmeasure`` coordinate with
+    ``(site, time)`` levels. The same operation can gather source-specific
+    state blocks into ``(source, region_in_source)`` without rectangular
+    padding. Any alignment policy for dimensions other than ``ragged_dim``
+    should be passed explicitly through ``concat_kwargs``.
 
     Args:
-        da_dict: dictionary of DataArrays
-        key_dim: dimension name for the keys of the dictionary
-        ragged_dim: name of the ragged dimension
-        stack_dim: name for the "stacked" multi-index dimension
-        **concat_kwargs: arguments to pass to xr.concat
+        da_dict: DataArrays keyed by the values to record in ``key_dim``.
+        key_dim: Dimension name for the mapping keys.
+        ragged_dim: Name of the ragged dimension.
+        stack_dim: Name for the gathered MultiIndex dimension.
+        **concat_kwargs: Arguments passed to :func:`xarray.concat`.
 
     Returns:
-        Combined DataArray with new stacked dimension.
+        Combined DataArray with a new gathered dimension.
 
     """
     stack_dim = stack_dim or (key_dim + "_" + ragged_dim)
@@ -344,6 +348,52 @@ def concat_gather_data_arrays(
     da = da.assign_coords(xr_multiindex)
 
     return da
+
+
+def select_gathered_data_array(
+    da: xr.DataArray,
+    *,
+    key: Any,
+    key_dim: str,
+    ragged_dim: str,
+    stack_dim: str,
+) -> xr.DataArray:
+    """Select one key from a gathered DataArray and restore its ragged index.
+
+    This is the labelled inverse of one branch of
+    :func:`concat_gather_data_arrays`. The gathered dimension remains named
+    ``stack_dim``, but its ``(key_dim, ragged_dim)`` MultiIndex is reduced to
+    the selected ``ragged_dim`` labels.
+
+    Args:
+        da: DataArray containing a gathered MultiIndex dimension.
+        key: Key value to select from the gathered index.
+        key_dim: Name of the key level in the gathered MultiIndex.
+        ragged_dim: Name of the ragged level in the gathered MultiIndex.
+        stack_dim: Name of the gathered dimension.
+
+    Returns:
+        Selected DataArray indexed by the original ragged labels.
+
+    Raises:
+        TypeError: If the gathered dimension does not use a pandas MultiIndex.
+        ValueError: If the gathered levels or requested key are invalid.
+    """
+    index = da.indexes.get(stack_dim)
+    if not isinstance(index, pd.MultiIndex):
+        raise TypeError(f"Dimension {stack_dim!r} must have a pandas MultiIndex.")
+    if list(index.names) != [key_dim, ragged_dim]:
+        raise ValueError(
+            f"Dimension {stack_dim!r} must gather ({key_dim!r}, {ragged_dim!r}); "
+            f"found levels {list(index.names)!r}."
+        )
+    if key not in index.get_level_values(key_dim):
+        raise ValueError(f"Gathered dimension {stack_dim!r} does not contain {key_dim} value {key!r}.")
+
+    positions = np.flatnonzero(index.get_level_values(key_dim) == key)
+    selected = da.isel({stack_dim: positions}).reset_index(stack_dim)
+    selected = selected.drop_vars(key_dim)
+    return selected.set_index({stack_dim: ragged_dim})
 
 
 def concat_gather_datasets(

--- a/openghg_inversions/basis/_helpers.py
+++ b/openghg_inversions/basis/_helpers.py
@@ -194,10 +194,10 @@ def _legacy_multisource_h_if_needed(
     """Legacy adapter for gathered multi-source H.
 
     ``MultiSourceBucketBasisOperator.sensitivity`` returns a gathered MultiIndex
-    state dimension. Current multisector model builders and legacy output code
-    still expect separate ``region`` and ``source`` dimensions, so this converts
-    to legacy ``(region, time, source)`` shape at the wrapper boundary until
-    downstream code accepts gathered H.
+    state dimension. ``fixedbasisMCMC`` and its legacy output path still expect
+    separate ``region`` and ``source`` dimensions, so this converts to legacy
+    ``(region, time, source)`` shape only at that wrapper boundary. Modern RHIME
+    preparation must not call this adapter.
     """
     source_dim = "source"
     region_in_source_dim = "region_in_source"

--- a/openghg_inversions/basis/_helpers.py
+++ b/openghg_inversions/basis/_helpers.py
@@ -199,10 +199,27 @@ def _legacy_multisource_h_if_needed(
     source_dim = "source"
     region_in_source_dim = "region_in_source"
     if source_dim in sensitivity.dims:
+        if "region" in sensitivity.dims and "source_region_count" not in sensitivity.coords:
+            sensitivity = sensitivity.assign_coords(
+                source_region_count=(
+                    source_dim,
+                    [sensitivity.sizes["region"]] * sensitivity.sizes[source_dim],
+                )
+            )
         return sensitivity
     if state_dim not in sensitivity.dims or source_dim not in sensitivity.coords:
         return sensitivity
 
+    source_labels = [str(source) for source in sensitivity.coords[source_dim].values]
+    available_sources = list(dict.fromkeys(source_labels))
+    missing_sources = [source for source in flux_sources if source not in available_sources]
+    extra_sources = [source for source in available_sources if source not in flux_sources]
+    if missing_sources or extra_sources:
+        raise ValueError(
+            "Multi-source sensitivity does not match requested flux sources; "
+            f"missing source(s): {missing_sources!r}; extra source(s): {extra_sources!r}."
+        )
+    region_counts = {source: source_labels.count(source) for source in set(source_labels)}
     legacy_h = sensitivity.unstack(state_dim).fillna(0)
     if region_in_source_dim in legacy_h.dims:
         legacy_h = legacy_h.rename({region_in_source_dim: "region"})
@@ -210,6 +227,12 @@ def _legacy_multisource_h_if_needed(
         return sensitivity
 
     legacy_h = legacy_h.reindex({source_dim: flux_sources}).fillna(0)
+    legacy_h = legacy_h.assign_coords(
+        source_region_count=(
+            source_dim,
+            [region_counts.get(source, 0) for source in flux_sources],
+        )
+    )
     dim_order = ["region"]
     if "time" in legacy_h.dims:
         dim_order.append("time")

--- a/openghg_inversions/basis/_helpers.py
+++ b/openghg_inversions/basis/_helpers.py
@@ -226,6 +226,9 @@ def _legacy_multisource_h_if_needed(
             [source_coord.values, region_coord.values],
             names=[source_dim, region_in_source_dim],
         )
+        sensitivity = sensitivity.assign_coords(
+            xr.Coordinates.from_pandas_multiindex(state_index, state_dim)
+        )
     occupied = xr.DataArray(
         np.ones(sensitivity.sizes[state_dim], dtype=bool),
         dims=state_dim,

--- a/openghg_inversions/basis/_helpers.py
+++ b/openghg_inversions/basis/_helpers.py
@@ -1,9 +1,12 @@
 """Functions to create fit basis functiosn and apply to data."""
 
+import numpy as np
+import pandas as pd
 import xarray as xr
 
 from openghg_inversions.array_ops import get_xr_dummies, sparse_xr_dot, to_dense
 from openghg_inversions.basis.basis_functions import BasisFunctions
+
 from ._functions import basis_boundary_conditions
 
 
@@ -199,13 +202,6 @@ def _legacy_multisource_h_if_needed(
     source_dim = "source"
     region_in_source_dim = "region_in_source"
     if source_dim in sensitivity.dims:
-        if "region" in sensitivity.dims and "source_region_count" not in sensitivity.coords:
-            sensitivity = sensitivity.assign_coords(
-                source_region_count=(
-                    source_dim,
-                    [sensitivity.sizes["region"]] * sensitivity.sizes[source_dim],
-                )
-            )
         return sensitivity
     if state_dim not in sensitivity.dims or source_dim not in sensitivity.coords:
         return sensitivity
@@ -220,13 +216,28 @@ def _legacy_multisource_h_if_needed(
             f"missing source(s): {missing_sources!r}; extra source(s): {extra_sources!r}."
         )
     region_counts = {source: source_labels.count(source) for source in set(source_labels)}
-    legacy_h = sensitivity.unstack(state_dim).fillna(0)
+    state_index = sensitivity.indexes.get(state_dim)
+    if not isinstance(state_index, pd.MultiIndex):
+        source_coord = sensitivity.coords[source_dim]
+        region_coord = sensitivity.coords.get(region_in_source_dim)
+        if source_coord.dims != (state_dim,) or region_coord is None or region_coord.dims != (state_dim,):
+            return sensitivity
+        state_index = pd.MultiIndex.from_arrays(
+            [source_coord.values, region_coord.values],
+            names=[source_dim, region_in_source_dim],
+        )
+    occupied = xr.DataArray(
+        np.ones(sensitivity.sizes[state_dim], dtype=bool),
+        dims=state_dim,
+        coords=xr.Coordinates.from_pandas_multiindex(state_index, state_dim),
+    ).unstack(state_dim).notnull()
+    legacy_h = sensitivity.unstack(state_dim).where(occupied, 0.0)
     if region_in_source_dim in legacy_h.dims:
         legacy_h = legacy_h.rename({region_in_source_dim: "region"})
     if source_dim not in legacy_h.dims or "region" not in legacy_h.dims:
         return sensitivity
 
-    legacy_h = legacy_h.reindex({source_dim: flux_sources}).fillna(0)
+    legacy_h = legacy_h.sel({source_dim: flux_sources})
     legacy_h = legacy_h.assign_coords(
         source_region_count=(
             source_dim,

--- a/openghg_inversions/basis/operators.py
+++ b/openghg_inversions/basis/operators.py
@@ -645,6 +645,7 @@ class MultiSourceBucketBasisOperator(BasisOperator):
             key_dim=self.source_dim,
             ragged_dim=self.region_in_source_dim,
             stack_dim=self.meta.state_dim,
+            join="exact",
         )
 
         # chunking

--- a/openghg_inversions/config/templates/rhime_template.ini
+++ b/openghg_inversions/config/templates/rhime_template.ini
@@ -30,7 +30,7 @@ fp_height = None
 fp_species = None
 ; flux_sources gives the OpenGHG source values used to retrieve flux data.
 flux_sources = []
-; Optional mapping from sector labels to OpenGHG source values.
+; Optional one-to-one mapping from sector labels to unique OpenGHG source values.
 sector_sources = None
 bc_input = None
 
@@ -46,7 +46,8 @@ country_directory = None
 
 [RHIME.PDF]
 x_prior = {"pdf": "lognormal", "mean": 1.0, "stdev": 1.0}
-; In multi-sector RHIME, sector_priors are keyed by sector name.
+; In multi-sector RHIME, sector_priors must contain every sector key when supplied.
+; Leave this as None to apply the shared x_prior to every sector.
 sector_priors = None
 bc_prior = {"pdf": "truncatednormal", "mu": 1.0, "sigma": 0.05, "lower": 0.0}
 sigma_prior = {"pdf": "uniform", "lower": 0.1, "upper": 3.0}

--- a/openghg_inversions/inversion_data/preparation.py
+++ b/openghg_inversions/inversion_data/preparation.py
@@ -443,6 +443,39 @@ def _bc_basis_directory_arg(bc_basis_directory: str | Path | None) -> str | None
     return str(bc_basis_directory) if isinstance(bc_basis_directory, Path) else bc_basis_directory
 
 
+def _validate_multisector_sensitivity_sources(
+    sensitivity: xr.DataArray,
+    *,
+    site: str,
+    flux_sources: list[str],
+) -> xr.DataArray:
+    """Validate and order one site's source-resolved sensitivity."""
+    if "source" not in sensitivity.coords:
+        raise ValueError(
+            f"Site {site!r} sensitivity is missing the 'source' coordinate required for "
+            f"flux source(s) {flux_sources!r}."
+        )
+
+    source_labels = [str(source) for source in sensitivity.coords["source"].values]
+    available_sources = list(dict.fromkeys(source_labels))
+    duplicate_sources = (
+        [source for source in available_sources if source_labels.count(source) > 1]
+        if "source" in sensitivity.dims
+        else []
+    )
+    missing_sources = [source for source in flux_sources if source not in available_sources]
+    extra_sources = [source for source in available_sources if source not in flux_sources]
+    if duplicate_sources or missing_sources or extra_sources:
+        raise ValueError(
+            f"Site {site!r} sensitivity source layout does not match requested flux sources; "
+            f"missing source(s): {missing_sources!r}; extra source(s): {extra_sources!r}; "
+            f"duplicate source(s): {duplicate_sources!r}."
+        )
+    if "source" in sensitivity.dims:
+        return sensitivity.sel(source=flux_sources)
+    return sensitivity
+
+
 def _rhime_site_data_from_basis_functions(
     *,
     merged: _MergedInversionData,
@@ -478,6 +511,11 @@ def _rhime_site_data_from_basis_functions(
             sensitivity = sensitivity.rename({state_dim: "region"})
             state_dim = "region"
         if split_by_sectors:
+            sensitivity = _validate_multisector_sensitivity_sources(
+                sensitivity,
+                site=site,
+                flux_sources=flux_sources,
+            )
             sensitivity = _legacy_multisource_h_if_needed(
                 sensitivity,
                 state_dim=state_dim,
@@ -781,7 +819,8 @@ def prepare_rhime_inputs(
         output_name: Base output name used for data and basis artifacts.
         flux_sources: OpenGHG flux ``source`` values requested for the run.
         split_by_sectors: Whether to keep sector-resolved sensitivity inputs
-            with a ``source`` coordinate.
+            with a ``source`` provenance coordinate. Semantic sector names are
+            applied later by the model specification.
         use_tracer: Unsupported placeholder for tracer inversions, where an
             additional species constrains the primary species through linked
             forward models.

--- a/openghg_inversions/inversion_data/preparation.py
+++ b/openghg_inversions/inversion_data/preparation.py
@@ -25,7 +25,7 @@ import xarray as xr
 
 from openghg_inversions._timing import log_timing, timed, timer_seconds, timer_start
 from openghg_inversions.basis import basis_functions_wrapper, make_basis_functions
-from openghg_inversions.basis._helpers import _legacy_multisource_h_if_needed, bc_sensitivity
+from openghg_inversions.basis._helpers import bc_sensitivity
 from openghg_inversions.basis.basis_functions import BasisFunctions
 from openghg_inversions.filters import filtering
 from openghg_inversions.flux_sanitization import FluxNonFiniteCheck, sanitize_flux_nonfinite
@@ -507,27 +507,29 @@ def _rhime_site_data_from_basis_functions(
                 "Could not identify the RHIME sensitivity state dimension from "
                 f"sensitivity dims {sensitivity.dims!r} and fp_x_flux dims {fp_x_flux.dims!r}."
             )
-        if state_dim != "region" and state_dim in sensitivity.dims:
-            sensitivity = sensitivity.rename({state_dim: "region"})
-            state_dim = "region"
         if split_by_sectors:
             sensitivity = _validate_multisector_sensitivity_sources(
                 sensitivity,
                 site=site,
                 flux_sources=flux_sources,
             )
-            sensitivity = _legacy_multisource_h_if_needed(
-                sensitivity,
-                state_dim=state_dim,
-                flux_sources=flux_sources,
-            )
+        if "source" in sensitivity.coords and "source" not in sensitivity.dims:
+            fp_data[site] = fp_data[site].drop_vars(fp_x_flux_name)
+            orphan_dims = [
+                dim
+                for dim in fp_x_flux.dims
+                if dim in fp_data[site].dims
+                and all(dim not in variable.dims for variable in fp_data[site].data_vars.values())
+            ]
+            if orphan_dims:
+                fp_data[site] = fp_data[site].drop_dims(orphan_dims)
         fp_data[site]["H"] = sensitivity
         log_timing(
             "rhime.prepare_inputs.footprint_sensitivity",
             timer_seconds(timing_start),
             site=site,
             nmeasure=fp_data[site].sizes.get("time"),
-            regions=sensitivity.sizes.get("region"),
+            state_size=sensitivity.sizes.get(state_dim),
             sources=sensitivity.sizes.get("source"),
         )
 

--- a/openghg_inversions/inversion_inputs.py
+++ b/openghg_inversions/inversion_inputs.py
@@ -2,16 +2,39 @@
 
 import datetime as dt
 import numbers
-from typing import Any, Iterable, Literal
+from collections.abc import Iterable
+from typing import Any, Literal
 
 import numpy as np
 import pandas as pd
 import xarray as xr
 
-from openghg_inversions.array_ops import get_xr_dummies, concat_gather_datasets
+from openghg_inversions.array_ops import concat_gather_datasets, get_xr_dummies
 from openghg_inversions.model_error import percentile_error_method, residual_error_method, xr_setup_min_error
 
 DatetimeLike = str | dt.datetime | np.datetime64 | pd.Timestamp
+
+
+def _validate_per_site_dimension_names(
+    site_data: dict[str, xr.Dataset],
+    *,
+    ragged_dim: str,
+) -> None:
+    """Reject shared variables whose structural dimension names differ by site."""
+    if len(site_data) < 2:
+        return
+
+    shared_vars = set.intersection(*(set(dataset.data_vars) for dataset in site_data.values()))
+    for name in sorted(shared_vars):
+        layouts = {
+            site: frozenset(str(dim) for dim in dataset[name].dims if dim != ragged_dim)
+            for site, dataset in site_data.items()
+        }
+        if len(set(layouts.values())) > 1:
+            raise ValueError(
+                f"Per-site variable {name!r} must use the same non-{ragged_dim} dimensions "
+                f"before gathering; found {layouts!r}."
+            )
 
 
 def _compact_integer_index(values: np.ndarray) -> np.ndarray:
@@ -175,6 +198,7 @@ def add_min_error(
     else:
         min_error_data = min_error_data.rename("min_error")
 
+    assert isinstance(min_error_data, xr.DataArray)
     ds["min_error"] = xr.DataArray(min_error_data.data, dims=("nmeasure",), name="min_error")
     return ds
 
@@ -331,14 +355,23 @@ def make_inv_inputs(
             configuration is invalid.
     """
     sites = sites or [k for k in fp_data if not k.startswith(".")]
+    site_data = {k: v for k, v in fp_data.items() if k in sites}
+    _validate_per_site_dimension_names(site_data, ragged_dim="time")
 
-    ds = concat_gather_datasets(
-        {k: v for k, v in fp_data.items() if k in sites},
-        key_dim="site",
-        ragged_dim="time",
-        stack_dim="nmeasure",
-        missing_data_vars="drop",
-    )
+    try:
+        ds = concat_gather_datasets(
+            site_data,
+            key_dim="site",
+            ragged_dim="time",
+            stack_dim="nmeasure",
+            missing_data_vars="drop",
+            join="exact",
+        )
+    except xr.AlignmentError as exc:
+        raise ValueError(
+            "Per-site inversion inputs must have identical indexes on every non-time dimension "
+            "before gathering into nmeasure."
+        ) from exc
 
     # Check that we have variables for standard RHIME inversion (`inferpymc`).
     # Note that mf_prior_factor and mf_prior_upper_level_factor are only needed

--- a/openghg_inversions/models/_rhime_compiler.py
+++ b/openghg_inversions/models/_rhime_compiler.py
@@ -1,0 +1,370 @@
+"""Private PyMC compiler for normalized RHIME linear forward plans.
+
+The frozen plan records contain only labelled xarray designs, prior metadata,
+semantic identifiers, and requested variable names. The compiler validates a
+complete plan before registering any objects on the active PyMC model, then
+creates each state once and applies its ordered forward terms.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+import math
+from numbers import Real
+from types import MappingProxyType
+from typing import Any, cast
+
+import numpy as np
+import pymc as pm
+import pytensor.tensor as pt
+import xarray as xr
+from pytensor.tensor.variable import TensorVariable
+
+from openghg_inversions.models.components import add_model_data, get_model_latent
+from openghg_inversions.models.coords import CoordRegistry
+from openghg_inversions.models.priors import PriorArgs, parse_prior
+
+
+@dataclass(frozen=True)
+class _StatePlan:
+    """Describe one semantic state and its backend variable metadata.
+
+    Args:
+        state_id: Stable semantic identifier for the state.
+        variable_name: Backend variable name used for the state prior.
+        prior_args: Prior metadata forwarded to the backend compiler.
+    """
+
+    state_id: str
+    variable_name: str
+    prior_args: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class _ForwardTermPlan:
+    """Describe one labelled linear application of a state to observations.
+
+    Args:
+        term_id: Stable semantic identifier for the forward term.
+        state_id: Semantic identifier of the state used by this term.
+        design: Selected two-dimensional labelled design matrix.
+        data_name: Backend model-data name for ``design``.
+        deterministic_name: Backend name for the term contribution.
+        coefficient: Fixed finite scalar multiplying the linear contribution.
+    """
+
+    term_id: str
+    state_id: str
+    design: xr.DataArray
+    data_name: str
+    deterministic_name: str
+    coefficient: float = 1.0
+
+
+@dataclass(frozen=True)
+class _FluxPlan:
+    """Describe ordered flux states and terms independently of compiler strategy.
+
+    Args:
+        states: State plans in stable declaration order.
+        terms: Forward terms in stable semantic order.
+        observation_dim: Shared observation dimension across term designs.
+        total_name: Backend deterministic name for the summed contribution.
+    """
+
+    states: tuple[_StatePlan, ...]
+    terms: tuple[_ForwardTermPlan, ...]
+    observation_dim: str = "nmeasure"
+    total_name: str = "mu"
+
+
+@dataclass(frozen=True)
+class _CompiledFlux:
+    """Expose compiled tensors keyed by their semantic identifiers.
+
+    Args:
+        mu: Total observation-space contribution.
+        states: User-facing state tensors keyed by state ID.
+        latents: Effective backend latent tensors keyed by state ID.
+        terms: Forward contribution tensors keyed by term ID.
+    """
+
+    mu: TensorVariable
+    states: Mapping[str, TensorVariable]
+    latents: Mapping[str, TensorVariable]
+    terms: Mapping[str, TensorVariable]
+
+
+def _require_unique(values: list[str], label: str) -> None:
+    """Require unique values in a plan identifier or backend-name collection.
+
+    Args:
+        values: Names or identifiers to validate.
+        label: Human-readable collection label for errors.
+
+    Raises:
+        ValueError: If ``values`` contains duplicates.
+    """
+    seen: set[str] = set()
+    duplicates: set[str] = set()
+    for value in values:
+        if value in seen:
+            duplicates.add(value)
+        seen.add(value)
+    if duplicates:
+        raise ValueError(f"Flux plan {label} must be unique; duplicates: {sorted(duplicates)!r}.")
+
+
+def _uses_reparameterized_lognormal(state: _StatePlan) -> bool:
+    """Return whether a state prior creates an additional backend latent."""
+    pdf = str(state.prior_args.get("pdf", "")).lower()
+    return pdf == "lognormal" and bool(state.prior_args.get("reparameterise", False))
+
+
+def _state_backend_names(state: _StatePlan) -> tuple[str, ...]:
+    """Return every backend name created by a state prior."""
+    if _uses_reparameterized_lognormal(state):
+        return (state.variable_name, f"{state.variable_name}_latent")
+    return (state.variable_name,)
+
+
+def _coords_for_dims(data: xr.DataArray, dims: tuple[str, ...]) -> dict[str, xr.DataArray]:
+    """Return non-scalar coordinates defined only over selected dimensions.
+
+    Args:
+        data: Labelled design matrix to inspect.
+        dims: Dimensions whose coordinates should be selected.
+
+    Returns:
+        Coordinate mapping suitable for exact layout comparison.
+    """
+    dim_set = set(dims)
+    return {
+        str(name): coord
+        for name, coord in data.coords.items()
+        if coord.dims and set(coord.dims).issubset(dim_set)
+    }
+
+
+def _require_exact_layout(
+    reference: xr.DataArray,
+    candidate: xr.DataArray,
+    dims: tuple[str, ...],
+    *,
+    label: str,
+) -> None:
+    """Require equal sizes and exact coordinates over selected dimensions.
+
+    Args:
+        reference: Reference design matrix.
+        candidate: Design matrix to compare.
+        dims: Dimensions whose sizes and coordinates must match.
+        label: Human-readable layout label for errors.
+
+    Raises:
+        ValueError: If sizes or labelled coordinates differ.
+    """
+    if any(reference.sizes[dim] != candidate.sizes[dim] for dim in dims):
+        raise ValueError(f"Flux plan terms must have exact {label} sizes.")
+
+    reference_coords = _coords_for_dims(reference, dims)
+    candidate_coords = _coords_for_dims(candidate, dims)
+    if reference_coords.keys() != candidate_coords.keys():
+        raise ValueError(f"Flux plan terms must have exact {label} coordinates.")
+    if any(not coord.identical(candidate_coords[name]) for name, coord in reference_coords.items()):
+        raise ValueError(f"Flux plan terms must have exact {label} coordinates.")
+
+
+def _preflight_state_priors(
+    plan: _FluxPlan,
+    terms_by_state: Mapping[str, list[_ForwardTermPlan]],
+    registry: CoordRegistry,
+) -> None:
+    """Validate state prior metadata in isolated scratch models.
+
+    Args:
+        plan: Flux plan whose priors should be checked.
+        terms_by_state: Forward terms grouped by semantic state ID.
+        registry: Validated global coordinate registry for the term designs.
+
+    Raises:
+        ValueError: If a prior cannot be constructed with its state dimensions.
+    """
+    coords = {name: np.asarray(values).tolist() for name, values in registry.pymc_coords.items()}
+    with pm.Model(coords=coords, model=None):
+        for state in plan.states:
+            design = terms_by_state[state.state_id][0].design
+            state_dims = tuple(str(dim) for dim in design.dims if dim != plan.observation_dim)
+            try:
+                parse_prior(
+                    state.variable_name,
+                    cast(PriorArgs, dict(state.prior_args)),
+                    dims=state_dims,
+                )
+            except (KeyError, TypeError, ValueError) as exc:
+                raise ValueError(f"Flux plan prior for state {state.state_id!r} is invalid.") from exc
+
+
+def _validate_flux_plan(plan: _FluxPlan) -> None:
+    """Validate a complete flux plan without mutating the active PyMC model.
+
+    Args:
+        plan: Ordered state and forward-term plan.
+
+    Raises:
+        TypeError: If a term design is not an xarray ``DataArray``.
+        ValueError: If identifiers, names, designs, coordinates, priors, state
+            references, or coefficients violate the compiler contract.
+    """
+    if not plan.states:
+        raise ValueError("Flux plans require at least one state.")
+    if not plan.terms:
+        raise ValueError("Flux plans require at least one forward term.")
+
+    _require_unique([state.state_id for state in plan.states], "state IDs")
+    _require_unique([term.term_id for term in plan.terms], "term IDs")
+    _require_unique([state.variable_name for state in plan.states], "variable names")
+    _require_unique([term.data_name for term in plan.terms], "data names")
+    _require_unique([term.deterministic_name for term in plan.terms], "deterministic names")
+
+    state_ids = {state.state_id for state in plan.states}
+    terms_by_state = {
+        state.state_id: [term for term in plan.terms if term.state_id == state.state_id]
+        for state in plan.states
+    }
+    unknown_state_ids = sorted({term.state_id for term in plan.terms} - state_ids)
+    if unknown_state_ids:
+        raise ValueError(f"Flux terms reference unknown state IDs: {unknown_state_ids!r}.")
+    unused_state_ids = sorted(state_id for state_id, terms in terms_by_state.items() if not terms)
+    if unused_state_ids:
+        raise ValueError(f"Flux states have no forward terms: {unused_state_ids!r}.")
+
+    total_collisions = [term for term in plan.terms if term.deterministic_name == plan.total_name]
+    compatible_single_term = len(plan.terms) == 1 and len(total_collisions) == 1
+    if total_collisions and not compatible_single_term:
+        raise ValueError(
+            "Flux total name collides with a term deterministic name; "
+            "this is only valid for a single-term compatibility plan."
+        )
+
+    backend_names = [name for state in plan.states for name in _state_backend_names(state)]
+    backend_names.extend(term.data_name for term in plan.terms)
+    backend_names.extend(
+        term.deterministic_name
+        for term in plan.terms
+        if not (compatible_single_term and term.deterministic_name == plan.total_name)
+    )
+    backend_names.append(plan.total_name)
+    _require_unique(backend_names, "backend names")
+
+    registry = CoordRegistry()
+    reference_observations: xr.DataArray | None = None
+    for term in plan.terms:
+        if not isinstance(term.design, xr.DataArray):
+            raise TypeError(f"Flux term {term.term_id!r} design must be an xarray DataArray.")
+        if term.design.ndim != 2 or plan.observation_dim not in term.design.dims:
+            raise ValueError(
+                f"Flux term {term.term_id!r} design must be two-dimensional and include "
+                f"{plan.observation_dim!r}."
+            )
+        missing_coords = [str(dim) for dim in term.design.dims if dim not in term.design.coords]
+        if missing_coords:
+            raise ValueError(
+                f"Flux term {term.term_id!r} design requires dimension coordinates for {missing_coords!r}."
+            )
+        if isinstance(term.coefficient, bool) or not isinstance(term.coefficient, Real):
+            raise ValueError(f"Flux term {term.term_id!r} coefficient must be a finite scalar.")
+        if not math.isfinite(float(term.coefficient)):
+            raise ValueError(f"Flux term {term.term_id!r} coefficient must be a finite scalar.")
+
+        if reference_observations is None:
+            reference_observations = term.design
+        else:
+            _require_exact_layout(
+                reference_observations,
+                term.design,
+                (plan.observation_dim,),
+                label="observation",
+            )
+        try:
+            registry.add(
+                term.design.coords,
+                model_dims=tuple(str(dim) for dim in term.design.dims),
+            )
+        except ValueError as exc:
+            raise ValueError("Flux plan terms have incompatible global coordinates.") from exc
+
+    for state_id, terms in terms_by_state.items():
+        reference = terms[0].design
+        state_dims = tuple(str(dim) for dim in reference.dims if dim != plan.observation_dim)
+        for term in terms[1:]:
+            candidate_dims = tuple(str(dim) for dim in term.design.dims if dim != plan.observation_dim)
+            if candidate_dims != state_dims:
+                raise ValueError(f"Flux terms for state {state_id!r} must have exact state dimensions.")
+            _require_exact_layout(reference, term.design, state_dims, label="state")
+
+    _preflight_state_priors(plan, terms_by_state, registry)
+
+
+def _compile_loop_sum(plan: _FluxPlan) -> _CompiledFlux:
+    """Compile a validated loop-sum plan into the active PyMC model.
+
+    Args:
+        plan: Ordered state and forward-term plan.
+
+    Returns:
+        Compiled total mean and semantic state/term tensor mappings.
+
+    Raises:
+        TypeError: If a term design is not an xarray ``DataArray``.
+        ValueError: If the complete plan is invalid.
+    """
+    _validate_flux_plan(plan)
+
+    state_tensors: dict[str, TensorVariable] = {}
+    latent_tensors: dict[str, TensorVariable] = {}
+    term_tensors: dict[str, TensorVariable] = {}
+    ordered_outputs: list[TensorVariable] = []
+    state_by_id = {state.state_id: state for state in plan.states}
+
+    for term in plan.terms:
+        design = term.design.transpose(plan.observation_dim, ...)
+        data = add_model_data(design, term.data_name)
+        if term.state_id not in state_tensors:
+            state = state_by_id[term.state_id]
+            state_dims = tuple(str(dim) for dim in design.dims if dim != plan.observation_dim)
+            user_facing = parse_prior(
+                state.variable_name,
+                cast(PriorArgs, dict(state.prior_args)),
+                dims=state_dims,
+            )
+            state_tensors[state.state_id] = user_facing
+            latent_tensors[state.state_id] = get_model_latent(user_facing, state.variable_name)
+
+        output = pt.dot(data, state_tensors[term.state_id])
+        if term.coefficient != 1.0:
+            output = term.coefficient * output
+        deterministic = pm.Deterministic(
+            term.deterministic_name,
+            output,
+            dims=plan.observation_dim,
+        )
+        term_tensors[term.term_id] = deterministic
+        ordered_outputs.append(deterministic)
+
+    if len(ordered_outputs) == 1 and plan.terms[0].deterministic_name == plan.total_name:
+        total_mu = ordered_outputs[0]
+    else:
+        total_mu = pm.Deterministic(
+            plan.total_name,
+            cast(Any, pt.stack(ordered_outputs, axis=0)).sum(axis=0),
+            dims=plan.observation_dim,
+        )
+
+    return _CompiledFlux(
+        mu=total_mu,
+        states=MappingProxyType(state_tensors),
+        latents=MappingProxyType(latent_tensors),
+        terms=MappingProxyType(term_tensors),
+    )

--- a/openghg_inversions/models/_rhime_flux.py
+++ b/openghg_inversions/models/_rhime_flux.py
@@ -1,0 +1,321 @@
+"""Lower RHIME flux declarations into private PyMC compiler plans."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import pandas as pd
+import xarray as xr
+
+from openghg_inversions.array_ops import select_gathered_data_array
+from openghg_inversions.models._rhime_compiler import (
+    _FluxPlan,
+    _ForwardTermPlan,
+    _StatePlan,
+)
+
+
+@dataclass(frozen=True)
+class _ResolvedSectorBinding:
+    """Bind one semantic sector to prepared source data and backend naming."""
+
+    name: str
+    flux_source: str
+    variable_suffix: str
+
+
+def safe_pymc_name(value: str) -> str:
+    """Return a stable PyMC-safe suffix for a user-facing sector/source name."""
+    name = re.sub(r"\W+", "_", str(value).strip().lower()).strip("_")
+    return name or "sector"
+
+
+def _prepared_sources(design: xr.DataArray, *, observation_dim: str = "nmeasure") -> list[str]:
+    """Return ordered source labels from rectangular or gathered sensitivity."""
+    source_coord = design.coords.get("source")
+    if source_coord is None:
+        raise ValueError(
+            "Multi-sector RHIME requires inv_inputs['H'] to contain OpenGHG source labels."
+        )
+
+    source_labels = [str(value) for value in source_coord.values]
+    if "source" in design.dims:
+        duplicate_sources = list(
+            dict.fromkeys(source for source in source_labels if source_labels.count(source) > 1)
+        )
+        if duplicate_sources:
+            raise ValueError(
+                "Multi-sector RHIME requires unique inv_inputs['H'].source labels; "
+                f"duplicate source {duplicate_sources[0]!r}."
+            )
+        return source_labels
+
+    state_dims = [str(dim) for dim in design.dims if dim != observation_dim]
+    if len(state_dims) != 1 or source_coord.dims != (state_dims[0],):
+        raise ValueError(
+            "Gathered multi-sector H requires one state dimension carrying the 'source' coordinate."
+        )
+    state_index = design.indexes.get(state_dims[0])
+    if not isinstance(state_index, pd.MultiIndex) or "source" not in state_index.names:
+        raise ValueError(
+            "Gathered multi-sector H requires its state dimension to use a MultiIndex "
+            "containing a 'source' level."
+        )
+    if not state_index.is_unique:
+        duplicate = state_index[state_index.duplicated()][0]
+        raise ValueError(
+            "Gathered multi-sector H requires unique state labels; "
+            f"duplicate state {duplicate!r}."
+        )
+    return list(dict.fromkeys(source_labels))
+
+
+def _resolve_sector_bindings(
+    inv_inputs: xr.Dataset,
+    sectors: Sequence[str] | None,
+    *,
+    sector_sources: Mapping[str, str] | None,
+    sector_variable_suffixes: Mapping[str, str] | None,
+) -> tuple[_ResolvedSectorBinding, ...]:
+    """Resolve semantic sectors against prepared source provenance."""
+    available = _prepared_sources(inv_inputs["H"])
+    if sectors is None:
+        sectors = list(sector_sources) if sector_sources is not None else available
+    sector_names = [str(sector) for sector in sectors]
+
+    if len(sector_names) < 2:
+        raise ValueError("Multi-sector RHIME requires at least two sectors.")
+    duplicate_sectors = list(
+        dict.fromkeys(sector for sector in sector_names if sector_names.count(sector) > 1)
+    )
+    if duplicate_sectors:
+        raise ValueError(
+            f"Multi-sector RHIME requires unique sector names; duplicate sector {duplicate_sectors[0]!r}."
+        )
+    if any(not sector.strip() for sector in sector_names):
+        raise ValueError("Multi-sector RHIME requires non-empty sector names.")
+
+    source_by_sector = (
+        {str(sector): str(source) for sector, source in sector_sources.items()}
+        if sector_sources is not None
+        else {sector: sector for sector in sector_names}
+    )
+    suffix_by_sector = (
+        {str(sector): str(suffix) for sector, suffix in sector_variable_suffixes.items()}
+        if sector_variable_suffixes is not None
+        else {}
+    )
+
+    unused_mappings = [sector for sector in source_by_sector if sector not in sector_names]
+    if unused_mappings:
+        raise ValueError(f"`sector_sources` contains unused sector key(s): {unused_mappings!r}.")
+    missing_mappings = [sector for sector in sector_names if sector not in source_by_sector]
+    if missing_mappings:
+        raise ValueError(f"Sector(s) {missing_mappings!r} are missing from `sector_sources`.")
+
+    source_sectors: dict[str, list[str]] = {}
+    for sector in sector_names:
+        source_sectors.setdefault(source_by_sector[sector], []).append(sector)
+    duplicate_sources = {
+        source: mapped_sectors
+        for source, mapped_sectors in source_sectors.items()
+        if len(mapped_sectors) > 1
+    }
+    if duplicate_sources:
+        details = ", ".join(
+            f"source {source!r} is mapped by sectors {mapped_sectors!r}"
+            for source, mapped_sectors in duplicate_sources.items()
+        )
+        raise ValueError(
+            "Multi-sector RHIME requires a distinct source for each current sector; "
+            + details
+            + "."
+        )
+
+    missing = [
+        (sector, source_by_sector[sector])
+        for sector in sector_names
+        if source_by_sector[sector] not in available
+    ]
+    if missing:
+        details = ", ".join(f"sector {sector!r} -> source {source!r}" for sector, source in missing)
+        raise ValueError(
+            f"Source data required by {details} is not present in inv_inputs['H'].source; "
+            f"available source(s): {available!r}."
+        )
+
+    unused_suffixes = [sector for sector in suffix_by_sector if sector not in sector_names]
+    if unused_suffixes:
+        raise ValueError(
+            f"`sector_variable_suffixes` contains unused sector key(s): {unused_suffixes!r}."
+        )
+    bindings = tuple(
+        _ResolvedSectorBinding(
+            name=sector,
+            flux_source=source_by_sector[sector],
+            variable_suffix=suffix_by_sector.get(sector, safe_pymc_name(sector)),
+        )
+        for sector in sector_names
+    )
+    suffixes = [binding.variable_suffix for binding in bindings]
+    if len(suffixes) != len(set(suffixes)):
+        duplicate = next(suffix for suffix in suffixes if suffixes.count(suffix) > 1)
+        raise ValueError(
+            "Sector names must be unique after PyMC name sanitisation; "
+            f"duplicate sanitized name {duplicate!r}."
+        )
+    return bindings
+
+
+def _validate_unpadded_sector_design(
+    design: xr.DataArray,
+    *,
+    sector: str,
+    source: str,
+    observation_dim: str = "nmeasure",
+) -> None:
+    """Reject rectangular source layouts containing declared padding."""
+    state_dims = [str(dim) for dim in design.dims if dim != observation_dim]
+    if design.ndim != 2 or observation_dim not in design.dims or len(state_dims) != 1:
+        return
+
+    state_dim = state_dims[0]
+    source_region_count = design.coords.get("source_region_count")
+    if source_region_count is None:
+        return
+    declared_regions = int(source_region_count.item())
+    prepared_regions = design.sizes[state_dim]
+    if declared_regions != prepared_regions:
+        raise ValueError(
+            f"Sector {sector!r} -> source {source!r} declares {declared_regions} "
+            f"{state_dim} elements but prepared H has {prepared_regions}. Ragged "
+            "source-specific state blocks must use a gathered state coordinate."
+        )
+
+
+def _select_sector_design(
+    design: xr.DataArray,
+    *,
+    sector: str,
+    source: str,
+    variable_suffix: str,
+    observation_dim: str = "nmeasure",
+) -> xr.DataArray:
+    """Select one source design from rectangular or gathered sensitivity."""
+    available_sources = _prepared_sources(design, observation_dim=observation_dim)
+    if source not in available_sources:
+        raise ValueError(
+            f"Sector {sector!r} requires source {source!r}, but prepared H contains "
+            f"{available_sources!r}."
+        )
+
+    if "source" in design.dims:
+        selected = design.sel(source=source, drop=False)
+        _validate_unpadded_sector_design(
+            selected,
+            sector=sector,
+            source=source,
+            observation_dim=observation_dim,
+        )
+        return design.sel(source=source, drop=True)
+
+    state_dims = [str(dim) for dim in design.dims if dim != observation_dim]
+    state_dim = state_dims[0]
+    index = design.indexes.get(state_dim)
+    assert isinstance(index, pd.MultiIndex)
+    ragged_levels = [str(name) for name in index.names if name != "source"]
+    if len(ragged_levels) != 1:
+        raise ValueError(
+            f"Gathered H state dimension {state_dim!r} must contain exactly the "
+            f"'source' and one ragged-region level; found {list(index.names)!r}."
+        )
+
+    selected = select_gathered_data_array(
+        design,
+        key=source,
+        key_dim="source",
+        ragged_dim=ragged_levels[0],
+        stack_dim=state_dim,
+    )
+    return selected.rename({state_dim: f"{state_dim}_{variable_suffix}"})
+
+
+def _normalize_standard_flux_plan(inv_inputs: xr.Dataset, x_prior: Mapping[str, Any]) -> _FluxPlan:
+    """Normalize the standard flux component into a one-state linear plan."""
+    state_id = "flux"
+    return _FluxPlan(
+        states=(
+            _StatePlan(
+                state_id=state_id,
+                variable_name="x",
+                prior_args=x_prior,
+            ),
+        ),
+        terms=(
+            _ForwardTermPlan(
+                term_id=state_id,
+                state_id=state_id,
+                design=inv_inputs["H"],
+                data_name="hx",
+                deterministic_name="mu",
+                coefficient=1.0,
+            ),
+        ),
+    )
+
+
+def _normalize_multisector_flux_plan(
+    inv_inputs: xr.Dataset,
+    sector_bindings: Sequence[_ResolvedSectorBinding],
+    *,
+    sector_priors: Mapping[str, Mapping[str, Any]] | None,
+    x_prior: Mapping[str, Any] | None,
+    default_x_prior: Mapping[str, Any],
+) -> _FluxPlan:
+    """Normalize selected sector designs into separate state and term plans."""
+    sector_names = [binding.name for binding in sector_bindings]
+    if sector_priors is not None:
+        missing_priors = [sector for sector in sector_names if sector not in sector_priors]
+        unused_priors = [sector for sector in sector_priors if sector not in sector_names]
+        if missing_priors or unused_priors:
+            raise ValueError(
+                "`sector_priors` must define exactly one prior for every sector when supplied; "
+                f"missing sector prior(s): {missing_priors!r}; "
+                f"unused sector prior key(s): {unused_priors!r}."
+            )
+
+    states: list[_StatePlan] = []
+    terms: list[_ForwardTermPlan] = []
+    for binding in sector_bindings:
+        design = _select_sector_design(
+            inv_inputs["H"],
+            sector=binding.name,
+            source=binding.flux_source,
+            variable_suffix=binding.variable_suffix,
+        )
+        prior = (
+            sector_priors[binding.name]
+            if sector_priors is not None
+            else default_x_prior if x_prior is None else x_prior
+        )
+        states.append(
+            _StatePlan(
+                state_id=binding.name,
+                variable_name=f"x_{binding.variable_suffix}",
+                prior_args=dict(prior),
+            )
+        )
+        terms.append(
+            _ForwardTermPlan(
+                term_id=binding.name,
+                state_id=binding.name,
+                design=design,
+                data_name=f"hx_{binding.variable_suffix}",
+                deterministic_name=f"mu_{binding.variable_suffix}",
+                coefficient=1.0,
+            )
+        )
+    return _FluxPlan(states=tuple(states), terms=tuple(terms))

--- a/openghg_inversions/models/rhime.py
+++ b/openghg_inversions/models/rhime.py
@@ -357,14 +357,32 @@ def _resolve_sector_definitions(
     """
     if "source" not in inv_inputs["H"].dims:
         raise ValueError("Multi-sector RHIME requires inv_inputs['H'] to include a 'source' dimension.")
+    if "source" not in inv_inputs["H"].coords:
+        raise ValueError(
+            "Multi-sector RHIME requires inv_inputs['H'].source to contain OpenGHG source labels."
+        )
 
     available = [str(value) for value in inv_inputs["H"].coords["source"].values]
+    duplicate_available = [source for source in available if available.count(source) > 1]
+    if duplicate_available:
+        duplicate = next(iter(dict.fromkeys(duplicate_available)))
+        raise ValueError(
+            "Multi-sector RHIME requires unique inv_inputs['H'].source labels; "
+            f"duplicate source {duplicate!r}."
+        )
     if sectors is None:
         sectors = list(sector_sources) if sector_sources is not None else available
     sector_names = [str(sector) for sector in sectors]
 
     if len(sector_names) < 2:
         raise ValueError("Multi-sector RHIME requires at least two sectors.")
+    duplicate_sectors = [sector for sector in sector_names if sector_names.count(sector) > 1]
+    if duplicate_sectors:
+        duplicate = next(iter(dict.fromkeys(duplicate_sectors)))
+        raise ValueError(f"Multi-sector RHIME requires unique sector names; duplicate sector {duplicate!r}.")
+    empty_sectors = [sector for sector in sector_names if not sector.strip()]
+    if empty_sectors:
+        raise ValueError("Multi-sector RHIME requires non-empty sector names.")
 
     source_by_sector = (
         {str(sector): str(source) for sector, source in sector_sources.items()}
@@ -377,16 +395,47 @@ def _resolve_sector_definitions(
         else {}
     )
 
+    unused_mappings = [sector for sector in source_by_sector if sector not in sector_names]
+    if unused_mappings:
+        raise ValueError(f"`sector_sources` contains unused sector key(s): {unused_mappings!r}.")
     missing_mapping = [sector for sector in sector_names if sector not in source_by_sector]
     if missing_mapping:
         raise ValueError(f"Sector(s) {missing_mapping!r} are missing from `sector_sources`.")
 
+    source_sectors: dict[str, list[str]] = {}
+    for sector in sector_names:
+        source_sectors.setdefault(source_by_sector[sector], []).append(sector)
+    duplicate_sources = {
+        source: mapped_sectors
+        for source, mapped_sectors in source_sectors.items()
+        if len(mapped_sectors) > 1
+    }
+    if duplicate_sources:
+        details = ", ".join(
+            f"source {source!r} is mapped by sectors {mapped_sectors!r}"
+            for source, mapped_sectors in duplicate_sources.items()
+        )
+        raise ValueError(
+            "Multi-sector RHIME requires a distinct source for each current sector; " + details + "."
+        )
+
     missing = [
-        source_by_sector[sector] for sector in sector_names if source_by_sector[sector] not in available
+        (sector, source_by_sector[sector])
+        for sector in sector_names
+        if source_by_sector[sector] not in available
     ]
     if missing:
-        raise ValueError(f"Source value(s) {missing!r} are not present in inv_inputs['H'].source.")
+        details = ", ".join(f"sector {sector!r} -> source {source!r}" for sector, source in missing)
+        raise ValueError(
+            f"Source data required by {details} is not present in inv_inputs['H'].source; "
+            f"available source(s): {available!r}."
+        )
 
+    unused_suffixes = [sector for sector in suffix_by_sector if sector not in sector_names]
+    if unused_suffixes:
+        raise ValueError(
+            f"`sector_variable_suffixes` contains unused sector key(s): {unused_suffixes!r}."
+        )
     definitions = [
         (sector, source_by_sector[sector], suffix_by_sector.get(sector, safe_pymc_name(sector)))
         for sector in sector_names
@@ -413,6 +462,32 @@ def _sector_prior(
     return dict(DEFAULT_X_PRIOR if x_prior is None else x_prior)
 
 
+def _validate_sector_design(
+    design: xr.DataArray,
+    *,
+    sector: str,
+    source: str,
+    observation_dim: str = "nmeasure",
+) -> None:
+    """Reject source layouts that would create latent variables for padding."""
+    state_dims = [str(dim) for dim in design.dims if dim != observation_dim]
+    if design.ndim != 2 or observation_dim not in design.dims or len(state_dims) != 1:
+        return
+
+    state_dim = state_dims[0]
+    source_region_count = design.coords.get("source_region_count")
+    if source_region_count is not None:
+        declared_regions = int(source_region_count.item())
+        prepared_regions = design.sizes[state_dim]
+        if declared_regions == prepared_regions:
+            return
+        raise ValueError(
+            f"Sector {sector!r} -> source {source!r} declares {declared_regions} "
+            f"{state_dim} elements but prepared H has {prepared_regions}. Ragged "
+            "source-specific state blocks are not supported by this builder."
+        )
+
+
 def _normalize_multisector_flux_plan(
     inv_inputs: xr.Dataset,
     sector_definitions: Sequence[tuple[str, str, str]],
@@ -426,14 +501,28 @@ def _normalize_multisector_flux_plan(
         inv_inputs: Canonical inversion inputs containing source-resolved ``H``.
         sector_definitions: Ordered ``(sector, source, variable_suffix)`` values.
         sector_priors: Optional priors keyed by semantic sector ID.
-        x_prior: Optional shared fallback prior.
+        x_prior: Optional shared prior used when ``sector_priors`` is absent.
 
     Returns:
         Backend-neutral multisector flux plan with selected 2-D designs.
     """
+    sector_names = [sector for sector, _, _ in sector_definitions]
+    if sector_priors is not None:
+        missing_priors = [sector for sector in sector_names if sector not in sector_priors]
+        unused_priors = [sector for sector in sector_priors if sector not in sector_names]
+        if missing_priors or unused_priors:
+            raise ValueError(
+                "`sector_priors` must define exactly one prior for every sector when supplied; "
+                f"missing sector prior(s): {missing_priors!r}; "
+                f"unused sector prior key(s): {unused_priors!r}."
+            )
+
     states: list[_StatePlan] = []
     terms: list[_ForwardTermPlan] = []
     for sector, source, variable_suffix in sector_definitions:
+        design = inv_inputs["H"].sel(source=source).drop_vars("source", errors="ignore")
+        _validate_sector_design(design, sector=sector, source=source)
+        design = design.drop_vars("source_region_count", errors="ignore")
         states.append(
             _StatePlan(
                 state_id=sector,
@@ -445,7 +534,6 @@ def _normalize_multisector_flux_plan(
                 ),
             )
         )
-        design = inv_inputs["H"].sel(source=source).drop_vars("source", errors="ignore")
         terms.append(
             _ForwardTermPlan(
                 term_id=sector,
@@ -497,7 +585,9 @@ def build_rhime_multisector_model(
         sector_variable_suffixes: Optional mapping from sector label to
             PyMC-safe suffix used in ``x_<suffix>`` and ``mu_<suffix>`` names.
         sector_priors: Optional per-sector flux-scaling priors.
-        x_prior: Shared fallback flux-scaling prior.
+            When supplied, the mapping must contain exactly one entry for every
+            sector.
+        x_prior: Shared flux-scaling prior used when ``sector_priors`` is absent.
         bc_prior: Prior specification for boundary-condition scaling factors.
         sigma_prior: Prior specification for model-error terms.
         offset_prior: Prior specification for optional offsets.

--- a/openghg_inversions/models/rhime.py
+++ b/openghg_inversions/models/rhime.py
@@ -13,16 +13,21 @@ and names PyMC variables by sector.
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 import re
-from collections.abc import Mapping, Sequence
-from typing import Any, cast
+from typing import Any
 
 import pymc as pm
-import pytensor.tensor as pt
 import xarray as xr
 
 from openghg_inversions.inversion_inputs import DatetimeLike
+from openghg_inversions.models._rhime_compiler import (
+    _FluxPlan,
+    _ForwardTermPlan,
+    _StatePlan,
+    _compile_loop_sum,
+)
 from openghg_inversions.models.components import (
     add_inferpymc_likelihood_component,
     add_linear_component,
@@ -127,6 +132,117 @@ def _prepare_builder_priors(
     return prepared_x_prior, prepared_bc_prior, prepared_sigma_prior, prepared_offset_prior
 
 
+def _normalize_standard_flux_plan(inv_inputs: xr.Dataset, x_prior: dict) -> _FluxPlan:
+    """Normalize the standard flux component into a one-state linear plan.
+
+    Args:
+        inv_inputs: Canonical inversion inputs containing ``H``.
+        x_prior: Prepared flux-scaling prior metadata.
+
+    Returns:
+        Backend-neutral standard flux plan.
+    """
+    state_id = "flux"
+    return _FluxPlan(
+        states=(
+            _StatePlan(
+                state_id=state_id,
+                variable_name="x",
+                prior_args=x_prior,
+            ),
+        ),
+        terms=(
+            _ForwardTermPlan(
+                term_id=state_id,
+                state_id=state_id,
+                design=inv_inputs["H"],
+                data_name="hx",
+                deterministic_name="mu",
+                coefficient=1.0,
+            ),
+        ),
+    )
+
+
+def _assemble_rhime_model(
+    inv_inputs: xr.Dataset,
+    *,
+    flux_plan: _FluxPlan,
+    sigma_alignment: SigmaAlignment,
+    bc_prior: dict,
+    sigma_prior: dict,
+    offset_prior: dict,
+    add_offset: bool,
+    use_bc: bool,
+    pollution_events_from_obs: bool,
+    no_model_error: bool,
+    offset_args: dict | None,
+    power: dict | float,
+) -> pm.Model:
+    """Assemble shared RHIME components around a normalized flux plan.
+
+    Args:
+        inv_inputs: Canonical inversion inputs.
+        flux_plan: Validated linear flux plan to compile.
+        sigma_alignment: Prepared observation alignment for model error.
+        bc_prior: Prepared boundary-condition prior.
+        sigma_prior: Prepared model-error prior.
+        offset_prior: Prepared optional offset prior.
+        add_offset: Whether to add an offset component.
+        use_bc: Whether to add a boundary-condition component.
+        pollution_events_from_obs: Whether error scaling uses observations.
+        no_model_error: Whether to suppress explicit model error.
+        offset_args: Extra offset-component arguments.
+        power: Likelihood error-scaling exponent or prior.
+
+    Returns:
+        Fully assembled PyMC model.
+    """
+    with pm.Model() as model:
+        attach_coord_registry(model, CoordRegistry())
+        compiled_flux = _compile_loop_sum(flux_plan)
+
+        mu_bc = None
+        if use_bc:
+            if "H_bc" not in inv_inputs:
+                raise ValueError("If `use_bc` is True, `inv_inputs` must contain `H_bc`.")
+            bc_component = add_linear_component(
+                inv_inputs["H_bc"],
+                data_name="hbc",
+                prior_args=bc_prior,
+                var_name="bc",
+                output_name="mu_bc",
+                output_dim="nmeasure",
+                compute_deterministic=True,
+            )
+            mu_bc = bc_component.output
+
+        offset = None
+        if add_offset:
+            offset = add_offset_component(
+                inv_inputs["site_indicator"],
+                prior_args=offset_prior,
+                output_name="offset",
+                output_dim="nmeasure",
+                **(offset_args or {}),
+            )
+
+        add_inferpymc_likelihood_component(
+            inv_inputs,
+            mu=compiled_flux.mu,
+            mu_bc=mu_bc,
+            offset=offset,
+            sigprior=sigma_prior,
+            sigma_alignment=sigma_alignment,
+            power=power,
+            pollution_events_from_obs=pollution_events_from_obs,
+            no_model_error=no_model_error,
+            output_dim="nmeasure",
+        )
+
+    return model
+
+
 def build_rhime_model(
     inv_inputs: xr.Dataset,
     *,
@@ -169,59 +285,21 @@ def build_rhime_model(
         sigma_prior=sigma_prior,
         offset_prior=offset_prior,
     )
-
-    with pm.Model() as model:
-        attach_coord_registry(model, CoordRegistry())
-        flux_component = add_linear_component(
-            inv_inputs["H"],
-            data_name="hx",
-            prior_args=x_prior,
-            var_name="x",
-            output_name="mu",
-            output_dim="nmeasure",
-            compute_deterministic=True,
-        )
-
-        mu_bc = None
-        if use_bc:
-            if "H_bc" not in inv_inputs:
-                raise ValueError("If `use_bc` is True, `inv_inputs` must contain `H_bc`.")
-            bc_component = add_linear_component(
-                inv_inputs["H_bc"],
-                data_name="hbc",
-                prior_args=bc_prior,
-                var_name="bc",
-                output_name="mu_bc",
-                output_dim="nmeasure",
-                compute_deterministic=True,
-            )
-            mu_bc = bc_component.output
-
-        offset = None
-        if add_offset:
-            offset_args = offset_args or {}
-            offset = add_offset_component(
-                inv_inputs["site_indicator"],
-                prior_args=offset_prior,
-                output_name="offset",
-                output_dim="nmeasure",
-                **offset_args,
-            )
-
-        add_inferpymc_likelihood_component(
-            inv_inputs,
-            mu=flux_component.output,
-            mu_bc=mu_bc,
-            offset=offset,
-            sigprior=sigma_prior,
-            sigma_alignment=sigma_alignment,
-            power=power,
-            pollution_events_from_obs=pollution_events_from_obs,
-            no_model_error=no_model_error,
-            output_dim="nmeasure",
-        )
-
-    return model
+    flux_plan = _normalize_standard_flux_plan(inv_inputs, x_prior)
+    return _assemble_rhime_model(
+        inv_inputs,
+        flux_plan=flux_plan,
+        sigma_alignment=sigma_alignment,
+        bc_prior=bc_prior,
+        sigma_prior=sigma_prior,
+        offset_prior=offset_prior,
+        add_offset=add_offset,
+        use_bc=use_bc,
+        pollution_events_from_obs=pollution_events_from_obs,
+        no_model_error=no_model_error,
+        offset_args=offset_args,
+        power=power,
+    )
 
 
 def build_rhime_model_from_spec(inv_inputs: xr.Dataset, model_spec: RhimeModelSpec) -> pm.Model:
@@ -313,6 +391,13 @@ def _resolve_sector_definitions(
         (sector, source_by_sector[sector], suffix_by_sector.get(sector, safe_pymc_name(sector)))
         for sector in sector_names
     ]
+    suffixes = [suffix for _, _, suffix in definitions]
+    if len(suffixes) != len(set(suffixes)):
+        duplicate = next(suffix for suffix in suffixes if suffixes.count(suffix) > 1)
+        raise ValueError(
+            "Sector names must be unique after PyMC name sanitisation; "
+            f"duplicate sanitized name {duplicate!r}."
+        )
     return definitions
 
 
@@ -326,6 +411,52 @@ def _sector_prior(
     if sector_priors is not None and sector in sector_priors:
         return dict(sector_priors[sector])
     return dict(DEFAULT_X_PRIOR if x_prior is None else x_prior)
+
+
+def _normalize_multisector_flux_plan(
+    inv_inputs: xr.Dataset,
+    sector_definitions: Sequence[tuple[str, str, str]],
+    *,
+    sector_priors: Mapping[str, dict] | None,
+    x_prior: dict | None,
+) -> _FluxPlan:
+    """Normalize selected sector designs into separate semantic state plans.
+
+    Args:
+        inv_inputs: Canonical inversion inputs containing source-resolved ``H``.
+        sector_definitions: Ordered ``(sector, source, variable_suffix)`` values.
+        sector_priors: Optional priors keyed by semantic sector ID.
+        x_prior: Optional shared fallback prior.
+
+    Returns:
+        Backend-neutral multisector flux plan with selected 2-D designs.
+    """
+    states: list[_StatePlan] = []
+    terms: list[_ForwardTermPlan] = []
+    for sector, source, variable_suffix in sector_definitions:
+        states.append(
+            _StatePlan(
+                state_id=sector,
+                variable_name=f"x_{variable_suffix}",
+                prior_args=_sector_prior(
+                    sector,
+                    sector_priors=sector_priors,
+                    x_prior=x_prior,
+                ),
+            )
+        )
+        design = inv_inputs["H"].sel(source=source).drop_vars("source", errors="ignore")
+        terms.append(
+            _ForwardTermPlan(
+                term_id=sector,
+                state_id=sector,
+                design=design,
+                data_name=f"hx_{variable_suffix}",
+                deterministic_name=f"mu_{variable_suffix}",
+                coefficient=1.0,
+            )
+        )
+    return _FluxPlan(states=tuple(states), terms=tuple(terms))
 
 
 def build_rhime_multisector_model(
@@ -387,81 +518,29 @@ def build_rhime_multisector_model(
         sector_sources=sector_sources,
         sector_variable_suffixes=sector_variable_suffixes,
     )
+    flux_plan = _normalize_multisector_flux_plan(
+        inv_inputs,
+        sector_definitions,
+        sector_priors=sector_priors,
+        x_prior=x_prior,
+    )
     bc_prior = dict(DEFAULT_BC_PRIOR if bc_prior is None else bc_prior)
     sigma_prior = dict(DEFAULT_SIGMA_PRIOR if sigma_prior is None else sigma_prior)
     offset_prior = dict(DEFAULT_OFFSET_PRIOR if offset_prior is None else offset_prior)
-
-    with pm.Model() as model:
-        attach_coord_registry(model, CoordRegistry())
-
-        sector_outputs = []
-        used_names: set[str] = set()
-        for sector, source, suffix in sector_definitions:
-            if suffix in used_names:
-                raise ValueError(
-                    "Sector names must be unique after PyMC name sanitisation; "
-                    f"duplicate sanitized name {suffix!r}."
-                )
-            used_names.add(suffix)
-
-            h_sector = inv_inputs["H"].sel(source=source).drop_vars("source", errors="ignore")
-            component = add_linear_component(
-                h_sector,
-                data_name=f"hx_{suffix}",
-                prior_args=_sector_prior(sector, sector_priors=sector_priors, x_prior=x_prior),
-                var_name=f"x_{suffix}",
-                output_name=f"mu_{suffix}",
-                output_dim="nmeasure",
-                compute_deterministic=True,
-            )
-            sector_outputs.append(component.output)
-
-        total_mu = pm.Deterministic(
-            "mu",
-            cast(Any, pt.stack(sector_outputs, axis=0)).sum(axis=0),
-            dims="nmeasure",
-        )
-
-        mu_bc = None
-        if use_bc:
-            if "H_bc" not in inv_inputs:
-                raise ValueError("If `use_bc` is True, `inv_inputs` must contain `H_bc`.")
-            bc_component = add_linear_component(
-                inv_inputs["H_bc"],
-                data_name="hbc",
-                prior_args=bc_prior,
-                var_name="bc",
-                output_name="mu_bc",
-                output_dim="nmeasure",
-                compute_deterministic=True,
-            )
-            mu_bc = bc_component.output
-
-        offset = None
-        if add_offset:
-            offset_args = offset_args or {}
-            offset = add_offset_component(
-                inv_inputs["site_indicator"],
-                prior_args=offset_prior,
-                output_name="offset",
-                output_dim="nmeasure",
-                **offset_args,
-            )
-
-        add_inferpymc_likelihood_component(
-            inv_inputs,
-            mu=total_mu,
-            mu_bc=mu_bc,
-            offset=offset,
-            sigprior=sigma_prior,
-            sigma_alignment=sigma_alignment,
-            power=power,
-            pollution_events_from_obs=pollution_events_from_obs,
-            no_model_error=no_model_error,
-            output_dim="nmeasure",
-        )
-
-    return model
+    return _assemble_rhime_model(
+        inv_inputs,
+        flux_plan=flux_plan,
+        sigma_alignment=sigma_alignment,
+        bc_prior=bc_prior,
+        sigma_prior=sigma_prior,
+        offset_prior=offset_prior,
+        add_offset=add_offset,
+        use_bc=use_bc,
+        pollution_events_from_obs=pollution_events_from_obs,
+        no_model_error=no_model_error,
+        offset_args=offset_args,
+        power=power,
+    )
 
 
 def build_rhime_multisector_model_from_spec(

--- a/openghg_inversions/models/rhime.py
+++ b/openghg_inversions/models/rhime.py
@@ -15,18 +15,20 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-import re
 from typing import Any
 
 import pymc as pm
 import xarray as xr
 
 from openghg_inversions.inversion_inputs import DatetimeLike
-from openghg_inversions.models._rhime_compiler import (
-    _FluxPlan,
-    _ForwardTermPlan,
-    _StatePlan,
-    _compile_loop_sum,
+from openghg_inversions.models._rhime_compiler import _compile_loop_sum, _FluxPlan
+from openghg_inversions.models._rhime_flux import (
+    _normalize_multisector_flux_plan,
+    _normalize_standard_flux_plan,
+    _resolve_sector_bindings,
+)
+from openghg_inversions.models._rhime_flux import (
+    safe_pymc_name as _safe_pymc_name,
 )
 from openghg_inversions.models.components import (
     add_inferpymc_likelihood_component,
@@ -41,6 +43,18 @@ DEFAULT_X_PRIOR: PriorArgs = {"pdf": "lognormal", "mean": 1.0, "stdev": 1.0, "re
 DEFAULT_BC_PRIOR: PriorArgs = {"pdf": "truncatednormal", "mu": 1.0, "sigma": 0.05, "lower": 0.0}
 DEFAULT_SIGMA_PRIOR: PriorArgs = {"pdf": "uniform", "lower": 0.1, "upper": 3.0}
 DEFAULT_OFFSET_PRIOR: PriorArgs = {"pdf": "normal", "mu": 0, "sigma": 1}
+
+
+def safe_pymc_name(value: str) -> str:
+    """Return a stable PyMC-safe suffix for a user-facing sector/source name.
+
+    Args:
+        value: User-facing sector or source name.
+
+    Returns:
+        Lowercase snake-case suffix safe to use in PyMC variable names.
+    """
+    return _safe_pymc_name(value)
 
 
 @dataclass(frozen=True)
@@ -104,19 +118,6 @@ class RhimeModelSpec:
     offset_args: dict[str, Any] | None = None
 
 
-def safe_pymc_name(value: str) -> str:
-    """Return a stable PyMC-safe suffix for a user-facing sector/source name.
-
-    Args:
-        value: User-facing sector or source name.
-
-    Returns:
-        Lowercase snake-case suffix safe to use in PyMC variable names.
-    """
-    name = re.sub(r"\W+", "_", str(value).strip().lower()).strip("_")
-    return name or "sector"
-
-
 def _prepare_builder_priors(
     *,
     x_prior: dict | None,
@@ -130,38 +131,6 @@ def _prepare_builder_priors(
     prepared_sigma_prior = DEFAULT_SIGMA_PRIOR.copy() if sigma_prior is None else sigma_prior.copy()
     prepared_offset_prior = DEFAULT_OFFSET_PRIOR.copy() if offset_prior is None else offset_prior.copy()
     return prepared_x_prior, prepared_bc_prior, prepared_sigma_prior, prepared_offset_prior
-
-
-def _normalize_standard_flux_plan(inv_inputs: xr.Dataset, x_prior: dict) -> _FluxPlan:
-    """Normalize the standard flux component into a one-state linear plan.
-
-    Args:
-        inv_inputs: Canonical inversion inputs containing ``H``.
-        x_prior: Prepared flux-scaling prior metadata.
-
-    Returns:
-        Backend-neutral standard flux plan.
-    """
-    state_id = "flux"
-    return _FluxPlan(
-        states=(
-            _StatePlan(
-                state_id=state_id,
-                variable_name="x",
-                prior_args=x_prior,
-            ),
-        ),
-        terms=(
-            _ForwardTermPlan(
-                term_id=state_id,
-                state_id=state_id,
-                design=inv_inputs["H"],
-                data_name="hx",
-                deterministic_name="mu",
-                coefficient=1.0,
-            ),
-        ),
-    )
 
 
 def _assemble_rhime_model(
@@ -342,211 +311,6 @@ def build_rhime_model_from_spec(inv_inputs: xr.Dataset, model_spec: RhimeModelSp
     )
 
 
-def _resolve_sector_definitions(
-    inv_inputs: xr.Dataset,
-    sectors: Sequence[str] | None,
-    *,
-    sector_sources: Mapping[str, str] | None,
-    sector_variable_suffixes: Mapping[str, str] | None,
-) -> list[tuple[str, str, str]]:
-    """Resolve model sectors against the flux ``source`` coordinate.
-
-    The input ``source`` coordinate records OpenGHG flux source metadata. The
-    returned sector definitions keep separately optimized sector labels,
-    OpenGHG source values, and PyMC variable suffixes together.
-    """
-    if "source" not in inv_inputs["H"].dims:
-        raise ValueError("Multi-sector RHIME requires inv_inputs['H'] to include a 'source' dimension.")
-    if "source" not in inv_inputs["H"].coords:
-        raise ValueError(
-            "Multi-sector RHIME requires inv_inputs['H'].source to contain OpenGHG source labels."
-        )
-
-    available = [str(value) for value in inv_inputs["H"].coords["source"].values]
-    duplicate_available = [source for source in available if available.count(source) > 1]
-    if duplicate_available:
-        duplicate = next(iter(dict.fromkeys(duplicate_available)))
-        raise ValueError(
-            "Multi-sector RHIME requires unique inv_inputs['H'].source labels; "
-            f"duplicate source {duplicate!r}."
-        )
-    if sectors is None:
-        sectors = list(sector_sources) if sector_sources is not None else available
-    sector_names = [str(sector) for sector in sectors]
-
-    if len(sector_names) < 2:
-        raise ValueError("Multi-sector RHIME requires at least two sectors.")
-    duplicate_sectors = [sector for sector in sector_names if sector_names.count(sector) > 1]
-    if duplicate_sectors:
-        duplicate = next(iter(dict.fromkeys(duplicate_sectors)))
-        raise ValueError(f"Multi-sector RHIME requires unique sector names; duplicate sector {duplicate!r}.")
-    empty_sectors = [sector for sector in sector_names if not sector.strip()]
-    if empty_sectors:
-        raise ValueError("Multi-sector RHIME requires non-empty sector names.")
-
-    source_by_sector = (
-        {str(sector): str(source) for sector, source in sector_sources.items()}
-        if sector_sources is not None
-        else {sector: sector for sector in sector_names}
-    )
-    suffix_by_sector = (
-        {str(sector): str(suffix) for sector, suffix in sector_variable_suffixes.items()}
-        if sector_variable_suffixes is not None
-        else {}
-    )
-
-    unused_mappings = [sector for sector in source_by_sector if sector not in sector_names]
-    if unused_mappings:
-        raise ValueError(f"`sector_sources` contains unused sector key(s): {unused_mappings!r}.")
-    missing_mapping = [sector for sector in sector_names if sector not in source_by_sector]
-    if missing_mapping:
-        raise ValueError(f"Sector(s) {missing_mapping!r} are missing from `sector_sources`.")
-
-    source_sectors: dict[str, list[str]] = {}
-    for sector in sector_names:
-        source_sectors.setdefault(source_by_sector[sector], []).append(sector)
-    duplicate_sources = {
-        source: mapped_sectors
-        for source, mapped_sectors in source_sectors.items()
-        if len(mapped_sectors) > 1
-    }
-    if duplicate_sources:
-        details = ", ".join(
-            f"source {source!r} is mapped by sectors {mapped_sectors!r}"
-            for source, mapped_sectors in duplicate_sources.items()
-        )
-        raise ValueError(
-            "Multi-sector RHIME requires a distinct source for each current sector; " + details + "."
-        )
-
-    missing = [
-        (sector, source_by_sector[sector])
-        for sector in sector_names
-        if source_by_sector[sector] not in available
-    ]
-    if missing:
-        details = ", ".join(f"sector {sector!r} -> source {source!r}" for sector, source in missing)
-        raise ValueError(
-            f"Source data required by {details} is not present in inv_inputs['H'].source; "
-            f"available source(s): {available!r}."
-        )
-
-    unused_suffixes = [sector for sector in suffix_by_sector if sector not in sector_names]
-    if unused_suffixes:
-        raise ValueError(
-            f"`sector_variable_suffixes` contains unused sector key(s): {unused_suffixes!r}."
-        )
-    definitions = [
-        (sector, source_by_sector[sector], suffix_by_sector.get(sector, safe_pymc_name(sector)))
-        for sector in sector_names
-    ]
-    suffixes = [suffix for _, _, suffix in definitions]
-    if len(suffixes) != len(set(suffixes)):
-        duplicate = next(suffix for suffix in suffixes if suffixes.count(suffix) > 1)
-        raise ValueError(
-            "Sector names must be unique after PyMC name sanitisation; "
-            f"duplicate sanitized name {duplicate!r}."
-        )
-    return definitions
-
-
-def _sector_prior(
-    sector: str,
-    *,
-    sector_priors: Mapping[str, dict] | None,
-    x_prior: dict | None,
-) -> dict:
-    """Resolve a sector prior, falling back to the shared flux-scaling prior."""
-    if sector_priors is not None and sector in sector_priors:
-        return dict(sector_priors[sector])
-    return dict(DEFAULT_X_PRIOR if x_prior is None else x_prior)
-
-
-def _validate_sector_design(
-    design: xr.DataArray,
-    *,
-    sector: str,
-    source: str,
-    observation_dim: str = "nmeasure",
-) -> None:
-    """Reject source layouts that would create latent variables for padding."""
-    state_dims = [str(dim) for dim in design.dims if dim != observation_dim]
-    if design.ndim != 2 or observation_dim not in design.dims or len(state_dims) != 1:
-        return
-
-    state_dim = state_dims[0]
-    source_region_count = design.coords.get("source_region_count")
-    if source_region_count is not None:
-        declared_regions = int(source_region_count.item())
-        prepared_regions = design.sizes[state_dim]
-        if declared_regions == prepared_regions:
-            return
-        raise ValueError(
-            f"Sector {sector!r} -> source {source!r} declares {declared_regions} "
-            f"{state_dim} elements but prepared H has {prepared_regions}. Ragged "
-            "source-specific state blocks are not supported by this builder."
-        )
-
-
-def _normalize_multisector_flux_plan(
-    inv_inputs: xr.Dataset,
-    sector_definitions: Sequence[tuple[str, str, str]],
-    *,
-    sector_priors: Mapping[str, dict] | None,
-    x_prior: dict | None,
-) -> _FluxPlan:
-    """Normalize selected sector designs into separate semantic state plans.
-
-    Args:
-        inv_inputs: Canonical inversion inputs containing source-resolved ``H``.
-        sector_definitions: Ordered ``(sector, source, variable_suffix)`` values.
-        sector_priors: Optional priors keyed by semantic sector ID.
-        x_prior: Optional shared prior used when ``sector_priors`` is absent.
-
-    Returns:
-        Backend-neutral multisector flux plan with selected 2-D designs.
-    """
-    sector_names = [sector for sector, _, _ in sector_definitions]
-    if sector_priors is not None:
-        missing_priors = [sector for sector in sector_names if sector not in sector_priors]
-        unused_priors = [sector for sector in sector_priors if sector not in sector_names]
-        if missing_priors or unused_priors:
-            raise ValueError(
-                "`sector_priors` must define exactly one prior for every sector when supplied; "
-                f"missing sector prior(s): {missing_priors!r}; "
-                f"unused sector prior key(s): {unused_priors!r}."
-            )
-
-    states: list[_StatePlan] = []
-    terms: list[_ForwardTermPlan] = []
-    for sector, source, variable_suffix in sector_definitions:
-        design = inv_inputs["H"].sel(source=source).drop_vars("source", errors="ignore")
-        _validate_sector_design(design, sector=sector, source=source)
-        design = design.drop_vars("source_region_count", errors="ignore")
-        states.append(
-            _StatePlan(
-                state_id=sector,
-                variable_name=f"x_{variable_suffix}",
-                prior_args=_sector_prior(
-                    sector,
-                    sector_priors=sector_priors,
-                    x_prior=x_prior,
-                ),
-            )
-        )
-        terms.append(
-            _ForwardTermPlan(
-                term_id=sector,
-                state_id=sector,
-                design=design,
-                data_name=f"hx_{variable_suffix}",
-                deterministic_name=f"mu_{variable_suffix}",
-                coefficient=1.0,
-            )
-        )
-    return _FluxPlan(states=tuple(states), terms=tuple(terms))
-
-
 def build_rhime_multisector_model(
     inv_inputs: xr.Dataset,
     *,
@@ -573,8 +337,10 @@ def build_rhime_multisector_model(
     contributions and is passed to the standard RHIME likelihood.
 
     Args:
-        inv_inputs: Canonical inversion-input dataset with
-            ``H(region, nmeasure, source)``.
+        inv_inputs: Canonical inversion-input dataset. Shared-basis inputs use
+            ``H(region, nmeasure, source)``. Source-specific bases use
+            ``H(state, nmeasure)`` with ``state`` gathered over
+            ``(source, region_in_source)``.
         sigma_alignment: Backend-neutral site and period alignment for sigma.
         sectors: Ordered model sector labels to optimize. Defaults to
             ``sector_sources`` keys when supplied, otherwise all
@@ -602,7 +368,7 @@ def build_rhime_multisector_model(
     Returns:
         Built PyMC model.
     """
-    sector_definitions = _resolve_sector_definitions(
+    sector_bindings = _resolve_sector_bindings(
         inv_inputs,
         sectors,
         sector_sources=sector_sources,
@@ -610,9 +376,10 @@ def build_rhime_multisector_model(
     )
     flux_plan = _normalize_multisector_flux_plan(
         inv_inputs,
-        sector_definitions,
+        sector_bindings,
         sector_priors=sector_priors,
         x_prior=x_prior,
+        default_x_prior=DEFAULT_X_PRIOR,
     )
     bc_prior = dict(DEFAULT_BC_PRIOR if bc_prior is None else bc_prior)
     sigma_prior = dict(DEFAULT_SIGMA_PRIOR if sigma_prior is None else sigma_prior)
@@ -640,8 +407,8 @@ def build_rhime_multisector_model_from_spec(
     """Build the shared-basis multi-sector RHIME model from a model spec.
 
     Args:
-        inv_inputs: Canonical inversion-input dataset with
-            ``H(region, nmeasure, source)``.
+        inv_inputs: Canonical inversion-input dataset using either rectangular
+            shared-basis or gathered source-specific sensitivity.
         model_spec: Normalized RHIME model specification.
 
     Returns:

--- a/openghg_inversions/postprocessing/make_outputs.py
+++ b/openghg_inversions/postprocessing/make_outputs.py
@@ -240,6 +240,9 @@ def _state_chunk_dim(trace: xr.Dataset, inv_out: InversionOutput) -> str:
         return "region"
     if "nx" in trace.dims:
         return "nx"
+    non_sample_dims = [str(dim) for dim in trace.dims if dim not in {"chain", "draw"}]
+    if len(non_sample_dims) == 1:
+        return non_sample_dims[0]
     raise ValueError(f"Could not find basis state dimension in trace dims {tuple(trace.dims)}.")
 
 

--- a/openghg_inversions/postprocessing/make_outputs.py
+++ b/openghg_inversions/postprocessing/make_outputs.py
@@ -297,12 +297,19 @@ def _sector_flux_trace_dataset(
 def _sector_scale_factor_stats(
     inv_out: InversionOutput,
     sector: OutputSector,
-    stats_args: dict,
+    *,
+    stats: list[str] | None,
+    stats_args: dict | None,
 ) -> xr.Dataset:
     """Return one sector's gridded scale-factor statistics."""
     trace = _sector_scale_trace(inv_out, sector)
     basis_functions = _sector_basis_functions(inv_out, sector, trace)
-    scale_stats = calculate_stats(trace, **stats_args)
+    sector_stats_args = _stats_args_with_defaults(
+        stats,
+        stats_args,
+        chunk_dim=_state_chunk_dim(trace, inv_out),
+    )
+    scale_stats = calculate_stats(trace, **sector_stats_args)
     result = reconstruct_scale_factor_stats(basis_functions, scale_stats)
     for data_var in result.data_vars:
         if data_var in scale_stats.data_vars:
@@ -509,19 +516,20 @@ def make_sector_flux_outputs(
         inv_out,
         report_flux_on_inversion_grid=report_flux_on_inversion_grid,
     )
-    sample_trace = _sector_scale_trace(inv_out, sectors[0])
-    scale_stats_args = _stats_args_with_defaults(
-        stats,
-        stats_args,
-        chunk_dim=_state_chunk_dim(sample_trace, inv_out),
-    )
     flux_stats_args = _stats_args_with_defaults(stats, stats_args)
 
     outputs = [calculate_stats(total_flux_trace, **flux_stats_args)]
     for sector, flux_trace in zip(sectors, sector_flux_traces, strict=True):
         outputs.append(calculate_stats(flux_trace, **flux_stats_args))
         if include_scale_factors:
-            outputs.append(_sector_scale_factor_stats(inv_out, sector, scale_stats_args))
+            outputs.append(
+                _sector_scale_factor_stats(
+                    inv_out,
+                    sector,
+                    stats=stats,
+                    stats_args=stats_args,
+                )
+            )
 
     result = _set_multisector_flux_attrs(xr.merge(outputs), inv_out, sectors).as_numpy()
     result = _copy_first_flux_nonfinite_metadata(result, [total_flux_trace, *sector_flux_traces])

--- a/openghg_inversions/rhime/params.py
+++ b/openghg_inversions/rhime/params.py
@@ -64,6 +64,17 @@ def as_list(value: str | Sequence[str] | None) -> list[str] | None:
     return [str(item) for item in value]
 
 
+def _duplicate_names(values: Sequence[str]) -> list[str]:
+    """Return duplicate names once each, preserving their first repeated order."""
+    seen: set[str] = set()
+    duplicates: list[str] = []
+    for value in values:
+        if value in seen and value not in duplicates:
+            duplicates.append(value)
+        seen.add(value)
+    return duplicates
+
+
 def resolve_flux_sources(
     *,
     flux_sources: str | Sequence[str] | None = None,
@@ -88,6 +99,12 @@ def resolve_flux_sources(
         resolved = as_list(emissions_name)
     if not resolved or any(source in {"", "None", "none"} for source in resolved):
         raise ValueError("At least one flux source must be supplied via `flux_sources`.")
+    duplicates = _duplicate_names(resolved)
+    if duplicates:
+        raise ValueError(
+            "`flux_sources` must contain unique OpenGHG source values; "
+            f"duplicate source(s): {duplicates!r}."
+        )
     return resolved
 
 
@@ -282,7 +299,18 @@ def normalise_sector_sources(
     """Copy optional sector-to-source mappings with string names."""
     if sector_sources is None:
         return None
-    return {str(sector): str(source) for sector, source in sector_sources.items()}
+    normalized = {str(sector): str(source) for sector, source in sector_sources.items()}
+    invalid = [
+        (sector, source)
+        for sector, source in normalized.items()
+        if not sector.strip() or not source.strip() or source in {"None", "none"}
+    ]
+    if invalid:
+        raise ValueError(
+            "`sector_sources` must map non-empty sector names to non-empty OpenGHG source values; "
+            f"invalid mapping(s): {invalid!r}."
+        )
+    return normalized
 
 
 def required_run_params() -> set[str]:
@@ -369,6 +397,38 @@ def _tuple_from_optional_sequence(value: Any) -> tuple[str | None, ...]:
     return (str(value),)
 
 
+def _validate_sector_source_mapping(
+    flux_sources: Sequence[str],
+    sector_sources: Mapping[str, str],
+) -> list[str]:
+    """Validate the current one-to-one sector/source routing contract."""
+    source_sectors: dict[str, list[str]] = {}
+    for sector, source in sector_sources.items():
+        source_sectors.setdefault(source, []).append(sector)
+    duplicate_sources = {
+        source: sector_names for source, sector_names in source_sectors.items() if len(sector_names) > 1
+    }
+    if duplicate_sources:
+        details = ", ".join(
+            f"source {source!r} is mapped by sectors {sector_names!r}"
+            for source, sector_names in duplicate_sources.items()
+        )
+        raise ValueError(
+            "`sector_sources` must map each current sector to a distinct OpenGHG source; " + details + "."
+        )
+
+    mapped_sources = list(sector_sources.values())
+    missing_sources = [source for source in flux_sources if source not in mapped_sources]
+    unrequested_sources = [source for source in mapped_sources if source not in flux_sources]
+    if missing_sources or unrequested_sources:
+        raise ValueError(
+            "`sector_sources` values must match `flux_sources`; "
+            f"missing source mapping(s): {missing_sources!r}; "
+            f"unrequested source value(s): {unrequested_sources!r}."
+        )
+    return mapped_sources
+
+
 def _make_model_spec(
     *,
     species: str,
@@ -395,15 +455,21 @@ def _make_model_spec(
     sectors = []
     used_suffixes: set[str] = set()
     if sector_sources is not None:
-        mapped_sources = list(dict.fromkeys(sector_sources.values()))
-        if set(mapped_sources) != set(flux_sources):
-            raise ValueError(
-                "`sector_sources` values must match `flux_sources` so RHIME can retrieve the "
-                "OpenGHG data used by each sector."
-            )
+        _validate_sector_source_mapping(flux_sources, sector_sources)
         sector_items = list(sector_sources.items())
     else:
         sector_items = [(source, source) for source in flux_sources]
+
+    sector_names = [name for name, _ in sector_items]
+    if sector_priors is not None:
+        missing_priors = [name for name in sector_names if name not in sector_priors]
+        unused_priors = [name for name in sector_priors if name not in sector_names]
+        if missing_priors or unused_priors:
+            raise ValueError(
+                "`sector_priors` must define exactly one prior for every sector when supplied; "
+                f"missing sector prior(s): {missing_priors!r}; "
+                f"unused sector prior key(s): {unused_priors!r}."
+            )
 
     for name, source in sector_items:
         suffix = safe_pymc_name(name)
@@ -413,9 +479,7 @@ def _make_model_spec(
                 f"duplicate sanitized name {suffix!r}."
             )
         used_suffixes.add(suffix)
-        prior = (
-            sector_priors[name] if sector_priors is not None and name in sector_priors else default_x_prior
-        )
+        prior = sector_priors[name] if sector_priors is not None else default_x_prior
         sectors.append(
             SectorSpec(
                 name=name,
@@ -460,13 +524,10 @@ def make_rhime_runner_setup(
     if not multisector and sector_sources is not None:
         raise ValueError("`sector_sources` is only supported by `run_rhime_multisector`.")
     data_flux_sources = (
-        list(dict.fromkeys(sector_sources.values())) if sector_sources is not None else flux_sources
+        _validate_sector_source_mapping(flux_sources, sector_sources)
+        if sector_sources is not None
+        else flux_sources
     )
-    if sector_sources is not None and set(data_flux_sources) != set(flux_sources):
-        raise ValueError(
-            "`sector_sources` values must match `flux_sources` so RHIME can retrieve the "
-            "OpenGHG data used by each sector."
-        )
     if multisector and len(data_flux_sources) < 2:
         raise ValueError("`run_rhime_multisector` requires at least two flux sources.")
     if not multisector and len(flux_sources) != 1:

--- a/openghg_inversions/rhime/runner.py
+++ b/openghg_inversions/rhime/runner.py
@@ -34,6 +34,7 @@ from pathlib import Path
 from typing import Any
 
 import arviz as az
+import pandas as pd
 import pymc as pm
 import xarray as xr
 
@@ -345,12 +346,19 @@ def run_rhime_from_prepared_inputs(
     if sector_count < 1:
         raise ValueError(f"`run_spec.model.sectors` must contain at least one sector; found {sector_count}.")
     multisector = sector_count > 1
-    prepared_is_multisector = "source" in prepared_inputs.inv_inputs["H"].coords
+    sensitivity = prepared_inputs.inv_inputs["H"]
+    source_coord = sensitivity.coords.get("source")
+    state_dims = [str(dim) for dim in sensitivity.dims if dim != "nmeasure"]
+    gathered_source = False
+    if source_coord is not None and len(state_dims) == 1 and source_coord.dims == (state_dims[0],):
+        source_index = sensitivity.indexes.get(state_dims[0])
+        gathered_source = isinstance(source_index, pd.MultiIndex) and "source" in source_index.names
+    prepared_is_multisector = "source" in sensitivity.dims or gathered_source
     if run_spec.split_by_sectors is not prepared_is_multisector:
         raise ValueError(
             "`run_spec.split_by_sectors` must agree with the prepared `H` layout: "
             f"split_by_sectors={run_spec.split_by_sectors}, "
-            f"source coordinate present={prepared_is_multisector}."
+            f"multisector source layout present={prepared_is_multisector}."
         )
     if run_spec.split_by_sectors is not multisector:
         raise ValueError(

--- a/openghg_inversions/rhime/runner.py
+++ b/openghg_inversions/rhime/runner.py
@@ -145,6 +145,65 @@ def _run_spec_with_prepared_inputs(
     )
 
 
+def _validate_multisector_basis_layout(
+    basis_functions: BasisFunctions,
+    model_spec: RhimeModelSpec,
+    inv_inputs: xr.Dataset,
+) -> None:
+    """Reject padded ragged bases unsupported by the current sector builder."""
+    operator = basis_functions.operator
+    design = inv_inputs["H"]
+    if "region" not in design.dims or "region" not in design.coords:
+        return
+    prepared_index = design.get_index("region")
+    operator_for_source = getattr(operator, "operator_for_source", None)
+    if not callable(operator_for_source):
+        state_dim = operator.meta.state_dim
+        basis_index = operator.basis_matrix.get_index(state_dim)
+        if not basis_index.equals(prepared_index):
+            sector_sources = [
+                (sector.name, sector.flux_source) for sector in model_spec.sectors
+            ]
+            raise ValueError(
+                "Retained shared basis state coordinates do not match prepared H.region for "
+                f"sector/source mapping(s) {sector_sources!r}: basis has {len(basis_index)} "
+                f"elements, prepared H has {len(prepared_index)}."
+            )
+        return
+
+    region_layouts: list[tuple[str, str, int, bool]] = []
+    for sector in model_spec.sectors:
+        try:
+            source_operator: Any = operator_for_source(sector.flux_source)
+        except ValueError as exc:
+            raise ValueError(
+                f"Sector {sector.name!r} requires source {sector.flux_source!r}, "
+                "but the retained basis has no matching source-specific basis."
+            ) from exc
+        state_dim = source_operator.meta.state_dim
+        basis_index = source_operator.basis_matrix.get_index(state_dim)
+        region_layouts.append(
+            (
+                sector.name,
+                sector.flux_source,
+                len(basis_index),
+                basis_index.equals(prepared_index),
+            )
+        )
+
+    if any(not coordinates_match for _, _, _, coordinates_match in region_layouts):
+        details = ", ".join(
+            f"sector {sector!r} -> source {source!r}: {count} regions"
+            + ("" if coordinates_match else " with coordinates differing from H.region")
+            for sector, source, count, coordinates_match in region_layouts
+        )
+        raise ValueError(
+            "Multi-sector RHIME currently requires compatible basis dimensions across sectors; "
+            f"prepared H has {len(prepared_index)} regions; {details}. Ragged or inconsistent "
+            "source-specific state blocks are not supported by this builder."
+        )
+
+
 def _execute_prepared_rhime(
     *,
     prepared: RhimePreparedInputs,
@@ -158,6 +217,11 @@ def _execute_prepared_rhime(
     build_and_sample_start = timer_start()
     timing_start = timer_start()
     if multisector:
+        _validate_multisector_basis_layout(
+            prepared.basis_functions,
+            run_spec.model,
+            prepared.inv_inputs,
+        )
         model = build_rhime_multisector_model_from_spec(prepared.inv_inputs, run_spec.model)
     else:
         model = build_rhime_model_from_spec(prepared.inv_inputs, run_spec.model)
@@ -356,11 +420,12 @@ def run_rhime_multisector(
             override values read from this file.
         **kwargs: RHIME run parameters using snake-case names. Multi-sector
             runs require at least two ``flux_sources`` and may include
-            ``sector_priors`` keyed by sector name. When model sector labels
-            differ from OpenGHG source values, pass ``sector_sources`` as a
-            mapping from sector name to one value in ``flux_sources``. Legacy
-            ``emissions_name`` is accepted only as a compatibility alias when
-            ``flux_sources`` is absent.
+            a complete ``sector_priors`` mapping keyed by sector name. When
+            model sector labels differ from OpenGHG source values, pass
+            ``sector_sources`` as a one-to-one mapping from sector name to one
+            unique value in ``flux_sources``. Legacy ``emissions_name`` is
+            accepted only as a compatibility alias when ``flux_sources`` is
+            absent.
 
     Returns:
         Modern RHIME result containing canonical inputs, InferenceData, specs,

--- a/openghg_inversions/rhime/runner.py
+++ b/openghg_inversions/rhime/runner.py
@@ -64,6 +64,7 @@ from openghg_inversions.models import (
     build_rhime_model_from_spec,
     build_rhime_multisector_model_from_spec,
 )
+from openghg_inversions.models._rhime_flux import _select_sector_design
 from openghg_inversions.postprocessing.inversion_output import InversionOutput
 
 __all__ = [
@@ -150,57 +151,55 @@ def _validate_multisector_basis_layout(
     model_spec: RhimeModelSpec,
     inv_inputs: xr.Dataset,
 ) -> None:
-    """Reject padded ragged bases unsupported by the current sector builder."""
-    operator = basis_functions.operator
+    """Require retained basis indexes to match each prepared sector design."""
     design = inv_inputs["H"]
-    if "region" not in design.dims or "region" not in design.coords:
-        return
-    prepared_index = design.get_index("region")
-    operator_for_source = getattr(operator, "operator_for_source", None)
-    if not callable(operator_for_source):
-        state_dim = operator.meta.state_dim
-        basis_index = operator.basis_matrix.get_index(state_dim)
-        if not basis_index.equals(prepared_index):
-            sector_sources = [
-                (sector.name, sector.flux_source) for sector in model_spec.sectors
-            ]
-            raise ValueError(
-                "Retained shared basis state coordinates do not match prepared H.region for "
-                f"sector/source mapping(s) {sector_sources!r}: basis has {len(basis_index)} "
-                f"elements, prepared H has {len(prepared_index)}."
-            )
-        return
 
-    region_layouts: list[tuple[str, str, int, bool]] = []
+    region_layouts: list[tuple[str, str, int, int, bool]] = []
     for sector in model_spec.sectors:
         try:
-            source_operator: Any = operator_for_source(sector.flux_source)
-        except ValueError as exc:
+            source_basis = basis_functions.for_source(sector.flux_source)
+        except (KeyError, ValueError) as exc:
             raise ValueError(
                 f"Sector {sector.name!r} requires source {sector.flux_source!r}, "
                 "but the retained basis has no matching source-specific basis."
             ) from exc
+        source_operator = source_basis.operator
         state_dim = source_operator.meta.state_dim
         basis_index = source_operator.basis_matrix.get_index(state_dim)
+        sector_design = _select_sector_design(
+            design,
+            sector=sector.name,
+            source=sector.flux_source,
+            variable_suffix=sector.variable_suffix,
+        )
+        prepared_state_dims = [str(dim) for dim in sector_design.dims if dim != "nmeasure"]
+        if len(prepared_state_dims) != 1:
+            raise ValueError(
+                f"Sector {sector.name!r} -> source {sector.flux_source!r} must have exactly "
+                f"one prepared state dimension; found {prepared_state_dims!r}."
+            )
+        prepared_index = sector_design.get_index(prepared_state_dims[0])
         region_layouts.append(
             (
                 sector.name,
                 sector.flux_source,
                 len(basis_index),
+                len(prepared_index),
                 basis_index.equals(prepared_index),
             )
         )
 
-    if any(not coordinates_match for _, _, _, coordinates_match in region_layouts):
+    if any(not coordinates_match for _, _, _, _, coordinates_match in region_layouts):
         details = ", ".join(
-            f"sector {sector!r} -> source {source!r}: {count} regions"
-            + ("" if coordinates_match else " with coordinates differing from H.region")
-            for sector, source, count, coordinates_match in region_layouts
+            f"sector {sector!r} -> source {source!r}: basis has {basis_count} regions, "
+            f"prepared H has {prepared_count}"
+            + ("" if coordinates_match else " with different coordinates")
+            for sector, source, basis_count, prepared_count, coordinates_match in region_layouts
         )
         raise ValueError(
-            "Multi-sector RHIME currently requires compatible basis dimensions across sectors; "
-            f"prepared H has {len(prepared_index)} regions; {details}. Ragged or inconsistent "
-            "source-specific state blocks are not supported by this builder."
+            "Retained source-specific basis state coordinates do not match prepared H; "
+            + details
+            + "."
         )
 
 
@@ -346,12 +345,12 @@ def run_rhime_from_prepared_inputs(
     if sector_count < 1:
         raise ValueError(f"`run_spec.model.sectors` must contain at least one sector; found {sector_count}.")
     multisector = sector_count > 1
-    prepared_is_multisector = "source" in prepared_inputs.inv_inputs["H"].dims
+    prepared_is_multisector = "source" in prepared_inputs.inv_inputs["H"].coords
     if run_spec.split_by_sectors is not prepared_is_multisector:
         raise ValueError(
             "`run_spec.split_by_sectors` must agree with the prepared `H` layout: "
             f"split_by_sectors={run_spec.split_by_sectors}, "
-            f"source dimension present={prepared_is_multisector}."
+            f"source coordinate present={prepared_is_multisector}."
         )
     if run_spec.split_by_sectors is not multisector:
         raise ValueError(

--- a/tests/postprocessing/test_make_outputs.py
+++ b/tests/postprocessing/test_make_outputs.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Callable, cast
 
+import arviz as az
 import numpy as np
 import pytest
 import xarray as xr
@@ -93,6 +94,59 @@ def test_multisector_flux_outputs_support_source_specific_basis(
     assert "flux_total_posterior_mode" in outputs
     assert float(outputs["flux_total_posterior_mean"].item()) == 2.0
     assert _flux_nonfinite_metadata(outputs).policy == NONFINITE_POLICY_ZERO_FILL
+
+
+def test_multisector_mode_kde_scale_factors_use_each_sector_state_dimension(
+    multisector_postprocessing_inv_out: Callable[..., InversionOutput],
+) -> None:
+    """Ragged sector scale-factor modes chunk each sector along its own state dimension."""
+    ff_basis = xr.DataArray(
+        [[1, 2]],
+        dims=("lat", "lon"),
+        coords={"lat": [0.0], "lon": [0.0, 1.0]},
+    )
+    ocean_basis = xr.DataArray(
+        [[1, 1]],
+        dims=("lat", "lon"),
+        coords={"lat": [0.0], "lon": [0.0, 1.0]},
+    )
+    flux = xr.DataArray(
+        np.ones((2, 1, 2)),
+        dims=("source", "lat", "lon"),
+        coords={
+            "source": ["ff-inventory", "ocean-inventory"],
+            "lat": [0.0],
+            "lon": [0.0, 1.0],
+        },
+        attrs={"units": "mol/m2/s"},
+    )
+    basis_functions = BasisFunctions.from_multi_source_flat_basis(
+        basis_flat={
+            "ff-inventory": ff_basis,
+            "ocean-inventory": ocean_basis,
+        },
+        flux=flux,
+        operator_kwargs={"state_dim": "state"},
+    )
+    inv_out = multisector_postprocessing_inv_out(basis_functions)
+    inv_out.trace = az.from_dict(
+        posterior={
+            "x_ff": np.array([[[1.0, 2.0], [1.5, 2.5], [2.0, 3.0], [2.5, 3.5]]]),
+            "x_ocean": np.array([[[0.5], [1.0], [1.5], [2.0]]]),
+        },
+        coords={"state_ff": [0, 1], "state_ocean": [0]},
+        dims={"x_ff": ["state_ff"], "x_ocean": ["state_ocean"]},
+    )
+
+    outputs = make_flux_outputs(
+        inv_out,
+        stats=["mode_kde"],
+        include_scale_factors=True,
+        report_flux_on_inversion_grid=False,
+    )
+
+    assert "scaling_ff_posterior_mode" in outputs
+    assert "scaling_ocean_posterior_mode" in outputs
 
 
 def test_multisector_flux_trace_materialization_is_optional(

--- a/tests/test_array_ops.py
+++ b/tests/test_array_ops.py
@@ -6,8 +6,10 @@ import xarray as xr
 
 from openghg_inversions.array_ops import (
     align_to_multi_index_level_values,
+    concat_gather_data_arrays,
     concat_gather_datatree,
     concat_gather_datasets,
+    select_gathered_data_array,
 )
 
 
@@ -154,6 +156,44 @@ def test_align_to_multi_index_level_values_with_other_level_as_dim_warns():
         )
 
     xr.testing.assert_equal(da_stack.a, da_aligned.a)
+
+
+def test_select_gathered_data_array_restores_ragged_labels_and_values() -> None:
+    """Selecting a gathered key should retain represented values, including NaNs."""
+    time = pd.date_range("2020-01-01", periods=2, freq="1h")
+    gathered = concat_gather_data_arrays(
+        {
+            "ff": xr.DataArray(
+                [[1.0, np.nan], [2.0, 3.0]],
+                dims=("region", "time"),
+                coords={"region": [10, 11], "time": time},
+            ),
+            "ocean": xr.DataArray(
+                [[4.0, 5.0]],
+                dims=("region", "time"),
+                coords={"region": [20], "time": time},
+            ),
+        },
+        key_dim="source",
+        ragged_dim="region",
+        stack_dim="state",
+        join="exact",
+    )
+
+    selected = select_gathered_data_array(
+        gathered,
+        key="ff",
+        key_dim="source",
+        ragged_dim="region",
+        stack_dim="state",
+    )
+
+    expected = xr.DataArray(
+        [[1.0, np.nan], [2.0, 3.0]],
+        dims=("state", "time"),
+        coords={"state": [10, 11], "time": time},
+    )
+    xr.testing.assert_identical(selected, expected)
 
 
 @pytest.mark.parametrize("use_datatree", [False, True], ids=["datasets", "datatree"])

--- a/tests/test_basis_functions.py
+++ b/tests/test_basis_functions.py
@@ -42,7 +42,11 @@ from openghg_inversions.basis.operators import (
     BucketBasisOperator,
     MultiSourceBucketBasisOperator,
 )
-from openghg_inversions.basis._helpers import apply_fp_basis_functions, fp_sensitivity
+from openghg_inversions.basis._helpers import (
+    _legacy_multisource_h_if_needed,
+    apply_fp_basis_functions,
+    fp_sensitivity,
+)
 from openghg_inversions.flux_sanitization import (
     FluxNonFiniteMetadata,
     NONFINITE_CHECKED_COMPUTED,
@@ -1414,6 +1418,32 @@ def test_basisfunctions_interpolate_trace_with_chain_dim():
 # --------------------------------------------------------------------------------------
 # Multi-source equivalence: gathered MultiIndex vs legacy padded H conversion
 # --------------------------------------------------------------------------------------
+def test_legacy_multisource_adapter_only_zero_fills_structural_padding() -> None:
+    """Legacy rectangularization must preserve NaNs in represented state cells."""
+    state_index = pd.MultiIndex.from_tuples(
+        [("ff", 0), ("ff", 1), ("ocean", 0)],
+        names=["source", "region_in_source"],
+    )
+    sensitivity = xr.DataArray(
+        [[1.0, 2.0], [np.nan, 4.0], [5.0, 6.0]],
+        dims=("state", "time"),
+        coords={
+            **xr.Coordinates.from_pandas_multiindex(state_index, "state"),
+            "time": [0, 1],
+        },
+    )
+
+    result = _legacy_multisource_h_if_needed(
+        sensitivity,
+        state_dim="state",
+        flux_sources=["ff", "ocean"],
+    )
+
+    assert np.isnan(result.sel(source="ff", region=1, time=0))
+    assert result.sel(source="ocean", region=1, time=0).item() == 0.0
+    assert result.coords["source_region_count"].to_dict()["data"] == [2, 1]
+
+
 def test_multisource_sensitivity_matches_legacy_padded_conversion_smoke():
     """Smoke test: gathered multi-source sensitivity matches legacy padded->gathered conversion.
 

--- a/tests/test_basis_functions.py
+++ b/tests/test_basis_functions.py
@@ -1418,17 +1418,27 @@ def test_basisfunctions_interpolate_trace_with_chain_dim():
 # --------------------------------------------------------------------------------------
 # Multi-source equivalence: gathered MultiIndex vs legacy padded H conversion
 # --------------------------------------------------------------------------------------
-def test_legacy_multisource_adapter_only_zero_fills_structural_padding() -> None:
+@pytest.mark.parametrize("use_multiindex", [True, False], ids=["multiindex", "auxiliary-coordinates"])
+def test_legacy_multisource_adapter_only_zero_fills_structural_padding(use_multiindex: bool) -> None:
     """Legacy rectangularization must preserve NaNs in represented state cells."""
     state_index = pd.MultiIndex.from_tuples(
         [("ff", 0), ("ff", 1), ("ocean", 0)],
         names=["source", "region_in_source"],
     )
+    state_coords: dict = (
+        dict(xr.Coordinates.from_pandas_multiindex(state_index, "state"))
+        if use_multiindex
+        else {
+            "state": [0, 1, 2],
+            "source": ("state", ["ff", "ff", "ocean"]),
+            "region_in_source": ("state", [0, 1, 0]),
+        }
+    )
     sensitivity = xr.DataArray(
         [[1.0, 2.0], [np.nan, 4.0], [5.0, 6.0]],
         dims=("state", "time"),
         coords={
-            **xr.Coordinates.from_pandas_multiindex(state_index, "state"),
+            **state_coords,
             "time": [0, 1],
         },
     )

--- a/tests/test_inversion_inputs.py
+++ b/tests/test_inversion_inputs.py
@@ -293,6 +293,55 @@ def test_make_inv_inputs_drops_non_shared_data_vars():
     assert "sigma_freq_index" not in result
 
 
+def test_make_inv_inputs_rejects_mismatched_gathered_state_indexes() -> None:
+    """Site gathering must not outer-align different source/region state layouts."""
+    fp_data = {
+        "AAA": _make_minimal_fp_site(mf_base=10.0, include_inlet_height=False),
+        "BBB": _make_minimal_fp_site(mf_base=20.0, include_inlet_height=False),
+    }
+    state_indexes = {
+        "AAA": pd.MultiIndex.from_tuples(
+            [("ff", 0), ("ff", 1), ("ocean", 0)],
+            names=["source", "region_in_source"],
+        ),
+        "BBB": pd.MultiIndex.from_tuples(
+            [("ff", 0), ("ocean", 0)],
+            names=["source", "region_in_source"],
+        ),
+    }
+    for site, state_index in state_indexes.items():
+        time = fp_data[site].coords["time"]
+        fp_data[site]["H"] = xr.DataArray(
+            np.ones((len(state_index), time.size)),
+            dims=("state", "time"),
+            coords={
+                **xr.Coordinates.from_pandas_multiindex(state_index, "state"),
+                "time": time,
+            },
+        )
+
+    with pytest.raises(ValueError, match="identical indexes on every non-time dimension"):
+        make_inv_inputs(fp_data=fp_data, sites=["AAA", "BBB"], min_error=0.0)
+
+
+def test_make_inv_inputs_rejects_mismatched_state_dimension_names() -> None:
+    """Site gathering must not broadcast differently named state dimensions."""
+    fp_data = {
+        "AAA": _make_minimal_fp_site(mf_base=10.0, include_inlet_height=False),
+        "BBB": _make_minimal_fp_site(mf_base=20.0, include_inlet_height=False),
+    }
+    for site, state_dim in (("AAA", "state"), ("BBB", "region")):
+        time = fp_data[site].coords["time"]
+        fp_data[site]["H"] = xr.DataArray(
+            np.ones((2, time.size)),
+            dims=(state_dim, "time"),
+            coords={state_dim: [0, 1], "time": time},
+        )
+
+    with pytest.raises(ValueError, match="variable 'H'.*same non-time dimensions"):
+        make_inv_inputs(fp_data=fp_data, sites=["AAA", "BBB"], min_error=0.0)
+
+
 def test_make_inv_inputs_raises_if_required_var_would_be_dropped():
     """`make_inv_inputs` should still fail clearly if a required var is not shared."""
     fp_data = {

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -1265,7 +1265,9 @@ def test_run_rhime_from_prepared_inputs_routes_without_preparation(
         split_by_sectors=sector_count > 1,
     )
     inv_inputs = _minimal_output_inv_inputs()
-    if sector_count == 2:
+    if sector_count == 1:
+        inv_inputs["H"] = inv_inputs["H"].assign_coords(source=sectors[0].flux_source)
+    else:
         inv_inputs["H"] = xr.concat(
             [inv_inputs["H"].expand_dims(source=[sector.flux_source]) for sector in model_spec.sectors],
             dim="source",

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -12,6 +12,7 @@ import pytest
 import xarray as xr
 
 import openghg_inversions.models as models
+import openghg_inversions.models._rhime_compiler as rhime_compiler_module
 import openghg_inversions.models.rhime as rhime_models_module
 import openghg_inversions.hbmcmc.inversion_pymc as legacy_mcmc
 import openghg_inversions.postprocessing.inversion_output as inversion_output_module
@@ -36,6 +37,12 @@ from openghg_inversions.flux_sanitization import (
 from openghg_inversions.inversion_data import RhimePreparedInputs, prepare_rhime_inputs
 from openghg_inversions.inversion_inputs import make_inv_inputs
 from openghg_inversions.basis.operators import BasisMeta, BasisOperator, BucketBasisOperator
+from openghg_inversions.models._rhime_compiler import (
+    _FluxPlan,
+    _ForwardTermPlan,
+    _StatePlan,
+    _compile_loop_sum,
+)
 from openghg_inversions.models import (
     build_rhime_model,
     build_rhime_model_from_spec,
@@ -43,6 +50,7 @@ from openghg_inversions.models import (
     build_rhime_multisector_model_from_spec,
     safe_pymc_name,
 )
+from openghg_inversions.models.coords import CoordRegistry, attach_coord_registry
 from openghg_inversions.postprocessing.inversion_output import InversionOutput
 from openghg_inversions.postprocessing._basis_products import (
     BASIS_ARTIFACT_PATH_OUTPUT_ATTR,
@@ -507,6 +515,240 @@ class _DynamicSectorSpyBasisFunctions(_SpyBasisFunctions):
         )
 
 
+def test_compile_loop_sum_reuses_state_and_sums_named_terms() -> None:
+    """One shared state feeds named coefficient-scaled terms and their total."""
+    coords = {"region": ["r0", "r1"], "nmeasure": ["obs0", "obs1", "obs2"]}
+    design_a = xr.DataArray(
+        [[1.0, 2.0, 3.0], [0.5, 1.0, 1.5]],
+        dims=("region", "nmeasure"),
+        coords=coords,
+    )
+    design_b = xr.DataArray(
+        [[4.0, 3.0, 2.0], [1.0, 2.0, 3.0]],
+        dims=("region", "nmeasure"),
+        coords=coords,
+    )
+    plan = _FluxPlan(
+        states=(
+            _StatePlan(
+                state_id="shared",
+                variable_name="x_shared",
+                prior_args={"pdf": "uniform", "lower": 1.0, "upper": 2.0},
+            ),
+        ),
+        terms=(
+            _ForwardTermPlan(
+                term_id="term_a",
+                state_id="shared",
+                design=design_a,
+                data_name="h_a",
+                deterministic_name="mu_a",
+            ),
+            _ForwardTermPlan(
+                term_id="term_b",
+                state_id="shared",
+                design=design_b,
+                data_name="h_b",
+                deterministic_name="mu_b",
+                coefficient=-0.25,
+            ),
+        ),
+    )
+
+    with pm.Model() as model:
+        attach_coord_registry(model, CoordRegistry())
+        compiled = _compile_loop_sum(plan)
+        trace = pm.sample_prior_predictive(
+            draws=3,
+            var_names=["x_shared", "mu_a", "mu_b", "mu"],
+            random_seed=402,
+        )
+
+    assert [rv.name for rv in model.free_RVs].count("x_shared") == 1
+    assert compiled.states["shared"] is model["x_shared"]
+    assert compiled.latents["shared"] is model["x_shared"]
+    assert compiled.terms["term_a"] is model["mu_a"]
+    assert compiled.terms["term_b"] is model["mu_b"]
+    prior = cast(Any, trace).prior
+    assert set(prior.data_vars) == {"x_shared", "mu_a", "mu_b", "mu"}
+    trace_coords = {"region": prior["region"], "nmeasure": prior["nmeasure"]}
+    expected_a = xr.dot(
+        prior["x_shared"],
+        design_a.assign_coords(trace_coords),
+        dim="region",
+    )
+    expected_b = -0.25 * xr.dot(
+        prior["x_shared"],
+        design_b.assign_coords(trace_coords),
+        dim="region",
+    )
+    xr.testing.assert_allclose(
+        prior["mu_a"],
+        expected_a.transpose(*prior["mu_a"].dims).rename("mu_a"),
+    )
+    xr.testing.assert_allclose(
+        prior["mu_b"],
+        expected_b.transpose(*prior["mu_b"].dims).rename("mu_b"),
+    )
+    xr.testing.assert_allclose(
+        prior["mu"],
+        (prior["mu_a"] + prior["mu_b"]).rename("mu"),
+    )
+
+
+def test_compile_loop_sum_separates_user_state_from_reparameterized_latent() -> None:
+    """Compiled state metadata distinguishes the physical state from its latent."""
+    design = xr.DataArray(
+        [[1.0]],
+        dims=("region", "nmeasure"),
+        coords={"region": [0], "nmeasure": [0]},
+    )
+    plan = _FluxPlan(
+        states=(
+            _StatePlan(
+                state_id="flux",
+                variable_name="x_flux",
+                prior_args={
+                    "pdf": "lognormal",
+                    "mean": 1.0,
+                    "stdev": 0.2,
+                    "reparameterise": True,
+                },
+            ),
+        ),
+        terms=(
+            _ForwardTermPlan(
+                term_id="flux",
+                state_id="flux",
+                design=design,
+                data_name="h_flux",
+                deterministic_name="mu",
+            ),
+        ),
+    )
+
+    with pm.Model() as model:
+        attach_coord_registry(model, CoordRegistry())
+        compiled = _compile_loop_sum(plan)
+
+    assert compiled.states["flux"] is model["x_flux"]
+    assert compiled.latents["flux"] is model["x_flux_latent"]
+
+
+@pytest.mark.parametrize(
+    ("state_id", "coefficient", "prior_args", "error"),
+    [
+        ("missing", 1.0, {"pdf": "normal", "mu": 1.0, "sigma": 0.2}, "unknown state IDs"),
+        ("shared", np.inf, {"pdf": "normal", "mu": 1.0, "sigma": 0.2}, "finite scalar"),
+        ("shared", 1.0, {"pdf": "not-a-distribution"}, "prior.*invalid"),
+    ],
+)
+def test_compile_loop_sum_rejects_invalid_plan_before_graph_mutation(
+    state_id: str,
+    coefficient: float,
+    prior_args: dict[str, Any],
+    error: str,
+) -> None:
+    """Invalid references, coefficients, and priors do not mutate the active graph."""
+    design = xr.DataArray(
+        [[1.0]],
+        dims=("region", "nmeasure"),
+        coords={"region": [0], "nmeasure": [0]},
+    )
+    plan = _FluxPlan(
+        states=(
+            _StatePlan(
+                state_id="shared",
+                variable_name="x_shared",
+                prior_args=prior_args,
+            ),
+        ),
+        terms=(
+            _ForwardTermPlan(
+                term_id="term",
+                state_id=state_id,
+                design=design,
+                data_name="h_term",
+                deterministic_name="mu_term",
+                coefficient=coefficient,
+            ),
+        ),
+    )
+
+    with pm.Model() as model, pytest.raises(ValueError, match=error):
+        _compile_loop_sum(plan)
+
+    assert model.named_vars == {}
+
+
+def test_compile_loop_sum_rejects_global_coordinate_conflicts_before_mutation() -> None:
+    """Repeated backend dimensions must carry one globally consistent coordinate."""
+    obs = ["obs0", "obs1"]
+    plan = _FluxPlan(
+        states=(
+            _StatePlan("a", "x_a", {"pdf": "normal", "mu": 1.0, "sigma": 0.2}),
+            _StatePlan("b", "x_b", {"pdf": "normal", "mu": 1.0, "sigma": 0.2}),
+        ),
+        terms=(
+            _ForwardTermPlan(
+                "a",
+                "a",
+                xr.DataArray(
+                    np.ones((2, 2)),
+                    dims=("region", "nmeasure"),
+                    coords={"region": ["a0", "a1"], "nmeasure": obs},
+                ),
+                "h_a",
+                "mu_a",
+            ),
+            _ForwardTermPlan(
+                "b",
+                "b",
+                xr.DataArray(
+                    np.ones((2, 2)),
+                    dims=("region", "nmeasure"),
+                    coords={"region": ["b0", "b1"], "nmeasure": obs},
+                ),
+                "h_b",
+                "mu_b",
+            ),
+        ),
+    )
+
+    with (
+        pm.Model() as model,
+        pytest.raises(ValueError, match="incompatible global coordinates"),
+    ):
+        _compile_loop_sum(plan)
+
+    assert model.named_vars == {}
+
+
+def test_compile_loop_sum_preserves_term_order_independent_of_state_order() -> None:
+    """The strategy follows term order while reusing independently declared states."""
+    design = xr.DataArray(
+        [[1.0]],
+        dims=("region", "nmeasure"),
+        coords={"region": [0], "nmeasure": [0]},
+    )
+    plan = _FluxPlan(
+        states=(
+            _StatePlan("b", "x_b", {"pdf": "normal", "mu": 1.0, "sigma": 0.2}),
+            _StatePlan("a", "x_a", {"pdf": "normal", "mu": 1.0, "sigma": 0.2}),
+        ),
+        terms=(
+            _ForwardTermPlan("a1", "a", design, "h_a1", "mu_a1"),
+            _ForwardTermPlan("b1", "b", design, "h_b1", "mu_b1"),
+            _ForwardTermPlan("a2", "a", design, "h_a2", "mu_a2"),
+        ),
+    )
+
+    with pm.Model():
+        compiled = _compile_loop_sum(plan)
+
+    assert list(compiled.terms) == ["a1", "b1", "a2"]
+
+
 def test_build_rhime_model_contains_expected_variables(
     rhime_inv_inputs: xr.Dataset, builder_args: dict
 ) -> None:
@@ -552,29 +794,107 @@ def test_build_rhime_multisector_model_contains_expected_variables(
 def test_build_rhime_multisector_model_uses_sector_names_for_variables(
     multisector_inv_inputs: xr.Dataset, builder_args: dict
 ) -> None:
-    """Sector labels can differ from OpenGHG source values used for data selection."""
+    """Distinct sector priors retain named states and additive mu deterministics."""
+    sector_priors = {
+        "FF": {"pdf": "uniform", "lower": 1.0, "upper": 2.0},
+        "ocean": {"pdf": "uniform", "lower": 10.0, "upper": 11.0},
+    }
     model = build_rhime_multisector_model(
         multisector_inv_inputs,
         sectors=["FF", "ocean"],
         sector_sources={"FF": "total-ukghg-edgar7", "ocean": "sector-2"},
         sector_variable_suffixes={"FF": "ff", "ocean": "ocean"},
-        sector_priors={"FF": {"pdf": "normal", "mu": 1.0, "sigma": 0.2}},
+        sector_priors=sector_priors,
         **builder_args,
     )
 
-    expected = {
+    expected_trace_names = {
         "x_ff",
         "mu_ff",
         "x_ocean",
         "mu_ocean",
         "mu",
+    }
+    expected_model_names = expected_trace_names | {
         "bc",
         "mu_bc",
         "sigma",
         "epsilon",
         "y",
     }
-    assert expected.issubset(model.named_vars)
+    assert expected_model_names.issubset(model.named_vars)
+    free_rv_names = [rv.name for rv in model.free_RVs]
+    assert free_rv_names.count("x_ff") == 1
+    assert free_rv_names.count("x_ocean") == 1
+
+    with model:
+        trace = pm.sample_prior_predictive(
+            draws=4,
+            var_names=sorted(expected_trace_names),
+            random_seed=412,
+        )
+
+    prior = cast(Any, trace).prior
+    assert set(prior.data_vars) == expected_trace_names
+    assert np.all((prior["x_ff"] >= 1.0) & (prior["x_ff"] <= 2.0))
+    assert np.all((prior["x_ocean"] >= 10.0) & (prior["x_ocean"] <= 11.0))
+    np.testing.assert_allclose(prior["mu"], prior["mu_ff"] + prior["mu_ocean"])
+
+
+def test_build_rhime_multisector_model_rejects_reparameterized_name_collisions(
+    multisector_inv_inputs: xr.Dataset,
+    builder_args: dict,
+) -> None:
+    """Generated latent names participate in pre-compilation name validation."""
+    reparameterized_prior = {
+        "pdf": "lognormal",
+        "mean": 1.0,
+        "stdev": 0.2,
+        "reparameterise": True,
+    }
+
+    with pytest.raises(ValueError, match="backend names"):
+        build_rhime_multisector_model(
+            multisector_inv_inputs,
+            sectors=["FF", "other"],
+            sector_sources={"FF": "total-ukghg-edgar7", "other": "sector-2"},
+            sector_variable_suffixes={"FF": "ff", "other": "ff_latent"},
+            sector_priors={"FF": reparameterized_prior, "other": reparameterized_prior},
+            **builder_args,
+        )
+
+
+def test_standard_and_multisector_builders_share_loop_sum_compiler(
+    monkeypatch: pytest.MonkeyPatch,
+    rhime_inv_inputs: xr.Dataset,
+    multisector_inv_inputs: xr.Dataset,
+    builder_args: dict,
+) -> None:
+    """Both public builders normalize fluxes through the same private compiler."""
+    captured_plans: list[_FluxPlan] = []
+
+    def compile_spy(plan: _FluxPlan) -> Any:
+        captured_plans.append(plan)
+        return rhime_compiler_module._compile_loop_sum(plan)
+
+    monkeypatch.setattr(rhime_models_module, "_compile_loop_sum", compile_spy)
+
+    build_rhime_model(rhime_inv_inputs, **builder_args)
+    build_rhime_multisector_model(
+        multisector_inv_inputs,
+        sectors=["FF", "ocean"],
+        sector_sources={"FF": "total-ukghg-edgar7", "ocean": "sector-2"},
+        sector_variable_suffixes={"FF": "ff", "ocean": "ocean"},
+        **builder_args,
+    )
+
+    assert len(captured_plans) == 2
+    standard_plan, multisector_plan = captured_plans
+    assert [state.variable_name for state in standard_plan.states] == ["x"]
+    assert [term.deterministic_name for term in standard_plan.terms] == ["mu"]
+    assert [state.variable_name for state in multisector_plan.states] == ["x_ff", "x_ocean"]
+    assert [term.deterministic_name for term in multisector_plan.terms] == ["mu_ff", "mu_ocean"]
+    assert all("strategy" not in parameter for parameter in inspect.signature(RhimeModelSpec).parameters)
 
 
 def test_build_rhime_multisector_model_requires_multiple_sectors(

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -865,6 +865,112 @@ def test_build_rhime_multisector_model_selects_sources_by_label(
     np.testing.assert_allclose(model["hx_ocean"].get_value(), expected_ocean.values)
 
 
+def test_build_rhime_multisector_model_accepts_gathered_ragged_states(
+    multisector_inv_inputs: xr.Dataset,
+    builder_args: dict,
+) -> None:
+    """Source-specific state blocks remain gathered until model normalization."""
+    state_index = pd.MultiIndex.from_tuples(
+        [
+            ("ff-inventory", 0),
+            ("ff-inventory", 1),
+            ("ocean-inventory", 0),
+            ("ocean-inventory", 1),
+            ("ocean-inventory", 2),
+        ],
+        names=["source", "region_in_source"],
+    )
+    nmeasure = multisector_inv_inputs.sizes["nmeasure"]
+    values = np.arange(len(state_index) * nmeasure, dtype=float).reshape(len(state_index), nmeasure)
+    inv_inputs = multisector_inv_inputs.drop_vars("H")
+    inv_inputs = inv_inputs.drop_dims([dim for dim in ("region", "source") if dim in inv_inputs.dims])
+    inv_inputs["H"] = xr.DataArray(
+        values,
+        dims=("state", "nmeasure"),
+        coords={
+            **xr.Coordinates.from_pandas_multiindex(state_index, "state"),
+            "nmeasure": multisector_inv_inputs.coords["nmeasure"],
+        },
+    )
+
+    model = build_rhime_multisector_model(
+        inv_inputs,
+        sectors=["FF", "ocean"],
+        sector_sources={"FF": "ff-inventory", "ocean": "ocean-inventory"},
+        sector_priors={
+            "FF": {"pdf": "normal", "mu": 1.0, "sigma": 0.2},
+            "ocean": {"pdf": "normal", "mu": 1.0, "sigma": 0.3},
+        },
+        **builder_args,
+    )
+
+    np.testing.assert_allclose(model["hx_ff"].get_value(), values[:2].T)
+    np.testing.assert_allclose(model["hx_ocean"].get_value(), values[2:].T)
+    assert model.named_vars_to_dims["x_ff"] == ("state_ff",)
+    assert model.named_vars_to_dims["x_ocean"] == ("state_ocean",)
+
+
+def test_build_rhime_multisector_model_rejects_ungathered_source_state(
+    multisector_inv_inputs: xr.Dataset,
+    builder_args: dict,
+) -> None:
+    """Source labels on a state axis require the canonical gathered MultiIndex."""
+    nmeasure = multisector_inv_inputs.sizes["nmeasure"]
+    inv_inputs = multisector_inv_inputs.drop_vars("H")
+    inv_inputs = inv_inputs.drop_dims([dim for dim in ("region", "source") if dim in inv_inputs.dims])
+    inv_inputs["H"] = xr.DataArray(
+        np.ones((2, nmeasure)),
+        dims=("state", "nmeasure"),
+        coords={
+            "state": [0, 1],
+            "source": ("state", ["ff-inventory", "ocean-inventory"]),
+            "nmeasure": multisector_inv_inputs.coords["nmeasure"],
+        },
+    )
+
+    with pytest.raises(ValueError, match="MultiIndex containing a 'source' level"):
+        build_rhime_multisector_model(
+            inv_inputs,
+            sectors=["FF", "ocean"],
+            sector_sources={"FF": "ff-inventory", "ocean": "ocean-inventory"},
+            **builder_args,
+        )
+
+
+def test_build_rhime_multisector_model_rejects_duplicate_gathered_states(
+    multisector_inv_inputs: xr.Dataset,
+    builder_args: dict,
+) -> None:
+    """Gathered scientific state coordinates must identify unique coefficients."""
+    state_index = pd.MultiIndex.from_tuples(
+        [
+            ("ff-inventory", 0),
+            ("ff-inventory", 0),
+            ("ocean-inventory", 0),
+        ],
+        names=["source", "region_in_source"],
+    )
+    nmeasure = multisector_inv_inputs.sizes["nmeasure"]
+    inv_inputs = multisector_inv_inputs.drop_vars("H")
+    inv_inputs = inv_inputs.drop_dims([dim for dim in ("region", "source") if dim in inv_inputs.dims])
+    inv_inputs["H"] = xr.DataArray(
+        np.ones((len(state_index), nmeasure)),
+        dims=("state", "nmeasure"),
+        coords={
+            **xr.Coordinates.from_pandas_multiindex(state_index, "state"),
+            "nmeasure": multisector_inv_inputs.coords["nmeasure"],
+        },
+    )
+
+    with pytest.raises(ValueError, match="unique state labels.*duplicate state.*ff-inventory"):
+        build_rhime_multisector_model(
+            inv_inputs,
+            sectors=["FF", "ocean"],
+            sector_sources={"FF": "ff-inventory", "ocean": "ocean-inventory"},
+            **builder_args,
+        )
+
+
 def test_build_rhime_multisector_model_rejects_duplicate_prepared_sources(
     multisector_inv_inputs: xr.Dataset,
     builder_args: dict,
@@ -2365,8 +2471,10 @@ def test_rhime_prepared_inputs_contract_exposes_only_modern_fields() -> None:
         assert not hasattr(prepared, legacy_attr)
 
 
-def test_prepared_multisector_runner_rejects_ragged_source_specific_basis_layout() -> None:
-    """Prepared-input execution rejects padded state layouts before model construction."""
+def test_prepared_multisector_runner_accepts_gathered_source_specific_basis_layout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Prepared-input validation accepts exact ragged source/state coordinates."""
     basis_ff = xr.DataArray(
         [[0, 0], [1, 1]],
         dims=("lat", "lon"),
@@ -2394,6 +2502,7 @@ def test_prepared_multisector_runner_rejects_ragged_source_specific_basis_layout
     model_spec = RhimeModelSpec(
         species="ch4",
         domain="EUROPE",
+        use_bc=False,
         sectors=(
             SectorSpec("FF", "ff-inventory", {"pdf": "normal", "mu": 1.0, "sigma": 0.2}, "ff"),
             SectorSpec(
@@ -2404,16 +2513,22 @@ def test_prepared_multisector_runner_rejects_ragged_source_specific_basis_layout
             ),
         ),
     )
-    inv_inputs = _minimal_output_inv_inputs().drop_dims("region")
-    inv_inputs["H"] = xr.DataArray(
-        np.ones((3, 1, 2)),
-        dims=("region", "nmeasure", "source"),
+    fp_x_flux = xr.DataArray(
+        np.ones((2, 2, 2, 1)),
+        dims=("source", "lat", "lon", "time"),
         coords={
-            "region": [0, 1, 2],
-            "nmeasure": inv_inputs.coords["nmeasure"],
             "source": ["ff-inventory", "ocean-inventory"],
+            "lat": [0.0, 1.0],
+            "lon": [0.0, 1.0],
+            "time": [0],
         },
     )
+    inv_inputs = _minimal_output_inv_inputs().drop_dims("region")
+    inv_inputs["min_error"] = xr.zeros_like(inv_inputs["mf"])
+    inv_inputs["H"] = basis_functions.sensitivity(fp_x_flux).rename(time="nmeasure").assign_coords(
+        nmeasure=inv_inputs.coords["nmeasure"]
+    )
+
     prepared = RhimePreparedInputs(
         inv_inputs=inv_inputs,
         basis_functions=basis_functions,
@@ -2430,13 +2545,21 @@ def test_prepared_multisector_runner_rejects_ragged_source_specific_basis_layout
         output=RhimeOutputSpec(output_format="none"),
         split_by_sectors=True,
     )
+    monkeypatch.setattr(
+        RhimeSampler,
+        "sample",
+        lambda self, model: _minimal_output_idata(),
+    )
+    monkeypatch.setattr(
+        rhime_module,
+        "make_multisector_output_bundle",
+        lambda **kwargs: rhime_outputs.RhimeOutputBundle(),
+    )
 
-    with pytest.raises(
-        ValueError,
-        match="prepared H has 3 regions.*sector 'FF' -> source 'ff-inventory': 2 regions.*"
-        "sector 'ocean' -> source 'ocean-inventory': 3 regions",
-    ):
-        run_rhime_from_prepared_inputs(prepared_inputs=prepared, run_spec=run_spec)
+    result = run_rhime_from_prepared_inputs(prepared_inputs=prepared, run_spec=run_spec)
+
+    assert result.model.named_vars_to_dims["x_ff"] == ("region_ff",)
+    assert result.model.named_vars_to_dims["x_ocean"] == ("region_ocean",)
 
 
 def test_multisector_runner_rejects_shared_basis_h_layout_mismatch() -> None:
@@ -2468,7 +2591,10 @@ def test_multisector_runner_rejects_shared_basis_h_layout_mismatch() -> None:
         },
     )
 
-    with pytest.raises(ValueError, match="Retained shared basis.*basis has 1 elements.*H has 2"):
+    with pytest.raises(
+        ValueError,
+        match="Retained source-specific basis.*basis has 1 regions.*prepared H has 2",
+    ):
         rhime_module._validate_multisector_basis_layout(
             _fake_basis_functions(),
             model_spec,
@@ -2516,10 +2642,7 @@ def test_prepare_rhime_inputs_multisector_keeps_source_dimension(
     assert isinstance(prepared.basis_functions, BasisFunctions)
     assert "source" in prepared.inv_inputs["H"].dims
     assert list(prepared.inv_inputs["H"].coords["source"].values) == flux_sources
-    assert list(prepared.inv_inputs["H"].coords["source_region_count"].values) == [
-        prepared.inv_inputs.sizes["region"],
-        prepared.inv_inputs.sizes["region"],
-    ]
+    assert "source_region_count" not in prepared.inv_inputs["H"].coords
 
 
 def test_multisector_sensitivity_sources_fail_before_site_gathering() -> None:
@@ -2571,6 +2694,60 @@ def test_multisector_sensitivity_sources_fail_before_site_gathering() -> None:
             bc_basis_case="NESW",
             bc_basis_directory=None,
         )
+
+
+def test_multisector_site_preparation_keeps_gathered_source_state() -> None:
+    """Modern preparation must not rectangularize ragged source-specific state."""
+    time = pd.date_range("2019-01-01", periods=2, freq="h")
+    state_index = pd.MultiIndex.from_tuples(
+        [("ff-inventory", 0), ("ff-inventory", 1), ("ocean-inventory", 0)],
+        names=["source", "region_in_source"],
+    )
+    sensitivity = xr.DataArray(
+        np.ones((3, 2)),
+        dims=("state", "time"),
+        coords={
+            **xr.Coordinates.from_pandas_multiindex(state_index, "state"),
+            "time": time,
+        },
+    )
+    fp_x_flux = xr.DataArray(
+        np.ones((2, 2)),
+        dims=("source", "time"),
+        coords={
+            "source": ["ff-inventory", "ocean-inventory"],
+            "time": time,
+        },
+        name="fp_x_flux_sectoral",
+    )
+
+    class GatheredBasis:
+        def sensitivity(self, _: xr.DataArray) -> xr.DataArray:
+            return sensitivity
+
+    merged = prep_module._MergedInversionData(
+        fp_all={"TAC": xr.Dataset({"fp_x_flux_sectoral": fp_x_flux})},
+        sites=["TAC"],
+        averaging_period=["1H"],
+    )
+
+    prepared = prep_module._rhime_site_data_from_basis_functions(
+        merged=merged,
+        basis_functions=cast(BasisFunctions, GatheredBasis()),
+        domain="EUROPE",
+        split_by_sectors=True,
+        flux_sources=["ff-inventory", "ocean-inventory"],
+        use_bc=False,
+        bc_basis_case="NESW",
+        bc_basis_directory=None,
+    )
+
+    xr.testing.assert_identical(prepared["TAC"]["H"], sensitivity.rename("H"))
+    assert "source" not in prepared["TAC"]["H"].dims
+    assert list(prepared["TAC"]["H"].indexes["state"].names) == [
+        "source",
+        "region_in_source",
+    ]
 
 
 def test_fixedbasis_preparation_adds_anchored_legacy_sigma_index(
@@ -2634,7 +2811,7 @@ def test_prepare_rhime_inputs_uses_basis_sensitivity_without_legacy_side_channel
         coords={"state": [0], "time": site_data.time},
         name="H",
     )
-    expected_sensitivity = sensitivity.rename({"state": "region"})
+    expected_sensitivity = sensitivity
     basis_functions = _SpyBasisFunctions(sensitivity)
     captured_fp_data_keys: set[str] = set()
 

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -841,6 +841,154 @@ def test_build_rhime_multisector_model_uses_sector_names_for_variables(
     np.testing.assert_allclose(prior["mu"], prior["mu_ff"] + prior["mu_ocean"])
 
 
+def test_build_rhime_multisector_model_selects_sources_by_label(
+    multisector_inv_inputs: xr.Dataset,
+    builder_args: dict,
+) -> None:
+    """Sector routing is independent of the prepared source-coordinate order."""
+    reversed_inputs = multisector_inv_inputs.sel(source=["sector-2", "total-ukghg-edgar7"])
+
+    model = build_rhime_multisector_model(
+        reversed_inputs,
+        sectors=["FF", "ocean"],
+        sector_sources={"FF": "total-ukghg-edgar7", "ocean": "sector-2"},
+        sector_priors={
+            "FF": {"pdf": "normal", "mu": 1.0, "sigma": 0.2},
+            "ocean": {"pdf": "normal", "mu": 1.0, "sigma": 0.3},
+        },
+        **builder_args,
+    )
+
+    expected_ff = reversed_inputs["H"].sel(source="total-ukghg-edgar7").transpose("nmeasure", "region")
+    expected_ocean = reversed_inputs["H"].sel(source="sector-2").transpose("nmeasure", "region")
+    np.testing.assert_allclose(model["hx_ff"].get_value(), expected_ff.values)
+    np.testing.assert_allclose(model["hx_ocean"].get_value(), expected_ocean.values)
+
+
+def test_build_rhime_multisector_model_rejects_duplicate_prepared_sources(
+    multisector_inv_inputs: xr.Dataset,
+    builder_args: dict,
+) -> None:
+    """Duplicate source coordinates fail before label selection becomes ambiguous."""
+    duplicate_sources = multisector_inv_inputs.sel(
+        source=["total-ukghg-edgar7", "total-ukghg-edgar7"]
+    )
+
+    with pytest.raises(ValueError, match="duplicate source 'total-ukghg-edgar7'"):
+        build_rhime_multisector_model(duplicate_sources, **builder_args)
+
+
+def test_build_rhime_multisector_model_rejects_padded_source_regions(
+    multisector_inv_inputs: xr.Dataset,
+    builder_args: dict,
+) -> None:
+    """Direct builders reject latent state elements introduced only by padding."""
+    region_count = multisector_inv_inputs.sizes["region"]
+    padded_inputs = multisector_inv_inputs.assign_coords(
+        source_region_count=(
+            "source",
+            [region_count - 1, region_count],
+        )
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            f"Sector 'FF' -> source 'total-ukghg-edgar7' declares {region_count - 1} "
+            f"region elements.*prepared H has {region_count}"
+        ),
+    ):
+        build_rhime_multisector_model(
+            padded_inputs,
+            sectors=["FF", "ocean"],
+            sector_sources={"FF": "total-ukghg-edgar7", "ocean": "sector-2"},
+            **builder_args,
+        )
+
+
+def test_build_rhime_multisector_model_allows_prior_only_regions(
+    multisector_inv_inputs: xr.Dataset,
+    builder_args: dict,
+) -> None:
+    """Zero sensitivity is not mistaken for padding when layout metadata matches."""
+    region_count = multisector_inv_inputs.sizes["region"]
+    inv_inputs = multisector_inv_inputs.assign_coords(
+        source_region_count=("source", [region_count, region_count])
+    ).copy(deep=True)
+    inv_inputs["H"].loc[{"source": "total-ukghg-edgar7", "region": 0}] = 0
+
+    model = build_rhime_multisector_model(
+        inv_inputs,
+        sectors=["FF", "ocean"],
+        sector_sources={"FF": "total-ukghg-edgar7", "ocean": "sector-2"},
+        **builder_args,
+    )
+
+    assert "x_ff" in model.named_vars
+
+
+def test_build_rhime_multisector_model_rejects_duplicate_sector_source_mappings(
+    multisector_inv_inputs: xr.Dataset,
+    builder_args: dict,
+) -> None:
+    """Independent sector states cannot select the same source sensitivity."""
+    with pytest.raises(ValueError, match="source 'total-ukghg-edgar7'.*\\['FF', 'other'\\]"):
+        build_rhime_multisector_model(
+            multisector_inv_inputs,
+            sectors=["FF", "other"],
+            sector_sources={"FF": "total-ukghg-edgar7", "other": "total-ukghg-edgar7"},
+            **builder_args,
+        )
+
+
+def test_build_rhime_multisector_model_names_sector_and_missing_source(
+    multisector_inv_inputs: xr.Dataset,
+    builder_args: dict,
+) -> None:
+    """Missing prepared data errors retain semantic sector and source identities."""
+    with pytest.raises(ValueError, match="sector 'FF' -> source 'missing-inventory'"):
+        build_rhime_multisector_model(
+            multisector_inv_inputs,
+            sectors=["FF", "ocean"],
+            sector_sources={"FF": "missing-inventory", "ocean": "sector-2"},
+            **builder_args,
+        )
+
+
+@pytest.mark.parametrize(
+    ("sector_priors", "error_fragment"),
+    [
+        (
+            {"FF": {"pdf": "normal", "mu": 1.0, "sigma": 0.2}},
+            "missing sector prior\\(s\\): \\['ocean'\\]",
+        ),
+        (
+            {
+                "FF": {"pdf": "normal", "mu": 1.0, "sigma": 0.2},
+                "ocean": {"pdf": "normal", "mu": 1.0, "sigma": 0.3},
+                "typo": {"pdf": "normal", "mu": 1.0, "sigma": 0.4},
+            },
+            "unused sector prior key\\(s\\): \\['typo'\\]",
+        ),
+    ],
+)
+def test_build_rhime_multisector_model_requires_exact_sector_prior_keys(
+    multisector_inv_inputs: xr.Dataset,
+    builder_args: dict,
+    sector_priors: dict[str, dict[str, Any]],
+    error_fragment: str,
+) -> None:
+    """Explicit per-sector priors must be complete and contain no unused keys."""
+    with pytest.raises(ValueError, match=error_fragment):
+        build_rhime_multisector_model(
+            multisector_inv_inputs,
+            sectors=["FF", "ocean"],
+            sector_sources={"FF": "total-ukghg-edgar7", "ocean": "sector-2"},
+            sector_priors=sector_priors,
+            **builder_args,
+        )
+
+
 def test_build_rhime_multisector_model_rejects_reparameterized_name_collisions(
     multisector_inv_inputs: xr.Dataset,
     builder_args: dict,
@@ -1388,8 +1536,10 @@ def test_rhime_runner_setup_builds_specs_before_preparation(tmp_path: Path) -> N
         "output_format": "none",
         "x_prior": {"pdf": "normal", "mu": 1.0, "sigma": 0.5},
         "sector_priors": {
+            "FF": {"pdf": "normal", "mu": 1.0, "sigma": 0.5},
             "GPP": {"pdf": "normal", "mu": 0.7, "sigma": 0.2},
             "TER": {"pdf": "normal", "mu": 1.3, "sigma": 0.3},
+            "ocean": {"pdf": "normal", "mu": 1.0, "sigma": 0.5},
         },
         "sigma_freq": "8D",
         "draws": "7",
@@ -2067,6 +2217,76 @@ def test_run_rhime_multisector_rejects_duplicate_sanitized_sector_names() -> Non
         )
 
 
+def test_resolve_flux_sources_rejects_duplicates() -> None:
+    """Repeated retrieval identities are rejected before OpenGHG access."""
+    with pytest.raises(ValueError, match="duplicate source.*ff-inventory"):
+        resolve_flux_sources(flux_sources=["ff-inventory", "ff-inventory"])
+
+
+def test_run_rhime_multisector_rejects_duplicate_sector_source_mappings() -> None:
+    """Current independent sector states require distinct source sensitivities."""
+    with pytest.raises(ValueError, match="source 'ff-inventory'.*\\['FF', 'other'\\]"):
+        rhime_module._make_rhime_runner_setup(
+            params={
+                "species": "ch4",
+                "sites": ["TAC"],
+                "averaging_period": ["1h"],
+                "domain": "EUROPE",
+                "start_date": "2019-01-01",
+                "end_date": "2019-01-02",
+                "output_name": "test",
+                "output_format": "none",
+                "flux_sources": ["ff-inventory"],
+                "sector_sources": {
+                    "FF": "ff-inventory",
+                    "other": "ff-inventory",
+                },
+            },
+            multisector=True,
+        )
+
+
+@pytest.mark.parametrize(
+    ("sector_priors", "error_fragment"),
+    [
+        (
+            {"FF": {"pdf": "normal", "mu": 1.0, "sigma": 0.2}},
+            "missing sector prior\\(s\\): \\['ocean'\\]",
+        ),
+        (
+            {
+                "FF": {"pdf": "normal", "mu": 1.0, "sigma": 0.2},
+                "ocean": {"pdf": "normal", "mu": 1.0, "sigma": 0.3},
+                "oecam": {"pdf": "normal", "mu": 1.0, "sigma": 0.4},
+            },
+            "unused sector prior key\\(s\\): \\['oecam'\\]",
+        ),
+    ],
+)
+def test_run_rhime_multisector_rejects_inexact_sector_prior_keys(
+    sector_priors: dict[str, dict[str, Any]],
+    error_fragment: str,
+) -> None:
+    """Missing and unused sector prior keys fail before data preparation."""
+    with pytest.raises(ValueError, match=error_fragment):
+        rhime_module._make_rhime_runner_setup(
+            params={
+                "species": "ch4",
+                "sites": ["TAC"],
+                "averaging_period": ["1h"],
+                "domain": "EUROPE",
+                "start_date": "2019-01-01",
+                "end_date": "2019-01-02",
+                "output_name": "test",
+                "output_format": "none",
+                "flux_sources": ["ff-inventory", "ocean-inventory"],
+                "sector_sources": {"FF": "ff-inventory", "ocean": "ocean-inventory"},
+                "sector_priors": sector_priors,
+            },
+            multisector=True,
+        )
+
+
 def test_new_rhime_docs_use_flux_sources_for_examples() -> None:
     """New RHIME docs keep legacy names out of config/API examples."""
     rhime_doc = Path("docs/usage/rhime.rst").read_text(encoding="utf-8")
@@ -2145,6 +2365,117 @@ def test_rhime_prepared_inputs_contract_exposes_only_modern_fields() -> None:
         assert not hasattr(prepared, legacy_attr)
 
 
+def test_prepared_multisector_runner_rejects_ragged_source_specific_basis_layout() -> None:
+    """Prepared-input execution rejects padded state layouts before model construction."""
+    basis_ff = xr.DataArray(
+        [[0, 0], [1, 1]],
+        dims=("lat", "lon"),
+        coords={"lat": [0.0, 1.0], "lon": [0.0, 1.0]},
+    )
+    basis_ocean = xr.DataArray(
+        [[0, 1], [2, 2]],
+        dims=("lat", "lon"),
+        coords={"lat": [0.0, 1.0], "lon": [0.0, 1.0]},
+    )
+    flux = xr.DataArray(
+        np.ones((2, 2, 2)),
+        dims=("source", "lat", "lon"),
+        coords={
+            "source": ["ff-inventory", "ocean-inventory"],
+            "lat": [0.0, 1.0],
+            "lon": [0.0, 1.0],
+        },
+    )
+    basis_functions = BasisFunctions.from_multi_source_flat_basis(
+        basis_flat={"ff-inventory": basis_ff, "ocean-inventory": basis_ocean},
+        flux=flux,
+        operator_kwargs={"state_dim": "region"},
+    )
+    model_spec = RhimeModelSpec(
+        species="ch4",
+        domain="EUROPE",
+        sectors=(
+            SectorSpec("FF", "ff-inventory", {"pdf": "normal", "mu": 1.0, "sigma": 0.2}, "ff"),
+            SectorSpec(
+                "ocean",
+                "ocean-inventory",
+                {"pdf": "normal", "mu": 1.0, "sigma": 0.3},
+                "ocean",
+            ),
+        ),
+    )
+    inv_inputs = _minimal_output_inv_inputs().drop_dims("region")
+    inv_inputs["H"] = xr.DataArray(
+        np.ones((3, 1, 2)),
+        dims=("region", "nmeasure", "source"),
+        coords={
+            "region": [0, 1, 2],
+            "nmeasure": inv_inputs.coords["nmeasure"],
+            "source": ["ff-inventory", "ocean-inventory"],
+        },
+    )
+    prepared = RhimePreparedInputs(
+        inv_inputs=inv_inputs,
+        basis_functions=basis_functions,
+        sites=("TAC",),
+        averaging_period=("1H",),
+        basis_artifact_source="generated",
+    )
+    run_spec = RhimeRunSpec(
+        start_date="2019-01-01",
+        end_date="2019-01-02",
+        sites=("TAC",),
+        averaging_period=("1H",),
+        model=model_spec,
+        output=RhimeOutputSpec(output_format="none"),
+        split_by_sectors=True,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="prepared H has 3 regions.*sector 'FF' -> source 'ff-inventory': 2 regions.*"
+        "sector 'ocean' -> source 'ocean-inventory': 3 regions",
+    ):
+        run_rhime_from_prepared_inputs(prepared_inputs=prepared, run_spec=run_spec)
+
+
+def test_multisector_runner_rejects_shared_basis_h_layout_mismatch() -> None:
+    """Retained shared-basis coordinates must match the prepared design state."""
+    model_spec = RhimeModelSpec(
+        species="ch4",
+        domain="EUROPE",
+        sectors=(
+            SectorSpec("FF", "ff-inventory", {"pdf": "normal", "mu": 1.0, "sigma": 0.2}, "ff"),
+            SectorSpec(
+                "ocean",
+                "ocean-inventory",
+                {"pdf": "normal", "mu": 1.0, "sigma": 0.3},
+                "ocean",
+            ),
+        ),
+    )
+    inv_inputs = xr.Dataset(
+        {
+            "H": (
+                ("region", "nmeasure", "source"),
+                np.ones((2, 1, 2)),
+            )
+        },
+        coords={
+            "region": [0, 1],
+            "nmeasure": [0],
+            "source": ["ff-inventory", "ocean-inventory"],
+        },
+    )
+
+    with pytest.raises(ValueError, match="Retained shared basis.*basis has 1 elements.*H has 2"):
+        rhime_module._validate_multisector_basis_layout(
+            _fake_basis_functions(),
+            model_spec,
+            inv_inputs,
+        )
+
+
 def test_prepare_rhime_inputs_single_sector_reloads_merged_data(
     tac_ch4_data_args, merged_data_dir, merged_data_file_name, default_bc_basis_directory
 ) -> None:
@@ -2184,7 +2515,62 @@ def test_prepare_rhime_inputs_multisector_keeps_source_dimension(
     assert prepared.basis_artifact_source == "generated"
     assert isinstance(prepared.basis_functions, BasisFunctions)
     assert "source" in prepared.inv_inputs["H"].dims
-    assert set(prepared.inv_inputs["H"].coords["source"].values) == set(flux_sources)
+    assert list(prepared.inv_inputs["H"].coords["source"].values) == flux_sources
+    assert list(prepared.inv_inputs["H"].coords["source_region_count"].values) == [
+        prepared.inv_inputs.sizes["region"],
+        prepared.inv_inputs.sizes["region"],
+    ]
+
+
+def test_multisector_sensitivity_sources_fail_before_site_gathering() -> None:
+    """Gathered sensitivity is validated before missing sources can be synthesized."""
+    time = pd.date_range("2019-01-01", periods=2, freq="h")
+    state_index = pd.MultiIndex.from_tuples(
+        [("ff-inventory", 0)],
+        names=["source", "region_in_source"],
+    )
+    sensitivity = xr.DataArray(
+        np.ones((1, 2)),
+        dims=("state", "time"),
+        coords={
+            **xr.Coordinates.from_pandas_multiindex(state_index, "state"),
+            "time": time,
+        },
+    )
+    fp_x_flux = xr.DataArray(
+        np.ones((2, 2)),
+        dims=("time", "source"),
+        coords={
+            "time": time,
+            "source": ["ff-inventory", "ocean-inventory"],
+        },
+        name="fp_x_flux_sectoral",
+    )
+
+    class MissingSourceBasis:
+        def sensitivity(self, _: xr.DataArray) -> xr.DataArray:
+            return sensitivity
+
+    merged = prep_module._MergedInversionData(
+        fp_all={"TAC": xr.Dataset({"fp_x_flux_sectoral": fp_x_flux})},
+        sites=["TAC"],
+        averaging_period=["1H"],
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Site 'TAC'.*missing source\\(s\\): \\['ocean-inventory'\\]",
+    ):
+        prep_module._rhime_site_data_from_basis_functions(
+            merged=merged,
+            basis_functions=cast(BasisFunctions, MissingSourceBasis()),
+            domain="EUROPE",
+            split_by_sectors=True,
+            flux_sources=["ff-inventory", "ocean-inventory"],
+            use_bc=False,
+            bc_basis_case="NESW",
+            bc_basis_directory=None,
+        )
 
 
 def test_fixedbasis_preparation_adds_anchored_legacy_sigma_index(
@@ -4401,7 +4787,10 @@ def test_run_rhime_multisector_api_smoke(
             "chains": 1,
             "reload_merged_data": False,
             "output_format": "none",
-            "x_prior": {"pdf": "normal", "mu": 1.0, "sigma": 1.0},
+            "sector_priors": {
+                "FF": {"pdf": "uniform", "lower": 0.8, "upper": 1.0},
+                "ocean": {"pdf": "uniform", "lower": 1.1, "upper": 1.3},
+            },
             "bc_prior": {"pdf": "normal", "mu": 1.0, "sigma": 1.0},
             "sigma_prior": {"pdf": "uniform", "lower": 0.1, "upper": 10.0},
             "sample_kwargs": {"random_seed": 123, "compute_convergence_checks": False},
@@ -4416,6 +4805,16 @@ def test_run_rhime_multisector_api_smoke(
     assert not hasattr(result, "basis_objects")
     assert result.run_spec.split_by_sectors is True
     assert [sector.name for sector in result.model_spec.sectors] == ["FF", "ocean"]
+    assert result.model_spec.sectors[0].x_prior == {
+        "pdf": "uniform",
+        "lower": 0.8,
+        "upper": 1.0,
+    }
+    assert result.model_spec.sectors[1].x_prior == {
+        "pdf": "uniform",
+        "lower": 1.1,
+        "upper": 1.3,
+    }
     posterior = cast(Any, result.idata).posterior
     assert "x_ff" in posterior
     assert "x_ocean" in posterior


### PR DESCRIPTION
## Summary

- introduce a private state/forward-term plan and loop-sum compiler for RHIME flux contributions
- normalize both the standard and multisector builders through that shared strategy while preserving current public APIs and trace names
- validate state references, backend names, priors, coefficients, and coordinate compatibility before mutating the active PyMC graph
- route explicit `flux_sources`, sector-to-source mappings, variable suffixes, and complete per-sector priors through multisector configuration, preparation, model specifications, and runner execution
- support both rectangular shared-basis `H(..., source)` inputs and source-specific ragged state blocks gathered over `(source, region_in_source)`
- keep modern gathered layouts isolated from legacy compatibility: rectangular multisource adaptation occurs only at the `fixedbasisMCMC` boundary
- reconstruct multisector flux and scale-factor outputs using each sector's own state layout, including ragged `mode_kde` output
- add focused coverage for shared states, term arithmetic, reparameterized latents, validation, source routing, ragged layouts, structural padding versus genuine NaNs, sector priors, and the common builder seam
- document the concrete standard and multisector RHIME models, current PyMC names, prepared-input layouts, and equivalent construction from public components
- add the issues #402/#403 design note covering the longer path toward semantic model representation
- add the required unreleased changelog entry for the combined work

Closes #402.
Closes #403.

Related to #414, #509, #528, #532, and #533.

## Verification

- `.venv/bin/pytest -q tests/test_rhime.py tests/test_basis_functions.py tests/test_array_ops.py tests/test_inversion_inputs.py tests/postprocessing/test_make_outputs.py tests/postprocessing/test_stats.py tests/test_inferpymc.py tests/models/test_components.py` (301 passed, 1 deselected)
- changed-file `.venv/bin/ruff check` across all 16 Python files changed by this PR (passed)
- `.venv/bin/pyright` across all 11 changed production modules (0 errors)
- `git diff --check` (passed)
- `uv run sphinx-build -b html docs /tmp/openghg-inversions-docs-529-tracked` (build succeeds with 23 existing autodoc/OpenGHG compatibility warnings)
- `tox -p --parallel-no-spinner`: `py310-openghgCur` passed in the earlier PR run; the repository-wide `lint` environment remains blocked by the pre-existing Ruff backlog. The current changed-file Ruff check passes.

## Scope

This closes #403 for the current explicit one-source-per-sector multisector contract. Every modeled sector must be listed and, when `sector_priors` is supplied, every sector must have a prior. The current implementation deliberately does not add grouped multiple sources behind one state, fixed sectors, virtual total sectors, non-scalar or random term coefficients, a public semantic-model schema, whole-model namespace allocation, or custom model/likelihood builders. Those remain tracked design follow-ups in #528, #532, and #533.