### PR TITLE
Add compound topology and PyMC HMC sampler

### DIFF
--- a/docs/plans/rjmcmc_full_tiling_compound_hmc.md
+++ b/docs/plans/rjmcmc_full_tiling_compound_hmc.md
@@ -4,8 +4,18 @@
 
 The core sampler, dedicated durable checkpoint schema, native real-data
 driver, and HPC validation plan are implemented on
-`codex/rjmcmc-compound-hmc`. Focused local validation is complete; the next
-gate is the frozen-input HPC calibration and real-data screen.
+`codex/rjmcmc-compound-hmc`. The first frozen-input H2 attempt at `88b12a5`
+stopped correctly before its first transition: the fresh initializer's
+physical masses and the HMC log coordinates differed by 3--7 ULP. The strict
+boundary audit was retained. Fresh states are now deterministically rebuilt
+from authoritative log coordinates before draw 0, and focused local
+validation covers that failure. The next gate is a clean, commit-addressed
+repeat of H0 and H2 before the real-data screen.
+
+The failed-run evidence is retained under
+`/group/chem/acrg/brendan_for_codex/rjmcmc_full_tiling_pymc_hmc/88b12a5717d4b490b6ccd67986c20c2a99094fed`;
+its report SHA-256 is
+`27027ee2c4393ff8e1d399c5afe4d0b751ff9665956bf303aabc756086279a4d`.
 
 The fixed-basis reference experiments established that the local continuous
 kernel, rather than the Gamma root model itself, was the main fixed-topology
@@ -133,6 +143,23 @@ resume additionally requires the selected checkpoint to belong to a complete
 parent segment whose `complete.json` certifies the current hashes of its
 manifest, trace, summary, and checkpoint.
 
+A fresh initializer is a different boundary from a durable continuation. Its
+scientific state is constructed in positive physical coordinates, so before
+the first retained boundary it is mapped through the HMC log chart and fully
+rebuilt by the scientific state oracle until
+
+```text
+exp(log_leaf_mass) == leaf_mass
+exp(log_fixed_coefficient) == fixed_coefficient
+```
+
+bit for bit. This deterministic canonicalization changes only the binary64
+representation of the fresh starting point; it is not an MCMC transition and
+does not weaken the scientific target or audit tolerance. It is idempotent
+and does not mutate the caller's state. Durable continuations bypass it
+because their physical state and authoritative log coordinates are already
+joint replay inputs.
+
 Production sampling requires the actual hashed strict-JSON calibration file,
 not only a caller-supplied identifier. Its v1 schema binds the frozen input,
 target controls, \(K\), coordinate/metric identities, resolved static kernel,
@@ -160,6 +187,8 @@ match.
 - Frozen step size, position-scale diagonal, and leapfrog count.
 - Exact seeded replay.
 - Exact awkward-boundary sample/continue replay.
+- Exact, idempotent fresh-boundary log/exp canonicalization without mutating
+  the supplied initializer.
 - Fail-closed problem, \(K\), precision, settings, and checkpoint checks.
 
 ## Local validation completed
@@ -176,6 +205,9 @@ On 2026-07-25:
   strict no-pickle checkpoint reload, calibration mismatch rejection,
   certified-parent rejection, artifact failure injection, and trace reopen
   audits are covered;
+- a regression with deliberately non-roundtripping fresh leaf and fixed
+  values verifies exact draw-0 coordinates, oracle reconstruction, manifest
+  lineage, and checkpoint state;
 - the full repository tox matrix was intentionally not run; the agreed gate
   for this experimental track is the focused experimental suite.
 

--- a/docs/plans/rjmcmc_full_tiling_compound_hmc.md
+++ b/docs/plans/rjmcmc_full_tiling_compound_hmc.md
@@ -1,0 +1,204 @@
+# Full-tiling topology plus HMC
+
+## Status
+
+The core sampler, dedicated durable checkpoint schema, native real-data
+driver, and HPC validation plan are implemented on
+`codex/rjmcmc-compound-hmc`. Focused local validation is complete; the next
+gate is the frozen-input HPC calibration and real-data screen.
+
+The fixed-basis reference experiments established that the local continuous
+kernel, rather than the Gamma root model itself, was the main fixed-topology
+bottleneck:
+
+- fixed-basis local sampling gave root bulk ESS of about 31 at both
+  \(K=50\) and \(K=250\);
+- diagonal NumPyro NUTS raised root bulk ESS to 1,684 and 2,071 respectively;
+- dense NumPyro NUTS at \(K=50\) raised it to 6,114 with no divergences.
+
+The next experiment therefore composes the existing posterior-invariant
+fixed-\(K\) topology transition with a gradient transition over all continuous
+coordinates. It is a mixing experiment, not a claim that the structural
+problem has been solved.
+
+## Decision
+
+Use native PyMC's one-transition API:
+
+```text
+custom topology BlockedStep -> PyMC HamiltonianMC
+```
+
+inside a `pm.CompoundStep`. The topology step is always followed by the HMC
+step, including after an accepted topology proposal, a valid rejection, or an
+invalid structural self-transition. Conditioning whether HMC runs on the
+topology outcome would create a different state-dependent schedule without an
+invariance argument.
+
+The first implementation uses static HMC:
+
+- fixed step size;
+- fixed leapfrog count;
+- frozen topology-neutral diagonal PyMC position scale;
+- no retained-sampling adaptation;
+- no transfer of a dense leaf metric between tilings.
+
+This makes the kernel ordinary Markov-chain composition and keeps exact
+restart state small. Step-size and metric adaptation can be performed in a
+separate discarded calibration run, then frozen for production.
+
+## Continuous chart
+
+For canonical leaf order on topology \(\tau\), use
+
+\[
+x_i = \log m_i,\qquad y_j = \log c_j,
+\]
+
+where \(m_i\) is positive leaf mass and \(c_j\) is a positive fixed
+coefficient. Define
+
+\[
+L=\operatorname{logsumexp}(x),\qquad
+T=e^L,\qquad
+s_i=e^{x_i-L}.
+\]
+
+The scientific full-tiling target is defined in \((T,s,c)\) coordinates.
+The required transformation terms are
+
+\[
+\log |J_m| = \sum_i x_i-(K-1)L,\qquad
+\log |J_c| = \sum_j y_j.
+\]
+
+Thus the computational target is
+
+\[
+\log\pi(x,y,\tau)
+=
+\log\pi(T,s,c,\tau)
++\sum_i x_i-(K-1)L+\sum_j y_j.
+\]
+
+This symmetric chart avoids choosing a distinguished simplex reference leaf.
+A scalar leaf block in the PyMC position scale is invariant to permutations
+of canonical leaf positions. With `is_cov=True`, this diagonal is the
+quadratic kinetic-energy coefficient and hence momentum precision; sampled
+momentum has its reciprocal covariance. Fixed coefficients may use distinct
+diagonal entries because their identities do not change with topology.
+
+The PyMC model is compiled once. Topology-dependent design columns and
+Dirichlet shapes have fixed array shapes at fixed \(K\) and are supplied
+through mutable `pm.Data`. Accepted topology moves update those arrays before
+the HMC step; rejected and invalid moves leave them unchanged.
+
+## Structural transition
+
+The existing edge-flip/resolution-relocation implementation remains the
+authoritative topology kernel. It is evaluated and accepted in the existing
+scientific mass / root-share coordinates, including its proven proposal and
+Jacobian accounting. The transformed PyMC target must not be substituted into
+that Metropolis-Hastings calculation because that would omit or double-count
+coordinate Jacobians.
+
+After the topology decision:
+
+1. encode the accepted/current scientific masses as log masses;
+2. atomically install the corresponding design matrix and Dirichlet shapes;
+3. run exactly one PyMC HMC transition;
+4. decode the HMC endpoint;
+5. fully rebuild `FullTilingPosteriorState` as an independent cache and target
+   oracle.
+
+## Reproducibility and checkpointing
+
+The baseline uses one authoritative NumPy PCG64 stream. Each compound sweep
+uses it for the structural proposal and decision, then draws a seed used to
+reset all randomness in the PyMC HMC step. Because HMC adaptation is disabled
+and the metric is static, exact continuation requires:
+
+- current scientific state and topology;
+- exact PCG64 state;
+- compound sweeps completed;
+- fixed \(K\);
+- requested HMC step size and leapfrog count; the one-ULP-adjusted effective
+  value is a trace diagnostic rather than continuation state;
+- complete PyMC position-scale specification;
+- schedule, target, precision, and backend-version identity.
+
+Boundary-inclusive trace arrays retain the authoritative PyMC \(x\) and \(y\)
+coordinates directly; they are not reconstructed as `log(exp(x))`. Durable
+resume additionally requires the selected checkpoint to belong to a complete
+parent segment whose `complete.json` certifies the current hashes of its
+manifest, trace, summary, and checkpoint.
+
+Production sampling requires the actual hashed strict-JSON calibration file,
+not only a caller-supplied identifier. Its v1 schema binds the frozen input,
+target controls, \(K\), coordinate/metric identities, resolved static kernel,
+bounded pilot design, decision statistics, source artifact hashes, and code
+revision. The driver reports transformed-target preflight compilation,
+production-kernel setup/compilation, and transition execution separately so
+sampling throughput excludes compilation.
+
+The HMC object's iteration counter and internal RNG do not define the next
+scientific transition because its RNG is reset from the checkpointed PCG64
+stream before every HMC call. Any recorded diagnostic counter must still be
+derived from the global sweep coordinate so direct and resumed diagnostics
+match.
+
+## Required local checks
+
+- PyMC transformed target against
+  `FullTilingPosteriorState.log_target + log|J_m| + log|J_c|`.
+- Independent closed-form transformed density.
+- Gradient finite-difference checks on small problems.
+- Topology acceptance/rejection remains the existing scientific transition.
+- Accepted, rejected, and invalid topology attempts each invoke HMC once.
+- HMC never changes the tiling.
+- Full posterior rebuild agrees with every accepted HMC endpoint.
+- Frozen step size, position-scale diagonal, and leapfrog count.
+- Exact seeded replay.
+- Exact awkward-boundary sample/continue replay.
+- Fail-closed problem, \(K\), precision, settings, and checkpoint checks.
+
+## Local validation completed
+
+On 2026-07-25:
+
+- the integrated outer pytest invocation passed; PyMC-dependent cases marked
+  as skipped in the parent are executed and required to pass inside isolated
+  float64 child processes;
+- Ruff check and format-check passed on all new/changed implementation and
+  test files;
+- Pyright reported zero errors on the core, I/O, and native driver;
+- exact authoritative-coordinate replay, arbitrary-boundary continuation,
+  strict no-pickle checkpoint reload, calibration mismatch rejection,
+  certified-parent rejection, artifact failure injection, and trace reopen
+  audits are covered;
+- the full repository tox matrix was intentionally not run; the agreed gate
+  for this experimental track is the focused experimental suite.
+
+## Real-data question
+
+The first real-data screen should answer a narrow question:
+
+> Does replacing local root/pair/fixed updates by a joint gradient transition
+> remove the persistent likelihood start separation while topology remains
+> mobile?
+
+It should not initially be used to compare posterior summaries. Four
+overdispersed topology starts at each of \(K=50\) and \(K=250\) are needed,
+with the same frozen PARIS input and scientific target as the earlier
+fixed-basis control. Static HMC controls should be calibrated only on
+discarded fixed-topology runs, then frozen identically across the mobile
+chains at a given \(K\).
+
+## Deferred work
+
+- NUTS in the mobile compound kernel.
+- Online or topology-dependent metric adaptation.
+- Dense leaf metrics or leaf/fixed cross blocks.
+- Variable-\(K\) topology transitions.
+- A scientifically different multi-root prior.
+- Promotion out of the experimental namespace.

--- a/docs/plans/rjmcmc_full_tiling_compound_hmc.md
+++ b/docs/plans/rjmcmc_full_tiling_compound_hmc.md
@@ -4,18 +4,31 @@
 
 The core sampler, dedicated durable checkpoint schema, native real-data
 driver, and HPC validation plan are implemented on
-`codex/rjmcmc-compound-hmc`. The first frozen-input H2 attempt at `88b12a5`
-stopped correctly before its first transition: the fresh initializer's
-physical masses and the HMC log coordinates differed by 3--7 ULP. The strict
-boundary audit was retained. Fresh states are now deterministically rebuilt
-from authoritative log coordinates before draw 0, and focused local
-validation covers that failure. The next gate is a clean, commit-addressed
-repeat of H0 and H2 before the real-data screen.
+`codex/rjmcmc-compound-hmc`. Three frozen-input calibration attempts now
+separate representation correctness from metric generalization:
+
+- the first H2 attempt at `88b12a5` stopped before transition one because the
+  fresh physical state was not an exact log/exp replay boundary;
+- `fe9e546` fixed that defect without relaxing the audit;
+- the diagonal-metric H2 passed at \(K=50\) but had no admissible candidate at
+  \(K=250\);
+- the bounded H2b refinement selected
+  \(\epsilon=0.08409,L=5\), but a held-out \(K=250\) topology had acceptance
+  0.031 and 42 divergences.
+
+The diagonal H2b result is therefore a certified hard stop, not a prompt for
+further step-size refinement. The next experiment is H2c: a static,
+permutation-invariant two-eigenvalue leaf metric that separates the normalized
+common log-mass direction from centered log-mass contrasts.
 
 The failed-run evidence is retained under
 `/group/chem/acrg/brendan_for_codex/rjmcmc_full_tiling_pymc_hmc/88b12a5717d4b490b6ccd67986c20c2a99094fed`;
 its report SHA-256 is
 `27027ee2c4393ff8e1d399c5afe4d0b751ff9665956bf303aabc756086279a4d`.
+The corrected diagonal run and H2b hard-stop evidence are retained under
+`/group/chem/acrg/brendan_for_codex/rjmcmc_full_tiling_pymc_hmc/fe9e546ab57a6b0ff852057e0e6afa13725a5419`;
+the original H2 report SHA-256 is
+`b149c99ed48071b2fce6873603e4eb138915bf0005d0f8189fcbeefb3779dd5e`.
 
 The fixed-basis reference experiments established that the local continuous
 kernel, rather than the Gamma root model itself, was the main fixed-topology
@@ -45,13 +58,14 @@ invalid structural self-transition. Conditioning whether HMC runs on the
 topology outcome would create a different state-dependent schedule without an
 invariance argument.
 
-The first implementation uses static HMC:
+The H2c implementation still uses static HMC:
 
 - fixed step size;
 - fixed leapfrog count;
-- frozen topology-neutral diagonal PyMC position scale;
+- a frozen topology-neutral total/contrast leaf block;
+- an ordered diagonal block for fixed coefficients, with zero cross terms;
 - no retained-sampling adaptation;
-- no transfer of a dense leaf metric between tilings.
+- no leaf-identity-specific covariance transfer between tilings.
 
 This makes the kernel ordinary Markov-chain composition and keeps exact
 restart state small. Step-size and metric adaptation can be performed in a
@@ -92,11 +106,48 @@ Thus the computational target is
 \]
 
 This symmetric chart avoids choosing a distinguished simplex reference leaf.
-A scalar leaf block in the PyMC position scale is invariant to permutations
-of canonical leaf positions. With `is_cov=True`, this diagonal is the
-quadratic kinetic-energy coefficient and hence momentum precision; sampled
-momentum has its reciprocal covariance. Fixed coefficients may use distinct
-diagonal entries because their identities do not change with topology.
+Let
+
+\[
+P_1=\frac{\mathbf1\mathbf1^\mathsf T}{K},
+\qquad
+P_\perp=I-P_1.
+\]
+
+The H2c leaf position scale is
+
+\[
+G_{\rm leaf}
+=g_{\rm contrast}P_\perp+g_{\rm total}P_1.
+\]
+
+The binary64 implementation evaluates the equivalent stable form
+
+\[
+G_{\rm leaf}
+=g_{\rm contrast}I+(g_{\rm total}-g_{\rm contrast})P_1,
+\]
+
+so equal eigenscales reduce bit for bit to the legacy scalar identity at the
+production \(K\) values.
+
+It has eigenvalue \(g_{\rm total}\) along the normalized common direction
+\(\mathbf1/\sqrt K\), eigenvalue \(g_{\rm contrast}\) on every zero-sum
+contrast, and satisfies \(PG_{\rm leaf}P^\mathsf T=G_{\rm leaf}\) for every
+leaf permutation \(P\). It is therefore dense but topology-neutral; no leaf
+identity is transferred between tilings. Fixed coefficients retain distinct
+diagonal entries because their identities are stable, and leaf/fixed cross
+terms remain zero.
+
+With `is_cov=True`, PyMC uses the complete matrix \(G\) as the quadratic
+kinetic-energy coefficient:
+
+\[
+K(p)=\tfrac12p^\mathsf T Gp,\qquad p\sim N(0,G^{-1}).
+\]
+
+Thus the configured position scale is momentum precision, not momentum
+covariance.
 
 The PyMC model is compiled once. Topology-dependent design columns and
 Dirichlet shapes have fixed array shapes at fixed \(K\) and are supplied
@@ -161,12 +212,22 @@ because their physical state and authoritative log coordinates are already
 joint replay inputs.
 
 Production sampling requires the actual hashed strict-JSON calibration file,
-not only a caller-supplied identifier. Its v1 schema binds the frozen input,
+not only a caller-supplied identifier. Its v2 schema binds the frozen input,
 target controls, \(K\), coordinate/metric identities, resolved static kernel,
-bounded pilot design, decision statistics, source artifact hashes, and code
-revision. The driver reports transformed-target preflight compilation,
-production-kernel setup/compilation, and transition execution separately so
-sampling throughput excludes compilation.
+bounded development search, role-specific topology and master-PCG64 seeds,
+untouched held-out validation, source artifact hashes, and code revision.
+Development candidates use common random numbers within each topology;
+validation uses separate streams, and calibration topology seeds are disjoint
+from retained-production starts. The fixed-basis NUTS metric-source topology
+and all mobile calibration topologies are recorded by canonical hash; exact
+collisions are rejected independently of seed identity. Per-sweep
+post-structure/pre-HMC coordinates make the candidate score HMC-only rather
+than a mixture of structural and continuous displacement. Version-1 diagonal
+calibrations and checkpoints fail closed; they remain evidence for the earlier
+experiment, not continuation inputs for H2c. The driver reports
+transformed-target preflight compilation, production-kernel setup/compilation,
+and transition execution separately so sampling throughput excludes
+compilation.
 
 The HMC object's iteration counter and internal RNG do not define the next
 scientific transition because its RNG is reset from the checkpointed PCG64
@@ -184,7 +245,11 @@ match.
 - Accepted, rejected, and invalid topology attempts each invoke HMC once.
 - HMC never changes the tiling.
 - Full posterior rebuild agrees with every accepted HMC endpoint.
-- Frozen step size, position-scale diagonal, and leapfrog count.
+- Frozen step size, total/contrast position-scale matrix, and leapfrog count.
+- Exact total/contrast eigenvalues, block ordering, positive definiteness, and
+  invariance under arbitrary leaf permutations.
+- Per-sweep post-structure/pre-HMC log coordinates isolate HMC displacement
+  from structural remapping.
 - Exact seeded replay.
 - Exact awkward-boundary sample/continue replay.
 - Exact, idempotent fresh-boundary log/exp canonicalization without mutating
@@ -222,15 +287,18 @@ The first real-data screen should answer a narrow question:
 It should not initially be used to compare posterior summaries. Four
 overdispersed topology starts at each of \(K=50\) and \(K=250\) are needed,
 with the same frozen PARIS input and scientific target as the earlier
-fixed-basis control. Static HMC controls should be calibrated only on
-discarded fixed-topology runs, then frozen identically across the mobile
+fixed-basis control. The initial total/contrast metric may be estimated only
+from checksum-verified fixed-basis NUTS draws. Step size and path length are
+then calibrated on separate discarded mobile compound runs, including an
+untouched held-out topology, and frozen identically across retained mobile
 chains at a given \(K\).
 
 ## Deferred work
 
 - NUTS in the mobile compound kernel.
 - Online or topology-dependent metric adaptation.
-- Dense leaf metrics or leaf/fixed cross blocks.
+- Leaf-identity-specific metrics or leaf/fixed cross blocks.
+- Riemannian or topology-dependent HMC metrics.
 - Variable-\(K\) topology transitions.
 - A scientifically different multi-root prior.
 - Promotion out of the experimental namespace.

--- a/docs/plans/rjmcmc_full_tiling_pymc_hmc_hpc_test_plan.md
+++ b/docs/plans/rjmcmc_full_tiling_pymc_hmc_hpc_test_plan.md
@@ -1,0 +1,465 @@
+# Full-tiling PyMC HMC HPC test plan
+
+## Purpose
+
+Test whether a joint gradient transition removes the likelihood
+start-separation seen with the local continuous sampler while the fixed-\(K\)
+full-tiling topology remains mobile.
+
+The experimental sweep is:
+
+```text
+one edge-flip/resolution-relocation attempt
+-> one static PyMC HamiltonianMC transition
+```
+
+The HMC transition runs after every structural outcome, including rejection
+and an invalid self-transition. This experiment changes the transition kernel,
+not the scientific target.
+
+Do not use its posterior summaries unless the predeclared convergence gates
+pass.
+
+## Code and environment identity
+
+Before submission, resolve and record the pushed revision and the H2
+calibration artifact:
+
+```text
+branch: codex/rjmcmc-compound-hmc
+commit: $CODE_REVISION from git rev-parse HEAD after pull --ff-only
+calibration file: $CALIBRATION_FILE created beneath $RUN_ROOT/calibration
+calibration SHA-256: $CALIBRATION_SHA computed from the final file bytes
+```
+
+Use the exact reviewed Stage C input and archived comparison bundles:
+
+```bash
+export FROZEN_INPUT=/group/chem/acrg/brendan_for_codex/rjmcmc_gamma_beta_hpc/dd687b92abb86ce0080a1c8a713f3eb9a57df3aa/input/paris_may_2014_gamma_beta_native.nc
+export FROZEN_INPUT_ID=paris-may-2014-gamma-beta-native-v1
+export FROZEN_INPUT_SHA=24da69cab978051608313901b1c958200e0ad885a0a349bfa4fa1f9a0aaad044
+export OUTER_LABELS=intem_label_0,intem_label_1,intem_label_2,intem_label_3,intem_label_4,intem_label_5
+export WEIGHT_POLICY=spherical-grid-cell-area-v1
+export MOBILE_FIXED_COMPARISON_ROOT=/group/chem/acrg/brendan_for_codex/rjmcmc_fixed_basis_control/d1c673eb7eae4ee8bf18a15050898b4b6bb78d5c
+export EARLIER_MOBILE_SCREEN_ROOT=/group/chem/acrg/brendan_for_codex/rjmcmc_full_tiling_mixing/548fa41f1fef8b8cab93a6afe8717fdb562f689f
+export NUTS_REFERENCE_ROOT=/group/chem/acrg/brendan_for_codex/rjmcmc_fixed_basis_nuts/c5f908ce51eac452df2ea7f9db0cbf015fff8ef4
+```
+
+The scientific controls are fixed before calibration:
+
+- \(K=50,\kappa=100\) and \(K=250,\kappa=500\);
+- Gamma root mean one and variance 0.25, hence shape/rate \(4/4\);
+- likelihood power one;
+- six ordered InTEM outer coefficients with arithmetic lognormal mean/SD
+  \(1/1\);
+- normalized spherical-grid-cell-area nominal weights;
+- input variables `fp_x_flux`, `mf`, `mf_error`, `nominal_weight`,
+  `outer_design`, and fixed `YaprioriBC`;
+- the fixed-\(K\) construction-history-free tiling target restricted to the
+  communication component reachable from the recorded initializer.
+
+Before calibration, verify the checksum manifests under all archived roots.
+Write `preflight/target-identity.json` containing the archived and candidate
+values plus a Boolean equality flag for every item above, the frozen input
+digest, ordered outer labels, variable contract, initial topology digest, and
+scientific target normalization statement. A false or missing equality flag
+is a hard stop. Absolute fixed-\(K\) targets must not be compared across
+\(K=50\) and \(K=250\).
+
+Use one CPU per chain. Pin numerical libraries to one thread:
+
+```bash
+export OMP_NUM_THREADS=1
+export OPENBLAS_NUM_THREADS=1
+export MKL_NUM_THREADS=1
+export NUMEXPR_NUM_THREADS=1
+export PYTENSOR_FLAGS=floatX=float64
+```
+
+Record:
+
+- Python minor version;
+- NumPy, PyMC, and PyTensor versions;
+- PyTensor `floatX`;
+- platform and architecture;
+- Git revision and clean-worktree status;
+- frozen input path, size, and SHA-256;
+- calibration path and SHA-256.
+
+Use a commit-addressed run root and never reuse it after a source change:
+
+```bash
+export DRIVER=examples/rjmcmc/full_tiling_pymc_hmc_native.py
+export CODE_REVISION="$(git rev-parse HEAD)"
+export RUN_ROOT=/group/chem/acrg/brendan_for_codex/rjmcmc_full_tiling_pymc_hmc/"$CODE_REVISION"
+mkdir -p "$RUN_ROOT"/{preflight,calibration,restart,smoke,matrix,analysis,report}
+test -z "$(git status --porcelain)"
+```
+
+The native-PyTensor kernel is required. The PyMC NumPyro/JAX sampler bridge
+must not be used for this compound transition.
+
+## Stage H0: source and synthetic gates
+
+Run only the experimental checks, not the repository-wide tox matrix:
+
+```bash
+pytest -q \
+  tests/experimental/rjmcmc/test_full_tiling_pymc_hmc.py \
+  tests/experimental/rjmcmc/test_full_tiling_pymc_hmc_io.py \
+  tests/experimental/rjmcmc/test_full_tiling_pymc_hmc_native.py
+
+uv run ruff check \
+  openghg_inversions/experimental/rjmcmc/full_tiling_pymc_hmc.py \
+  openghg_inversions/experimental/rjmcmc/full_tiling_pymc_hmc_io.py \
+  examples/rjmcmc/full_tiling_pymc_hmc_native.py \
+  tests/experimental/rjmcmc/test_full_tiling_pymc_hmc.py \
+  tests/experimental/rjmcmc/test_full_tiling_pymc_hmc_io.py \
+  tests/experimental/rjmcmc/test_full_tiling_pymc_hmc_native.py
+
+uv run pyright \
+  openghg_inversions/experimental/rjmcmc/full_tiling_pymc_hmc.py \
+  openghg_inversions/experimental/rjmcmc/full_tiling_pymc_hmc_io.py \
+  examples/rjmcmc/full_tiling_pymc_hmc_native.py
+```
+
+Hard gates:
+
+- the compiled transformed density equals the independent scientific target
+  plus both declared chart Jacobians;
+- exact static position-scale/momentum-precision semantics reach PyMC;
+- accepted, rejected, and invalid structural attempts each produce one HMC
+  transition;
+- HMC leaves topology unchanged;
+- every endpoint closes through a full scientific state rebuild;
+- direct execution and awkward split continuation are byte-identical for all
+  non-timing state, trace, PCG64, HMC-seed, and checkpoint fields;
+- unrepresentable exponentiated coordinates are rejected by the PyMC target;
+- corrupted or incompatible durable checkpoints fail closed.
+
+Do not submit real-data jobs if any H0 gate fails.
+
+## Stage H1: real-input dry runs
+
+Execute Stage H2 first, because the production driver deliberately refuses
+even a dry run unless it can verify the final calibration artifact. H1 is
+numbered as an input/target gate but is submitted only after calibration.
+
+Use the same frozen reconstructed PARIS May 2014 input and target as the
+earlier full-tiling comparison:
+
+- 1,382 observations from 12 sites;
+- 23,424 native inner cells;
+- six inferred fixed InTEM outer coefficients;
+- fixed archived row-aligned boundary contribution;
+- Gamma(4, rate 4) root and globally additive Dirichlet allocation prior
+  with \(\kappa=2K\);
+- fixed \(K=50\) and \(K=250\);
+- likelihood power one;
+- outer arithmetic-lognormal mean/SD \(1/1\);
+- the exact normalization, variable contract, and outer-label order declared
+  above.
+
+Run no-output dry runs for the deterministic initializer and the three
+random-recursive initializers declared in Stage H5 at each \(K\). It must
+verify:
+
+- input SHA-256 before and after eager loading;
+- PARIS dimensions, outer labels, and closure;
+- finite scientific and transformed initial targets;
+- transformed-target parity;
+- all PyMC continuous value variables are float64;
+- resolved position-covariance diagonal, dimension, and coordinate ordering
+  from the verified calibration identity; H0 separately proves that this
+  exact ordering reaches PyMC's momentum precision;
+- initial topology and state fingerprints plus the canonical
+  `manifest_payload_sha256` that binds the complete input/model/sampler
+  identity.
+
+The repeated dry run for each random initializer must reproduce the exact
+topology and state fingerprints. The four starts at each \(K\) must have four
+distinct topology fingerprints. The dry run must also emit the values needed
+for `preflight/target-identity.json`.
+
+## Stage H2: bounded static-HMC calibration
+
+Calibration is discarded and must finish before retained mobile sampling.
+There is no online adaptation.
+
+The production driver requires an already selected calibration certificate,
+so do not fabricate decision statistics to run these pilots. Use a
+run-specific calibration harness that calls
+`sample_full_tiling_pymc_hmc()` with the same frozen-input adapter and target
+construction as the driver, writes only beneath `$RUN_ROOT/calibration`, and
+records its own source SHA-256, clean repository revision, input digest,
+resolved target, topology fingerprint, settings, trace, and runtime identity.
+Archive the harness source and hash it as one of
+`source_artifact_sha256` entries in the final calibration file. The HPC agent
+may debug this harness, but any harness change requires a new
+content-digest-addressed calibration subroot and complete repetition of H2;
+any repository source change requires a new commit-addressed run root.
+
+### Initial metric
+
+Use the checksum-verified fixed-basis NUTS reference draws at the same \(K\)
+and target:
+
+1. verify the NUTS bundle checksum manifest, then transform each retained
+   leaf mass and fixed coefficient to the compound
+   kernel's authoritative coordinates,
+   \(x_i=\log m_i\) and \(y_j=\log c_j\);
+2. define each robust variance as
+   \([1.4826\,\operatorname{median}|z-\operatorname{median}(z)|]^2\);
+3. use a single scalar leaf position scale equal to the median robust
+   variance over leaf coordinates;
+4. use one robust log-coordinate variance per fixed coefficient;
+5. clip every resolved position scale to \([10^{-4},10^2]\);
+6. set leaf/fixed cross terms to zero;
+7. record that PyMC uses this position scale as momentum precision, then write
+   the source artifact hashes, estimator, clipping rule, resolved diagonal,
+   and coordinate-layout ID to `calibration.json`.
+
+Do not transfer a dense leaf metric by canonical leaf position. Leaf identity
+changes with topology.
+
+### Step and path search
+
+For each \(K\):
+
+1. start at step size 0.1 with 10 leapfrog steps and halve the step size at
+   most eight times until both pilot topologies have finite states and zero
+   divergences;
+2. evaluate exactly the in-range members of
+   \(\{\epsilon/2,\epsilon,2\epsilon\}\times\{5,10,20\}\), where \(\epsilon\)
+   is the first zero-divergence halving result;
+3. use exactly 100 sweeps from the largest-nominal topology and 100 sweeps
+   from random-recursive initializer seed 51051 at \(K=50\), or 51251 at
+   \(K=250\), for every candidate;
+4. require mean HMC acceptance between 0.6 and 0.9 for every pilot topology;
+5. reject any candidate with a non-finite state, divergence, or acceptance
+   outside the band;
+6. choose the surviving candidate with greatest median Euclidean displacement
+   in log coordinates per reported leapfrog step, breaking ties first toward
+   fewer leapfrog steps and then toward the smaller step size.
+
+The calibration search is bounded before results are inspected. Do not widen
+it opportunistically. Hash the final calibration file and bind that digest
+into every production manifest.
+
+`calibration.json` must use exactly the driver-enforced v1 schema documented
+by `python "$DRIVER" --help` and the driver module docstring. Its root keys
+are `schema`, `calibration_id`, `fixed_k`, `input_sha256`, `target`, `kernel`,
+and `evidence`; extra keys are rejected. The exact `evidence` object contains
+the code revision, robust estimator, clipping bounds, two pilot
+strategy/seed/sweep records, candidate grid, one decision row per candidate,
+and a nonempty source-artifact SHA-256 map. The driver verifies file bytes,
+all target/kernel identities, one selected requested candidate, finite
+zero-divergence evidence, and both pilot acceptance means in the frozen band.
+Pass the actual file path and independently computed digest to the driver;
+caller-supplied ID or digest text is not sufficient.
+
+The strict schema intentionally does not claim to prove the search procedure
+from summary rows alone. Write a separate
+`calibration-search-audit.json` that records the two pilot topology
+fingerprints, clean-worktree check, initial epsilon and every halving result,
+the derived adjacent candidate grid, source NUTS paths and verified hashes,
+all raw per-topology diagnostics, the score ordering, and the declared
+tie-break calculation. Include the audit file and calibration-harness source
+hashes in `source_artifact_sha256`. An independent H2 analysis must recompute
+these fields and emit an all-true decision before H1/H3/H4/H5; the production
+driver enforces the selected candidate's identity and basic gates, while this
+external audit enforces bounded-search derivation and optimal selection.
+The H2 decision script must resolve every source-artifact ID to an immutable
+path recorded in the audit, recompute the file SHA-256, and require equality
+with `calibration.json["evidence"]["source_artifact_sha256"]`. In particular,
+the map must contain `calibration-search-audit`,
+`calibration-harness-source`, and the K-specific NUTS trace/checksum manifest.
+Write these path/hash/equality results to `calibration-source-audit.json` and
+require all true before any production-driver invocation.
+
+## Stage H3: exact real-input restart gate
+
+At both \(K=50\) and \(K=250\), run a short chain in two ways:
+
+```text
+direct:       N sweeps
+segmented:    a sweeps + fresh-process restart + (N-a) sweeps
+```
+
+Choose \(a\) so it is not half of \(N\). Recompile PyTensor in a fresh process
+for the resumed segment.
+
+Require exact equality for:
+
+- authoritative log leaf masses and log fixed coefficients;
+- decoded scientific masses and coefficients;
+- rectangle bounds;
+- every posterior cache and target component;
+- structural diagnostics;
+- HMC accepted/divergent/acceptance/energy-error/step-size/step-count fields;
+- per-sweep uint64 HMC seeds;
+- final PCG64 state;
+- final checkpoint arrays and metadata.
+
+Compilation and elapsed-time fields are explicitly excluded. Reject wrong
+input, manifest, \(K\), calibration digest, requested step size, leapfrog
+count, metric,
+schedule, coordinate layout, precision, and backend version.
+
+## Stage H4: execution smoke
+
+Run:
+
+- one 100-sweep chain at \(K=50\);
+- one 50-to-100-sweep chain at \(K=250\).
+
+Report separately:
+
+- input/setup time;
+- PyTensor compilation time;
+- sampling time;
+- sweeps/s;
+- leapfrog steps/s;
+- peak RSS;
+- structural validity and acceptance;
+- HMC acceptance and divergences;
+- energy-error quantiles;
+- likelihood and root displacement.
+
+Stop before the comparison matrix if throughput or memory makes the proposed
+budget infeasible, any divergence occurs, or acceptance leaves the calibrated
+band.
+
+For H1, H3, H4, and H5, the launcher must read the calibration ID and kernel
+fields from the verified JSON rather than transcribing them independently.
+The common production invocation is:
+
+```bash
+pixi run -e dev --frozen python "$DRIVER" \
+  --input "$FROZEN_INPUT" --output-directory "$OUTPUT" \
+  --k "$K" --sweeps "$SEGMENT_SWEEPS" \
+  --seed "$SAMPLER_SEED" --chain-id "k${K}-chain${CHAIN}" \
+  "${INITIALIZATION_ARGUMENTS[@]}" "${RESUME_ARGUMENTS[@]}" \
+  --step-size "$STEP_SIZE" --leapfrog-steps "$LEAPFROG_STEPS" \
+  --leaf-position-scale "$LEAF_POSITION_SCALE" \
+  --fixed-coefficient-position-scale "$FIXED_POSITION_SCALES" \
+  --calibration-file "$CALIBRATION_FILE" \
+  --calibration-id "$CALIBRATION_ID" \
+  --calibration-sha256 "$CALIBRATION_SHA" \
+  --concentration "$KAPPA" --root-variance 0.25 \
+  --likelihood-power 1 \
+  --fixed-prior-mean 1 --fixed-prior-sd 1 \
+  --input-id "$FROZEN_INPUT_ID" \
+  --expected-input-sha256 "$FROZEN_INPUT_SHA" \
+  --code-revision "$CODE_REVISION" \
+  --nominal-weight-policy "$WEIGHT_POLICY" \
+  --expected-outer-labels "$OUTER_LABELS" \
+  --require-paris-profile \
+  --input-netcdf-engine h5netcdf --netcdf-engine h5netcdf
+```
+
+Use `INITIALIZATION_ARGUMENTS=(--initialization largest-nominal)` for chain
+zero. For chains one through three use
+`--initialization random-recursive --initialization-seed <declared seed>`.
+Use an empty `RESUME_ARGUMENTS` array for a fresh segment and
+`--resume-checkpoint <certified parent bundle>/checkpoint.npz` thereafter.
+The driver must reject a parent whose sibling `complete.json` or any
+certificate hash is missing or stale.
+
+## Stage H5: real-data comparison
+
+For each \(K=50\) and \(K=250\):
+
+- four independently seeded chains;
+- exactly one largest-nominal and three random-recursive topology starts;
+- 2,500 compound sweeps per chain;
+- immutable 500-sweep segments;
+- discard the first 500 sweeps only during analysis;
+- retain every post-warmup sweep.
+
+This is 20,000 HMC sweeps total across both \(K\) values. Do not extend the
+chains until the planned analysis has been generated.
+
+Use the exact established topology and sampler streams:
+
+| \(K\) | chain | start | initialization seed | master sampler seed |
+|---:|---:|---|---:|---:|
+| 50 | 0 | largest-nominal | none | 61050 |
+| 50 | 1 | random-recursive | 51051 | 61051 |
+| 50 | 2 | random-recursive | 51052 | 61052 |
+| 50 | 3 | random-recursive | 51053 | 61053 |
+| 250 | 0 | largest-nominal | none | 61250 |
+| 250 | 1 | random-recursive | 51251 | 61251 |
+| 250 | 2 | random-recursive | 51252 | 61252 |
+| 250 | 3 | random-recursive | 51253 | 61253 |
+
+Every 500-sweep segment contains its boundary state. Before analysis, require
+the final state/checkpoint of segment \(j\) to equal the initial state of
+segment \(j+1\) exactly, concatenate all per-sweep diagnostics, and concatenate
+state traces after dropping draw zero from every segment after the first.
+Then remove states with global `state_sweep <= 500`; never remove 500 rows
+independently from every segment.
+
+The primary same-target control is the earlier mobile local sampler. The
+fixed-basis local and fixed-basis NUTS runs are conditional diagnostics, not
+direct mobile-posterior competitors. Reuse archived controls only when their
+input, prior, topology/\(K\), and model manifests match exactly.
+Select the `mobile` \(K=50\) and \(K=250\) cells beneath
+`$MOBILE_FIXED_COMPARISON_ROOT` as the primary control because those cells
+were run in the same checked matrix as the deterministic fixed-basis
+comparison. Record their exact bundle paths and artifact hashes in
+`analysis/control-identity.json`, and require every target-defining equality
+from `preflight/target-identity.json`. The separately pinned
+`$EARLIER_MOBILE_SCREEN_ROOT` is secondary continuity evidence only; do not
+silently substitute it or a fixed-basis cell for the declared primary
+comparison.
+
+## Diagnostics
+
+Common scientific coordinates:
+
+- log likelihood;
+- root total;
+- six outer coefficients;
+- the existing 24 predeclared native-field projections;
+- native-field between-chain distances.
+
+Sampler/structure coordinates:
+
+- structural validity and acceptance;
+- unique tilings;
+- edge-flip versus relocation outcomes;
+- HMC acceptance probability;
+- divergence count;
+- energy-error quantiles;
+- BFMI where the recorded energy sequence supports it;
+- step size and leapfrog count;
+- scientific displacement per sweep and per leapfrog step.
+
+Report rank-normalized split \(\hat R\), bulk and tail ESS, MCSE,
+ESS/sweep, ESS/leapfrog-step, ESS/wall-hour, CPU-hour, throughput, and peak
+RSS. A fixed leaf coordinate is not a valid mobile-chain convergence
+coordinate because its geometric meaning changes with topology.
+
+## Decision gates
+
+The mobile HMC result passes only if all of the following hold:
+
+- zero restart, hash, schema, or fail-closed errors;
+- finite retained scientific coordinates and target components;
+- zero HMC divergences;
+- mean HMC acceptance in 0.6--0.9 for every chain;
+- structural movement is accepted and more than one tiling is visited;
+- \(\hat R\le 1.01\), bulk ESS at least 400, and tail ESS at least 200 for
+  likelihood, root, all six outers, and all 24 projections;
+- BFMI at least 0.3 when evaluable;
+- no persistent start-separated likelihood band.
+
+If the continuous diagnostics pass but topology-sensitive likelihood bands
+remain separated, conclude that the continuous bottleneck was repaired but
+the topology kernel still mixes poorly. If HMC itself fails, revise the
+coordinate/metric/calibration scheme before drawing conclusions about the
+topology model.
+
+No output is written to `PARIS_inversions` unless all scientific convergence
+gates pass and a separate promotion decision is made.

--- a/docs/plans/rjmcmc_full_tiling_pymc_hmc_hpc_test_plan.md
+++ b/docs/plans/rjmcmc_full_tiling_pymc_hmc_hpc_test_plan.md
@@ -22,7 +22,7 @@ pass.
 
 ## Code and environment identity
 
-Before submission, resolve and record the pushed revision and the H2
+Before submission, resolve and record the pushed revision and the H2c
 calibration artifact:
 
 ```text
@@ -99,29 +99,36 @@ test -z "$(git status --porcelain)"
 The native-PyTensor kernel is required. The PyMC NumPyro/JAX sampler bridge
 must not be used for this compound transition.
 
-### Required rerun after the `88b12a5` boundary failure
+### Completed H2/H2b history and H2c boundary
 
 The first H2 attempt stopped at boundary draw 0, before any topology or HMC
 transition. The initializer's physical leaf masses failed the exact
 `exp(log(m)) == m` replay audit by 3--7 ULP. This was a real representation
-defect, not evidence about HMC calibration, and the exact audit must not be
-relaxed.
+defect, not evidence about HMC calibration, and the exact audit was not
+relaxed. Commit `fe9e546` corrected it.
 
-For the first revision containing the fix:
+The corrected diagonal H2 selected a valid \(K=50\) calibration but found no
+candidate satisfying both development topologies at \(K=250\). The separately
+predeclared H2b interior grid selected
+\(\epsilon=0.08409,L=5\); its untouched held-out random topology had
+acceptance 0.031 and 42 divergences over 500 discarded sweeps. H2b therefore
+stopped without a \(K=250\) calibration or production output.
 
-1. pull the pushed branch with `git pull --ff-only`, record the new revision,
-   require a clean worktree, and create a new commit-addressed `RUN_ROOT`;
-2. rerun H0, archived checksum verification, and
-   `preflight/target-identity.json` from source;
-3. rerun the complete bounded H2 search at both \(K=50\) and \(K=250\);
-4. do not copy calibration candidates, decisions, checkpoints, hashes, or
-   completion markers from the `88b12a5` run root;
-5. proceed to H1 and H3--H5 only after the new H2 hard gate passes.
+The immutable evidence is under
+`/group/chem/acrg/brendan_for_codex/rjmcmc_full_tiling_pymc_hmc/fe9e546ab57a6b0ff852057e0e6afa13725a5419`,
+including `report/H2B_RESULTS.md` and
+`calibration/H2B_HARD_STOP.json`. Preserve it unchanged.
+
+H2c changes the metric contract. The earlier \(K=50\) calibration remains
+valid evidence for commit `fe9e546`, but it is a version-1 diagonal
+calibration and cannot be used with the version-2 total/contrast driver.
+Both \(K\) values require new H2c calibration certificates before H1 or
+H3--H5.
 
 The agent may diagnose and repair run harnesses, Slurm scripts, module loads,
 and analysis scripts beneath the new run root. Preserve failed artifacts for
 provenance. A calibration-harness change requires a new
-content-digest-addressed calibration subroot and complete H2 repetition. A
+content-digest-addressed calibration subroot and complete H2c repetition. A
 repository-source change must be committed and pushed, and requires a new
 commit-addressed run root. Do not work around a gate by editing an artifact,
 loosening an exact comparison, or continuing from a failed checkpoint.
@@ -155,6 +162,11 @@ Hard gates:
 - the compiled transformed density equals the independent scientific target
   plus both declared chart Jacobians;
 - exact static position-scale/momentum-precision semantics reach PyMC;
+- the leaf block has the declared total and contrast eigenvalues, is
+  symmetric positive definite, and is invariant under arbitrary leaf
+  permutations;
+- the fixed block is exactly diagonal and all leaf/fixed cross terms are
+  exactly zero;
 - accepted, rejected, and invalid structural attempts each produce one HMC
   transition;
 - HMC leaves topology unchanged;
@@ -173,7 +185,7 @@ Do not submit real-data jobs if any H0 gate fails.
 
 ## Stage H1: real-input dry runs
 
-Execute Stage H2 first, because the production driver deliberately refuses
+Execute Stage H2c first, because the production driver deliberately refuses
 even a dry run unless it can verify the final calibration artifact. H1 is
 numbered as an input/target gate but is submitted only after calibration.
 
@@ -192,16 +204,15 @@ earlier full-tiling comparison:
 - the exact normalization, variable contract, and outer-label order declared
   above.
 
-Run no-output dry runs for the deterministic initializer and the three
-random-recursive initializers declared in Stage H5 at each \(K\). It must
-verify:
+Run no-output dry runs for the four random-recursive initializers declared in
+Stage H5 at each \(K\). It must verify:
 
 - input SHA-256 before and after eager loading;
 - PARIS dimensions, outer labels, and closure;
 - finite scientific and transformed initial targets;
 - transformed-target parity;
 - all PyMC continuous value variables are float64;
-- resolved position-covariance diagonal, dimension, and coordinate ordering
+- resolved position-covariance matrix, dimension, and coordinate ordering
   from the verified calibration identity; H0 separately proves that this
   exact ordering reaches PyMC's momentum precision;
 - initial topology and state fingerprints plus the canonical
@@ -210,10 +221,11 @@ verify:
 
 The repeated dry run for each random initializer must reproduce the exact
 topology and state fingerprints. The four starts at each \(K\) must have four
-distinct topology fingerprints. The dry run must also emit the values needed
-for `preflight/target-identity.json`.
+distinct topology fingerprints, and none may equal the calibration
+metric-source, development, or held-out topology hashes. The dry run must
+also emit the values needed for `preflight/target-identity.json`.
 
-## Stage H2: bounded static-HMC calibration
+## Stage H2c: bounded total/contrast static-HMC calibration
 
 Calibration is discarded and must finish before retained mobile sampling.
 There is no online adaptation.
@@ -228,31 +240,63 @@ resolved target, topology fingerprint, settings, trace, and runtime identity.
 Archive the harness source and hash it as one of
 `source_artifact_sha256` entries in the final calibration file. The HPC agent
 may debug this harness, but any harness change requires a new
-content-digest-addressed calibration subroot and complete repetition of H2;
+content-digest-addressed calibration subroot and complete repetition of H2c;
 any repository source change requires a new commit-addressed run root.
 
 ### Initial metric
 
-Use the checksum-verified fixed-basis NUTS reference draws at the same \(K\)
-and target:
+Use only checksum-verified, post-warmup fixed-basis NUTS draws at the same
+\(K\) and target. The archived NUTS reference uses the deterministic
+largest-nominal topology; record its canonical topology hash as the
+calibration metric source, and exclude that topology from H5. Let
+\(X_{di}=\log m_{di}\) and
+\(Y_{dj}=\log c_{dj}\). Define the normalized common coordinate and centered
+contrasts by
+
+\[
+z_d=\frac{1}{\sqrt K}\sum_i X_{di},
+\qquad
+R_{di}=X_{di}-\frac1K\sum_l X_{dl}.
+\]
+
+For any scalar series \(a\), define
+
+\[
+V_{\rm MAD}(a)
+=
+\left[1.4826\,\operatorname{median}
+|a-\operatorname{median}(a)|\right]^2.
+\]
+
+Construct the frozen metric as follows:
 
 1. verify the NUTS bundle checksum manifest, then transform each retained
-   leaf mass and fixed coefficient to the compound
-   kernel's authoritative coordinates,
-   \(x_i=\log m_i\) and \(y_j=\log c_j\);
-2. define each robust variance as
-   \([1.4826\,\operatorname{median}|z-\operatorname{median}(z)|]^2\);
-3. use a single scalar leaf position scale equal to the median robust
-   variance over leaf coordinates;
-4. use one robust log-coordinate variance per fixed coefficient;
-5. clip every resolved position scale to \([10^{-4},10^2]\);
-6. set leaf/fixed cross terms to zero;
-7. record that PyMC uses this position scale as momentum precision, then write
-   the source artifact hashes, estimator, clipping rule, resolved diagonal,
-   and coordinate-layout ID to `calibration.json`.
+   masses and fixed coefficients to \(X\) and \(Y\);
+2. set
+   \(g_{\rm total}=V_{\rm MAD}(z)\);
+3. set
+   \[
+   g_{\rm contrast}
+   =
+   \frac{\operatorname{median}_i V_{\rm MAD}(R_{\cdot i})}
+        {1-1/K};
+   \]
+4. set each fixed scale to \(V_{\rm MAD}(Y_{\cdot j})\);
+5. require every raw estimate to be finite and strictly positive before
+   clipping it independently to \([10^{-4},10^2]\);
+6. require
+   \(\max(g_{\rm total},g_{\rm contrast})/
+     \min(g_{\rm total},g_{\rm contrast})\le10^4\);
+7. assemble
+   \(G_{\rm leaf}=g_{\rm contrast}P_\perp+g_{\rm total}P_1\),
+   retain the fixed diagonal, and set leaf/fixed cross terms to zero;
+8. record raw and clipped values, clipping flags, source hashes, estimator ID
+   `normalized_common_and_centered_contrast_scaled_mad_v1`, normalized
+   direction, \(1-1/K\) correction, and coordinate-layout ID.
 
-Do not transfer a dense leaf metric by canonical leaf position. Leaf identity
-changes with topology.
+This dense leaf block is permitted because it is invariant under every leaf
+permutation. Do not transfer an arbitrary leaf-by-leaf covariance learned in
+one fixed basis.
 
 ### Step and path search
 
@@ -264,50 +308,112 @@ For each \(K\):
 2. evaluate exactly the in-range members of
    \(\{\epsilon/2,\epsilon,2\epsilon\}\times\{5,10,20\}\), where \(\epsilon\)
    is the first zero-divergence halving result;
-3. use exactly 100 sweeps from the largest-nominal topology and 100 sweeps
-   from random-recursive initializer seed 51051 at \(K=50\), or 51251 at
-   \(K=250\), for every candidate;
+3. use exactly 200 sweeps from each of two random-recursive development
+   topologies for every candidate, with the frozen topology/master-PCG64
+   seeds in the table below;
 4. require mean HMC acceptance between 0.6 and 0.9 for every pilot topology;
 5. reject any candidate with a non-finite state, divergence, or acceptance
    outside the band;
-6. choose the surviving candidate with greatest median Euclidean displacement
-   in log coordinates per reported leapfrog step, breaking ties first toward
-   fewer leapfrog steps and then toward the smaller step size.
+6. for each sweep, concatenate
+   `log_leaf_mass[post-HMC] - hmc_start_log_leaf_mass` and
+   `log_fixed_coefficient[post-HMC] -
+   hmc_start_log_fixed_coefficient`, then take its Euclidean norm; rejected
+   HMC transitions therefore contribute zero and accepted structural motion
+   contributes nothing;
+7. pool the 400 HMC-only displacement values from the two equally sized
+   development runs, divide each by the candidate's reported leapfrog count,
+   and choose the surviving candidate with greatest binary64 median;
+8. break an exactly equal score first toward fewer leapfrog steps and then
+   toward the smaller step size.
+
+The development identities are:
+
+| \(K\) | role | topology seed | master PCG64 seed |
+|---:|---|---:|---:|
+| 50 | development-a | 41050 | 71050 |
+| 50 | development-b | 41051 | 71051 |
+| 250 | development-a | 41250 | 71250 |
+| 250 | development-b | 41251 | 71251 |
+
+For each role, restart the same master PCG64 seed for every candidate. This is
+the frozen common-random-number policy for candidate comparison. Do not
+advance one shared stream sequentially across candidates, and do not choose
+new seeds after inspecting results.
+
+After selecting one candidate, freeze its metric and HMC controls and write a
+selection-lock hash before running validation. Validate exactly 500 discarded
+sweeps from each frozen topology/master-PCG64 pair:
+
+| \(K\) | role | topology seed | validation master PCG64 seed |
+|---:|---|---:|---:|
+| 50 | development-a | 41050 | 72050 |
+| 50 | development-b | 41051 | 72051 |
+| 50 | held-out | 41052 | 72052 |
+| 250 | development-a | 41250 | 72250 |
+| 250 | development-b | 41251 | 72251 |
+| 250 | held-out | 41252 | 72252 |
+
+All three must be finite, have zero divergences, and have mean HMC acceptance
+in \([0.6,0.9]\). Failure of the held-out topology is a hard stop: do not use
+its result to retune the metric, step size, path length, estimator, or gates.
+A new attempt requires a new predeclared metric or parameterization and a new
+content-addressed calibration root.
+
+All calibration topologies and master streams are disjoint from the H5
+retained-production starts. The deterministic largest-nominal topology is the
+fixed-basis NUTS metric source and is therefore calibration-exposed; it is not
+used by H5.
 
 The calibration search is bounded before results are inspected. Do not widen
 it opportunistically. Hash the final calibration file and bind that digest
 into every production manifest.
 
-`calibration.json` must use exactly the driver-enforced v1 schema documented
+`calibration.json` must use exactly the driver-enforced v2 schema documented
 by `python "$DRIVER" --help` and the driver module docstring. Its root keys
 are `schema`, `calibration_id`, `fixed_k`, `input_sha256`, `target`, `kernel`,
-and `evidence`; extra keys are rejected. The exact `evidence` object contains
-the code revision, robust estimator, clipping bounds, two pilot
-strategy/seed/sweep records, candidate grid, one decision row per candidate,
-and a nonempty source-artifact SHA-256 map. The driver verifies file bytes,
-all target/kernel identities, one selected requested candidate, finite
-zero-divergence evidence, and both pilot acceptance means in the frozen band.
-Pass the actual file path and independently computed digest to the driver;
-caller-supplied ID or digest text is not sufficient.
+and `evidence`; extra keys are rejected. The exact evidence binds the code
+revision, robust and leaf-metric estimator IDs, clipping bounds, two
+development initializer records including topology and master-PCG64 seeds,
+candidate grid, one decision row per candidate, the three-case 500-sweep
+selected validation with separate master seeds, and a nonempty source-artifact
+SHA-256 map. It also binds four distinct excluded topology hashes: the
+fixed-basis NUTS metric source, development-a, development-b, and held-out.
+The driver verifies file bytes, all target/kernel identities, role-specific
+seeds, the selected requested candidate, development gates, and all three
+validation gates. It rejects retained-production random-recursive starts that
+reuse a calibration topology seed or whose actual canonical topology hash
+collides with any excluded hash. Pass the actual file path and independently
+computed digest to the driver; caller-supplied ID or digest text is not
+sufficient.
 
-The strict schema intentionally does not claim to prove the search procedure
-from summary rows alone. Write a separate
-`calibration-search-audit.json` that records the two pilot topology
-fingerprints, clean-worktree check, initial epsilon and every halving result,
-the derived adjacent candidate grid, source NUTS paths and verified hashes,
-all raw per-topology diagnostics, the score ordering, and the declared
-tie-break calculation. Include the audit file and calibration-harness source
-hashes in `source_artifact_sha256`. An independent H2 analysis must recompute
-these fields and emit an all-true decision before H1/H3/H4/H5; the production
-driver enforces the selected candidate's identity and basic gates, while this
-external audit enforces bounded-search derivation and optimal selection.
-The H2 decision script must resolve every source-artifact ID to an immutable
+The strict schema intentionally does not claim to prove metric derivation or
+the search procedure from summary rows alone. Write a separate
+`calibration-search-audit.json` that records the metric projections and raw
+estimates, clipping and condition calculation, development and held-out
+topology fingerprints, topology/master seeds, the common-random-number
+policy, disjoint production/calibration topology sets, clean-worktree check,
+initial epsilon and every halving result, the derived adjacent candidate grid,
+source NUTS paths and verified hashes, all raw diagnostics, HMC-start and
+post-HMC coordinates used by the displacement score, the selection-lock hash,
+score pooling/order, and tie-break calculation. Include the audit file and
+calibration-harness source hashes in `source_artifact_sha256`. An independent
+H2c analysis must recompute these fields and emit an all-true decision before
+H1/H3/H4/H5; the production driver enforces the selected candidate and basic
+gates, while the external audit enforces metric derivation, bounded search,
+held-out isolation, common random numbers, and optimal selection. The H2c
+decision script must
+resolve every source-artifact ID to an immutable
 path recorded in the audit, recompute the file SHA-256, and require equality
 with `calibration.json["evidence"]["source_artifact_sha256"]`. In particular,
 the map must contain `calibration-search-audit`,
 `calibration-harness-source`, and the K-specific NUTS trace/checksum manifest.
 Write these path/hash/equality results to `calibration-source-audit.json` and
 require all true before any production-driver invocation.
+
+The audit must reconstruct and hash the fixed-basis NUTS source topology and
+all three mobile calibration topologies. Those exact four digests populate
+`excluded_production_topology_sha256`; seed inequality alone is not accepted
+as proof of topology disjointness.
 
 ## Stage H3: exact real-input restart gate
 
@@ -328,6 +434,7 @@ Require exact equality for:
 - rectangle bounds;
 - every posterior cache and target component;
 - structural diagnostics;
+- post-structure/pre-HMC authoritative log coordinates;
 - HMC accepted/divergent/acceptance/energy-error/step-size/step-count fields;
 - per-sweep uint64 HMC seeds;
 - final PCG64 state;
@@ -373,7 +480,8 @@ pixi run -e dev --frozen python "$DRIVER" \
   --seed "$SAMPLER_SEED" --chain-id "k${K}-chain${CHAIN}" \
   "${INITIALIZATION_ARGUMENTS[@]}" "${RESUME_ARGUMENTS[@]}" \
   --step-size "$STEP_SIZE" --leapfrog-steps "$LEAPFROG_STEPS" \
-  --leaf-position-scale "$LEAF_POSITION_SCALE" \
+  --leaf-contrast-position-scale "$LEAF_CONTRAST_POSITION_SCALE" \
+  --leaf-total-position-scale "$LEAF_TOTAL_POSITION_SCALE" \
   --fixed-coefficient-position-scale "$FIXED_POSITION_SCALES" \
   --calibration-file "$CALIBRATION_FILE" \
   --calibration-id "$CALIBRATION_ID" \
@@ -390,9 +498,9 @@ pixi run -e dev --frozen python "$DRIVER" \
   --input-netcdf-engine h5netcdf --netcdf-engine h5netcdf
 ```
 
-Use `INITIALIZATION_ARGUMENTS=(--initialization largest-nominal)` for chain
-zero. For chains one through three use
-`--initialization random-recursive --initialization-seed <declared seed>`.
+For every chain use
+`INITIALIZATION_ARGUMENTS=(--initialization random-recursive
+--initialization-seed <declared seed>)`.
 Use an empty `RESUME_ARGUMENTS` array for a fresh segment and
 `--resume-checkpoint <certified parent bundle>/checkpoint.npz` thereafter.
 The driver must reject a parent whose sibling `complete.json` or any
@@ -403,7 +511,7 @@ certificate hash is missing or stale.
 For each \(K=50\) and \(K=250\):
 
 - four independently seeded chains;
-- exactly one largest-nominal and three random-recursive topology starts;
+- four random-recursive topology starts disjoint from calibration;
 - 2,500 compound sweeps per chain;
 - immutable 500-sweep segments;
 - discard the first 500 sweeps only during analysis;
@@ -416,11 +524,11 @@ Use the exact established topology and sampler streams:
 
 | \(K\) | chain | start | initialization seed | master sampler seed |
 |---:|---:|---|---:|---:|
-| 50 | 0 | largest-nominal | none | 61050 |
+| 50 | 0 | random-recursive | 51050 | 61050 |
 | 50 | 1 | random-recursive | 51051 | 61051 |
 | 50 | 2 | random-recursive | 51052 | 61052 |
 | 50 | 3 | random-recursive | 51053 | 61053 |
-| 250 | 0 | largest-nominal | none | 61250 |
+| 250 | 0 | random-recursive | 51250 | 61250 |
 | 250 | 1 | random-recursive | 51251 | 61251 |
 | 250 | 2 | random-recursive | 51252 | 61252 |
 | 250 | 3 | random-recursive | 51253 | 61253 |

--- a/docs/plans/rjmcmc_full_tiling_pymc_hmc_hpc_test_plan.md
+++ b/docs/plans/rjmcmc_full_tiling_pymc_hmc_hpc_test_plan.md
@@ -99,6 +99,33 @@ test -z "$(git status --porcelain)"
 The native-PyTensor kernel is required. The PyMC NumPyro/JAX sampler bridge
 must not be used for this compound transition.
 
+### Required rerun after the `88b12a5` boundary failure
+
+The first H2 attempt stopped at boundary draw 0, before any topology or HMC
+transition. The initializer's physical leaf masses failed the exact
+`exp(log(m)) == m` replay audit by 3--7 ULP. This was a real representation
+defect, not evidence about HMC calibration, and the exact audit must not be
+relaxed.
+
+For the first revision containing the fix:
+
+1. pull the pushed branch with `git pull --ff-only`, record the new revision,
+   require a clean worktree, and create a new commit-addressed `RUN_ROOT`;
+2. rerun H0, archived checksum verification, and
+   `preflight/target-identity.json` from source;
+3. rerun the complete bounded H2 search at both \(K=50\) and \(K=250\);
+4. do not copy calibration candidates, decisions, checkpoints, hashes, or
+   completion markers from the `88b12a5` run root;
+5. proceed to H1 and H3--H5 only after the new H2 hard gate passes.
+
+The agent may diagnose and repair run harnesses, Slurm scripts, module loads,
+and analysis scripts beneath the new run root. Preserve failed artifacts for
+provenance. A calibration-harness change requires a new
+content-digest-addressed calibration subroot and complete H2 repetition. A
+repository-source change must be committed and pushed, and requires a new
+commit-addressed run root. Do not work around a gate by editing an artifact,
+loosening an exact comparison, or continuing from a failed checkpoint.
+
 ## Stage H0: source and synthetic gates
 
 Run only the experimental checks, not the repository-wide tox matrix:
@@ -132,6 +159,11 @@ Hard gates:
   transition;
 - HMC leaves topology unchanged;
 - every endpoint closes through a full scientific state rebuild;
+- fresh draw 0 is the canonical scientific boundary: physical leaf masses
+  and fixed coefficients equal the exponentials of the retained
+  authoritative log coordinates bit for bit, the manifest initial-state hash
+  equals the segment-start hash, and the draw-0 target equals both recorded
+  initial targets;
 - direct execution and awkward split continuation are byte-identical for all
   non-timing state, trace, PCG64, HMC-seed, and checkpoint fields;
 - unrepresentable exponentiated coordinates are rejected by the PyMC target;

--- a/examples/rjmcmc/full_tiling_pymc_hmc_native.py
+++ b/examples/rjmcmc/full_tiling_pymc_hmc_native.py
@@ -5,8 +5,10 @@ native Gamma--Dirichlet full-tiling problem without guessing scientific
 variables, and runs exactly one complete-sweep segment of the experimental
 structural-then-static-HMC kernel. Fresh chains may use the deterministic
 largest-nominal initializer or a separately seeded random-recursive topology.
-Resumed chains load the dedicated checksummed no-pickle checkpoint and retain
-the original immutable run manifest.
+Fresh states are canonicalized in the HMC log chart before preflight,
+fingerprinting, and sampling. Resumed chains load the dedicated checksummed
+no-pickle checkpoint, preserve its authoritative coordinates unchanged, and
+retain the original immutable run manifest.
 
 PyTensor must use float64. Before a dry run, fresh segment, or resumed segment,
 the compiled PyMC density is checked against the independently assembled
@@ -105,6 +107,9 @@ from typing import Any, Literal, cast
 import numpy as np
 import xarray as xr
 
+from openghg_inversions.experimental.rjmcmc import (
+    full_tiling_pymc_hmc as full_tiling_pymc_hmc_kernel,
+)
 from openghg_inversions.experimental.rjmcmc.full_tiling import (
     LeafTiling,
     Rectangle,
@@ -2233,6 +2238,10 @@ def _requested_kernel_settings(
 def run(arguments: argparse.Namespace) -> dict[str, Any]:
     """Validate, run, and publish one fresh or resumed complete-sweep segment.
 
+    A fresh initializer is canonicalized before closure, transformed-target
+    preflight, manifest construction, and sampling. A resume instead uses the
+    exact scientific/log-coordinate boundary stored in the checkpoint.
+
     Args:
         arguments: Namespace returned by :func:`build_parser`.
 
@@ -2292,6 +2301,14 @@ def run(arguments: argparse.Namespace) -> dict[str, Any]:
                 k=arguments.k,
                 seed=arguments.initialization_seed,
             )
+        (
+            initial_state,
+            initial_log_leaf_mass,
+            initial_log_fixed_coefficient,
+        ) = full_tiling_pymc_hmc_kernel.canonicalize_full_tiling_pymc_hmc_fresh_state(
+            problem,
+            initial_state,
+        )
         if not np.isfinite(initial_state.log_target):
             raise ValueError("Initial full-tiling log target is not finite.")
         closure = _closure_audit(
@@ -2326,6 +2343,8 @@ def run(arguments: argparse.Namespace) -> dict[str, Any]:
         initial_preflight = _transformed_target_preflight(
             problem,
             initial_state,
+            log_leaf_mass=initial_log_leaf_mass,
+            log_fixed_coefficient=initial_log_fixed_coefficient,
         )
         preflight_seconds = perf_counter() - preflight_started
         manifest = _build_manifest(

--- a/examples/rjmcmc/full_tiling_pymc_hmc_native.py
+++ b/examples/rjmcmc/full_tiling_pymc_hmc_native.py
@@ -1,0 +1,2512 @@
+"""Run or resume one static PyMC HMC mobile full-tiling data segment.
+
+The driver consumes one explicitly frozen NetCDF snapshot, constructs the
+native Gamma--Dirichlet full-tiling problem without guessing scientific
+variables, and runs exactly one complete-sweep segment of the experimental
+structural-then-static-HMC kernel. Fresh chains may use the deterministic
+largest-nominal initializer or a separately seeded random-recursive topology.
+Resumed chains load the dedicated checksummed no-pickle checkpoint and retain
+the original immutable run manifest.
+
+PyTensor must use float64. Before a dry run, fresh segment, or resumed segment,
+the compiled PyMC density is checked against the independently assembled
+scientific target plus the symmetric log-coordinate Jacobians. Static HMC
+settings are calibration outputs: no adaptation, online tuning, randomized
+step size, or topology-dependent metric is enabled here.
+
+``--calibration-file`` is a strict-JSON v1 calibration identity with exactly
+this shape (values shown symbolically):
+
+.. code-block:: json
+
+   {
+     "schema": "openghg_inversions.full_tiling_pymc_hmc_calibration.v1",
+     "calibration_id": "<--calibration-id>",
+     "fixed_k": "<--k>",
+     "input_sha256": "<--expected-input-sha256>",
+     "target": {
+       "concentration": "<--concentration>",
+       "root_variance": "<--root-variance>",
+       "likelihood_power": "<--likelihood-power>",
+       "fixed_prior_mean": ["<resolved fixed prior means>"],
+       "fixed_prior_sd": ["<resolved fixed prior SDs>"],
+       "nominal_weight_policy": "<--nominal-weight-policy>",
+       "normalize_weights": "<--normalize-weights>"
+     },
+     "kernel": {
+       "step_size": "<--step-size>",
+       "leapfrog_steps": "<--leapfrog-steps>",
+       "coordinate_layout_id": "<driver coordinate layout ID>",
+       "metric_semantics_id": "<driver metric semantics ID>",
+       "leaf_position_scale": "<--leaf-position-scale>",
+       "fixed_coefficient_position_scale": ["<resolved fixed scales>"]
+     },
+     "evidence": {
+       "code_revision": "<--code-revision>",
+       "robust_variance_estimator": "squared_scaled_median_absolute_deviation_1.4826",
+       "clipping_bounds": [0.0001, 100.0],
+       "pilot_initializers": [
+         {"strategy": "largest-nominal", "seed": null, "sweeps": 100},
+         {"strategy": "random-recursive", "seed": "<seed>", "sweeps": 100}
+       ],
+       "candidate_grid": [
+         {"step_size": "<candidate>", "leapfrog_steps": "<candidate>"}
+       ],
+       "decision_statistics": [
+         {
+           "step_size": "<candidate>",
+           "leapfrog_steps": "<candidate>",
+           "largest_nominal_mean_acceptance": "<finite value>",
+           "random_recursive_mean_acceptance": "<finite value>",
+           "divergences": "<non-negative integer>",
+           "finite": "<Boolean>",
+           "median_log_displacement_per_leapfrog_step": "<finite value>",
+           "selected": "<Boolean>"
+         }
+       ],
+       "source_artifact_sha256": {"<artifact ID>": "<SHA-256>"}
+     }
+   }
+
+The file must contain no additional keys, duplicate object keys, or non-finite
+JSON constants. Its bytes must match ``--calibration-sha256`` and every
+identity value must match the current invocation. Candidate rows and decision
+rows must correspond one-to-one; exactly one finite, zero-divergence decision
+must be selected, must match the requested kernel, and must have both pilot
+acceptance means in the inclusive interval 0.6--0.9. Production ``K=50`` and
+``K=250`` evidence additionally requires the reviewed random-recursive pilot
+seeds 51051 and 51251, respectively.
+
+Successful runs publish ``manifest.json``, ``trace.nc``, ``summary.json``, and
+``checkpoint.npz`` inside a new output directory. Every artifact is reopened
+and audited before ``complete.json`` is hash-certified and written last.
+Interrupted directories therefore cannot masquerade as complete results.
+``--dry-run`` performs input, closure, backend, manifest, and transformed
+target checks without creating the output directory. The driver refuses every
+output path beneath a directory whose name contains ``PARIS_inversions``.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict
+import errno
+from hashlib import sha256
+import json
+import math
+import os
+from pathlib import Path
+import tempfile
+from time import perf_counter
+from typing import Any, Literal, cast
+
+import numpy as np
+import xarray as xr
+
+from openghg_inversions.experimental.rjmcmc.full_tiling import (
+    LeafTiling,
+    Rectangle,
+    TilingState,
+)
+from openghg_inversions.experimental.rjmcmc.full_tiling_io import (
+    full_tiling_state_fingerprint,
+)
+from openghg_inversions.experimental.rjmcmc.full_tiling_posterior import (
+    FullTilingPosteriorState,
+    FullTilingProblem,
+    build_full_tiling_posterior_state,
+    full_tiling_problem_from_gamma_beta_adapter,
+    initialize_full_tiling_posterior_state,
+    initialize_random_full_tiling_posterior_state,
+)
+from openghg_inversions.experimental.rjmcmc.full_tiling_pymc_hmc import (
+    FULL_TILING_PYMC_HMC_COORDINATE_LAYOUT_ID,
+    FULL_TILING_PYMC_HMC_METRIC_SEMANTICS_ID,
+    FULL_TILING_PYMC_HMC_SCHEDULE_ID,
+    FullTilingPyMCHMCCheckpoint,
+    FullTilingPyMCHMCConfig,
+    FullTilingPyMCHMCKernelSettings,
+    FullTilingPyMCHMCSamplingResult,
+    build_full_tiling_pymc_hmc_model,
+    continue_full_tiling_pymc_hmc,
+    full_tiling_pymc_hmc_runtime_identity,
+    sample_full_tiling_pymc_hmc,
+)
+from openghg_inversions.experimental.rjmcmc.full_tiling_pymc_hmc_io import (
+    load_full_tiling_pymc_hmc_checkpoint,
+    save_full_tiling_pymc_hmc_checkpoint,
+)
+from openghg_inversions.experimental.rjmcmc.gamma_beta_adapter import (
+    GammaBetaRHIMEAdapterResult,
+    gamma_beta_problem_from_rhime_inputs,
+)
+
+NetCDFEngine = Literal["h5netcdf", "netcdf4", "scipy"]
+
+MANIFEST_FILENAME = "manifest.json"
+TRACE_FILENAME = "trace.nc"
+SUMMARY_FILENAME = "summary.json"
+CHECKPOINT_FILENAME = "checkpoint.npz"
+COMPLETION_FILENAME = "complete.json"
+CALIBRATION_SCHEMA = "openghg_inversions.full_tiling_pymc_hmc_calibration.v1"
+COMPLETION_SCHEMA = "openghg_inversions.full_tiling_pymc_hmc_native_completion.v1"
+ROBUST_VARIANCE_ESTIMATOR = "squared_scaled_median_absolute_deviation_1.4826"
+PARIS_OBSERVATIONS = 1_382
+PARIS_GRID_SHAPE = (183, 128)
+PARIS_OUTER_COEFFICIENTS = 6
+_CLOSURE_RTOL = 1.0e-12
+_CLOSURE_ATOL = 1.0e-12
+_TRANSFORMED_TARGET_ATOL = 5.0e-10
+_COMMUNICATION_COMPONENT = "component_reachable_from_recorded_initial_tiling"
+_BUNDLE_ARTIFACTS = (
+    MANIFEST_FILENAME,
+    TRACE_FILENAME,
+    SUMMARY_FILENAME,
+    CHECKPOINT_FILENAME,
+)
+
+
+def _sha256_file(path: Path) -> str:
+    """Return the SHA-256 digest of one regular file."""
+    digest = sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _canonical_json(value: object) -> str:
+    """Return deterministic strict JSON terminated by one newline."""
+    return (
+        json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        )
+        + "\n"
+    )
+
+
+def _reject_json_constant(value: str) -> None:
+    """Reject non-standard JSON constants such as NaN and Infinity."""
+    raise ValueError(f"Non-standard JSON constant {value!r} is forbidden.")
+
+
+def _strict_json_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Build one JSON object while rejecting duplicate member names."""
+    result: dict[str, Any] = {}
+    for name, value in pairs:
+        if name in result:
+            raise ValueError(f"Duplicate JSON object member {name!r} is forbidden.")
+        result[name] = value
+    return result
+
+
+def _load_strict_json_object(path: Path, *, description: str) -> dict[str, Any]:
+    """Load one UTF-8 strict-JSON file whose root must be an object.
+
+    Args:
+        path: JSON file to load.
+        description: Human-readable artifact name for validation errors.
+
+    Returns:
+        Parsed JSON object with duplicate keys and non-finite constants
+        rejected at every nesting level.
+
+    Raises:
+        FileNotFoundError: If ``path`` is not a regular file.
+        ValueError: If UTF-8 decoding, JSON parsing, or root-type validation
+            fails.
+        OSError: If the file cannot be read.
+    """
+    if not path.is_file():
+        raise FileNotFoundError(f"{description} is not a file: {path}")
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as error:
+        raise ValueError(f"{description} is not valid UTF-8.") from error
+    try:
+        parsed = json.loads(
+            text,
+            parse_constant=_reject_json_constant,
+            object_pairs_hook=_strict_json_object,
+        )
+    except json.JSONDecodeError as error:
+        raise ValueError(f"{description} is not valid strict JSON.") from error
+    if not isinstance(parsed, dict):
+        raise ValueError(f"{description} root must be a JSON object.")
+    return parsed
+
+
+def _fsync_directory(path: Path) -> None:
+    """Flush one directory entry where supported."""
+    unsupported = {
+        errno.EACCES,
+        errno.EBADF,
+        errno.EINVAL,
+        errno.EPERM,
+        getattr(errno, "ENOTSUP", errno.EINVAL),
+        getattr(errno, "EOPNOTSUPP", errno.EINVAL),
+    }
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as error:
+        if error.errno in unsupported:
+            return
+        raise
+    try:
+        try:
+            os.fsync(descriptor)
+        except OSError as error:
+            if error.errno not in unsupported:
+                raise
+    finally:
+        os.close(descriptor)
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    """Atomically write and flush one UTF-8 text artifact."""
+    temporary = path.with_name(f".{path.name}.tmp")
+    try:
+        with temporary.open("x", encoding="utf-8") as handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.link(temporary, path)
+        temporary.unlink()
+        _fsync_directory(path.parent)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _atomic_write_trace(
+    dataset: xr.Dataset,
+    path: Path,
+    *,
+    engine: NetCDFEngine,
+) -> None:
+    """Publish one create-only NetCDF trace through a same-directory link.
+
+    Args:
+        dataset: Fully materialized trace dataset to serialize. The dataset is
+            read but not closed or mutated.
+        path: Final artifact path, whose parent must already exist. An
+            existing target is never replaced.
+        engine: Explicit xarray NetCDF backend used for serialization.
+
+    Raises:
+        FileExistsError: If ``path`` already exists when the temporary file is
+            linked into place.
+        OSError: If temporary-file creation, serialization, flushing, linking,
+            cleanup, or directory synchronization fails.
+        ValueError: If ``dataset`` cannot be represented by ``engine``.
+
+    Notes:
+        Serialization occurs in a uniquely named sibling temporary file. The
+        file is flushed, linked create-only to ``path``, and followed by a
+        parent-directory sync; best-effort temporary cleanup runs on every
+        exit path.
+    """
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=path.parent,
+    )
+    os.close(descriptor)
+    temporary = Path(temporary_name)
+    temporary.unlink()
+    try:
+        dataset.to_netcdf(temporary, engine=engine)
+        with temporary.open("rb") as handle:
+            os.fsync(handle.fileno())
+        os.link(temporary, path)
+        temporary.unlink()
+        _fsync_directory(path.parent)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _preflight_output_backend(
+    parent: Path,
+    *,
+    engine: NetCDFEngine,
+) -> None:
+    """Verify exact trace-like NetCDF round trips on the output filesystem.
+
+    Args:
+        parent: Existing directory in which the temporary probe is written.
+        engine: Explicit xarray NetCDF backend to exercise.
+
+    Raises:
+        OSError: If the probe cannot be created, written, reopened, or removed.
+        RuntimeError: If float64, int64, uint64, or string values change during
+            the backend round trip.
+        ValueError: If the selected backend cannot serialize the probe.
+
+    Notes:
+        The probe exercises the dtypes required by production traces. It is
+        always removed and never creates the requested output directory.
+    """
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=".full-tiling-pymc-hmc-netcdf-preflight-",
+        suffix=".nc",
+        dir=parent,
+    )
+    os.close(descriptor)
+    temporary = Path(temporary_name)
+    temporary.unlink()
+    try:
+        probe = xr.Dataset(
+            {
+                "float64": ("item", np.asarray([1.0], dtype=np.float64)),
+                "int64": ("item", np.asarray([1], dtype=np.int64)),
+                "uint64": ("item", np.asarray([2**63 + 1], dtype=np.uint64)),
+                "string": ("item", np.asarray(["probe"], dtype=np.str_)),
+            }
+        )
+        probe.to_netcdf(temporary, engine=engine)
+        probe.close()
+        with xr.open_dataset(temporary, engine=engine) as reopened:
+            loaded = reopened.load()
+        try:
+            for name in ("float64", "int64", "uint64", "string"):
+                if not np.array_equal(
+                    np.asarray(loaded[name].values),
+                    np.asarray(probe[name].values),
+                ):
+                    raise RuntimeError(f"NetCDF backend preflight changed {name} data.")
+        finally:
+            loaded.close()
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _positive_values(value: str) -> float | tuple[float, ...]:
+    """Parse one scalar or comma-separated vector of positive floats."""
+    try:
+        values = tuple(float(item.strip()) for item in value.split(","))
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("expected a scalar or comma-separated floats") from error
+    if not values or any(not np.isfinite(item) or item <= 0.0 for item in values):
+        raise argparse.ArgumentTypeError("all values must be finite and strictly positive")
+    return values[0] if len(values) == 1 else values
+
+
+def _comma_separated_labels(value: str) -> tuple[str, ...]:
+    """Parse a nonempty comma-separated sequence of unique labels."""
+    labels = tuple(item.strip() for item in value.split(","))
+    if not labels or any(not label for label in labels):
+        raise argparse.ArgumentTypeError("labels must be nonempty")
+    if len(set(labels)) != len(labels):
+        raise argparse.ArgumentTypeError("labels must be unique")
+    return labels
+
+
+def _expand_values(
+    values: float | tuple[float, ...],
+    *,
+    size: int,
+    name: str,
+) -> tuple[float, ...]:
+    """Broadcast one positive scalar or validate one exact-width vector."""
+    if not isinstance(values, tuple):
+        return (float(values),) * size
+    if len(values) != size:
+        raise ValueError(f"{name} must be scalar or contain exactly {size} values.")
+    return values
+
+
+def _validate_sha256(value: str, *, name: str) -> None:
+    """Require one lower- or upper-case hexadecimal SHA-256 string."""
+    if len(value) != 64 or any(character not in "0123456789abcdefABCDEF" for character in value):
+        raise ValueError(f"{name} must be exactly 64 hexadecimal characters.")
+
+
+def _load_frozen_dataset(path: Path, *, engine: NetCDFEngine) -> xr.Dataset:
+    """Eagerly load and close one immutable-on-entry NetCDF input."""
+    if not path.is_file():
+        raise FileNotFoundError(f"Frozen input is not a file: {path}")
+    with xr.open_dataset(path, engine=engine) as opened:
+        return opened.load()
+
+
+def _input_array(dataset: xr.Dataset, name: str) -> xr.DataArray:
+    """Return one explicitly named data variable."""
+    if name not in dataset.data_vars:
+        raise ValueError(f"Frozen input is missing required data variable {name!r}.")
+    return dataset[name]
+
+
+def _dimension_labels(dataset: xr.Dataset, dimension: str) -> np.ndarray:
+    """Return stable string labels for one dimension."""
+    if dimension in dataset.coords:
+        values = np.asarray(dataset.coords[dimension].values)
+    else:
+        values = np.arange(dataset.sizes[dimension], dtype=np.int64)
+    return np.asarray(
+        [str(value) for value in values.tolist()],
+        dtype=np.str_,
+    )
+
+
+def _build_adapter(
+    dataset: xr.Dataset,
+    arguments: argparse.Namespace,
+) -> GammaBetaRHIMEAdapterResult:
+    """Build a fixed-``K`` Gamma--Beta adapter from explicit CLI controls.
+
+    Args:
+        dataset: Eagerly loaded frozen native input dataset.
+        arguments: Validated CLI namespace naming every scientific input
+            variable and supplying target, weight, and fixed-prior controls.
+
+    Returns:
+        Adapter result whose problem, spatial metadata, and normalization
+        factor are derived from ``dataset`` without variable-name inference.
+
+    Raises:
+        ValueError: If a required variable is absent, the fixed design is not
+            two-dimensional with ``nmeasure``, scalar/vector priors cannot be
+            resolved to the fixed-block width, or adapter scientific
+            validation fails.
+    """
+    fixed_design = _input_array(dataset, arguments.fixed_design_name)
+    if fixed_design.ndim != 2 or "nmeasure" not in fixed_design.dims:
+        raise ValueError(
+            f"{arguments.fixed_design_name!r} must have dimensions ('nmeasure', <fixed coefficient>)."
+        )
+    fixed_dimension = next(dimension for dimension in fixed_design.dims if dimension != "nmeasure")
+    n_fixed = int(fixed_design.sizes[fixed_dimension])
+    fixed_mean = _expand_values(
+        arguments.fixed_prior_mean,
+        size=n_fixed,
+        name="fixed_prior_mean",
+    )
+    fixed_sd = _expand_values(
+        arguments.fixed_prior_sd,
+        size=n_fixed,
+        name="fixed_prior_sd",
+    )
+    return gamma_beta_problem_from_rhime_inputs(
+        dataset,
+        nominal_weight=_input_array(
+            dataset,
+            arguments.nominal_weight_name,
+        ),
+        k_min=arguments.k,
+        k_max=arguments.k,
+        concentration=arguments.concentration,
+        root_variance=arguments.root_variance,
+        normalize_weights=arguments.normalize_weights,
+        likelihood_power=arguments.likelihood_power,
+        sensitivity_name=arguments.sensitivity_name,
+        observation_name=arguments.observation_name,
+        observation_sd_name=arguments.observation_sd_name,
+        fixed_design_name=arguments.fixed_design_name,
+        fixed_offset_name=arguments.fixed_offset_name,
+        fixed_coefficient_prior_mean=fixed_mean,
+        fixed_coefficient_prior_sd=fixed_sd,
+    )
+
+
+def _require_paris_profile(
+    dataset: xr.Dataset,
+    adapter: GammaBetaRHIMEAdapterResult,
+    *,
+    fixed_design_name: str,
+    expected_outer_labels: tuple[str, ...],
+) -> None:
+    """Require the exact reviewed modern PARIS dimensions and labels.
+
+    Args:
+        dataset: Frozen dataset containing fixed-design and coordinate labels.
+        adapter: Scientific adapter whose observation, grid, and fixed-block
+            dimensions are checked.
+        fixed_design_name: Explicit fixed-design variable name.
+        expected_outer_labels: Reviewed six-label sequence in model order.
+
+    Raises:
+        KeyError: If the fixed design or a required dimension is absent.
+        ValueError: If observation count, grid shape, fixed-block width,
+            dimension names, outer-label order, or unique observation labels
+            differ from the reviewed profile.
+    """
+    actual = (
+        int(adapter.problem.observations.size),
+        adapter.spatial_shape,
+        adapter.problem.n_fixed_coefficients,
+    )
+    expected = (
+        PARIS_OBSERVATIONS,
+        PARIS_GRID_SHAPE,
+        PARIS_OUTER_COEFFICIENTS,
+    )
+    if actual != expected:
+        raise ValueError(
+            "--require-paris-profile expected "
+            f"{expected[0]} observations, grid {expected[1]}, and "
+            f"{expected[2]} fixed coefficients; found {actual}."
+        )
+    fixed_design = dataset[fixed_design_name]
+    if set(fixed_design.dims) != {"nmeasure", "outer_region"}:
+        raise ValueError(
+            "--require-paris-profile requires fixed design dimensions 'nmeasure' and 'outer_region'."
+        )
+    if len(expected_outer_labels) != PARIS_OUTER_COEFFICIENTS:
+        raise ValueError("--expected-outer-labels must contain exactly six reviewed labels.")
+    actual_labels = tuple(_dimension_labels(dataset, "outer_region").astype(str).tolist())
+    if actual_labels != expected_outer_labels:
+        raise ValueError("Frozen outer_region labels/order do not match --expected-outer-labels.")
+    if "nmeasure" not in dataset.coords:
+        raise ValueError("--require-paris-profile requires explicit nmeasure labels.")
+    labels = _dimension_labels(dataset, "nmeasure").astype(str).tolist()
+    if len(set(labels)) != PARIS_OBSERVATIONS:
+        raise ValueError("--require-paris-profile requires unique nmeasure labels.")
+
+
+def _closure_audit(
+    dataset: xr.Dataset,
+    adapter: GammaBetaRHIMEAdapterResult,
+    *,
+    initial_state: FullTilingPosteriorState,
+    sensitivity_name: str,
+    fixed_design_name: str,
+    fixed_offset_name: str,
+) -> dict[str, float]:
+    """Verify mass-coordinate and complete prior-mean prediction closure.
+
+    Args:
+        dataset: Frozen dataset containing raw sensitivity, fixed design, and
+            fixed offset arrays.
+        adapter: Adapted Gamma--Beta problem whose mass-coordinate sensitivity
+            and fixed prior are audited.
+        initial_state: Prior-mean initialized scientific state.
+        sensitivity_name: Raw gridded sensitivity variable name.
+        fixed_design_name: Fixed coefficient design variable name.
+        fixed_offset_name: Always-active observation-offset variable name.
+
+    Returns:
+        Maximum absolute mass-coordinate and complete prior-mean prediction
+        errors, both computed in observation space.
+
+    Raises:
+        KeyError: If a named input variable or required dimension is absent.
+        ValueError: If array dimensions are incompatible or either closure
+            comparison exceeds the frozen relative/absolute tolerances.
+        RuntimeError: If the adapted problem lacks required fixed design or
+            offset terms.
+    """
+    problem = adapter.problem
+    sensitivity = dataset[sensitivity_name].transpose(
+        "nmeasure",
+        "lat",
+        "lon",
+    )
+    scaling_prediction = np.asarray(
+        sensitivity.values,
+        dtype=np.float64,
+    ).sum(axis=(1, 2))
+    mass_prediction = problem.sensitivity @ problem.prior.nominal_cell_mass
+    mass_error = np.asarray(
+        mass_prediction - scaling_prediction,
+        dtype=np.float64,
+    )
+    if not np.allclose(
+        mass_prediction,
+        scaling_prediction,
+        rtol=_CLOSURE_RTOL,
+        atol=_CLOSURE_ATOL,
+    ):
+        raise ValueError(
+            "Mass-coordinate closure failed: sensitivity_per_mass @ "
+            "nominal_weight does not reproduce the all-one fp_x_flux "
+            "prediction."
+        )
+    if problem.fixed_block is None or problem.fixed_offset is None:
+        raise RuntimeError("The native PyMC HMC driver requires fixed design and offset terms.")
+    fixed_design = dataset[fixed_design_name]
+    fixed_dimension = next(dimension for dimension in fixed_design.dims if dimension != "nmeasure")
+    fixed_values = np.asarray(
+        fixed_design.transpose("nmeasure", fixed_dimension).values,
+        dtype=np.float64,
+    )
+    offset = np.asarray(
+        dataset[fixed_offset_name].transpose("nmeasure").values,
+        dtype=np.float64,
+    )
+    expected_total = offset + scaling_prediction + fixed_values @ problem.fixed_block.coefficient_prior_mean
+    total_error = np.asarray(
+        initial_state.prediction - expected_total,
+        dtype=np.float64,
+    )
+    if not np.allclose(
+        initial_state.prediction,
+        expected_total,
+        rtol=_CLOSURE_RTOL,
+        atol=_CLOSURE_ATOL,
+    ):
+        raise ValueError(
+            "Prior-mean closure failed against raw fp_x_flux, fixed boundary "
+            "offset, and all fixed-coefficient prior means."
+        )
+    return {
+        "mass_coordinate_max_abs_error": float(np.max(np.abs(mass_error), initial=0.0)),
+        "prior_mean_total_max_abs_error": float(np.max(np.abs(total_error), initial=0.0)),
+    }
+
+
+def _rectangle_bounds(state: FullTilingPosteriorState) -> list[list[int]]:
+    """Return canonical rectangle bounds as strict-JSON integers."""
+    return [
+        [
+            leaf.row_start,
+            leaf.row_stop,
+            leaf.col_start,
+            leaf.col_stop,
+        ]
+        for leaf in state.tiling_state.tiling.leaves
+    ]
+
+
+def _topology_sha256(bounds: list[list[int]]) -> str:
+    """Hash canonical rectangle bounds independently of sampler output."""
+    return sha256(_canonical_json(bounds).encode("utf-8")).hexdigest()
+
+
+def _input_contract(arguments: argparse.Namespace) -> dict[str, object]:
+    """Return the complete explicit scientific input-variable contract."""
+    return {
+        "sensitivity": arguments.sensitivity_name,
+        "observation": arguments.observation_name,
+        "observation_sd": arguments.observation_sd_name,
+        "nominal_weight": arguments.nominal_weight_name,
+        "fixed_design": arguments.fixed_design_name,
+        "fixed_offset": arguments.fixed_offset_name,
+        "normalize_weights": bool(arguments.normalize_weights),
+        "nominal_weight_policy": arguments.nominal_weight_policy,
+    }
+
+
+def _transformed_target_preflight(
+    problem: FullTilingProblem,
+    state: FullTilingPosteriorState,
+    *,
+    log_leaf_mass: np.ndarray | None = None,
+    log_fixed_coefficient: np.ndarray | None = None,
+) -> dict[str, float]:
+    """Compare compiled PyMC logp with the exact transformed target.
+
+    Args:
+        problem: Scientific problem owning ``state``.
+        state: Supported scientific state to audit.
+        log_leaf_mass: Optional authoritative symmetric leaf coordinates.
+        log_fixed_coefficient: Optional authoritative fixed coordinates.
+
+    Returns:
+        Strict-JSON-compatible compiled, expected, Jacobian, difference, and
+        tolerance values.
+
+    Raises:
+        ValueError: If coordinates do not exactly decode to ``state`` or the
+            compiled target differs beyond the float64 audit tolerance.
+        ImportError: If PyMC or PyTensor is unavailable.
+        RuntimeError: If PyTensor is not configured for float64.
+    """
+    runtime = full_tiling_pymc_hmc_runtime_identity()
+    if runtime.pytensor_float_x != "float64":
+        raise RuntimeError("PyTensor floatX must be exactly float64.")
+    x = (
+        np.asarray(log_leaf_mass, dtype=np.float64)
+        if log_leaf_mass is not None
+        else np.log(state.leaf_masses)
+    )
+    y = (
+        np.asarray(log_fixed_coefficient, dtype=np.float64)
+        if log_fixed_coefficient is not None
+        else np.log(state.fixed_coefficients)
+    )
+    if x.shape != state.leaf_masses.shape or y.shape != state.fixed_coefficients.shape:
+        raise ValueError("Transformed-target preflight coordinates have invalid shapes.")
+    if (
+        np.any(~np.isfinite(x))
+        or np.any(~np.isfinite(y))
+        or not np.array_equal(np.exp(x), state.leaf_masses)
+        or not np.array_equal(np.exp(y), state.fixed_coefficients)
+    ):
+        raise ValueError(
+            "Transformed-target preflight coordinates do not exactly decode to the scientific state."
+        )
+    model = build_full_tiling_pymc_hmc_model(problem, state)
+    point = model.initial_point()
+    point["x"] = np.array(x, copy=True)
+    if state.fixed_coefficients.size:
+        point["y"] = np.array(y, copy=True)
+    compiled = float(model.compile_logp()(point))
+    log_total = float(np.logaddexp.reduce(x))
+    leaf_jacobian = float(x.sum() - (state.k - 1) * log_total)
+    fixed_jacobian = float(y.sum())
+    expected = float(state.log_target + leaf_jacobian + fixed_jacobian)
+    difference = float(compiled - expected)
+    tolerance = float(
+        max(
+            _TRANSFORMED_TARGET_ATOL,
+            128.0 * np.finfo(np.float64).eps * max(1.0, abs(compiled), abs(expected)),
+        )
+    )
+    if not math.isfinite(compiled) or not math.isfinite(expected) or abs(difference) > tolerance:
+        raise ValueError(
+            "Compiled PyMC transformed target does not match the exact "
+            f"scientific target plus Jacobians: difference={difference:.17g}, "
+            f"tolerance={tolerance:.17g}."
+        )
+    return {
+        "compiled_logp": compiled,
+        "scientific_log_target": float(state.log_target),
+        "leaf_log_coordinate_jacobian": leaf_jacobian,
+        "fixed_log_coordinate_jacobian": fixed_jacobian,
+        "expected_transformed_logp": expected,
+        "difference": difference,
+        "absolute_tolerance": tolerance,
+    }
+
+
+def _build_manifest(
+    arguments: argparse.Namespace,
+    adapter: GammaBetaRHIMEAdapterResult,
+    *,
+    initial_state: FullTilingPosteriorState,
+    input_digest: str,
+    outer_labels: np.ndarray,
+    fixed_position_scales: tuple[float, ...],
+    calibration: Mapping[str, Any],
+    calibration_digest: str,
+) -> dict[str, object]:
+    """Build immutable checkpoint identity independent of segment reporting.
+
+    The manifest intentionally excludes segment length, output paths, wall
+    timings, and parent-checkpoint location so one logical chain can resume
+    through any number of separately published complete-sweep segments.
+
+    Args:
+        arguments: Validated CLI arguments.
+        adapter: Frozen RHIME-to-Gamma--Beta adapter result.
+        initial_state: Deterministically reconstructed fresh-chain state.
+        input_digest: Frozen input whole-file SHA-256.
+        outer_labels: Ordered fixed-coefficient labels.
+        fixed_position_scales: Fully resolved fixed-coordinate position scale.
+        calibration: Verified v1 calibration identity.
+        calibration_digest: Verified whole-file calibration SHA-256.
+
+    Returns:
+        Strict-JSON-compatible immutable run identity.
+
+    Raises:
+        RuntimeError: If the required fixed block is absent.
+    """
+    fixed_block = adapter.problem.fixed_block
+    if fixed_block is None:
+        raise RuntimeError("The native PyMC HMC driver requires a fixed design block.")
+    bounds = _rectangle_bounds(initial_state)
+    runtime_identity = asdict(full_tiling_pymc_hmc_runtime_identity())
+    manifest: dict[str, object] = {
+        "schema": ("openghg_inversions.full_tiling_pymc_hmc_native_manifest.v1"),
+        "status": "experimental_mobile_hmc_not_convergence_evidence",
+        "input": {
+            "id": arguments.input_id,
+            "sha256": input_digest,
+            "contract": _input_contract(arguments),
+            "weight_normalization_factor": (adapter.weight_normalization_factor),
+        },
+        "model": {
+            "fixed_k": int(arguments.k),
+            "grid_shape": list(adapter.spatial_shape),
+            "observations": int(adapter.problem.observations.size),
+            "fixed_coefficients": adapter.problem.n_fixed_coefficients,
+            "outer_labels": outer_labels.astype(str).tolist(),
+            "concentration": float(arguments.concentration),
+            "root_variance": float(arguments.root_variance),
+            "root_prior_shape": float(adapter.problem.prior.root_shape),
+            "root_prior_rate": float(adapter.problem.prior.root_rate),
+            "likelihood_power": float(arguments.likelihood_power),
+            "fixed_prior_mean": (fixed_block.coefficient_prior_mean.astype(float).tolist()),
+            "fixed_prior_sd": (fixed_block.coefficient_prior_sd.astype(float).tolist()),
+            "structural_target": ("uniform_over_unique_canonical_tilings_at_fixed_k"),
+            "communication_component": _COMMUNICATION_COMPONENT,
+            "connectivity_proven": False,
+        },
+        "initialization": {
+            "strategy": arguments.initialization,
+            "seed": arguments.initialization_seed,
+            "rng_stream": ("dedicated_pcg64" if arguments.initialization == "random-recursive" else "none"),
+            "rectangle_bounds": bounds,
+            "topology_sha256": _topology_sha256(bounds),
+            "state_sha256": full_tiling_state_fingerprint(
+                initial_state.problem,
+                initial_state,
+            ),
+        },
+        "sampler": {
+            "name": "full_tiling_structure_then_static_pymc_hmc",
+            "schedule_id": FULL_TILING_PYMC_HMC_SCHEDULE_ID,
+            "chains_per_invocation": 1,
+            "step_size_requested": float(arguments.step_size),
+            "leapfrog_steps": int(arguments.leapfrog_steps),
+            "leaf_position_scale": float(arguments.leaf_position_scale),
+            "fixed_coefficient_position_scale": list(fixed_position_scales),
+            "metric_semantics_id": (FULL_TILING_PYMC_HMC_METRIC_SEMANTICS_ID),
+            "coordinate_layout_id": (FULL_TILING_PYMC_HMC_COORDINATE_LAYOUT_ID),
+            "adapt_step_size": False,
+            "step_size_randomization": False,
+            "topology_dependent_metric": False,
+            "runtime_identity": runtime_identity,
+            "calibration": {
+                "schema": calibration["schema"],
+                "id": calibration["calibration_id"],
+                "sha256": calibration_digest,
+            },
+        },
+        "provenance": {
+            "input_id": arguments.input_id,
+            "code_revision": arguments.code_revision,
+            "chain_id": arguments.chain_id,
+            "original_master_seed": int(arguments.seed),
+            "single_process": True,
+            "durable_checkpoint": True,
+        },
+    }
+    manifest["manifest_payload_sha256"] = sha256(_canonical_json(manifest).encode("utf-8")).hexdigest()
+    return manifest
+
+
+def _expected_calibration_identity(
+    arguments: argparse.Namespace,
+    adapter: GammaBetaRHIMEAdapterResult,
+    *,
+    input_digest: str,
+    fixed_position_scales: tuple[float, ...],
+) -> dict[str, Any]:
+    """Build the exact minimal v1 calibration identity for this invocation.
+
+    Args:
+        arguments: Validated driver arguments.
+        adapter: Frozen scientific adapter with resolved fixed priors.
+        input_digest: Verified frozen-input whole-file SHA-256.
+        fixed_position_scales: Resolved fixed-coordinate position scales.
+
+    Returns:
+        Strict-JSON-compatible calibration identity.
+
+    Raises:
+        RuntimeError: If the required fixed coefficient block is absent.
+    """
+    fixed_block = adapter.problem.fixed_block
+    if fixed_block is None:
+        raise RuntimeError("The native PyMC HMC driver requires a fixed design block.")
+    return {
+        "schema": CALIBRATION_SCHEMA,
+        "calibration_id": arguments.calibration_id,
+        "fixed_k": int(arguments.k),
+        "input_sha256": input_digest,
+        "target": {
+            "concentration": float(arguments.concentration),
+            "root_variance": float(arguments.root_variance),
+            "likelihood_power": float(arguments.likelihood_power),
+            "fixed_prior_mean": fixed_block.coefficient_prior_mean.astype(float).tolist(),
+            "fixed_prior_sd": fixed_block.coefficient_prior_sd.astype(float).tolist(),
+            "nominal_weight_policy": arguments.nominal_weight_policy,
+            "normalize_weights": bool(arguments.normalize_weights),
+        },
+        "kernel": {
+            "step_size": float(arguments.step_size),
+            "leapfrog_steps": int(arguments.leapfrog_steps),
+            "coordinate_layout_id": FULL_TILING_PYMC_HMC_COORDINATE_LAYOUT_ID,
+            "metric_semantics_id": FULL_TILING_PYMC_HMC_METRIC_SEMANTICS_ID,
+            "leaf_position_scale": float(arguments.leaf_position_scale),
+            "fixed_coefficient_position_scale": list(fixed_position_scales),
+        },
+    }
+
+
+def _require_exact_keys(
+    value: object,
+    expected: set[str],
+    *,
+    name: str,
+) -> dict[str, Any]:
+    """Require one JSON object with exactly the expected member names."""
+    if not isinstance(value, dict) or set(value) != expected:
+        raise ValueError(f"{name} must contain exactly {sorted(expected)!r}.")
+    return value
+
+
+def _finite_json_number(value: object, *, name: str) -> float:
+    """Return one finite JSON number while rejecting Booleans."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{name} must be a finite JSON number.")
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError(f"{name} must be a finite JSON number.")
+    return result
+
+
+def _calibration_candidate(value: object, *, name: str) -> tuple[float, int]:
+    """Validate and return one declared static-HMC candidate."""
+    candidate = _require_exact_keys(
+        value,
+        {"step_size", "leapfrog_steps"},
+        name=name,
+    )
+    step_size = _finite_json_number(candidate["step_size"], name=f"{name}.step_size")
+    leapfrog_steps = candidate["leapfrog_steps"]
+    if step_size <= 0.0:
+        raise ValueError(f"{name}.step_size must be positive.")
+    if isinstance(leapfrog_steps, bool) or not isinstance(leapfrog_steps, int):
+        raise ValueError(f"{name}.leapfrog_steps must be a positive integer.")
+    if leapfrog_steps < 1:
+        raise ValueError(f"{name}.leapfrog_steps must be a positive integer.")
+    return step_size, leapfrog_steps
+
+
+def _validate_calibration_evidence(
+    value: object,
+    arguments: argparse.Namespace,
+) -> None:
+    """Validate calibration provenance and its selected static-HMC candidate.
+
+    Args:
+        value: Parsed strict-JSON calibration ``evidence`` value.
+        arguments: Validated CLI namespace supplying the current code
+            revision, fixed ``K``, step size, and leapfrog count.
+
+    Raises:
+        ValueError: If evidence keys, code revision, robust estimator, clipping
+            bounds, pilot identities, candidate grid, decision statistics,
+            selected candidate, acceptance gates, or source SHA-256 values
+            violate the v1 contract.
+
+    Notes:
+        Candidate and decision rows must correspond one-to-one. Exactly one
+        finite, zero-divergence candidate must be selected, and production
+        ``K=50``/``K=250`` evidence is bound to the reviewed random-recursive
+        pilot seeds.
+    """
+    evidence = _require_exact_keys(
+        value,
+        {
+            "code_revision",
+            "robust_variance_estimator",
+            "clipping_bounds",
+            "pilot_initializers",
+            "candidate_grid",
+            "decision_statistics",
+            "source_artifact_sha256",
+        },
+        name="Calibration evidence",
+    )
+    if evidence["code_revision"] != arguments.code_revision:
+        raise ValueError("Calibration evidence code_revision does not match --code-revision.")
+    if evidence["robust_variance_estimator"] != ROBUST_VARIANCE_ESTIMATOR:
+        raise ValueError("Calibration evidence robust variance estimator is incompatible.")
+    if _canonical_json(evidence["clipping_bounds"]) != _canonical_json([1.0e-4, 1.0e2]):
+        raise ValueError("Calibration evidence clipping_bounds must be [0.0001, 100.0].")
+
+    pilots = evidence["pilot_initializers"]
+    if not isinstance(pilots, list) or len(pilots) != 2:
+        raise ValueError("Calibration evidence must declare exactly two pilot initializers.")
+    expected_strategies = ("largest-nominal", "random-recursive")
+    for index, expected_strategy in enumerate(expected_strategies):
+        pilot = _require_exact_keys(
+            pilots[index],
+            {"strategy", "seed", "sweeps"},
+            name=f"Calibration pilot {index}",
+        )
+        if pilot["strategy"] != expected_strategy or pilot["sweeps"] != 100:
+            raise ValueError("Calibration pilot strategies and sweep counts are incompatible.")
+        seed = pilot["seed"]
+        if expected_strategy == "largest-nominal":
+            if seed is not None:
+                raise ValueError("Largest-nominal calibration pilot seed must be null.")
+        elif isinstance(seed, bool) or not isinstance(seed, int) or seed < 0:
+            raise ValueError("Random-recursive calibration pilot seed must be non-negative.")
+    required_random_seed = {50: 51051, 250: 51251}.get(arguments.k)
+    if required_random_seed is not None and pilots[1]["seed"] != required_random_seed:
+        raise ValueError(
+            f"Calibration evidence for K={arguments.k} requires pilot seed {required_random_seed}."
+        )
+
+    candidate_grid = evidence["candidate_grid"]
+    if not isinstance(candidate_grid, list) or not candidate_grid:
+        raise ValueError("Calibration candidate_grid must be a nonempty array.")
+    candidates = [
+        _calibration_candidate(item, name=f"Calibration candidate {index}")
+        for index, item in enumerate(candidate_grid)
+    ]
+    if len(set(candidates)) != len(candidates):
+        raise ValueError("Calibration candidate_grid entries must be unique.")
+
+    decisions = evidence["decision_statistics"]
+    if not isinstance(decisions, list) or len(decisions) != len(candidates):
+        raise ValueError("Calibration decision_statistics must match candidate_grid length.")
+    decision_candidates: list[tuple[float, int]] = []
+    selected: list[tuple[tuple[float, int], dict[str, Any]]] = []
+    decision_keys = {
+        "step_size",
+        "leapfrog_steps",
+        "largest_nominal_mean_acceptance",
+        "random_recursive_mean_acceptance",
+        "divergences",
+        "finite",
+        "median_log_displacement_per_leapfrog_step",
+        "selected",
+    }
+    for index, item in enumerate(decisions):
+        decision = _require_exact_keys(
+            item,
+            decision_keys,
+            name=f"Calibration decision {index}",
+        )
+        candidate = _calibration_candidate(
+            {
+                "step_size": decision["step_size"],
+                "leapfrog_steps": decision["leapfrog_steps"],
+            },
+            name=f"Calibration decision {index}",
+        )
+        decision_candidates.append(candidate)
+        for field in (
+            "largest_nominal_mean_acceptance",
+            "random_recursive_mean_acceptance",
+            "median_log_displacement_per_leapfrog_step",
+        ):
+            _finite_json_number(decision[field], name=f"Calibration decision {index}.{field}")
+        divergences = decision["divergences"]
+        if isinstance(divergences, bool) or not isinstance(divergences, int) or divergences < 0:
+            raise ValueError("Calibration decision divergences must be non-negative integers.")
+        if not isinstance(decision["finite"], bool) or not isinstance(decision["selected"], bool):
+            raise ValueError("Calibration decision finite and selected fields must be Booleans.")
+        if decision["selected"]:
+            selected.append((candidate, decision))
+    if set(decision_candidates) != set(candidates) or len(decision_candidates) != len(
+        set(decision_candidates)
+    ):
+        raise ValueError("Calibration decision candidates must exactly match candidate_grid.")
+    if len(selected) != 1:
+        raise ValueError("Calibration evidence must select exactly one candidate.")
+    selected_candidate, selected_decision = selected[0]
+    requested_candidate = (float(arguments.step_size), int(arguments.leapfrog_steps))
+    if selected_candidate != requested_candidate:
+        raise ValueError("Selected calibration candidate does not match requested HMC controls.")
+    if (
+        selected_decision["finite"] is not True
+        or selected_decision["divergences"] != 0
+        or not 0.6 <= float(selected_decision["largest_nominal_mean_acceptance"]) <= 0.9
+        or not 0.6 <= float(selected_decision["random_recursive_mean_acceptance"]) <= 0.9
+    ):
+        raise ValueError("Selected calibration decision does not pass the frozen acceptance gates.")
+
+    sources = evidence["source_artifact_sha256"]
+    if not isinstance(sources, dict) or not sources:
+        raise ValueError("Calibration source_artifact_sha256 must be a nonempty object.")
+    for source, digest in sources.items():
+        if not source or not isinstance(digest, str):
+            raise ValueError("Calibration source artifact IDs and hashes must be strings.")
+        _validate_sha256(digest, name=f"Calibration source artifact {source!r} SHA-256")
+
+
+def _load_verified_calibration(
+    arguments: argparse.Namespace,
+    adapter: GammaBetaRHIMEAdapterResult,
+    *,
+    input_digest: str,
+    fixed_position_scales: tuple[float, ...],
+) -> tuple[dict[str, Any], str]:
+    """Load, hash, and exactly validate the invocation's calibration file.
+
+    Args:
+        arguments: Validated driver arguments.
+        adapter: Frozen scientific adapter with resolved fixed priors.
+        input_digest: Verified frozen-input whole-file SHA-256.
+        fixed_position_scales: Resolved fixed-coordinate position scales.
+
+    Returns:
+        Verified calibration object and lowercase whole-file SHA-256.
+
+    Raises:
+        FileNotFoundError: If the calibration file is absent.
+        OSError: If the calibration file cannot be read.
+        ValueError: If its hash, strict JSON, stability, or v1 identity does
+            not exactly match the current invocation.
+    """
+    path = cast(Path, arguments.calibration_file)
+    digest = _sha256_file(path)
+    if digest.lower() != arguments.calibration_sha256.lower():
+        raise ValueError("Calibration file SHA-256 does not match --calibration-sha256.")
+    calibration = _load_strict_json_object(
+        path,
+        description="Calibration file",
+    )
+    if _sha256_file(path) != digest:
+        raise ValueError("Calibration file changed while it was being validated.")
+    expected = _expected_calibration_identity(
+        arguments,
+        adapter,
+        input_digest=input_digest,
+        fixed_position_scales=fixed_position_scales,
+    )
+    if set(calibration) != {*expected, "evidence"}:
+        raise ValueError("Calibration v1 root keys are incompatible.")
+    identity = {name: calibration[name] for name in expected}
+    if _canonical_json(identity) != _canonical_json(expected):
+        raise ValueError("Calibration v1 identity does not exactly match the current invocation.")
+    _validate_calibration_evidence(calibration["evidence"], arguments)
+    return calibration, digest
+
+
+def _trace_states(
+    problem: FullTilingProblem,
+    result: FullTilingPyMCHMCSamplingResult,
+) -> tuple[FullTilingPosteriorState, ...]:
+    """Rebuild every retained trace state through the scientific oracle.
+
+    Args:
+        problem: Scientific problem for the completed segment.
+        result: Completed HMC sampling segment.
+
+    Returns:
+        Rebuilt states in trace order.
+
+    Raises:
+        RuntimeError: If topology, coordinates, or retained log targets fail
+            reconstruction.
+    """
+    states: list[FullTilingPosteriorState] = []
+    for draw, bounds in enumerate(result.trace.rectangle_bounds):
+        try:
+            rectangles = tuple(Rectangle(*(int(value) for value in row)) for row in bounds.tolist())
+            state = build_full_tiling_posterior_state(
+                problem,
+                allocation=TilingState(
+                    LeafTiling(problem.shape, rectangles),
+                    result.trace.leaf_masses[draw],
+                ),
+                fixed_coefficients=result.trace.fixed_coefficients[draw],
+            )
+        except (TypeError, ValueError) as error:
+            raise RuntimeError(f"Trace state {draw} failed scientific reconstruction.") from error
+        target_difference = abs(float(state.log_target - result.trace.log_target[draw]))
+        tolerance = max(
+            _TRANSFORMED_TARGET_ATOL,
+            128.0
+            * np.finfo(np.float64).eps
+            * max(
+                1.0,
+                abs(state.log_target),
+                abs(float(result.trace.log_target[draw])),
+            ),
+        )
+        if target_difference > tolerance:
+            raise RuntimeError(
+                f"Trace state {draw} log target differs from its scientific "
+                f"rebuild by {target_difference:.17g}."
+            )
+        states.append(state)
+    return tuple(states)
+
+
+def _stack_state_field(
+    states: tuple[FullTilingPosteriorState, ...],
+    name: str,
+) -> np.ndarray:
+    """Stack one array-valued posterior-state field across retained draws."""
+    return np.stack([np.asarray(getattr(state, name)) for state in states])
+
+
+def _trace_to_dataset(
+    result: FullTilingPyMCHMCSamplingResult,
+    *,
+    problem: FullTilingProblem,
+    adapter: GammaBetaRHIMEAdapterResult,
+    observation_labels: np.ndarray,
+    outer_labels: np.ndarray,
+    input_digest: str,
+    manifest_digest: str,
+) -> xr.Dataset:
+    """Convert all state, target, and diagnostic fields to labelled xarray.
+
+    Args:
+        result: Completed full-tiling PyMC HMC segment.
+        problem: Scientific problem used by the segment.
+        adapter: Native-data adapter supplying grid coordinates.
+        observation_labels: Stable labels in observation order.
+        outer_labels: Fixed-coefficient labels in exact model order.
+        input_digest: Frozen input whole-file SHA-256.
+        manifest_digest: Canonical immutable-manifest SHA-256.
+
+    Returns:
+        Audited in-memory trace dataset ready for NetCDF serialization.
+        Boundary variables use a ``draw`` dimension of ``sweeps + 1``;
+        transition diagnostics use ``sweep`` of length ``sweeps``. The
+        returned dataset owns no open file handle.
+
+    Raises:
+        RuntimeError: If any retained topology, scientific state, or log
+            target cannot be reconstructed exactly enough for the audit.
+        TypeError: If retained trace arrays cannot rebuild valid tilings or
+            scientific states.
+        ValueError: If labels, shapes, or coordinates are incompatible with
+            the completed problem and adapter.
+
+    Notes:
+        Authoritative boundary-inclusive ``log_leaf_mass`` and
+        ``log_fixed_coefficient`` arrays are copied from the sampler trace;
+        they are not regenerated from decoded scientific values. Input and
+        manifest digests are attached as immutable dataset identity metadata.
+    """
+    trace = result.trace
+    states = _trace_states(problem, result)
+    draws = len(states)
+    sweeps = int(trace.global_sweep.size)
+    log_fields = (
+        "log_gaussian_likelihood",
+        "log_likelihood",
+        "log_root_prior",
+        "log_allocation_prior",
+        "log_fixed_coefficient_prior",
+        "log_target",
+    )
+    data_vars: dict[str, Any] = {
+        "state_sweep": (
+            ("draw",),
+            trace.state_sweep,
+            {"long_name": "global completed compound-sweep coordinate"},
+        ),
+        "rectangle_bounds": (
+            ("draw", "region", "bound"),
+            trace.rectangle_bounds,
+            {"long_name": "canonical half-open native-grid rectangle bounds"},
+        ),
+        "leaf_mass": (
+            ("draw", "region"),
+            trace.leaf_masses,
+            {"long_name": "positive allocation in canonical leaf order"},
+        ),
+        "log_leaf_mass": (
+            ("draw", "region"),
+            trace.log_leaf_mass,
+            {"long_name": "symmetric PyMC log leaf-mass coordinate"},
+        ),
+        "root_total": (
+            ("draw",),
+            np.asarray(
+                [state.root_total for state in states],
+                dtype=np.float64,
+            ),
+            {"long_name": "positive total allocation coordinate"},
+        ),
+        "fixed_coefficient": (
+            ("draw", "fixed_parameter"),
+            trace.fixed_coefficients,
+            {"long_name": "positive always-active fixed coefficient"},
+        ),
+        "log_fixed_coefficient": (
+            ("draw", "fixed_parameter"),
+            trace.log_fixed_coefficient,
+            {"long_name": "PyMC log fixed-coefficient coordinate"},
+        ),
+        "dynamic_prediction": (
+            ("draw", "observation"),
+            _stack_state_field(states, "dynamic_prediction"),
+            {"long_name": "dynamic full-tiling prediction cache"},
+        ),
+        "fixed_prediction": (
+            ("draw", "observation"),
+            _stack_state_field(states, "fixed_prediction"),
+            {"long_name": "fixed offset and outer prediction cache"},
+        ),
+        "prediction": (
+            ("draw", "observation"),
+            _stack_state_field(states, "prediction"),
+            {"long_name": "complete observation-space prediction cache"},
+        ),
+        "residual": (
+            ("draw", "observation"),
+            _stack_state_field(states, "residual"),
+            {"long_name": "prediction minus frozen observation"},
+        ),
+        "structural_move": (
+            ("sweep",),
+            trace.structural_move,
+            {"long_name": "attempted structural proposal"},
+        ),
+        "structural_valid": (
+            ("sweep",),
+            trace.structural_valid,
+            {"long_name": "structural proposal reached MH decision"},
+        ),
+        "structural_accepted": (
+            ("sweep",),
+            trace.structural_accepted,
+            {"long_name": "structural proposal changed the state"},
+        ),
+        "structural_log_acceptance_ratio": (
+            ("sweep",),
+            trace.structural_log_acceptance_ratio,
+            {"long_name": "raw structural log acceptance ratio"},
+        ),
+        "structural_invalid_reason": (
+            ("sweep",),
+            trace.structural_invalid_reason,
+            {"long_name": "empty for valid structural proposals"},
+        ),
+        "hmc_accepted": (
+            ("sweep",),
+            trace.hmc_accepted,
+            {"long_name": "PyMC accepted the HMC endpoint"},
+        ),
+        "hmc_acceptance_probability": (
+            ("sweep",),
+            trace.hmc_acceptance_probability,
+            {"long_name": "HMC Metropolis acceptance probability"},
+        ),
+        "hmc_diverging": (
+            ("sweep",),
+            trace.hmc_diverging,
+            {"long_name": "PyMC trajectory divergence flag"},
+        ),
+        "hmc_energy": (
+            ("sweep",),
+            trace.hmc_energy,
+            {"long_name": "PyMC endpoint Hamiltonian"},
+        ),
+        "hmc_energy_error": (
+            ("sweep",),
+            trace.hmc_energy_error,
+            {"long_name": "endpoint-minus-start Hamiltonian error"},
+        ),
+        "hmc_step_size": (
+            ("sweep",),
+            trace.hmc_step_size,
+            {"long_name": "effective PyMC leapfrog step size"},
+        ),
+        "hmc_n_steps": (
+            ("sweep",),
+            trace.hmc_n_steps,
+            {"long_name": "reported leapfrog step count"},
+        ),
+        "hmc_seed": (
+            ("sweep",),
+            trace.hmc_seed,
+            {"long_name": "per-sweep uint64 PyMC reseed from master PCG64"},
+        ),
+    }
+    for name in log_fields:
+        data_vars[name] = (
+            ("draw",),
+            np.asarray(
+                [getattr(state, name) for state in states],
+                dtype=np.float64,
+            ),
+            {"long_name": name.replace("_", " ")},
+        )
+    dataset = xr.Dataset(
+        data_vars=data_vars,
+        coords={
+            "draw": np.arange(draws, dtype=np.int64),
+            "sweep": trace.global_sweep,
+            "region": np.arange(result.final_state.k, dtype=np.int64),
+            "bound": np.asarray(
+                ("row_start", "row_stop", "col_start", "col_stop"),
+                dtype=np.str_,
+            ),
+            "fixed_parameter": outer_labels,
+            "observation": observation_labels,
+            "lat": adapter.latitudes,
+            "lon": adapter.longitudes,
+        },
+        attrs={
+            "schema": ("openghg_inversions.full_tiling_pymc_hmc_native_trace.v1"),
+            "title": "Static PyMC HMC mobile full-tiling segment",
+            "diagnostic_only": "true",
+            "convergence_claim": "none",
+            "fixed_k": result.final_state.k,
+            "schedule_id": FULL_TILING_PYMC_HMC_SCHEDULE_ID,
+            "coordinate_layout_id": (FULL_TILING_PYMC_HMC_COORDINATE_LAYOUT_ID),
+            "metric_semantics_id": (FULL_TILING_PYMC_HMC_METRIC_SEMANTICS_ID),
+            "communication_component": _COMMUNICATION_COMPONENT,
+            "connectivity_proven": "false",
+            "input_sha256": input_digest,
+            "manifest_sha256": manifest_digest,
+            "segment_sweeps": sweeps,
+            "durable_checkpoint": "true",
+        },
+    )
+    dataset["draw"].attrs["long_name"] = "segment-local retained-state index"
+    dataset["sweep"].attrs["long_name"] = "global compound-sweep coordinate"
+    return dataset
+
+
+def _finite_summary(
+    values: np.ndarray,
+) -> dict[str, float | int | None]:
+    """Summarize finite values while retaining non-finite counts."""
+    array = np.asarray(values, dtype=np.float64)
+    finite = array[np.isfinite(array)]
+    return {
+        "finite_count": int(finite.size),
+        "nonfinite_count": int(array.size - finite.size),
+        "mean": None if not finite.size else float(np.mean(finite)),
+        "minimum": None if not finite.size else float(np.min(finite)),
+        "maximum": None if not finite.size else float(np.max(finite)),
+    }
+
+
+def _summary(
+    result: FullTilingPyMCHMCSamplingResult,
+    *,
+    chain_initial_state: FullTilingPosteriorState,
+    segment_initial_state: FullTilingPosteriorState,
+    closure: dict[str, float],
+    preflight: Mapping[str, float],
+    input_path: Path,
+    input_digest: str,
+    parent_checkpoint_sha256: str | None,
+    parent_completion_sha256: str | None,
+    parent_artifact_sha256: Mapping[str, str] | None,
+    input_seconds: float,
+    problem_setup_seconds: float,
+    preflight_seconds: float,
+) -> dict[str, Any]:
+    """Build a strict-JSON-compatible report for one completed segment.
+
+    Args:
+        result: Completed segment, including boundary trace, checkpoint, and
+            kernel/transition timings.
+        chain_initial_state: Reconstructed immutable start of the logical
+            chain.
+        segment_initial_state: Exact fresh or resumed state at this segment's
+            boundary.
+        closure: Scientific closure-audit metrics.
+        preflight: Compiled transformed-target parity metrics for the segment
+            boundary.
+        input_path: Frozen native input path recorded for provenance.
+        input_digest: Verified whole-file input SHA-256.
+        parent_checkpoint_sha256: Certified parent checkpoint SHA-256 for a
+            resumed segment, or ``None`` for a fresh segment.
+        parent_completion_sha256: Verified parent ``complete.json`` SHA-256,
+            or ``None`` for a fresh segment.
+        parent_artifact_sha256: Complete certified parent artifact-hash map,
+            or ``None`` for a fresh segment.
+        input_seconds: Non-authoritative input hashing/loading duration.
+        problem_setup_seconds: Non-authoritative scientific setup duration.
+        preflight_seconds: Non-authoritative transformed-target compilation
+            and parity-check duration.
+
+    Returns:
+        Nested summary containing lineage, target decomposition, structural
+        and HMC diagnostics, and timing categories. Sweep and leapfrog
+        throughput use transition execution time only.
+
+    Notes:
+        Timing values are reporting metadata and are excluded from immutable
+        chain identity and exact-replay comparisons.
+    """
+    trace = result.trace
+    invalid = Counter(
+        str(reason) for reason in trace.structural_invalid_reason[~trace.structural_valid].tolist()
+    )
+    sweeps = int(trace.global_sweep.size)
+    structural_valid = int(np.count_nonzero(trace.structural_valid))
+    structural_accepted = int(np.count_nonzero(trace.structural_accepted))
+    hmc_accepted = int(np.count_nonzero(trace.hmc_accepted))
+    divergences = int(np.count_nonzero(trace.hmc_diverging))
+    leapfrog_steps = int(np.sum(trace.hmc_n_steps))
+    return {
+        "schema": ("openghg_inversions.full_tiling_pymc_hmc_native_summary.v1"),
+        "status": "experimental_not_convergence_evidence",
+        "input": {
+            "path": str(input_path.resolve()),
+            "sha256": input_digest,
+        },
+        "closure": closure,
+        "transformed_target_preflight": dict(preflight),
+        "lineage": {
+            "parent_checkpoint_sha256": parent_checkpoint_sha256,
+            "parent_completion_sha256": parent_completion_sha256,
+            "parent_artifact_sha256": (
+                None if parent_artifact_sha256 is None else dict(parent_artifact_sha256)
+            ),
+            "segment_start_state_sha256": full_tiling_state_fingerprint(
+                segment_initial_state.problem,
+                segment_initial_state,
+            ),
+        },
+        "run": {
+            "fixed_k": result.final_state.k,
+            "schedule_id": result.checkpoint.schedule_id,
+            "segment_sweeps": sweeps,
+            "segment_start_sweep": int(trace.state_sweep[0]),
+            "segment_end_sweep": result.checkpoint.sweeps_completed,
+            "retained_states": int(trace.state_sweep.size),
+            "durable_checkpoint": True,
+        },
+        "target": {
+            "chain_initial_log_target": float(chain_initial_state.log_target),
+            "segment_initial_log_target": float(segment_initial_state.log_target),
+            "final_log_gaussian_likelihood": float(result.final_state.log_gaussian_likelihood),
+            "final_log_likelihood": float(result.final_state.log_likelihood),
+            "final_log_root_prior": float(result.final_state.log_root_prior),
+            "final_log_allocation_prior": float(result.final_state.log_allocation_prior),
+            "final_log_fixed_coefficient_prior": float(result.final_state.log_fixed_coefficient_prior),
+            "final_log_target": float(result.final_state.log_target),
+            "normalization": ("fixed-K communication-component structural constant omitted"),
+        },
+        "structural": {
+            "valid": structural_valid,
+            "accepted": structural_accepted,
+            "valid_rate": structural_valid / sweeps,
+            "acceptance_rate": structural_accepted / sweeps,
+            "acceptance_rate_given_valid": (
+                None if structural_valid == 0 else structural_accepted / structural_valid
+            ),
+            "invalid_reasons": dict(sorted(invalid.items())),
+        },
+        "hmc": {
+            "accepted": hmc_accepted,
+            "acceptance_rate": hmc_accepted / sweeps,
+            "divergences": divergences,
+            "acceptance_probability": _finite_summary(trace.hmc_acceptance_probability),
+            "energy": _finite_summary(trace.hmc_energy),
+            "energy_error": _finite_summary(trace.hmc_energy_error),
+            "effective_step_size": _finite_summary(trace.hmc_step_size),
+            "reported_leapfrog_steps": {
+                "minimum": int(np.min(trace.hmc_n_steps)),
+                "maximum": int(np.max(trace.hmc_n_steps)),
+            },
+        },
+        "performance": {
+            "input_hash_and_load_seconds": input_seconds,
+            "problem_setup_seconds": problem_setup_seconds,
+            "transformed_target_preflight_compile_seconds": preflight_seconds,
+            "kernel_setup_and_compile_seconds": result.kernel_setup_seconds,
+            "transition_sampling_seconds": result.transition_seconds,
+            "sweeps_per_second": (
+                None if result.transition_seconds <= 0.0 else sweeps / result.transition_seconds
+            ),
+            "leapfrog_steps_per_second": (
+                None if result.transition_seconds <= 0.0 else leapfrog_steps / result.transition_seconds
+            ),
+        },
+    }
+
+
+def _assert_checkpoint_equal(
+    actual: FullTilingPyMCHMCCheckpoint,
+    expected: FullTilingPyMCHMCCheckpoint,
+) -> None:
+    """Require exact equality of two durable continuation boundaries.
+
+    Args:
+        actual: Checkpoint reopened from the published no-pickle artifact.
+        expected: In-memory checkpoint produced by the completed sampler.
+
+    Raises:
+        RuntimeError: If RNG state, sweep count, kernel/runtime identity,
+            topology, scientific state arrays, target components, or
+            authoritative log coordinates differ.
+
+    Notes:
+        Array comparisons are exact and do not use numerical tolerances,
+        because the checkpoint is an exact replay boundary rather than a
+        scientific equivalence artifact.
+    """
+    if (
+        actual.rng_state != expected.rng_state
+        or actual.sweeps_completed != expected.sweeps_completed
+        or actual.kernel_settings != expected.kernel_settings
+        or actual.runtime_identity != expected.runtime_identity
+        or actual.schedule_id != expected.schedule_id
+        or actual.state.tiling_state.tiling != expected.state.tiling_state.tiling
+    ):
+        raise RuntimeError("Reopened checkpoint metadata or topology does not match.")
+    array_fields = (
+        "leaf_masses",
+        "fixed_coefficients",
+        "dynamic_prediction",
+        "fixed_prediction",
+        "prediction",
+        "residual",
+    )
+    for name in array_fields:
+        if not np.array_equal(
+            getattr(actual.state, name),
+            getattr(expected.state, name),
+        ):
+            raise RuntimeError(f"Reopened checkpoint state field {name} does not match.")
+    for name in (
+        "log_gaussian_likelihood",
+        "log_likelihood",
+        "log_root_prior",
+        "log_allocation_prior",
+        "log_fixed_coefficient_prior",
+        "log_target",
+    ):
+        if getattr(actual.state, name) != getattr(expected.state, name):
+            raise RuntimeError(f"Reopened checkpoint target field {name} does not match.")
+    if not np.array_equal(
+        actual.log_leaf_mass,
+        expected.log_leaf_mass,
+    ) or not np.array_equal(
+        actual.log_fixed_coefficient,
+        expected.log_fixed_coefficient,
+    ):
+        raise RuntimeError("Reopened checkpoint authoritative log coordinates do not match.")
+
+
+def _audit_reopened_trace(
+    expected: xr.Dataset,
+    path: Path,
+    *,
+    engine: NetCDFEngine,
+) -> None:
+    """Reopen a trace and require exact content, coordinates, and identity.
+
+    Args:
+        expected: In-memory dataset passed to NetCDF serialization.
+        path: Published trace artifact to reopen and hash.
+        engine: Explicit xarray backend used for the reopen.
+
+    Raises:
+        OSError: If the trace cannot be hashed, opened, loaded, or closed.
+        RuntimeError: If data-variable or coordinate sets, dimensions, values,
+            identity attributes, or the file hash differ from expectations.
+
+    Notes:
+        Floating arrays compare exactly while treating NaNs in corresponding
+        positions as equal. The whole-file SHA-256 is checked before and after
+        the reopen audit to detect concurrent modification.
+    """
+    before = _sha256_file(path)
+    with xr.open_dataset(path, engine=engine) as opened:
+        actual = opened.load()
+    try:
+        if set(actual.data_vars) != set(expected.data_vars):
+            raise RuntimeError("Reopened trace has an incompatible data-variable set.")
+        if set(actual.coords) != set(expected.coords):
+            raise RuntimeError("Reopened trace has an incompatible coordinate set.")
+        if dict(actual.sizes) != dict(expected.sizes):
+            raise RuntimeError("Reopened trace dimensions do not match.")
+        for name in expected.data_vars:
+            left = np.asarray(actual[name].values)
+            right = np.asarray(expected[name].values)
+            equal_nan = np.issubdtype(left.dtype, np.inexact) and np.issubdtype(
+                right.dtype,
+                np.inexact,
+            )
+            if not np.array_equal(left, right, equal_nan=equal_nan):
+                raise RuntimeError(f"Reopened trace variable {name} does not match.")
+        for name in expected.coords:
+            if actual[name].dims != expected[name].dims:
+                raise RuntimeError(f"Reopened trace coordinate {name} dimensions do not match.")
+            left = np.asarray(actual[name].values)
+            right = np.asarray(expected[name].values)
+            equal_nan = np.issubdtype(left.dtype, np.inexact) and np.issubdtype(
+                right.dtype,
+                np.inexact,
+            )
+            if not np.array_equal(left, right, equal_nan=equal_nan):
+                raise RuntimeError(f"Reopened trace coordinate {name} does not match.")
+        for name in (
+            "schema",
+            "schedule_id",
+            "coordinate_layout_id",
+            "metric_semantics_id",
+            "input_sha256",
+            "manifest_sha256",
+        ):
+            if actual.attrs.get(name) != expected.attrs.get(name):
+                raise RuntimeError(f"Reopened trace attribute {name} does not match.")
+    finally:
+        actual.close()
+    if _sha256_file(path) != before:
+        raise RuntimeError("Trace changed while it was being reopened.")
+
+
+def _certify_parent_segment_bundle(
+    checkpoint_path: Path,
+) -> tuple[str, dict[str, str]]:
+    """Require a checkpoint to belong to one complete hash-certified bundle.
+
+    Args:
+        checkpoint_path: Requested parent checkpoint, which must be the
+            canonical ``checkpoint.npz`` sibling named by ``complete.json``.
+
+    Returns:
+        Verified ``complete.json`` SHA-256 and exact certified hashes of the
+        four parent segment artifacts.
+
+    Raises:
+        FileNotFoundError: If the completion certificate or any certified
+            artifact is absent.
+        OSError: If a parent artifact cannot be read.
+        ValueError: If the completion certificate is malformed, incompatible,
+            or does not certify the current bytes of every parent artifact.
+    """
+    if checkpoint_path.name != CHECKPOINT_FILENAME:
+        raise ValueError(f"--resume-checkpoint must name the certified {CHECKPOINT_FILENAME} artifact.")
+    completion_path = checkpoint_path.parent / COMPLETION_FILENAME
+    if not completion_path.is_file():
+        raise FileNotFoundError(f"Parent completion certificate is not a file: {completion_path}")
+    completion_digest = _sha256_file(completion_path)
+    completion = _load_strict_json_object(
+        completion_path,
+        description="Parent completion certificate",
+    )
+    if completion.get("schema") != COMPLETION_SCHEMA:
+        raise ValueError("Parent completion certificate schema is incompatible.")
+    if completion.get("status") != "complete":
+        raise ValueError("Parent completion certificate status is not complete.")
+    if completion.get("durable_checkpoint") is not True:
+        raise ValueError("Parent completion certificate is not durable.")
+    if completion.get("schedule_id") != FULL_TILING_PYMC_HMC_SCHEDULE_ID:
+        raise ValueError("Parent completion certificate schedule is incompatible.")
+    names = {
+        "manifest": MANIFEST_FILENAME,
+        "trace": TRACE_FILENAME,
+        "summary": SUMMARY_FILENAME,
+        "checkpoint": CHECKPOINT_FILENAME,
+    }
+    for field, expected_name in names.items():
+        if completion.get(field) != expected_name:
+            raise ValueError(f"Parent completion certificate {field} name is incompatible.")
+    certified = completion.get("sha256")
+    if not isinstance(certified, dict) or set(certified) != set(_BUNDLE_ARTIFACTS):
+        raise ValueError("Parent completion certificate artifact hashes are incomplete.")
+    hashes: dict[str, str] = {}
+    for name in _BUNDLE_ARTIFACTS:
+        digest = certified.get(name)
+        if not isinstance(digest, str):
+            raise ValueError(f"Parent completion hash for {name} is not a string.")
+        _validate_sha256(digest, name=f"parent {name} SHA-256")
+        artifact = checkpoint_path.parent / name
+        if not artifact.is_file():
+            raise FileNotFoundError(f"Certified parent artifact is not a file: {artifact}")
+        actual = _sha256_file(artifact)
+        if actual.lower() != digest.lower():
+            raise ValueError(f"Certified parent artifact SHA-256 does not match: {name}")
+        hashes[name] = actual
+    if _sha256_file(completion_path) != completion_digest:
+        raise ValueError("Parent completion certificate changed while it was being validated.")
+    return completion_digest, hashes
+
+
+def _write_outputs(
+    output_directory: Path,
+    result: FullTilingPyMCHMCSamplingResult,
+    *,
+    problem: FullTilingProblem,
+    manifest: dict[str, object],
+    summary: dict[str, Any],
+    trace_dataset: xr.Dataset,
+    netcdf_engine: NetCDFEngine,
+) -> None:
+    """Publish one create-only bundle and write its certificate last.
+
+    Args:
+        output_directory: New directory for the segment bundle.
+        result: Completed segment and continuation checkpoint.
+        problem: Reconstructed scientific problem used for checkpoint reopen.
+        manifest: Immutable chain identity used by durable checkpoint I/O.
+        summary: Segment-local diagnostic report.
+        trace_dataset: Audited full state/target/diagnostic trace.
+        netcdf_engine: Selected output backend.
+
+    Raises:
+        FileExistsError: If the output directory or an artifact exists.
+        OSError: If writing, syncing, or reopening fails.
+        RuntimeError: If any reopened artifact differs.
+
+    Notes:
+        ``complete.json`` is written only after all four hashed artifacts pass
+        their reopen audits.
+    """
+    output_directory.mkdir()
+    _fsync_directory(output_directory.parent)
+    manifest_path = output_directory / MANIFEST_FILENAME
+    trace_path = output_directory / TRACE_FILENAME
+    summary_path = output_directory / SUMMARY_FILENAME
+    checkpoint_path = output_directory / CHECKPOINT_FILENAME
+    _atomic_write_text(manifest_path, _canonical_json(manifest))
+    _atomic_write_trace(
+        trace_dataset,
+        trace_path,
+        engine=netcdf_engine,
+    )
+    _atomic_write_text(
+        summary_path,
+        json.dumps(
+            summary,
+            indent=2,
+            sort_keys=True,
+            ensure_ascii=False,
+            allow_nan=False,
+        )
+        + "\n",
+    )
+    save_full_tiling_pymc_hmc_checkpoint(
+        checkpoint_path,
+        result.checkpoint,
+        run_manifest=manifest,
+    )
+
+    with manifest_path.open(encoding="utf-8") as handle:
+        reopened_manifest = json.load(handle)
+    if reopened_manifest != manifest:
+        raise RuntimeError("Reopened manifest does not match.")
+    with summary_path.open(encoding="utf-8") as handle:
+        reopened_summary = json.load(handle)
+    if reopened_summary != summary:
+        raise RuntimeError("Reopened summary does not match.")
+    _audit_reopened_trace(
+        trace_dataset,
+        trace_path,
+        engine=netcdf_engine,
+    )
+    checkpoint_hash = _sha256_file(checkpoint_path)
+    reopened_checkpoint = load_full_tiling_pymc_hmc_checkpoint(
+        checkpoint_path,
+        problem,
+        expected_run_manifest=manifest,
+    )
+    if _sha256_file(checkpoint_path) != checkpoint_hash:
+        raise RuntimeError("Checkpoint changed while it was being reopened.")
+    _assert_checkpoint_equal(reopened_checkpoint, result.checkpoint)
+
+    artifact_hashes = {
+        name: _sha256_file(output_directory / name)
+        for name in (
+            MANIFEST_FILENAME,
+            TRACE_FILENAME,
+            SUMMARY_FILENAME,
+            CHECKPOINT_FILENAME,
+        )
+    }
+    completion = {
+        "schema": COMPLETION_SCHEMA,
+        "status": "complete",
+        "manifest": MANIFEST_FILENAME,
+        "trace": TRACE_FILENAME,
+        "summary": SUMMARY_FILENAME,
+        "checkpoint": CHECKPOINT_FILENAME,
+        "schedule_id": FULL_TILING_PYMC_HMC_SCHEDULE_ID,
+        "segment_sweeps": int(result.trace.global_sweep.size),
+        "segment_start_sweep": int(result.trace.state_sweep[0]),
+        "segment_end_sweep": result.checkpoint.sweeps_completed,
+        "parent_checkpoint_sha256": summary["lineage"]["parent_checkpoint_sha256"],
+        "parent_completion_sha256": summary["lineage"]["parent_completion_sha256"],
+        "parent_artifact_sha256": summary["lineage"]["parent_artifact_sha256"],
+        "durable_checkpoint": True,
+        "sha256": artifact_hashes,
+    }
+    _atomic_write_text(
+        output_directory / COMPLETION_FILENAME,
+        _canonical_json(completion),
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the restartable native full-tiling PyMC HMC CLI.
+
+    Returns:
+        Parser exposing all frozen scientific inputs, initialization identity,
+        static HMC settings, calibration provenance, restart controls, and
+        artifact backends.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--input",
+        type=Path,
+        required=True,
+        help="Explicitly frozen native NetCDF snapshot.",
+    )
+    parser.add_argument(
+        "--output-directory",
+        type=Path,
+        required=True,
+        help="New artifact directory; existing paths are rejected.",
+    )
+    parser.add_argument(
+        "--k",
+        "--fixed-k",
+        dest="k",
+        type=int,
+        required=True,
+        help="Fixed active rectangle count.",
+    )
+    parser.add_argument(
+        "--sweeps",
+        type=int,
+        required=True,
+        help="Positive complete structural-then-HMC sweeps in this segment.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        required=True,
+        help="Original non-negative master PCG64 seed for the logical chain.",
+    )
+    parser.add_argument(
+        "--chain-id",
+        required=True,
+        help="Stable logical chain identifier.",
+    )
+    parser.add_argument(
+        "--initialization",
+        choices=("largest-nominal", "random-recursive"),
+        default="largest-nominal",
+        help="Fresh-chain fixed-K topology initializer.",
+    )
+    parser.add_argument(
+        "--initialization-seed",
+        type=int,
+        help=("Required separate PCG64 seed for --initialization random-recursive."),
+    )
+    parser.add_argument(
+        "--resume-checkpoint",
+        type=Path,
+        help=(
+            "Certified checkpoint.npz in a complete parent segment bundle "
+            "whose complete.json hashes all four sibling artifacts."
+        ),
+    )
+    parser.add_argument(
+        "--step-size",
+        "--hmc-step-size",
+        dest="step_size",
+        type=float,
+        required=True,
+        help="Requested unscaled static leapfrog step size.",
+    )
+    parser.add_argument(
+        "--leapfrog-steps",
+        type=int,
+        required=True,
+        help="Exact static leapfrog count per compound sweep.",
+    )
+    parser.add_argument(
+        "--leaf-position-scale",
+        type=float,
+        required=True,
+        help=(
+            "Shared positive PyMC position-covariance diagonal for symmetric "
+            "log leaf masses; equivalently momentum precision."
+        ),
+    )
+    parser.add_argument(
+        "--fixed-coefficient-position-scale",
+        "--fixed-position-scales",
+        dest="fixed_coefficient_position_scale",
+        type=_positive_values,
+        required=True,
+        metavar="VALUE[,VALUE...]",
+        help=("Shared or ordered fixed-coordinate PyMC position-covariance diagonal."),
+    )
+    parser.add_argument(
+        "--calibration-id",
+        required=True,
+        help="Stable identifier exactly repeated by the v1 calibration file.",
+    )
+    parser.add_argument(
+        "--calibration-file",
+        type=Path,
+        required=True,
+        help=(
+            "Strict-JSON v1 calibration identity binding K, input SHA, target "
+            "controls, kernel controls, coordinate layout, metric semantics, "
+            "resolved position scales, bounded-search decisions, source "
+            "artifact hashes, and calibration code revision."
+        ),
+    )
+    parser.add_argument(
+        "--calibration-sha256",
+        required=True,
+        help="Required whole-file SHA-256 of --calibration-file.",
+    )
+    parser.add_argument(
+        "--concentration",
+        type=float,
+        required=True,
+        help="Positive additive-alpha Dirichlet concentration.",
+    )
+    parser.add_argument(
+        "--root-variance",
+        type=float,
+        required=True,
+        help="Positive Gamma root-total prior variance.",
+    )
+    parser.add_argument(
+        "--likelihood-power",
+        type=float,
+        default=1.0,
+        help="Non-negative Gaussian likelihood multiplier.",
+    )
+    parser.add_argument(
+        "--fixed-prior-mean",
+        type=_positive_values,
+        default=1.0,
+        metavar="VALUE[,VALUE...]",
+        help="Arithmetic lognormal prior mean(s) for fixed coefficients.",
+    )
+    parser.add_argument(
+        "--fixed-prior-sd",
+        type=_positive_values,
+        required=True,
+        metavar="VALUE[,VALUE...]",
+        help="Arithmetic lognormal prior SD(s) for fixed coefficients.",
+    )
+    parser.add_argument(
+        "--input-id",
+        required=True,
+        help="Stable logical frozen-input identifier.",
+    )
+    parser.add_argument(
+        "--expected-input-sha256",
+        required=True,
+        help="Required whole-file frozen-input SHA-256.",
+    )
+    parser.add_argument(
+        "--code-revision",
+        required=True,
+        help="Clean source revision used for this chain.",
+    )
+    parser.add_argument(
+        "--nominal-weight-policy",
+        required=True,
+        help="Reviewed strictly positive nominal-base-measure identifier.",
+    )
+    parser.add_argument(
+        "--normalize-weights",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Normalize nominal weights to sum to one (default: true).",
+    )
+    parser.add_argument("--sensitivity-name", default="fp_x_flux")
+    parser.add_argument("--observation-name", default="mf")
+    parser.add_argument("--observation-sd-name", default="mf_error")
+    parser.add_argument("--nominal-weight-name", default="nominal_weight")
+    parser.add_argument("--fixed-design-name", default="outer_design")
+    parser.add_argument("--fixed-offset-name", default="YaprioriBC")
+    parser.add_argument(
+        "--require-paris-profile",
+        action="store_true",
+        help=(
+            "Require the reviewed 1382 by 183x128 PARIS shape, six outer "
+            "coefficients, exact input hash, and ordered outer labels."
+        ),
+    )
+    parser.add_argument(
+        "--expected-outer-labels",
+        type=_comma_separated_labels,
+        help="Expected comma-separated outer_region labels in exact order.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Validate frozen input, closure, float64 runtime, manifest, and "
+            "compiled transformed target without sampling or publishing."
+        ),
+    )
+    parser.add_argument(
+        "--input-netcdf-engine",
+        choices=("h5netcdf", "netcdf4", "scipy"),
+        default="h5netcdf",
+    )
+    parser.add_argument(
+        "--netcdf-engine",
+        choices=("h5netcdf", "netcdf4", "scipy"),
+        default="h5netcdf",
+    )
+    return parser
+
+
+def _validate_arguments(arguments: argparse.Namespace) -> None:
+    """Validate CLI values and create-only paths before scientific I/O.
+
+    Args:
+        arguments: Namespace produced by :func:`build_parser`.
+
+    Raises:
+        FileExistsError: If the requested output directory already exists.
+        FileNotFoundError: If the output parent, calibration file, or requested
+            resume checkpoint is absent.
+        ValueError: If output policy, seeds, initialization combinations,
+            static-HMC controls, scientific scalars, required identifiers,
+            SHA-256 syntax, or PARIS-profile arguments are invalid.
+
+    Notes:
+        Validation does not create the output directory or read scientific
+        dataset contents. Create-only publication remains authoritative in
+        :func:`_write_outputs`.
+    """
+    if arguments.output_directory.exists():
+        raise FileExistsError(f"Output path already exists: {arguments.output_directory}")
+    if not arguments.output_directory.parent.is_dir():
+        raise FileNotFoundError(
+            f"Output parent directory does not exist: {arguments.output_directory.parent}"
+        )
+    resolved_output = arguments.output_directory.resolve(strict=False)
+    if any("paris_inversions" in part.lower() for part in resolved_output.parts):
+        raise ValueError("Output and NetCDF preflight writes beneath PARIS_inversions are forbidden.")
+    if arguments.k < 1:
+        raise ValueError("--k must be positive.")
+    if arguments.sweeps < 1:
+        raise ValueError("--sweeps must be positive.")
+    if arguments.seed < 0:
+        raise ValueError("--seed must be non-negative.")
+    if not arguments.chain_id:
+        raise ValueError("--chain-id must be nonempty.")
+    if arguments.initialization == "random-recursive":
+        if arguments.initialization_seed is None:
+            raise ValueError("--initialization random-recursive requires --initialization-seed.")
+        if arguments.initialization_seed < 0:
+            raise ValueError("--initialization-seed must be non-negative.")
+        if arguments.initialization_seed == arguments.seed:
+            raise ValueError("--initialization-seed must differ from the master --seed.")
+    elif arguments.initialization_seed is not None:
+        raise ValueError("--initialization-seed is only valid with --initialization random-recursive.")
+    if arguments.dry_run and arguments.resume_checkpoint is not None:
+        raise ValueError("--dry-run cannot be combined with --resume-checkpoint.")
+    for name in (
+        "step_size",
+        "leaf_position_scale",
+        "concentration",
+        "root_variance",
+    ):
+        value = float(getattr(arguments, name))
+        if not np.isfinite(value) or value <= 0.0:
+            raise ValueError(f"--{name.replace('_', '-')} must be finite and positive.")
+    if arguments.leapfrog_steps < 1:
+        raise ValueError("--leapfrog-steps must be positive.")
+    if not np.isfinite(arguments.likelihood_power) or arguments.likelihood_power < 0.0:
+        raise ValueError("--likelihood-power must be finite and non-negative.")
+    if not arguments.input_id:
+        raise ValueError("--input-id must be nonempty.")
+    if not arguments.code_revision:
+        raise ValueError("--code-revision must be nonempty.")
+    if not arguments.calibration_id:
+        raise ValueError("--calibration-id must be nonempty.")
+    _validate_sha256(
+        arguments.expected_input_sha256,
+        name="--expected-input-sha256",
+    )
+    _validate_sha256(
+        arguments.calibration_sha256,
+        name="--calibration-sha256",
+    )
+    if not arguments.calibration_file.is_file():
+        raise FileNotFoundError(f"Calibration file is not a file: {arguments.calibration_file}")
+    if arguments.require_paris_profile and arguments.expected_outer_labels is None:
+        raise ValueError("--require-paris-profile requires --expected-outer-labels.")
+    if arguments.resume_checkpoint is not None and not arguments.resume_checkpoint.is_file():
+        raise FileNotFoundError(f"Resume checkpoint is not a file: {arguments.resume_checkpoint}")
+
+
+def _requested_kernel_settings(
+    arguments: argparse.Namespace,
+    fixed_position_scales: tuple[float, ...],
+) -> FullTilingPyMCHMCKernelSettings:
+    """Return the exact resolved CLI kernel settings."""
+    return FullTilingPyMCHMCKernelSettings(
+        fixed_k=arguments.k,
+        step_size=arguments.step_size,
+        leapfrog_steps=arguments.leapfrog_steps,
+        leaf_position_scale=arguments.leaf_position_scale,
+        fixed_coefficient_position_scale=fixed_position_scales,
+    )
+
+
+def run(arguments: argparse.Namespace) -> dict[str, Any]:
+    """Validate, run, and publish one fresh or resumed complete-sweep segment.
+
+    Args:
+        arguments: Namespace returned by :func:`build_parser`.
+
+    Returns:
+        Strict-JSON-compatible dry-run or completed-segment summary.
+
+    Raises:
+        FileExistsError: If a create-only output target already exists.
+        FileNotFoundError: If an input, checkpoint, or output parent is absent.
+        ImportError: If the required PyMC/PyTensor runtime is unavailable.
+        OSError: If input, preflight, checkpoint, or artifact I/O fails.
+        ValueError: If scientific inputs, hashes, settings, initialization,
+            backend identity, closure, target, or checkpoint are incompatible.
+        RuntimeError: If sampling or artifact reopen validation fails.
+    """
+    _validate_arguments(arguments)
+    _preflight_output_backend(
+        arguments.output_directory.parent,
+        engine=arguments.netcdf_engine,
+    )
+    input_started = perf_counter()
+    input_digest = _sha256_file(arguments.input)
+    if input_digest.lower() != arguments.expected_input_sha256.lower():
+        raise ValueError("Frozen input SHA-256 does not match --expected-input-sha256.")
+    dataset = _load_frozen_dataset(
+        arguments.input,
+        engine=arguments.input_netcdf_engine,
+    )
+    try:
+        if _sha256_file(arguments.input) != input_digest:
+            raise ValueError("Frozen input changed while it was being loaded.")
+        input_seconds = perf_counter() - input_started
+        setup_started = perf_counter()
+        adapter = _build_adapter(dataset, arguments)
+        if arguments.require_paris_profile:
+            _require_paris_profile(
+                dataset,
+                adapter,
+                fixed_design_name=arguments.fixed_design_name,
+                expected_outer_labels=cast(
+                    tuple[str, ...],
+                    arguments.expected_outer_labels,
+                ),
+            )
+        problem = full_tiling_problem_from_gamma_beta_adapter(
+            adapter,
+            concentration=arguments.concentration,
+        )
+        if arguments.initialization == "largest-nominal":
+            initial_state = initialize_full_tiling_posterior_state(
+                problem,
+                k=arguments.k,
+            )
+        else:
+            initial_state = initialize_random_full_tiling_posterior_state(
+                problem,
+                k=arguments.k,
+                seed=arguments.initialization_seed,
+            )
+        if not np.isfinite(initial_state.log_target):
+            raise ValueError("Initial full-tiling log target is not finite.")
+        closure = _closure_audit(
+            dataset,
+            adapter,
+            initial_state=initial_state,
+            sensitivity_name=arguments.sensitivity_name,
+            fixed_design_name=arguments.fixed_design_name,
+            fixed_offset_name=arguments.fixed_offset_name,
+        )
+        fixed_design = dataset[arguments.fixed_design_name]
+        fixed_dimension = next(dimension for dimension in fixed_design.dims if dimension != "nmeasure")
+        outer_labels = _dimension_labels(dataset, fixed_dimension)
+        observation_labels = _dimension_labels(dataset, "nmeasure")
+        fixed_position_scales = _expand_values(
+            arguments.fixed_coefficient_position_scale,
+            size=adapter.problem.n_fixed_coefficients,
+            name="fixed_coefficient_position_scale",
+        )
+        requested_settings = _requested_kernel_settings(
+            arguments,
+            fixed_position_scales,
+        )
+        calibration, calibration_digest = _load_verified_calibration(
+            arguments,
+            adapter,
+            input_digest=input_digest,
+            fixed_position_scales=fixed_position_scales,
+        )
+        problem_setup_seconds = perf_counter() - setup_started
+        preflight_started = perf_counter()
+        initial_preflight = _transformed_target_preflight(
+            problem,
+            initial_state,
+        )
+        preflight_seconds = perf_counter() - preflight_started
+        manifest = _build_manifest(
+            arguments,
+            adapter,
+            initial_state=initial_state,
+            input_digest=input_digest,
+            outer_labels=outer_labels,
+            fixed_position_scales=fixed_position_scales,
+            calibration=calibration,
+            calibration_digest=calibration_digest,
+        )
+        if arguments.dry_run:
+            return {
+                "schema": ("openghg_inversions.full_tiling_pymc_hmc_native_summary.v1"),
+                "status": "dry_run",
+                "input": {
+                    "id": arguments.input_id,
+                    "path": str(arguments.input.resolve()),
+                    "sha256": input_digest,
+                },
+                "fixed_k": arguments.k,
+                "requested_segment_sweeps": arguments.sweeps,
+                "closure": closure,
+                "transformed_target_preflight": initial_preflight,
+                "runtime_identity": asdict(full_tiling_pymc_hmc_runtime_identity()),
+                "manifest": manifest,
+                "performance": {
+                    "input_hash_and_load_seconds": input_seconds,
+                    "problem_setup_seconds": problem_setup_seconds,
+                    "transformed_target_preflight_compile_seconds": (preflight_seconds),
+                },
+            }
+
+        parent_checkpoint_sha256: str | None
+        parent_completion_sha256: str | None
+        parent_checkpoint_path: Path | None
+        parent_artifact_hashes: dict[str, str] | None
+        parent_certification: tuple[str, dict[str, str]] | None
+        if arguments.resume_checkpoint is None:
+            parent_checkpoint_sha256 = None
+            parent_completion_sha256 = None
+            parent_checkpoint_path = None
+            parent_artifact_hashes = None
+            parent_certification = None
+            segment_initial_state = initial_state
+            preflight = initial_preflight
+            result = sample_full_tiling_pymc_hmc(
+                problem,
+                initial_state,
+                FullTilingPyMCHMCConfig(
+                    iterations=arguments.sweeps,
+                    step_size=arguments.step_size,
+                    leapfrog_steps=arguments.leapfrog_steps,
+                    leaf_position_scale=arguments.leaf_position_scale,
+                    fixed_coefficient_position_scale=(fixed_position_scales),
+                    seed=arguments.seed,
+                ),
+            )
+        else:
+            parent_checkpoint_path = cast(Path, arguments.resume_checkpoint)
+            parent_certification = _certify_parent_segment_bundle(parent_checkpoint_path)
+            parent_completion_sha256, parent_artifact_hashes = parent_certification
+            parent_checkpoint_sha256 = parent_artifact_hashes[CHECKPOINT_FILENAME]
+            checkpoint = load_full_tiling_pymc_hmc_checkpoint(
+                parent_checkpoint_path,
+                problem,
+                expected_run_manifest=manifest,
+            )
+            if _certify_parent_segment_bundle(parent_checkpoint_path) != parent_certification:
+                raise ValueError("Parent segment bundle changed while it was being loaded.")
+            if checkpoint.kernel_settings != requested_settings:
+                raise ValueError("Resume checkpoint HMC settings do not match the CLI.")
+            segment_initial_state = checkpoint.state
+            resumed_preflight_started = perf_counter()
+            preflight = _transformed_target_preflight(
+                problem,
+                checkpoint.state,
+                log_leaf_mass=checkpoint.log_leaf_mass,
+                log_fixed_coefficient=(checkpoint.log_fixed_coefficient),
+            )
+            preflight_seconds += perf_counter() - resumed_preflight_started
+            result = continue_full_tiling_pymc_hmc(
+                problem,
+                checkpoint,
+                iterations=arguments.sweeps,
+            )
+        if (
+            result.trace.global_sweep.size != arguments.sweeps
+            or result.trace.state_sweep.size != arguments.sweeps + 1
+            or result.checkpoint.sweeps_completed != int(result.trace.state_sweep[-1])
+        ):
+            raise RuntimeError("Sampler did not finish the requested complete-sweep segment.")
+        if (
+            result.checkpoint.kernel_settings != requested_settings
+            or result.checkpoint.schedule_id != FULL_TILING_PYMC_HMC_SCHEDULE_ID
+            or result.checkpoint.runtime_identity != full_tiling_pymc_hmc_runtime_identity()
+        ):
+            raise RuntimeError("Sampler checkpoint identity differs from requested settings.")
+        if np.any(result.trace.hmc_n_steps != arguments.leapfrog_steps):
+            raise RuntimeError("Trace HMC leapfrog counts differ from the frozen setting.")
+        summary = _summary(
+            result,
+            chain_initial_state=initial_state,
+            segment_initial_state=segment_initial_state,
+            closure=closure,
+            preflight=preflight,
+            input_path=arguments.input,
+            input_digest=input_digest,
+            parent_checkpoint_sha256=parent_checkpoint_sha256,
+            parent_completion_sha256=parent_completion_sha256,
+            parent_artifact_sha256=parent_artifact_hashes,
+            input_seconds=input_seconds,
+            problem_setup_seconds=problem_setup_seconds,
+            preflight_seconds=preflight_seconds,
+        )
+        manifest_text = _canonical_json(manifest)
+        trace_dataset = _trace_to_dataset(
+            result,
+            problem=problem,
+            adapter=adapter,
+            observation_labels=observation_labels,
+            outer_labels=outer_labels,
+            input_digest=input_digest,
+            manifest_digest=sha256(manifest_text.encode("utf-8")).hexdigest(),
+        )
+        try:
+            if (
+                parent_checkpoint_path is not None
+                and parent_certification is not None
+                and _certify_parent_segment_bundle(parent_checkpoint_path) != parent_certification
+            ):
+                raise ValueError("Parent segment bundle changed before child publication.")
+            _write_outputs(
+                arguments.output_directory,
+                result,
+                problem=problem,
+                manifest=manifest,
+                summary=summary,
+                trace_dataset=trace_dataset,
+                netcdf_engine=arguments.netcdf_engine,
+            )
+        finally:
+            trace_dataset.close()
+        return summary
+    finally:
+        dataset.close()
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run one native HMC segment and print its machine-readable summary.
+
+    Args:
+        argv: Optional command-line arguments excluding the program name.
+
+    Returns:
+        Zero after a successful dry run or completed artifact workflow.
+
+    Raises:
+        SystemExit: If command-line parsing fails.
+        Exception: Propagates validation, sampling, and publication failures
+            so batch jobs fail closed.
+
+    Notes:
+        On success, one indented strict-JSON summary is written to standard
+        output. Non-dry runs publish their create-only artifact bundle before
+        the summary is printed.
+    """
+    arguments = build_parser().parse_args(argv)
+    summary = run(arguments)
+    print(
+        json.dumps(
+            summary,
+            indent=2,
+            sort_keys=True,
+            ensure_ascii=False,
+            allow_nan=False,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/rjmcmc/full_tiling_pymc_hmc_native.py
+++ b/examples/rjmcmc/full_tiling_pymc_hmc_native.py
@@ -15,14 +15,18 @@ the compiled PyMC density is checked against the independently assembled
 scientific target plus the symmetric log-coordinate Jacobians. Static HMC
 settings are calibration outputs: no adaptation, online tuning, randomized
 step size, or topology-dependent metric is enabled here.
+The larger leaf-metric eigenvalue may be at most 10,000 times the smaller one.
 
-``--calibration-file`` is a strict-JSON v1 calibration identity with exactly
+``--calibration-file`` is a strict-JSON v2 calibration identity with exactly
 this shape (values shown symbolically):
+
+Calibration v1 used the retired scalar diagonal leaf metric and is rejected;
+no automatic converter is provided.
 
 .. code-block:: json
 
    {
-     "schema": "openghg_inversions.full_tiling_pymc_hmc_calibration.v1",
+     "schema": "openghg_inversions.full_tiling_pymc_hmc_calibration.v2",
      "calibration_id": "<--calibration-id>",
      "fixed_k": "<--k>",
      "input_sha256": "<--expected-input-sha256>",
@@ -40,16 +44,30 @@ this shape (values shown symbolically):
        "leapfrog_steps": "<--leapfrog-steps>",
        "coordinate_layout_id": "<driver coordinate layout ID>",
        "metric_semantics_id": "<driver metric semantics ID>",
-       "leaf_position_scale": "<--leaf-position-scale>",
+       "leaf_contrast_position_scale": "<--leaf-contrast-position-scale>",
+       "leaf_total_position_scale": "<--leaf-total-position-scale>",
        "fixed_coefficient_position_scale": ["<resolved fixed scales>"]
      },
      "evidence": {
        "code_revision": "<--code-revision>",
        "robust_variance_estimator": "squared_scaled_median_absolute_deviation_1.4826",
+       "leaf_metric_estimator": "normalized_common_and_centered_contrast_scaled_mad_v1",
        "clipping_bounds": [0.0001, 100.0],
-       "pilot_initializers": [
-         {"strategy": "largest-nominal", "seed": null, "sweeps": 100},
-         {"strategy": "random-recursive", "seed": "<seed>", "sweeps": 100}
+       "development_initializers": [
+         {
+           "role": "development-a",
+           "strategy": "random-recursive",
+           "seed": "<development topology seed A>",
+           "sampler_seed": "<development sampler seed A>",
+           "sweeps": 200
+         },
+         {
+           "role": "development-b",
+           "strategy": "random-recursive",
+           "seed": "<development topology seed B>",
+           "sampler_seed": "<development sampler seed B>",
+           "sweeps": 200
+         }
        ],
        "candidate_grid": [
          {"step_size": "<candidate>", "leapfrog_steps": "<candidate>"}
@@ -58,14 +76,56 @@ this shape (values shown symbolically):
          {
            "step_size": "<candidate>",
            "leapfrog_steps": "<candidate>",
-           "largest_nominal_mean_acceptance": "<finite value>",
-           "random_recursive_mean_acceptance": "<finite value>",
+           "development_a_mean_acceptance": "<finite value>",
+           "development_b_mean_acceptance": "<finite value>",
            "divergences": "<non-negative integer>",
            "finite": "<Boolean>",
-           "median_log_displacement_per_leapfrog_step": "<finite value>",
+           "median_hmc_log_displacement_per_leapfrog_step": "<finite value>",
            "selected": "<Boolean>"
          }
        ],
+       "selected_validation": {
+         "step_size": "<selected candidate>",
+         "leapfrog_steps": "<selected candidate>",
+         "initializers": [
+           {
+             "role": "development-a",
+             "strategy": "random-recursive",
+             "seed": "<development topology seed A>",
+             "sampler_seed": "<validation sampler seed A>",
+             "sweeps": 500,
+             "mean_acceptance": "<finite value>",
+             "divergences": 0,
+             "finite": true
+           },
+           {
+             "role": "development-b",
+             "strategy": "random-recursive",
+             "seed": "<development topology seed B>",
+             "sampler_seed": "<validation sampler seed B>",
+             "sweeps": 500,
+             "mean_acceptance": "<finite value>",
+             "divergences": 0,
+             "finite": true
+           },
+           {
+             "role": "held-out",
+             "strategy": "random-recursive",
+             "seed": "<held-out topology seed>",
+             "sampler_seed": "<held-out validation sampler seed>",
+             "sweeps": 500,
+             "mean_acceptance": "<finite value>",
+             "divergences": 0,
+             "finite": true
+           }
+         ]
+       },
+       "excluded_production_topology_sha256": {
+         "metric_source": "<SHA-256>",
+         "development_a": "<SHA-256>",
+         "development_b": "<SHA-256>",
+         "held_out": "<SHA-256>"
+       },
        "source_artifact_sha256": {"<artifact ID>": "<SHA-256>"}
      }
    }
@@ -74,10 +134,17 @@ The file must contain no additional keys, duplicate object keys, or non-finite
 JSON constants. Its bytes must match ``--calibration-sha256`` and every
 identity value must match the current invocation. Candidate rows and decision
 rows must correspond one-to-one; exactly one finite, zero-divergence decision
-must be selected, must match the requested kernel, and must have both pilot
-acceptance means in the inclusive interval 0.6--0.9. Production ``K=50`` and
-``K=250`` evidence additionally requires the reviewed random-recursive pilot
-seeds 51051 and 51251, respectively.
+must be selected, must match the requested kernel, and must have both
+development acceptance means in the inclusive interval 0.6--0.9. The selected
+candidate must also have three ordered 500-sweep validation initializers with
+finite acceptance in that interval and zero divergences. Production ``K=50``
+and ``K=250`` evidence additionally requires reviewed, role-specific topology
+and master PCG64 seeds. Candidate development runs reuse the same master seed
+for a given topology across every candidate (common random numbers);
+validation uses distinct streams, and all calibration topology seeds are
+disjoint from retained-production starts. The driver also rejects exact
+collisions between a proposed production topology hash and the four
+calibration topology hashes, including the fixed-basis NUTS metric source.
 
 Successful runs publish ``manifest.json``, ``trace.nc``, ``summary.json``, and
 ``checkpoint.npz`` inside a new output directory. Every artifact is reopened
@@ -155,9 +222,29 @@ TRACE_FILENAME = "trace.nc"
 SUMMARY_FILENAME = "summary.json"
 CHECKPOINT_FILENAME = "checkpoint.npz"
 COMPLETION_FILENAME = "complete.json"
-CALIBRATION_SCHEMA = "openghg_inversions.full_tiling_pymc_hmc_calibration.v1"
-COMPLETION_SCHEMA = "openghg_inversions.full_tiling_pymc_hmc_native_completion.v1"
+CALIBRATION_SCHEMA = "openghg_inversions.full_tiling_pymc_hmc_calibration.v2"
+LEGACY_CALIBRATION_SCHEMA = "openghg_inversions.full_tiling_pymc_hmc_calibration.v1"
+COMPLETION_SCHEMA = "openghg_inversions.full_tiling_pymc_hmc_native_completion.v2"
 ROBUST_VARIANCE_ESTIMATOR = "squared_scaled_median_absolute_deviation_1.4826"
+LEAF_METRIC_ESTIMATOR = "normalized_common_and_centered_contrast_scaled_mad_v1"
+MAX_LEAF_METRIC_CONDITION_RATIO = 1.0e4
+POSITION_SCALE_CLIPPING_BOUNDS = (1.0e-4, 1.0e2)
+CALIBRATION_DEVELOPMENT_TOPOLOGY_SEEDS = {
+    50: (41050, 41051),
+    250: (41250, 41251),
+}
+CALIBRATION_HELD_OUT_TOPOLOGY_SEEDS = {
+    50: 41052,
+    250: 41252,
+}
+CALIBRATION_DEVELOPMENT_SAMPLER_SEEDS = {
+    50: (71050, 71051),
+    250: (71250, 71251),
+}
+CALIBRATION_VALIDATION_SAMPLER_SEEDS = {
+    50: (72050, 72051, 72052),
+    250: (72250, 72251, 72252),
+}
 PARIS_OBSERVATIONS = 1_382
 PARIS_GRID_SHAPE = (183, 128)
 PARIS_OUTER_COEFFICIENTS = 6
@@ -804,7 +891,7 @@ def _build_manifest(
         input_digest: Frozen input whole-file SHA-256.
         outer_labels: Ordered fixed-coefficient labels.
         fixed_position_scales: Fully resolved fixed-coordinate position scale.
-        calibration: Verified v1 calibration identity.
+        calibration: Verified v2 calibration identity.
         calibration_digest: Verified whole-file calibration SHA-256.
 
     Returns:
@@ -819,7 +906,7 @@ def _build_manifest(
     bounds = _rectangle_bounds(initial_state)
     runtime_identity = asdict(full_tiling_pymc_hmc_runtime_identity())
     manifest: dict[str, object] = {
-        "schema": ("openghg_inversions.full_tiling_pymc_hmc_native_manifest.v1"),
+        "schema": ("openghg_inversions.full_tiling_pymc_hmc_native_manifest.v2"),
         "status": "experimental_mobile_hmc_not_convergence_evidence",
         "input": {
             "id": arguments.input_id,
@@ -861,7 +948,8 @@ def _build_manifest(
             "chains_per_invocation": 1,
             "step_size_requested": float(arguments.step_size),
             "leapfrog_steps": int(arguments.leapfrog_steps),
-            "leaf_position_scale": float(arguments.leaf_position_scale),
+            "leaf_contrast_position_scale": float(arguments.leaf_contrast_position_scale),
+            "leaf_total_position_scale": float(arguments.leaf_total_position_scale),
             "fixed_coefficient_position_scale": list(fixed_position_scales),
             "metric_semantics_id": (FULL_TILING_PYMC_HMC_METRIC_SEMANTICS_ID),
             "coordinate_layout_id": (FULL_TILING_PYMC_HMC_COORDINATE_LAYOUT_ID),
@@ -895,7 +983,7 @@ def _expected_calibration_identity(
     input_digest: str,
     fixed_position_scales: tuple[float, ...],
 ) -> dict[str, Any]:
-    """Build the exact minimal v1 calibration identity for this invocation.
+    """Build the exact minimal v2 calibration identity for this invocation.
 
     Args:
         arguments: Validated driver arguments.
@@ -931,7 +1019,8 @@ def _expected_calibration_identity(
             "leapfrog_steps": int(arguments.leapfrog_steps),
             "coordinate_layout_id": FULL_TILING_PYMC_HMC_COORDINATE_LAYOUT_ID,
             "metric_semantics_id": FULL_TILING_PYMC_HMC_METRIC_SEMANTICS_ID,
-            "leaf_position_scale": float(arguments.leaf_position_scale),
+            "leaf_contrast_position_scale": float(arguments.leaf_contrast_position_scale),
+            "leaf_total_position_scale": float(arguments.leaf_total_position_scale),
             "fixed_coefficient_position_scale": list(fixed_position_scales),
         },
     }
@@ -990,25 +1079,28 @@ def _validate_calibration_evidence(
 
     Raises:
         ValueError: If evidence keys, code revision, robust estimator, clipping
-            bounds, pilot identities, candidate grid, decision statistics,
-            selected candidate, acceptance gates, or source SHA-256 values
-            violate the v1 contract.
+            bounds, development identities, candidate grid, decision
+            statistics, selected candidate validation, acceptance gates, or
+            source SHA-256 values violate the v2 contract.
 
     Notes:
         Candidate and decision rows must correspond one-to-one. Exactly one
         finite, zero-divergence candidate must be selected, and production
         ``K=50``/``K=250`` evidence is bound to the reviewed random-recursive
-        pilot seeds.
+        development and held-out seeds.
     """
     evidence = _require_exact_keys(
         value,
         {
             "code_revision",
             "robust_variance_estimator",
+            "leaf_metric_estimator",
             "clipping_bounds",
-            "pilot_initializers",
+            "development_initializers",
             "candidate_grid",
             "decision_statistics",
+            "selected_validation",
+            "excluded_production_topology_sha256",
             "source_artifact_sha256",
         },
         name="Calibration evidence",
@@ -1017,31 +1109,58 @@ def _validate_calibration_evidence(
         raise ValueError("Calibration evidence code_revision does not match --code-revision.")
     if evidence["robust_variance_estimator"] != ROBUST_VARIANCE_ESTIMATOR:
         raise ValueError("Calibration evidence robust variance estimator is incompatible.")
-    if _canonical_json(evidence["clipping_bounds"]) != _canonical_json([1.0e-4, 1.0e2]):
+    if evidence["leaf_metric_estimator"] != LEAF_METRIC_ESTIMATOR:
+        raise ValueError("Calibration evidence leaf metric estimator is incompatible.")
+    if _canonical_json(evidence["clipping_bounds"]) != _canonical_json(list(POSITION_SCALE_CLIPPING_BOUNDS)):
         raise ValueError("Calibration evidence clipping_bounds must be [0.0001, 100.0].")
 
-    pilots = evidence["pilot_initializers"]
-    if not isinstance(pilots, list) or len(pilots) != 2:
-        raise ValueError("Calibration evidence must declare exactly two pilot initializers.")
-    expected_strategies = ("largest-nominal", "random-recursive")
-    for index, expected_strategy in enumerate(expected_strategies):
-        pilot = _require_exact_keys(
-            pilots[index],
-            {"strategy", "seed", "sweeps"},
-            name=f"Calibration pilot {index}",
+    development_initializers = evidence["development_initializers"]
+    if not isinstance(development_initializers, list) or len(development_initializers) != 2:
+        raise ValueError("Calibration evidence must declare exactly two development initializers.")
+    development_topology_seeds: list[int] = []
+    development_sampler_seeds: list[int] = []
+    for index in range(2):
+        initializer = _require_exact_keys(
+            development_initializers[index],
+            {"role", "strategy", "seed", "sampler_seed", "sweeps"},
+            name=f"Calibration development initializer {index}",
         )
-        if pilot["strategy"] != expected_strategy or pilot["sweeps"] != 100:
-            raise ValueError("Calibration pilot strategies and sweep counts are incompatible.")
-        seed = pilot["seed"]
-        if expected_strategy == "largest-nominal":
-            if seed is not None:
-                raise ValueError("Largest-nominal calibration pilot seed must be null.")
-        elif isinstance(seed, bool) or not isinstance(seed, int) or seed < 0:
-            raise ValueError("Random-recursive calibration pilot seed must be non-negative.")
-    required_random_seed = {50: 51051, 250: 51251}.get(arguments.k)
-    if required_random_seed is not None and pilots[1]["seed"] != required_random_seed:
+        sweeps = initializer["sweeps"]
+        if (
+            initializer["role"] != f"development-{chr(ord('a') + index)}"
+            or initializer["strategy"] != "random-recursive"
+            or isinstance(sweeps, bool)
+            or not isinstance(sweeps, int)
+            or sweeps != 200
+        ):
+            raise ValueError(
+                "Calibration development initializer strategies and sweep counts are incompatible."
+            )
+        seed = initializer["seed"]
+        sampler_seed = initializer["sampler_seed"]
+        if isinstance(seed, bool) or not isinstance(seed, int) or seed < 0:
+            raise ValueError("Calibration development topology seeds must be non-negative.")
+        if isinstance(sampler_seed, bool) or not isinstance(sampler_seed, int) or sampler_seed < 0:
+            raise ValueError("Calibration development sampler seeds must be non-negative.")
+        development_topology_seeds.append(seed)
+        development_sampler_seeds.append(sampler_seed)
+    if len(set(development_topology_seeds)) != 2 or len(set(development_sampler_seeds)) != 2:
+        raise ValueError("Calibration development topology and sampler seeds must be distinct.")
+    required_development_topology_seeds = CALIBRATION_DEVELOPMENT_TOPOLOGY_SEEDS.get(arguments.k)
+    if (
+        required_development_topology_seeds is not None
+        and tuple(development_topology_seeds) != required_development_topology_seeds
+    ):
         raise ValueError(
-            f"Calibration evidence for K={arguments.k} requires pilot seed {required_random_seed}."
+            f"Calibration evidence for K={arguments.k} has incompatible development topology seeds."
+        )
+    required_development_sampler_seeds = CALIBRATION_DEVELOPMENT_SAMPLER_SEEDS.get(arguments.k)
+    if (
+        required_development_sampler_seeds is not None
+        and tuple(development_sampler_seeds) != required_development_sampler_seeds
+    ):
+        raise ValueError(
+            f"Calibration evidence for K={arguments.k} has incompatible development sampler seeds."
         )
 
     candidate_grid = evidence["candidate_grid"]
@@ -1062,11 +1181,11 @@ def _validate_calibration_evidence(
     decision_keys = {
         "step_size",
         "leapfrog_steps",
-        "largest_nominal_mean_acceptance",
-        "random_recursive_mean_acceptance",
+        "development_a_mean_acceptance",
+        "development_b_mean_acceptance",
         "divergences",
         "finite",
-        "median_log_displacement_per_leapfrog_step",
+        "median_hmc_log_displacement_per_leapfrog_step",
         "selected",
     }
     for index, item in enumerate(decisions):
@@ -1084,9 +1203,9 @@ def _validate_calibration_evidence(
         )
         decision_candidates.append(candidate)
         for field in (
-            "largest_nominal_mean_acceptance",
-            "random_recursive_mean_acceptance",
-            "median_log_displacement_per_leapfrog_step",
+            "development_a_mean_acceptance",
+            "development_b_mean_acceptance",
+            "median_hmc_log_displacement_per_leapfrog_step",
         ):
             _finite_json_number(decision[field], name=f"Calibration decision {index}.{field}")
         divergences = decision["divergences"]
@@ -1109,10 +1228,120 @@ def _validate_calibration_evidence(
     if (
         selected_decision["finite"] is not True
         or selected_decision["divergences"] != 0
-        or not 0.6 <= float(selected_decision["largest_nominal_mean_acceptance"]) <= 0.9
-        or not 0.6 <= float(selected_decision["random_recursive_mean_acceptance"]) <= 0.9
+        or not 0.6 <= float(selected_decision["development_a_mean_acceptance"]) <= 0.9
+        or not 0.6 <= float(selected_decision["development_b_mean_acceptance"]) <= 0.9
     ):
         raise ValueError("Selected calibration decision does not pass the frozen acceptance gates.")
+
+    selected_validation = _require_exact_keys(
+        evidence["selected_validation"],
+        {"step_size", "leapfrog_steps", "initializers"},
+        name="Calibration selected_validation",
+    )
+    validation_candidate = _calibration_candidate(
+        {
+            "step_size": selected_validation["step_size"],
+            "leapfrog_steps": selected_validation["leapfrog_steps"],
+        },
+        name="Calibration selected_validation",
+    )
+    if validation_candidate != selected_candidate:
+        raise ValueError("Calibration selected_validation candidate does not match the selected decision.")
+    validation_initializers = selected_validation["initializers"]
+    if not isinstance(validation_initializers, list) or len(validation_initializers) != 3:
+        raise ValueError("Calibration selected_validation must declare exactly three initializers.")
+    expected_validation_identities = (
+        ("development-a", development_topology_seeds[0]),
+        ("development-b", development_topology_seeds[1]),
+        ("held-out", None),
+    )
+    held_out_seed: int | None = None
+    validation_sampler_seeds: list[int] = []
+    for index, (expected_role, expected_seed) in enumerate(expected_validation_identities):
+        initializer = _require_exact_keys(
+            validation_initializers[index],
+            {
+                "role",
+                "strategy",
+                "seed",
+                "sampler_seed",
+                "sweeps",
+                "mean_acceptance",
+                "divergences",
+                "finite",
+            },
+            name=f"Calibration selected validation initializer {index}",
+        )
+        sweeps = initializer["sweeps"]
+        if (
+            initializer["role"] != expected_role
+            or initializer["strategy"] != "random-recursive"
+            or isinstance(sweeps, bool)
+            or not isinstance(sweeps, int)
+            or sweeps != 500
+        ):
+            raise ValueError(
+                "Calibration selected validation initializer identities and sweep counts are incompatible."
+            )
+        seed = initializer["seed"]
+        if index < 2:
+            if seed != expected_seed or isinstance(seed, bool):
+                raise ValueError("Calibration selected validation development seeds are incompatible.")
+        elif isinstance(seed, bool) or not isinstance(seed, int) or seed < 0:
+            raise ValueError("Calibration held-out random-recursive seed must be non-negative.")
+        else:
+            held_out_seed = seed
+        sampler_seed = initializer["sampler_seed"]
+        if isinstance(sampler_seed, bool) or not isinstance(sampler_seed, int) or sampler_seed < 0:
+            raise ValueError("Calibration selected validation sampler seeds must be non-negative.")
+        validation_sampler_seeds.append(sampler_seed)
+        mean_acceptance = _finite_json_number(
+            initializer["mean_acceptance"],
+            name=f"Calibration selected validation initializer {index}.mean_acceptance",
+        )
+        divergences = initializer["divergences"]
+        if (
+            initializer["finite"] is not True
+            or isinstance(divergences, bool)
+            or not isinstance(divergences, int)
+            or divergences != 0
+            or not 0.6 <= mean_acceptance <= 0.9
+        ):
+            raise ValueError(
+                "Calibration selected validation initializer does not pass the frozen acceptance gates."
+            )
+    if held_out_seed in development_topology_seeds:
+        raise ValueError("Calibration held-out topology seed must differ from development seeds.")
+    if len(set(validation_sampler_seeds)) != 3:
+        raise ValueError("Calibration selected validation sampler seeds must be distinct.")
+    if set(validation_sampler_seeds) & set(development_sampler_seeds):
+        raise ValueError("Calibration validation sampler seeds must differ from development sampler seeds.")
+    required_held_out_seed = CALIBRATION_HELD_OUT_TOPOLOGY_SEEDS.get(arguments.k)
+    if required_held_out_seed is not None and held_out_seed != required_held_out_seed:
+        raise ValueError(
+            f"Calibration evidence for K={arguments.k} has an incompatible held-out topology seed."
+        )
+    required_validation_sampler_seeds = CALIBRATION_VALIDATION_SAMPLER_SEEDS.get(arguments.k)
+    if (
+        required_validation_sampler_seeds is not None
+        and tuple(validation_sampler_seeds) != required_validation_sampler_seeds
+    ):
+        raise ValueError(
+            f"Calibration evidence for K={arguments.k} has incompatible validation sampler seeds."
+        )
+
+    excluded_topologies = _require_exact_keys(
+        evidence["excluded_production_topology_sha256"],
+        {"metric_source", "development_a", "development_b", "held_out"},
+        name="Calibration excluded production topologies",
+    )
+    for role, digest in excluded_topologies.items():
+        _validate_sha256(
+            digest,
+            name=f"Calibration excluded topology {role!r} SHA-256",
+        )
+    if len(set(excluded_topologies.values())) != len(excluded_topologies):
+        raise ValueError("Calibration excluded production topology hashes must be distinct.")
 
     sources = evidence["source_artifact_sha256"]
     if not isinstance(sources, dict) or not sources:
@@ -1144,7 +1373,7 @@ def _load_verified_calibration(
     Raises:
         FileNotFoundError: If the calibration file is absent.
         OSError: If the calibration file cannot be read.
-        ValueError: If its hash, strict JSON, stability, or v1 identity does
+        ValueError: If its hash, strict JSON, stability, or v2 identity does
             not exactly match the current invocation.
     """
     path = cast(Path, arguments.calibration_file)
@@ -1157,6 +1386,8 @@ def _load_verified_calibration(
     )
     if _sha256_file(path) != digest:
         raise ValueError("Calibration file changed while it was being validated.")
+    if calibration.get("schema") == LEGACY_CALIBRATION_SCHEMA:
+        raise ValueError("Calibration v1 uses the retired diagonal metric; calibration v2 is required.")
     expected = _expected_calibration_identity(
         arguments,
         adapter,
@@ -1164,10 +1395,10 @@ def _load_verified_calibration(
         fixed_position_scales=fixed_position_scales,
     )
     if set(calibration) != {*expected, "evidence"}:
-        raise ValueError("Calibration v1 root keys are incompatible.")
+        raise ValueError("Calibration v2 root keys are incompatible.")
     identity = {name: calibration[name] for name in expected}
     if _canonical_json(identity) != _canonical_json(expected):
-        raise ValueError("Calibration v1 identity does not exactly match the current invocation.")
+        raise ValueError("Calibration v2 identity does not exactly match the current invocation.")
     _validate_calibration_evidence(calibration["evidence"], arguments)
     return calibration, digest
 
@@ -1368,6 +1599,16 @@ def _trace_to_dataset(
             trace.structural_invalid_reason,
             {"long_name": "empty for valid structural proposals"},
         ),
+        "hmc_start_log_leaf_mass": (
+            ("sweep", "region"),
+            trace.hmc_start_log_leaf_mass,
+            {"long_name": ("post-structure pre-HMC log leaf masses in post-HMC canonical order")},
+        ),
+        "hmc_start_log_fixed_coefficient": (
+            ("sweep", "fixed_parameter"),
+            trace.hmc_start_log_fixed_coefficient,
+            {"long_name": "post-structure pre-HMC log fixed coefficients"},
+        ),
         "hmc_accepted": (
             ("sweep",),
             trace.hmc_accepted,
@@ -1434,7 +1675,7 @@ def _trace_to_dataset(
             "lon": adapter.longitudes,
         },
         attrs={
-            "schema": ("openghg_inversions.full_tiling_pymc_hmc_native_trace.v1"),
+            "schema": ("openghg_inversions.full_tiling_pymc_hmc_native_trace.v2"),
             "title": "Static PyMC HMC mobile full-tiling segment",
             "diagnostic_only": "true",
             "convergence_claim": "none",
@@ -1531,7 +1772,7 @@ def _summary(
     divergences = int(np.count_nonzero(trace.hmc_diverging))
     leapfrog_steps = int(np.sum(trace.hmc_n_steps))
     return {
-        "schema": ("openghg_inversions.full_tiling_pymc_hmc_native_summary.v1"),
+        "schema": ("openghg_inversions.full_tiling_pymc_hmc_native_summary.v2"),
         "status": "experimental_not_convergence_evidence",
         "input": {
             "path": str(input_path.resolve()),
@@ -2003,12 +2244,25 @@ def build_parser() -> argparse.ArgumentParser:
         help="Exact static leapfrog count per compound sweep.",
     )
     parser.add_argument(
-        "--leaf-position-scale",
+        "--leaf-contrast-position-scale",
+        dest="leaf_contrast_position_scale",
         type=float,
         required=True,
         help=(
-            "Shared positive PyMC position-covariance diagonal for symmetric "
-            "log leaf masses; equivalently momentum precision."
+            "Positive PyMC position-covariance eigenvalue on normalized "
+            "centered log-leaf contrasts; equivalently momentum precision. "
+            "The contrast/total maximum-to-minimum ratio may not exceed 10000."
+        ),
+    )
+    parser.add_argument(
+        "--leaf-total-position-scale",
+        dest="leaf_total_position_scale",
+        type=float,
+        required=True,
+        help=(
+            "Positive PyMC position-covariance eigenvalue on the normalized "
+            "common log-leaf total direction; equivalently momentum precision. "
+            "The contrast/total maximum-to-minimum ratio may not exceed 10000."
         ),
     )
     parser.add_argument(
@@ -2018,19 +2272,22 @@ def build_parser() -> argparse.ArgumentParser:
         type=_positive_values,
         required=True,
         metavar="VALUE[,VALUE...]",
-        help=("Shared or ordered fixed-coordinate PyMC position-covariance diagonal."),
+        help=(
+            "Shared or ordered fixed-coordinate PyMC position-covariance "
+            "diagonal; equivalently momentum precision."
+        ),
     )
     parser.add_argument(
         "--calibration-id",
         required=True,
-        help="Stable identifier exactly repeated by the v1 calibration file.",
+        help="Stable identifier exactly repeated by the v2 calibration file.",
     )
     parser.add_argument(
         "--calibration-file",
         type=Path,
         required=True,
         help=(
-            "Strict-JSON v1 calibration identity binding K, input SHA, target "
+            "Strict-JSON v2 calibration identity binding K, input SHA, target "
             "controls, kernel controls, coordinate layout, metric semantics, "
             "resolved position scales, bounded-search decisions, source "
             "artifact hashes, and calibration code revision."
@@ -2167,8 +2424,8 @@ def _validate_arguments(arguments: argparse.Namespace) -> None:
     resolved_output = arguments.output_directory.resolve(strict=False)
     if any("paris_inversions" in part.lower() for part in resolved_output.parts):
         raise ValueError("Output and NetCDF preflight writes beneath PARIS_inversions are forbidden.")
-    if arguments.k < 1:
-        raise ValueError("--k must be positive.")
+    if arguments.k < 2:
+        raise ValueError("--k must be at least two for total/contrast calibration.")
     if arguments.sweeps < 1:
         raise ValueError("--sweeps must be positive.")
     if arguments.seed < 0:
@@ -2182,19 +2439,49 @@ def _validate_arguments(arguments: argparse.Namespace) -> None:
             raise ValueError("--initialization-seed must be non-negative.")
         if arguments.initialization_seed == arguments.seed:
             raise ValueError("--initialization-seed must differ from the master --seed.")
+        calibration_topology_seeds = (
+            *CALIBRATION_DEVELOPMENT_TOPOLOGY_SEEDS.get(arguments.k, ()),
+            *(
+                ()
+                if arguments.k not in CALIBRATION_HELD_OUT_TOPOLOGY_SEEDS
+                else (CALIBRATION_HELD_OUT_TOPOLOGY_SEEDS[arguments.k],)
+            ),
+        )
+        if arguments.initialization_seed in calibration_topology_seeds:
+            raise ValueError("--initialization-seed must be disjoint from H2c calibration topology seeds.")
     elif arguments.initialization_seed is not None:
         raise ValueError("--initialization-seed is only valid with --initialization random-recursive.")
     if arguments.dry_run and arguments.resume_checkpoint is not None:
         raise ValueError("--dry-run cannot be combined with --resume-checkpoint.")
     for name in (
         "step_size",
-        "leaf_position_scale",
+        "leaf_contrast_position_scale",
+        "leaf_total_position_scale",
         "concentration",
         "root_variance",
     ):
         value = float(getattr(arguments, name))
         if not np.isfinite(value) or value <= 0.0:
             raise ValueError(f"--{name.replace('_', '-')} must be finite and positive.")
+    leaf_metric_scales = (
+        float(arguments.leaf_contrast_position_scale),
+        float(arguments.leaf_total_position_scale),
+    )
+    if max(leaf_metric_scales) / min(leaf_metric_scales) > MAX_LEAF_METRIC_CONDITION_RATIO:
+        raise ValueError(
+            "The leaf metric maximum-to-minimum position-scale ratio must not exceed "
+            f"{MAX_LEAF_METRIC_CONDITION_RATIO:g}."
+        )
+    position_scale_values = (
+        *leaf_metric_scales,
+        *(float(value) for value in arguments.fixed_coefficient_position_scale),
+    )
+    lower_scale, upper_scale = POSITION_SCALE_CLIPPING_BOUNDS
+    if any(value < lower_scale or value > upper_scale for value in position_scale_values):
+        raise ValueError(
+            "All requested position scales must lie within the frozen clipping "
+            f"bounds [{lower_scale:g}, {upper_scale:g}]."
+        )
     if arguments.leapfrog_steps < 1:
         raise ValueError("--leapfrog-steps must be positive.")
     if not np.isfinite(arguments.likelihood_power) or arguments.likelihood_power < 0.0:
@@ -2225,12 +2512,23 @@ def _requested_kernel_settings(
     arguments: argparse.Namespace,
     fixed_position_scales: tuple[float, ...],
 ) -> FullTilingPyMCHMCKernelSettings:
-    """Return the exact resolved CLI kernel settings."""
+    """Return the exact resolved v2 CLI kernel settings.
+
+    Args:
+        arguments: Validated namespace containing fixed ``K``, trajectory
+            controls, and both leaf position-covariance eigenscales.
+        fixed_position_scales: Ordered fixed-coefficient
+            position-covariance diagonal.
+
+    Returns:
+        Complete immutable total/contrast HMC kernel settings.
+    """
     return FullTilingPyMCHMCKernelSettings(
         fixed_k=arguments.k,
         step_size=arguments.step_size,
         leapfrog_steps=arguments.leapfrog_steps,
-        leaf_position_scale=arguments.leaf_position_scale,
+        leaf_contrast_position_scale=arguments.leaf_contrast_position_scale,
+        leaf_total_position_scale=arguments.leaf_total_position_scale,
         fixed_coefficient_position_scale=fixed_position_scales,
     )
 
@@ -2338,6 +2636,12 @@ def run(arguments: argparse.Namespace) -> dict[str, Any]:
             input_digest=input_digest,
             fixed_position_scales=fixed_position_scales,
         )
+        initial_topology_sha256 = _topology_sha256(_rectangle_bounds(initial_state))
+        excluded_topologies = calibration["evidence"]["excluded_production_topology_sha256"]
+        if initial_topology_sha256 in excluded_topologies.values():
+            raise ValueError(
+                "Initial topology hash was used by H2c calibration and is excluded from retained production."
+            )
         problem_setup_seconds = perf_counter() - setup_started
         preflight_started = perf_counter()
         initial_preflight = _transformed_target_preflight(
@@ -2359,7 +2663,7 @@ def run(arguments: argparse.Namespace) -> dict[str, Any]:
         )
         if arguments.dry_run:
             return {
-                "schema": ("openghg_inversions.full_tiling_pymc_hmc_native_summary.v1"),
+                "schema": ("openghg_inversions.full_tiling_pymc_hmc_native_summary.v2"),
                 "status": "dry_run",
                 "input": {
                     "id": arguments.input_id,
@@ -2399,7 +2703,8 @@ def run(arguments: argparse.Namespace) -> dict[str, Any]:
                     iterations=arguments.sweeps,
                     step_size=arguments.step_size,
                     leapfrog_steps=arguments.leapfrog_steps,
-                    leaf_position_scale=arguments.leaf_position_scale,
+                    leaf_contrast_position_scale=(arguments.leaf_contrast_position_scale),
+                    leaf_total_position_scale=arguments.leaf_total_position_scale,
                     fixed_coefficient_position_scale=(fixed_position_scales),
                     seed=arguments.seed,
                 ),

--- a/openghg_inversions/experimental/rjmcmc/__init__.py
+++ b/openghg_inversions/experimental/rjmcmc/__init__.py
@@ -20,10 +20,11 @@ full-tiling model and deliberately does not widen the Voronoi state schema.
 The construction-history-free full-tiling track currently provides a
 fixed-``K`` NumPy smoke sampler with edge flips, resolution relocations, and
 an additive-alpha allocation prior. It includes an exact log-root slice
-update, output-only movement diagnostics, and strict durable continuation.
-Production-grid connectivity and variable-``K`` inference are not yet
-claimed. Full-tiling APIs remain explicitly module-qualified while this track
-is experimental.
+update, output-only movement diagnostics, strict durable continuation, and an
+optional static PyMC HMC transition over all continuous coordinates after
+each topology attempt. Production-grid connectivity and variable-``K``
+inference are not yet claimed. Full-tiling APIs remain explicitly
+module-qualified while this track is experimental.
 """
 
 from openghg_inversions.experimental.rjmcmc.core import (

--- a/openghg_inversions/experimental/rjmcmc/full_tiling_pymc_hmc.py
+++ b/openghg_inversions/experimental/rjmcmc/full_tiling_pymc_hmc.py
@@ -21,8 +21,11 @@ topology-dependent metric is allowed.  In-memory checkpoints retain the
 scientific state, exact unconstrained coordinates, immutable settings, sweep
 coordinate, and master PCG64 state.  Reconstructing and reseeding PyMC at every
 continuation boundary makes split execution exactly replayable without
-persisting mutable backend sampler state. This explicitly experimental module
-performs no durable file I/O.
+persisting mutable backend sampler state. Fresh initializer states instead
+pass through :func:`canonicalize_full_tiling_pymc_hmc_fresh_state` before draw
+zero so their physical values decode exactly from the authoritative log
+coordinates. This explicitly experimental module performs no durable file
+I/O.
 """
 
 from __future__ import annotations
@@ -79,6 +82,7 @@ __all__ = [
     "FullTilingPyMCHMCSamplingResult",
     "FullTilingPyMCHMCTrace",
     "build_full_tiling_pymc_hmc_model",
+    "canonicalize_full_tiling_pymc_hmc_fresh_state",
     "continue_full_tiling_pymc_hmc",
     "full_tiling_pymc_hmc_runtime_identity",
     "sample_full_tiling_pymc_hmc",
@@ -1239,6 +1243,94 @@ def _state_from_point(
     )
 
 
+def canonicalize_full_tiling_pymc_hmc_fresh_state(
+    problem: FullTilingProblem,
+    state: FullTilingPosteriorState,
+) -> tuple[FullTilingPosteriorState, FloatArray, FloatArray]:
+    """Canonicalize a fresh scientific state in the PyMC log chart.
+
+    Fresh initializers construct scientific masses and fixed coefficients
+    directly, but the HMC kernel's authoritative boundary coordinates are
+    their elementwise binary64 natural logarithms. This function repeatedly
+    maps those positive values through ``log -> exp``, performs a complete
+    scientific-oracle rebuild, and stops only at an exact log/exp fixed point.
+    The returned arrays therefore decode bit-for-bit to the returned state,
+    and applying this function again preserves the state and coordinate bits.
+    Neither input object is mutated.
+
+    This public entry point supports fresh initializer states only.
+    :func:`continue_full_tiling_pymc_hmc` bypasses it because a durable
+    checkpoint's stored scientific state and log coordinates are already
+    authoritative replay inputs and must not be rebuilt.
+
+    Args:
+        problem: Exact full-tiling posterior problem that owns ``state``.
+        state: Supported fresh scientific state to canonicalize.
+
+    Returns:
+        A tuple containing the fully rebuilt canonical scientific state,
+        read-only authoritative log leaf masses with shape ``(K,)``, and
+        read-only authoritative log fixed coefficients with shape
+        ``(n_fixed,)``.
+
+    Raises:
+        TypeError: If either argument has an incompatible public type.
+        ValueError: If ``state`` does not belong to ``problem`` or a decoded
+            state violates scientific support.
+        RuntimeError: If the binary64 log/exp mapping does not reach an exact
+            fixed point within the bounded canonicalization audit.
+    """
+    if not isinstance(problem, FullTilingProblem):
+        raise TypeError("problem must be a FullTilingProblem.")
+    if not isinstance(state, FullTilingPosteriorState):
+        raise TypeError("state must be a FullTilingPosteriorState.")
+    if state.problem is not problem:
+        raise ValueError("state must belong to the exact supplied problem.")
+
+    current = state
+    for _ in range(8):
+        log_leaf_mass = np.log(current.leaf_masses)
+        log_fixed_coefficient = np.log(current.fixed_coefficients)
+        with np.errstate(over="ignore", under="ignore", invalid="ignore"):
+            leaf_masses = np.exp(log_leaf_mass)
+            fixed_coefficients = np.exp(log_fixed_coefficient)
+        canonical = build_full_tiling_posterior_state(
+            problem,
+            allocation=TilingState(
+                current.tiling_state.tiling,
+                leaf_masses,
+            ),
+            fixed_coefficients=fixed_coefficients,
+        )
+        if np.array_equal(np.log(canonical.leaf_masses), log_leaf_mass) and np.array_equal(
+            np.log(canonical.fixed_coefficients),
+            log_fixed_coefficient,
+        ):
+            authoritative_leaf = _readonly_array(
+                log_leaf_mass,
+                dtype=np.float64,
+                ndim=1,
+                name="log_leaf_mass",
+            )
+            authoritative_fixed = _readonly_array(
+                log_fixed_coefficient,
+                dtype=np.float64,
+                ndim=1,
+                name="log_fixed_coefficient",
+            )
+            with np.errstate(over="ignore", under="ignore", invalid="ignore"):
+                decoded_leaf = np.exp(authoritative_leaf)
+                decoded_fixed = np.exp(authoritative_fixed)
+            if not np.array_equal(decoded_leaf, canonical.leaf_masses) or not np.array_equal(
+                decoded_fixed,
+                canonical.fixed_coefficients,
+            ):
+                raise RuntimeError("fresh-state canonicalization produced non-authoritative log coordinates.")
+            return canonical, authoritative_leaf, authoritative_fixed
+        current = canonical
+    raise RuntimeError("fresh-state canonicalization did not reach an exact binary64 log/exp fixed point.")
+
+
 def _run_segment(
     problem: FullTilingProblem,
     initial_state: FullTilingPosteriorState,
@@ -1433,9 +1525,14 @@ def sample_full_tiling_pymc_hmc(
 ) -> FullTilingPyMCHMCSamplingResult:
     """Run a fresh mobile full-tiling compound HMC segment.
 
+    Before draw zero, the supplied scientific state is rebuilt at an exact
+    binary64 natural-log/exp fixed point. The caller's state is not mutated,
+    but the retained boundary may differ from it by a few ULPs.
+
     Args:
         problem: Fixed-``K`` full-tiling posterior problem.
-        initial_state: State built for the exact problem object.
+        initial_state: Fresh initializer state built for the exact problem
+            object.
         config: Fresh-chain sweep count, static HMC controls, position scales,
             and optional master PCG64 seed. Exact replay from chain start
             requires an explicit seed.
@@ -1448,8 +1545,9 @@ def sample_full_tiling_pymc_hmc(
         ValueError: If problem identity, support, or resolved fixed position
             scales are incompatible.
         ImportError: If the optional PyMC runtime is unavailable.
-        RuntimeError: If PyTensor is not float64 or PyMC does not execute the
-            configured leapfrog count.
+        RuntimeError: If fresh-state canonicalization does not converge,
+            PyTensor is not float64, or PyMC does not execute the configured
+            leapfrog count.
     """
     if not isinstance(problem, FullTilingProblem):
         raise TypeError("problem must be a FullTilingProblem.")
@@ -1468,13 +1566,19 @@ def sample_full_tiling_pymc_hmc(
         leaf_position_scale=config.leaf_position_scale,
         fixed_coefficient_position_scale=fixed_position_scale,
     )
-    return _run_segment(
+    canonical_state, log_leaf_mass, log_fixed_coefficient = canonicalize_full_tiling_pymc_hmc_fresh_state(
         problem,
         initial_state,
+    )
+    return _run_segment(
+        problem,
+        canonical_state,
         iterations=config.iterations,
         sweeps_completed=0,
         settings=settings,
         rng=np.random.Generator(np.random.PCG64(config.seed)),
+        log_leaf_mass=log_leaf_mass,
+        log_fixed_coefficient=log_fixed_coefficient,
     )
 
 
@@ -1485,6 +1589,10 @@ def continue_full_tiling_pymc_hmc(
     iterations: int,
 ) -> FullTilingPyMCHMCSamplingResult:
     """Continue exactly from an in-memory compound HMC checkpoint.
+
+    The checkpoint's scientific state and log-coordinate arrays are joint
+    authoritative replay inputs. They are passed through unchanged and are
+    not fresh-state canonicalized or rebuilt at the segment boundary.
 
     Args:
         problem: Exact problem object retained by the checkpoint.

--- a/openghg_inversions/experimental/rjmcmc/full_tiling_pymc_hmc.py
+++ b/openghg_inversions/experimental/rjmcmc/full_tiling_pymc_hmc.py
@@ -1,0 +1,1526 @@
+"""Experimental PyMC compound kernel for mobile fixed-``K`` full tilings.
+
+This module composes one existing full-tiling structural Metropolis--Hastings
+proposal with one static PyMC Hamiltonian Monte Carlo trajectory.  The
+continuous HMC chart is symmetric in the active leaves: ``x_i = log(m_i)``
+for leaf masses and ``y_j = log(c_j)`` for always-active coefficients.
+The PyMC model uses flat computational variables plus one explicitly
+normalized potential for the scientific ``(T, shares, c)`` target, including
+the chart Jacobians.
+
+Topology-dependent design columns and Dirichlet shapes are same-shaped
+``pm.Data`` containers.  A custom ``BlockedStep`` owns a harmless one-state
+discrete token, calls the existing structural draw and acceptance functions
+unchanged in scientific coordinates, updates both data containers before HMC,
+and reseeds the PyMC HMC step from the sole NumPy PCG64 stream on every sweep.
+Thus accepted, rejected, and invalid structural attempts are all followed by
+exactly one HMC trajectory.
+
+The HMC kernel is deliberately static: no tuning, step-size randomization, or
+topology-dependent metric is allowed.  In-memory checkpoints retain the
+scientific state, exact unconstrained coordinates, immutable settings, sweep
+coordinate, and master PCG64 state.  Reconstructing and reseeding PyMC at every
+continuation boundary makes split execution exactly replayable without
+persisting mutable backend sampler state. This explicitly experimental module
+performs no durable file I/O.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib import import_module
+import math
+from numbers import Integral
+import platform
+import sys
+import time
+from typing import TYPE_CHECKING, Any, TypeAlias
+
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
+
+from .core import lognormal_mu_sigma
+from .full_tiling import TilingState
+from .full_tiling_compound_sampling import _draw_structural_transition
+from .full_tiling_posterior import (
+    FullTilingPosteriorState,
+    FullTilingProblem,
+    accept_or_reject,
+    build_full_tiling_posterior_state,
+)
+from .sampling import PCG64State
+
+if TYPE_CHECKING:
+    from pymc import Model
+
+FloatArray: TypeAlias = NDArray[np.float64]
+IntArray: TypeAlias = NDArray[np.int64]
+BoolArray: TypeAlias = NDArray[np.bool_]
+StringArray: TypeAlias = NDArray[np.str_]
+UIntArray: TypeAlias = NDArray[np.uint64]
+
+FULL_TILING_PYMC_HMC_SCHEDULE_ID = "full_tiling_1_structure_1_static_pymc_hmc_v1"
+"""Versioned identity of the structural-then-HMC sweep."""
+
+FULL_TILING_PYMC_HMC_COORDINATE_LAYOUT_ID = "symmetric_log_leaf_mass_then_log_fixed_coefficient_v1"
+"""Versioned ordering and interpretation of the HMC value coordinates."""
+
+FULL_TILING_PYMC_HMC_METRIC_SEMANTICS_ID = "pymc_position_covariance_momentum_precision_diagonal_v1"
+"""Versioned meaning of the diagonal passed to PyMC with ``is_cov=True``."""
+
+__all__ = [
+    "FULL_TILING_PYMC_HMC_COORDINATE_LAYOUT_ID",
+    "FULL_TILING_PYMC_HMC_METRIC_SEMANTICS_ID",
+    "FULL_TILING_PYMC_HMC_SCHEDULE_ID",
+    "FullTilingPyMCHMCCheckpoint",
+    "FullTilingPyMCHMCConfig",
+    "FullTilingPyMCHMCKernelSettings",
+    "FullTilingPyMCHMCRuntimeIdentity",
+    "FullTilingPyMCHMCSamplingResult",
+    "FullTilingPyMCHMCTrace",
+    "build_full_tiling_pymc_hmc_model",
+    "continue_full_tiling_pymc_hmc",
+    "full_tiling_pymc_hmc_runtime_identity",
+    "sample_full_tiling_pymc_hmc",
+]
+
+
+def _import_runtime() -> tuple[Any, Any]:
+    """Import PyMC and PyTensor with one actionable optional-runtime error."""
+    try:
+        pm = import_module("pymc")
+        pt = import_module("pytensor.tensor")
+    except ImportError as error:
+        raise ImportError(
+            "The experimental full-tiling compound HMC kernel requires PyMC "
+            "and PyTensor from the repository environment."
+        ) from error
+    return pm, pt
+
+
+def _require_float64() -> None:
+    """Require the process-global PyTensor default to be binary64."""
+    try:
+        pytensor = import_module("pytensor")
+    except ImportError as error:
+        raise ImportError("The experimental full-tiling compound HMC kernel requires PyTensor.") from error
+    float_x = str(pytensor.config.floatX)
+    if float_x != "float64":
+        raise RuntimeError(
+            f"PyTensor floatX must be float64 for the full-tiling compound HMC kernel; found {float_x!r}."
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class FullTilingPyMCHMCRuntimeIdentity:
+    """Backend and coordinate identity required for exact continuation.
+
+    Attributes:
+        python_minor: Python major/minor version.
+        platform_system: Operating-system family.
+        platform_machine: Hardware architecture.
+        numpy_version: NumPy version.
+        pymc_version: PyMC version.
+        pytensor_version: PyTensor version.
+        pytensor_float_x: Required PyTensor floating-point default.
+        coordinate_layout_id: Versioned unconstrained-coordinate ordering.
+        metric_semantics_id: Versioned interpretation of the PyMC potential
+            diagonal.
+    """
+
+    python_minor: str
+    platform_system: str
+    platform_machine: str
+    numpy_version: str
+    pymc_version: str
+    pytensor_version: str
+    pytensor_float_x: str
+    coordinate_layout_id: str
+    metric_semantics_id: str
+
+
+def full_tiling_pymc_hmc_runtime_identity() -> FullTilingPyMCHMCRuntimeIdentity:
+    """Return the exact backend identity used by a compound HMC checkpoint.
+
+    Returns:
+        Immutable versions, precision, architecture, coordinate layout, and
+        metric semantics.
+
+    Raises:
+        ImportError: If PyMC or PyTensor is unavailable.
+        RuntimeError: If PyTensor is not configured for float64.
+    """
+    _require_float64()
+    pm, _ = _import_runtime()
+    pytensor = import_module("pytensor")
+    return FullTilingPyMCHMCRuntimeIdentity(
+        python_minor=f"{sys.version_info.major}.{sys.version_info.minor}",
+        platform_system=platform.system(),
+        platform_machine=platform.machine(),
+        numpy_version=str(np.__version__),
+        pymc_version=str(pm.__version__),
+        pytensor_version=str(pytensor.__version__),
+        pytensor_float_x=str(pytensor.config.floatX),
+        coordinate_layout_id=FULL_TILING_PYMC_HMC_COORDINATE_LAYOUT_ID,
+        metric_semantics_id=FULL_TILING_PYMC_HMC_METRIC_SEMANTICS_ID,
+    )
+
+
+def _positive_float(value: object, *, name: str) -> float:
+    """Return one finite strictly positive scalar."""
+    if isinstance(value, (bool, np.bool_)):
+        raise TypeError(f"{name} must be a real number.")
+    try:
+        result = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError, OverflowError) as error:
+        raise TypeError(f"{name} must be a real number.") from error
+    if not math.isfinite(result) or result <= 0.0:
+        raise ValueError(f"{name} must be finite and strictly positive.")
+    return result
+
+
+def _nonnegative_float(value: object, *, name: str) -> float:
+    """Return one finite non-negative scalar."""
+    if isinstance(value, (bool, np.bool_)):
+        raise TypeError(f"{name} must be a real number.")
+    try:
+        result = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError, OverflowError) as error:
+        raise TypeError(f"{name} must be a real number.") from error
+    if not math.isfinite(result) or result < 0.0:
+        raise ValueError(f"{name} must be finite and non-negative.")
+    return result
+
+
+def _positive_integer(value: object, *, name: str, allow_zero: bool = False) -> int:
+    """Return one validated built-in integer."""
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Integral):
+        raise TypeError(f"{name} must be an integer.")
+    result = int(value)
+    minimum = 0 if allow_zero else 1
+    if result < minimum:
+        adjective = "non-negative" if allow_zero else "positive"
+        raise ValueError(f"{name} must be {adjective}.")
+    return result
+
+
+def _normalize_position_scale(
+    value: float | ArrayLike,
+    *,
+    name: str,
+) -> float | tuple[float, ...]:
+    """Normalize a positive scalar or one-dimensional position-scale block."""
+    array = np.asarray(value)
+    if array.ndim == 0:
+        return _positive_float(array.item(), name=name)
+    if array.ndim != 1:
+        raise ValueError(f"{name} must be scalar or one-dimensional.")
+    return tuple(_positive_float(item, name=name) for item in array.tolist())
+
+
+def _resolve_fixed_position_scale(
+    value: float | tuple[float, ...],
+    *,
+    n_fixed: int,
+) -> tuple[float, ...]:
+    """Resolve one shared or position-specific PyMC position scale."""
+    if isinstance(value, tuple):
+        if len(value) != n_fixed:
+            raise ValueError("fixed_coefficient_position_scale must have one entry per fixed coefficient.")
+        return value
+    return (value,) * n_fixed
+
+
+def _readonly_array(
+    values: object,
+    *,
+    dtype: np.dtype[np.generic] | type[np.generic],
+    ndim: int,
+    name: str,
+) -> np.ndarray:
+    """Return an owned read-only array of the requested rank."""
+    result = np.array(values, dtype=dtype, copy=True)
+    if result.ndim != ndim:
+        raise ValueError(f"{name} must be {ndim}-dimensional.")
+    result.setflags(write=False)
+    return result
+
+
+def _rectangle_bounds(state: FullTilingPosteriorState) -> IntArray:
+    """Return canonical rectangle bounds for one fixed-``K`` state."""
+    return np.asarray(
+        [
+            (
+                leaf.row_start,
+                leaf.row_stop,
+                leaf.col_start,
+                leaf.col_stop,
+            )
+            for leaf in state.tiling_state.tiling.leaves
+        ],
+        dtype=np.int64,
+    )
+
+
+def _topology_arrays(
+    problem: FullTilingProblem,
+    state: FullTilingPosteriorState,
+) -> tuple[FloatArray, FloatArray, float]:
+    """Return design, Dirichlet shapes, and its exact normalized constant."""
+    design = np.column_stack([problem.design_column(leaf) for leaf in state.tiling_state.tiling.leaves])
+    alpha = problem.allocation_prior.leaf_alphas(state.tiling_state.tiling)
+    log_normalizer = float(
+        math.lgamma(problem.allocation_prior.concentration)
+        - sum(math.lgamma(float(value)) for value in alpha)
+    )
+    return (
+        np.asarray(design, dtype=np.float64),
+        np.asarray(alpha, dtype=np.float64),
+        log_normalizer,
+    )
+
+
+def _fixed_log_parameters(problem: FullTilingProblem) -> tuple[FloatArray, FloatArray]:
+    """Return normal-space parameters of arithmetic-moment lognormal priors."""
+    block = problem.base.fixed_block
+    if block is None:
+        return (
+            np.empty(0, dtype=np.float64),
+            np.empty(0, dtype=np.float64),
+        )
+    pairs = tuple(
+        lognormal_mu_sigma(float(mean), float(sd))
+        for mean, sd in zip(
+            block.coefficient_prior_mean,
+            block.coefficient_prior_sd,
+            strict=True,
+        )
+    )
+    mu, sigma = zip(*pairs, strict=True)
+    return (
+        np.asarray(mu, dtype=np.float64),
+        np.asarray(sigma, dtype=np.float64),
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class FullTilingPyMCHMCConfig:
+    """Configuration for a fresh compound structural plus HMC segment.
+
+    Args:
+        iterations: Positive number of structural-then-HMC sweeps.
+        step_size: Requested unscaled leapfrog step size. PyMC's internal
+            ``exp(log(epsilon))`` representation may move the effective value
+            reported in the trace by one binary64 ULP.
+        leapfrog_steps: Exact positive number of leapfrog steps per sweep.
+        leaf_position_scale: Shared positive PyMC position-covariance scale
+            for every symmetric log-leaf-mass coordinate. This is momentum
+            precision, not momentum covariance.
+        fixed_coefficient_position_scale: Shared positive PyMC
+            position-covariance scale or a positive vector in deterministic
+            fixed-coefficient order.
+        seed: Optional non-negative seed for the sole NumPy PCG64 stream.
+
+    Raises:
+        TypeError: If integer or scalar settings have invalid types.
+        ValueError: If settings lie outside their supported ranges.
+    """
+
+    iterations: int
+    step_size: float
+    leapfrog_steps: int
+    leaf_position_scale: float = 1.0
+    fixed_coefficient_position_scale: float | tuple[float, ...] = 1.0
+    seed: int | None = None
+
+    def __post_init__(self) -> None:
+        """Normalize and validate problem-independent settings."""
+        object.__setattr__(
+            self,
+            "iterations",
+            _positive_integer(self.iterations, name="iterations"),
+        )
+        object.__setattr__(
+            self,
+            "step_size",
+            _positive_float(self.step_size, name="step_size"),
+        )
+        object.__setattr__(
+            self,
+            "leapfrog_steps",
+            _positive_integer(self.leapfrog_steps, name="leapfrog_steps"),
+        )
+        object.__setattr__(
+            self,
+            "leaf_position_scale",
+            _positive_float(
+                self.leaf_position_scale,
+                name="leaf_position_scale",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "fixed_coefficient_position_scale",
+            _normalize_position_scale(
+                self.fixed_coefficient_position_scale,
+                name="fixed_coefficient_position_scale",
+            ),
+        )
+        if self.seed is not None:
+            object.__setattr__(
+                self,
+                "seed",
+                _positive_integer(self.seed, name="seed", allow_zero=True),
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class FullTilingPyMCHMCKernelSettings:
+    """Immutable problem-resolved static HMC kernel settings.
+
+    Args:
+        fixed_k: Positive leaf count preserved by the structural kernel.
+        step_size: Requested unscaled leapfrog step size. The exact effective
+            PyMC value is recorded for every sweep and may differ by one
+            binary64 ULP.
+        leapfrog_steps: Exact number of leapfrog steps.
+        leaf_position_scale: Shared PyMC position-covariance diagonal for all
+            log leaf masses. The sampled momentum has reciprocal covariance.
+        fixed_coefficient_position_scale: Resolved per-coefficient PyMC
+            position-covariance diagonal.
+
+    Raises:
+        TypeError: If an integer setting has an invalid type.
+        ValueError: If a mass, size, or count lies outside supported ranges.
+    """
+
+    fixed_k: int
+    step_size: float
+    leapfrog_steps: int
+    leaf_position_scale: float
+    fixed_coefficient_position_scale: tuple[float, ...]
+
+    def __post_init__(self) -> None:
+        """Validate all resolved settings and finite trajectory length."""
+        object.__setattr__(
+            self,
+            "fixed_k",
+            _positive_integer(self.fixed_k, name="fixed_k"),
+        )
+        step_size = _positive_float(self.step_size, name="step_size")
+        steps = _positive_integer(self.leapfrog_steps, name="leapfrog_steps")
+        if not math.isfinite(step_size * steps):
+            raise ValueError("step_size times leapfrog_steps must be finite.")
+        object.__setattr__(self, "step_size", step_size)
+        object.__setattr__(self, "leapfrog_steps", steps)
+        object.__setattr__(
+            self,
+            "leaf_position_scale",
+            _positive_float(
+                self.leaf_position_scale,
+                name="leaf_position_scale",
+            ),
+        )
+        masses = tuple(
+            _positive_float(
+                value,
+                name="fixed_coefficient_position_scale",
+            )
+            for value in self.fixed_coefficient_position_scale
+        )
+        object.__setattr__(
+            self,
+            "fixed_coefficient_position_scale",
+            masses,
+        )
+        dimension_factor = (self.fixed_k + len(self.fixed_coefficient_position_scale)) ** 0.25
+        if not math.isfinite(self.step_size * dimension_factor):
+            raise ValueError("dimension-adjusted PyMC step scale must be finite.")
+
+    @property
+    def position_scale_diagonal(self) -> FloatArray:
+        """Return the topology-neutral PyMC position-covariance diagonal.
+
+        Returns:
+            Read-only float64 array of shape ``(fixed_k + n_fixed,)``, with
+            the exchangeable leaf block followed by fixed-coefficient order.
+        """
+        result = np.asarray(
+            (self.leaf_position_scale,) * self.fixed_k + self.fixed_coefficient_position_scale,
+            dtype=np.float64,
+        )
+        result.setflags(write=False)
+        return result
+
+
+@dataclass(frozen=True, slots=True)
+class FullTilingPyMCHMCTrace:
+    """Every-sweep structural/HMC diagnostics and visited scientific states.
+
+    State arrays include the segment boundary followed by every post-HMC
+    state. Diagnostic arrays contain one row per completed sweep.
+
+    Args:
+        state_sweep: Global sweep coordinates of retained states.
+        rectangle_bounds: Canonical bounds with shape ``(draw, K, 4)``.
+        leaf_masses: Canonical positive masses with shape ``(draw, K)``.
+        fixed_coefficients: Positive fixed coefficients with shape
+            ``(draw, n_fixed)``.
+        log_leaf_mass: Authoritative PyMC ``x`` coordinates with shape
+            ``(draw, K)``.
+        log_fixed_coefficient: Authoritative PyMC ``y`` coordinates with
+            shape ``(draw, n_fixed)``.
+        log_target: Exact scientific target value by draw.
+        global_sweep: Consecutive one-based diagnostic coordinates.
+        structural_move: Existing structural proposal name.
+        structural_valid: Whether the structural proposal reached MH.
+        structural_accepted: Whether the topology/masses changed.
+        structural_log_acceptance_ratio: Raw untruncated structural log ratio.
+        structural_invalid_reason: Empty for valid proposals.
+        hmc_accepted: Whether PyMC accepted the HMC endpoint.
+        hmc_acceptance_probability: HMC Metropolis acceptance probability.
+        hmc_diverging: Whether PyMC flagged the trajectory as divergent.
+        hmc_energy: Endpoint Hamiltonian reported by PyMC. A divergent,
+            rejected trajectory may report a non-finite diagnostic.
+        hmc_energy_error: Endpoint-minus-start Hamiltonian error. A divergent,
+            rejected trajectory may report a non-finite diagnostic.
+        hmc_step_size: Actual step size reported by PyMC.
+        hmc_n_steps: Leapfrog step count reported by PyMC.
+        hmc_seed: Per-sweep uint64 seed drawn from the master PCG64 stream and
+            used to reseed the complete PyMC HMC step.
+
+    Raises:
+        ValueError: If state arrays do not share the boundary-inclusive draw
+            coordinates, diagnostic arrays do not share the sweep coordinate,
+            or support and transition invariants are violated.
+    """
+
+    state_sweep: IntArray
+    rectangle_bounds: IntArray
+    leaf_masses: FloatArray
+    fixed_coefficients: FloatArray
+    log_leaf_mass: FloatArray
+    log_fixed_coefficient: FloatArray
+    log_target: FloatArray
+    global_sweep: IntArray
+    structural_move: StringArray
+    structural_valid: BoolArray
+    structural_accepted: BoolArray
+    structural_log_acceptance_ratio: FloatArray
+    structural_invalid_reason: StringArray
+    hmc_accepted: BoolArray
+    hmc_acceptance_probability: FloatArray
+    hmc_diverging: BoolArray
+    hmc_energy: FloatArray
+    hmc_energy_error: FloatArray
+    hmc_step_size: FloatArray
+    hmc_n_steps: IntArray
+    hmc_seed: UIntArray
+
+    def __post_init__(self) -> None:
+        """Copy arrays read-only and validate their fixed-width contracts."""
+        state_specs = {
+            "state_sweep": (np.int64, 1),
+            "rectangle_bounds": (np.int64, 3),
+            "leaf_masses": (np.float64, 2),
+            "fixed_coefficients": (np.float64, 2),
+            "log_leaf_mass": (np.float64, 2),
+            "log_fixed_coefficient": (np.float64, 2),
+            "log_target": (np.float64, 1),
+        }
+        diagnostic_specs = {
+            "global_sweep": (np.int64, 1),
+            "structural_move": (np.dtype("U24"), 1),
+            "structural_valid": (np.bool_, 1),
+            "structural_accepted": (np.bool_, 1),
+            "structural_log_acceptance_ratio": (np.float64, 1),
+            "structural_invalid_reason": (np.dtype("U96"), 1),
+            "hmc_accepted": (np.bool_, 1),
+            "hmc_acceptance_probability": (np.float64, 1),
+            "hmc_diverging": (np.bool_, 1),
+            "hmc_energy": (np.float64, 1),
+            "hmc_energy_error": (np.float64, 1),
+            "hmc_step_size": (np.float64, 1),
+            "hmc_n_steps": (np.int64, 1),
+            "hmc_seed": (np.uint64, 1),
+        }
+        for name, (dtype, ndim) in state_specs.items():
+            object.__setattr__(
+                self,
+                name,
+                _readonly_array(
+                    getattr(self, name),
+                    dtype=dtype,
+                    ndim=ndim,
+                    name=name,
+                ),
+            )
+        for name, (dtype, ndim) in diagnostic_specs.items():
+            object.__setattr__(
+                self,
+                name,
+                _readonly_array(
+                    getattr(self, name),
+                    dtype=dtype,
+                    ndim=ndim,
+                    name=name,
+                ),
+            )
+
+        draws = self.state_sweep.size
+        if self.rectangle_bounds.shape[0] != draws or self.rectangle_bounds.shape[2:] != (4,):
+            raise ValueError("rectangle_bounds must have shape (draw, K, 4).")
+        fixed_k = self.rectangle_bounds.shape[1]
+        if self.leaf_masses.shape != (draws, fixed_k):
+            raise ValueError("leaf_masses must have shape (draw, K).")
+        if self.fixed_coefficients.shape[0] != draws:
+            raise ValueError("fixed_coefficients must have one row per state.")
+        if self.log_leaf_mass.shape != (draws, fixed_k):
+            raise ValueError("log_leaf_mass must have shape (draw, K).")
+        if self.log_fixed_coefficient.shape != self.fixed_coefficients.shape:
+            raise ValueError("log_fixed_coefficient must match the fixed_coefficients shape.")
+        if self.log_target.shape != (draws,):
+            raise ValueError("log_target must have one entry per state.")
+        with np.errstate(over="ignore", under="ignore", invalid="ignore"):
+            decoded_leaf_mass = np.exp(self.log_leaf_mass)
+            decoded_fixed = np.exp(self.log_fixed_coefficient)
+        if draws and (
+            np.any(np.diff(self.state_sweep) != 1)
+            or np.any(self.state_sweep < 0)
+            or np.any(~np.isfinite(self.leaf_masses))
+            or np.any(self.leaf_masses <= 0.0)
+            or np.any(~np.isfinite(self.fixed_coefficients))
+            or np.any(self.fixed_coefficients <= 0.0)
+            or np.any(~np.isfinite(self.log_leaf_mass))
+            or np.any(~np.isfinite(self.log_fixed_coefficient))
+            or not np.array_equal(decoded_leaf_mass, self.leaf_masses)
+            or not np.array_equal(decoded_fixed, self.fixed_coefficients)
+            or np.any(~np.isfinite(self.log_target))
+        ):
+            raise ValueError("retained states violate support or sweep ordering.")
+
+        sweeps = self.global_sweep.size
+        for name in diagnostic_specs:
+            if getattr(self, name).shape != (sweeps,):
+                raise ValueError(f"{name} must have one entry per sweep.")
+        if draws != sweeps + 1 or not np.array_equal(
+            self.state_sweep[1:],
+            self.global_sweep,
+        ):
+            raise ValueError(
+                "state coordinates must contain one boundary followed by every diagnostic sweep."
+            )
+        if sweeps and (
+            np.any(np.diff(self.global_sweep) != 1)
+            or np.any(self.global_sweep < 1)
+            or np.any(
+                ~np.isin(
+                    self.structural_move,
+                    ("edge_flip", "resolution_relocation"),
+                )
+            )
+            or np.any(self.structural_accepted & ~self.structural_valid)
+            or np.any(np.isnan(self.structural_log_acceptance_ratio))
+            or np.any(self.structural_log_acceptance_ratio == np.inf)
+            or np.any(self.structural_valid & (self.structural_invalid_reason != ""))
+            or np.any(~self.structural_valid & (self.structural_invalid_reason == ""))
+            or np.any(~np.isfinite(self.hmc_acceptance_probability))
+            or np.any((self.hmc_acceptance_probability < 0.0) | (self.hmc_acceptance_probability > 1.0))
+            or np.any(self.hmc_accepted & self.hmc_diverging)
+            or np.any(
+                ~self.hmc_diverging & (~np.isfinite(self.hmc_energy) | ~np.isfinite(self.hmc_energy_error))
+            )
+            or np.any(~np.isfinite(self.hmc_step_size))
+            or np.any(self.hmc_step_size <= 0.0)
+            or np.any(self.hmc_n_steps < 1)
+        ):
+            raise ValueError("per-sweep diagnostics violate kernel invariants.")
+
+    @property
+    def k(self) -> int:
+        """Return the fixed leaf count."""
+        return int(self.rectangle_bounds.shape[1])
+
+
+@dataclass(frozen=True, slots=True)
+class FullTilingPyMCHMCCheckpoint:
+    """Exact in-memory continuation boundary for the compound HMC kernel.
+
+    Args:
+        problem: Exact in-memory problem object.
+        state: Post-HMC scientific state at the boundary.
+        log_leaf_mass: Exact authoritative PyMC ``x`` coordinate.
+        log_fixed_coefficient: Exact authoritative PyMC ``y`` coordinate.
+        rng_state: Exact state of the sole master PCG64 stream.
+        sweeps_completed: Global number of completed compound sweeps.
+        kernel_settings: Complete static HMC settings.
+        runtime_identity: Backend, precision, layout, and metric identity.
+        schedule_id: Exact compatible schedule identifier.
+
+    Raises:
+        TypeError: If fields have invalid public types.
+        ValueError: If identity, dimension, support, or schedule invariants
+            are inconsistent.
+        ImportError: If PyMC or PyTensor is unavailable while validating
+            runtime identity.
+        RuntimeError: If PyTensor is not configured for float64.
+    """
+
+    problem: FullTilingProblem
+    state: FullTilingPosteriorState
+    log_leaf_mass: FloatArray
+    log_fixed_coefficient: FloatArray
+    rng_state: PCG64State
+    sweeps_completed: int
+    kernel_settings: FullTilingPyMCHMCKernelSettings
+    runtime_identity: FullTilingPyMCHMCRuntimeIdentity
+    schedule_id: str = FULL_TILING_PYMC_HMC_SCHEDULE_ID
+
+    def __post_init__(self) -> None:
+        """Validate the complete in-memory continuation contract."""
+        if not isinstance(self.problem, FullTilingProblem):
+            raise TypeError("problem must be a FullTilingProblem.")
+        if not isinstance(self.state, FullTilingPosteriorState):
+            raise TypeError("state must be a FullTilingPosteriorState.")
+        if self.state.problem is not self.problem:
+            raise ValueError("checkpoint state must belong to checkpoint problem.")
+        log_leaf_mass = _readonly_array(
+            self.log_leaf_mass,
+            dtype=np.float64,
+            ndim=1,
+            name="log_leaf_mass",
+        )
+        log_fixed = _readonly_array(
+            self.log_fixed_coefficient,
+            dtype=np.float64,
+            ndim=1,
+            name="log_fixed_coefficient",
+        )
+        if log_leaf_mass.shape != (self.state.k,) or np.any(~np.isfinite(log_leaf_mass)):
+            raise ValueError("log_leaf_mass must contain one finite value per leaf.")
+        if log_fixed.shape != self.state.fixed_coefficients.shape or np.any(~np.isfinite(log_fixed)):
+            raise ValueError("log_fixed_coefficient must match the finite fixed block.")
+        with np.errstate(over="ignore", under="ignore", invalid="ignore"):
+            decoded_leaf_mass = np.exp(log_leaf_mass)
+            decoded_fixed = np.exp(log_fixed)
+        if not np.array_equal(decoded_leaf_mass, self.state.leaf_masses):
+            raise ValueError("log_leaf_mass must exactly encode checkpoint state.")
+        if not np.array_equal(decoded_fixed, self.state.fixed_coefficients):
+            raise ValueError("log_fixed_coefficient must exactly encode checkpoint state.")
+        if not isinstance(self.rng_state, PCG64State):
+            raise TypeError("rng_state must be a PCG64State.")
+        completed = _positive_integer(
+            self.sweeps_completed,
+            name="sweeps_completed",
+            allow_zero=True,
+        )
+        if not isinstance(
+            self.kernel_settings,
+            FullTilingPyMCHMCKernelSettings,
+        ):
+            raise TypeError("kernel_settings must be FullTilingPyMCHMCKernelSettings.")
+        if not isinstance(
+            self.runtime_identity,
+            FullTilingPyMCHMCRuntimeIdentity,
+        ):
+            raise TypeError("runtime_identity must be a FullTilingPyMCHMCRuntimeIdentity.")
+        if self.state.k != self.kernel_settings.fixed_k:
+            raise ValueError("checkpoint state K must match fixed kernel K.")
+        if self.state.fixed_coefficients.size != len(self.kernel_settings.fixed_coefficient_position_scale):
+            raise ValueError("checkpoint fixed block must match resolved position scales.")
+        if self.schedule_id != FULL_TILING_PYMC_HMC_SCHEDULE_ID:
+            raise ValueError("checkpoint schedule is incompatible.")
+        if self.runtime_identity != full_tiling_pymc_hmc_runtime_identity():
+            raise ValueError("checkpoint runtime identity is incompatible.")
+        if not math.isfinite(self.state.log_target):
+            raise ValueError("checkpoint state must have finite target support.")
+        object.__setattr__(self, "log_leaf_mass", log_leaf_mass)
+        object.__setattr__(self, "log_fixed_coefficient", log_fixed)
+        object.__setattr__(self, "sweeps_completed", completed)
+
+
+@dataclass(frozen=True, slots=True)
+class FullTilingPyMCHMCSamplingResult:
+    """One compound HMC segment and its exact continuation boundary.
+
+    Attributes:
+        trace: Boundary-inclusive visited states and every-sweep diagnostics.
+        final_state: Scientific oracle state after the final HMC step.
+        checkpoint: Exact next in-memory continuation boundary.
+        kernel_setup_seconds: Non-authoritative elapsed time spent building
+            the PyMC model and compound step for this segment.
+        transition_seconds: Non-authoritative elapsed time spent executing
+            this segment's compound sweeps.
+
+    Raises:
+        TypeError: If either elapsed time is not a real number.
+        ValueError: If either elapsed time is non-finite or negative.
+    """
+
+    trace: FullTilingPyMCHMCTrace
+    final_state: FullTilingPosteriorState
+    checkpoint: FullTilingPyMCHMCCheckpoint
+    kernel_setup_seconds: float
+    transition_seconds: float
+
+    def __post_init__(self) -> None:
+        """Validate and normalize the non-authoritative elapsed timings."""
+        for name in ("kernel_setup_seconds", "transition_seconds"):
+            object.__setattr__(
+                self,
+                name,
+                _nonnegative_float(getattr(self, name), name=name),
+            )
+
+
+def build_full_tiling_pymc_hmc_model(
+    problem: FullTilingProblem,
+    initial_state: FullTilingPosteriorState,
+) -> Model:
+    """Build the exact dynamic-topology PyMC model in unconstrained charts.
+
+    ``x`` contains log leaf masses and ``y`` contains log fixed
+    coefficients. For the current topology ``tau``, the model density is
+    ``log_target(T(x), shares(x), c(y), tau) + sum(x)
+    - (K - 1) * logsumexp(x) + sum(y)``. At the encoded initial state this is
+    ``initial_state.log_target`` plus the two chart Jacobians. The final sum
+    is absent when there is no fixed block.
+
+    Args:
+        problem: Full-tiling observation model and normalized priors.
+        initial_state: Valid state supplying fixed ``K``, topology, and
+            computational initial values.
+
+    Returns:
+        PyMC model containing mutable same-shaped ``dynamic_design`` and
+        ``dirichlet_alpha`` data, the mutable exact Dirichlet log normalizer,
+        flat ``x``/``y`` variables, a one-state ``topology_token``, scientific
+        deterministics, and normalized target potential.
+
+    Raises:
+        TypeError: If arguments have invalid public types.
+        ValueError: If the state belongs to another problem or lacks finite
+            target support.
+        ImportError: If PyMC or PyTensor is unavailable.
+        RuntimeError: If PyTensor is not configured for float64.
+    """
+    if not isinstance(problem, FullTilingProblem):
+        raise TypeError("problem must be a FullTilingProblem.")
+    if not isinstance(initial_state, FullTilingPosteriorState):
+        raise TypeError("initial_state must be a FullTilingPosteriorState.")
+    if initial_state.problem is not problem:
+        raise ValueError("initial_state must belong to the exact supplied problem.")
+    if not math.isfinite(initial_state.log_target):
+        raise ValueError("initial_state must have finite target support.")
+
+    _require_float64()
+    pm, pt = _import_runtime()
+    dynamic_design, alpha, dirichlet_log_normalizer = _topology_arrays(
+        problem,
+        initial_state,
+    )
+    fixed_block = problem.base.fixed_block
+    n_fixed = initial_state.fixed_coefficients.size
+    fixed_mu, fixed_sigma = _fixed_log_parameters(problem)
+    fixed_offset = problem.base.fixed_offset
+    if fixed_offset is None:
+        raise RuntimeError("validated full-tiling problem has no fixed offset.")
+
+    with pm.Model() as model:
+        dynamic_data = pm.Data(
+            "dynamic_design",
+            dynamic_design,
+        )
+        alpha_data = pm.Data(
+            "dirichlet_alpha",
+            alpha,
+        )
+        dirichlet_log_normalizer_data = pm.Data(
+            "dirichlet_log_normalizer",
+            np.float64(dirichlet_log_normalizer),
+        )
+        x = pm.Flat(
+            "x",
+            shape=initial_state.k,
+            initval=np.log(initial_state.leaf_masses),
+            dtype="float64",
+        )
+        if n_fixed:
+            if fixed_block is None:
+                raise RuntimeError("fixed coefficients require a fixed design block.")
+            y = pm.Flat(
+                "y",
+                shape=n_fixed,
+                initval=np.log(initial_state.fixed_coefficients),
+                dtype="float64",
+            )
+            coefficient = pt.exp(y)
+            fixed_prediction = pt.dot(
+                pt.as_tensor_variable(fixed_block.design),
+                coefficient,
+            )
+        else:
+            y = pt.zeros((0,), dtype="float64")
+            coefficient = y
+            fixed_prediction = pt.zeros_like(
+                pt.as_tensor_variable(fixed_offset),
+                dtype="float64",
+            )
+        # This RV gives the structural BlockedStep a harmless discrete owner.
+        pm.Categorical(
+            "topology_token",
+            p=np.asarray([1.0], dtype=np.float64),
+            initval=0,
+        )
+
+        log_total = pt.logsumexp(x)
+        root_total = pt.exp(log_total)
+        log_share = x - log_total
+        leaf_mass = pt.exp(x)
+        mean_observation = (
+            pt.as_tensor_variable(fixed_offset) + pt.dot(dynamic_data, leaf_mass) + fixed_prediction
+        )
+        residual = (mean_observation - pt.as_tensor_variable(problem.observations)) / (
+            pt.as_tensor_variable(problem.observation_sd)
+        )
+
+        prior = problem.base.prior
+        log_gamma = (
+            np.float64(prior.root_shape * math.log(prior.root_rate) - math.lgamma(prior.root_shape))
+            + np.float64(prior.root_shape - 1.0) * log_total
+            - np.float64(prior.root_rate) * root_total
+        )
+        log_dirichlet = dirichlet_log_normalizer_data + pt.dot(alpha_data - 1.0, log_share)
+        n_observations = problem.observations.size
+        log_gaussian = (
+            -0.5 * pt.dot(residual, residual)
+            - np.float64(np.log(problem.observation_sd).sum())
+            - np.float64(0.5 * n_observations * math.log(2.0 * math.pi))
+        )
+        likelihood_power = problem.base.likelihood_power
+        log_likelihood = (
+            np.float64(0.0) if likelihood_power == 0.0 else np.float64(likelihood_power) * log_gaussian
+        )
+        if n_fixed:
+            # This is normalized LogNormal(c | mu, sigma) plus dc/dy.
+            log_fixed = pt.sum(
+                -0.5 * ((y - fixed_mu) / fixed_sigma) ** 2
+                - np.log(fixed_sigma)
+                - np.float64(0.5 * math.log(2.0 * math.pi))
+            )
+        else:
+            log_fixed = np.float64(0.0)
+        log_x_jacobian = pt.sum(x) - np.float64(initial_state.k - 1) * log_total
+        largest_float = np.float64(np.finfo(np.float64).max)
+        representable = pt.all((leaf_mass > 0.0) & (leaf_mass <= largest_float))
+        representable = representable & (root_total <= largest_float)
+        if n_fixed:
+            representable = representable & pt.all((coefficient > 0.0) & (coefficient <= largest_float))
+        scientific_log_target = log_likelihood + log_gamma + log_dirichlet + log_fixed + log_x_jacobian
+        pm.Potential(
+            "scientific_target",
+            pt.switch(
+                representable,
+                scientific_log_target,
+                np.float64(-math.inf),
+            ),
+        )
+        pm.Deterministic("root_total", root_total)
+        pm.Deterministic("leaf_share", pt.exp(log_share))
+        pm.Deterministic("leaf_mass", leaf_mass)
+        pm.Deterministic("fixed_coefficient", coefficient)
+        pm.Deterministic("mean_observation", mean_observation)
+    return model
+
+
+def _set_topology_data_atomically(
+    model: Any,
+    dynamic_design: FloatArray,
+    alpha: FloatArray,
+    dirichlet_log_normalizer: float,
+) -> None:
+    """Replace all topology-dependent PyMC data with rollback on failure.
+
+    Args:
+        model: PyMC model containing the ``dynamic_design``,
+            ``dirichlet_alpha``, and ``dirichlet_log_normalizer`` mutable-data
+            containers.
+        dynamic_design: New observation-by-leaf design matrix. Its shape must
+            exactly match the existing container.
+        alpha: New length-``K`` Dirichlet parameter vector. Its shape must
+            exactly match the existing container.
+        dirichlet_log_normalizer: Scalar log normalizer associated with
+            ``alpha``.
+
+    Raises:
+        KeyError: If a required mutable-data container is absent.
+        ValueError: If either array update would change its container shape.
+        Exception: Propagates a container update failure after restoring all
+            three original values.
+
+    Notes:
+        This function mutates the model only when all three assignments
+        succeed. A failed assignment restores copies of the complete prior
+        topology payload before re-raising.
+    """
+    dynamic_data = model["dynamic_design"]
+    alpha_data = model["dirichlet_alpha"]
+    normalizer_data = model["dirichlet_log_normalizer"]
+    old_dynamic = np.array(dynamic_data.get_value(borrow=False), copy=True)
+    old_alpha = np.array(alpha_data.get_value(borrow=False), copy=True)
+    old_normalizer = np.array(
+        normalizer_data.get_value(borrow=False),
+        copy=True,
+    )
+    if dynamic_design.shape != old_dynamic.shape or alpha.shape != old_alpha.shape:
+        raise ValueError("topology updates must preserve dynamic-design and alpha shapes.")
+    try:
+        dynamic_data.set_value(dynamic_design, borrow=False)
+        alpha_data.set_value(alpha, borrow=False)
+        normalizer_data.set_value(
+            np.asarray(dirichlet_log_normalizer, dtype=np.float64),
+            borrow=False,
+        )
+    except Exception:
+        dynamic_data.set_value(old_dynamic, borrow=False)
+        alpha_data.set_value(old_alpha, borrow=False)
+        normalizer_data.set_value(old_normalizer, borrow=False)
+        raise
+
+
+def _build_compound_kernel(
+    problem: FullTilingProblem,
+    state: FullTilingPosteriorState,
+    settings: FullTilingPyMCHMCKernelSettings,
+    rng: np.random.Generator,
+    *,
+    log_leaf_mass: ArrayLike | None = None,
+    log_fixed_coefficient: ArrayLike | None = None,
+) -> tuple[Any, Any, Any, dict[str, np.ndarray]]:
+    """Build a stopped structural-then-HMC kernel and exact initial point.
+
+    Args:
+        problem: Fixed-``K`` scientific posterior problem.
+        state: Scientific initial state belonging to ``problem``.
+        settings: Resolved static-HMC settings, including the exact leaf and
+            fixed-coordinate position-scale diagonal.
+        rng: Authoritative compound-chain generator. The returned structural
+            step closes over this object and advances it for proposals,
+            acceptance uniforms, and per-sweep HMC seeds.
+        log_leaf_mass: Optional authoritative length-``K`` log-mass
+            coordinates. When provided, exponentiation must reproduce
+            ``state.leaf_masses`` exactly, enabling bitwise checkpoint replay.
+        log_fixed_coefficient: Optional authoritative log coordinates with
+            the same shape as ``state.fixed_coefficients``. It must be empty
+            when the problem has no fixed block and must exactly encode the
+            fixed coefficients otherwise.
+
+    Returns:
+        A tuple containing the PyMC model, stopped compound step, structural
+        substep, and copied initial point mapping. The point contains ``x`` of
+        shape ``(K,)`` and, when present, ``y`` of shape ``(n_fixed,)``.
+
+    Raises:
+        ImportError: If the optional PyMC/PyTensor runtime is unavailable.
+        KeyError: If the generated model does not expose an expected variable.
+        ValueError: If authoritative coordinates have incompatible shapes,
+            contain non-finite values, or do not exactly encode ``state``.
+        RuntimeError: If the constructed compound kernel is not fully static.
+
+    Notes:
+        Construction itself does not advance ``rng``. Each later structural
+        step advances it and resets the HMC substep to a freshly drawn PCG64
+        seed, preserving single-stream replay semantics.
+    """
+    pm, _ = _import_runtime()
+    model = build_full_tiling_pymc_hmc_model(problem, state)
+    point = model.initial_point()
+    if log_leaf_mass is not None:
+        x = np.asarray(log_leaf_mass, dtype=np.float64)
+        if x.shape != (settings.fixed_k,) or np.any(~np.isfinite(x)):
+            raise ValueError("log_leaf_mass must contain one finite value per leaf.")
+        if not np.array_equal(np.exp(x), state.leaf_masses):
+            raise ValueError("log_leaf_mass must exactly encode the initial state.")
+        point["x"] = np.array(x, copy=True)
+    if state.fixed_coefficients.size:
+        if log_fixed_coefficient is not None:
+            y = np.asarray(log_fixed_coefficient, dtype=np.float64)
+            if y.shape != state.fixed_coefficients.shape or np.any(~np.isfinite(y)):
+                raise ValueError("log_fixed_coefficient must match the finite fixed block.")
+            if not np.array_equal(np.exp(y), state.fixed_coefficients):
+                raise ValueError("log_fixed_coefficient must exactly encode the initial state.")
+            point["y"] = np.array(y, copy=True)
+    elif log_fixed_coefficient is not None:
+        y = np.asarray(log_fixed_coefficient, dtype=np.float64)
+        if y.shape != (0,):
+            raise ValueError("log_fixed_coefficient must be empty without a fixed block.")
+    continuous_rvs = [model["x"]]
+    if state.fixed_coefficients.size:
+        continuous_rvs.append(model["y"])
+    dimension = settings.fixed_k + len(settings.fixed_coefficient_position_scale)
+    # BaseHMC divides step_scale by dimension**0.25. This inverse supplies
+    # the caller's actual requested step size to the integrator.
+    step_scale = settings.step_size * dimension**0.25
+    hmc = pm.HamiltonianMC(
+        vars=continuous_rvs,
+        model=model,
+        scaling=np.array(settings.position_scale_diagonal, copy=True),
+        is_cov=True,
+        step_scale=step_scale,
+        path_length=settings.step_size * settings.leapfrog_steps,
+        max_steps=settings.leapfrog_steps,
+        adapt_step_size=False,
+        step_rand=None,
+        rng=np.random.Generator(np.random.PCG64(0)),
+        initial_point=point,
+    )
+    hmc.stop_tuning()
+    # DualAverageAdaptation represents even a non-adapting step through an
+    # exp(log(epsilon)) round trip, which can move the requested value by one
+    # binary64 ULP. Derive the path from that actual value so integer
+    # truncation inside PyMC always gives the requested leapfrog count.
+    effective_step_size = float(hmc.step_adapt.current(False))
+    hmc.path_length = float(
+        np.nextafter(
+            effective_step_size * settings.leapfrog_steps,
+            math.inf,
+        )
+    )
+
+    class _StructuralTilingStep(pm.BlockedStep):
+        """Custom one-token step that runs structural MH then reseeds HMC."""
+
+        name = "full_tiling_structure"
+        default_blocked = True
+        stats_dtypes_shapes = {
+            "move": (object, []),
+            "valid": (bool, []),
+            "accepted": (bool, []),
+            "log_acceptance_ratio": (np.float64, []),
+            "invalid_reason": (object, []),
+            "hmc_seed": (np.uint64, []),
+        }
+
+        def __init__(
+            self,
+            vars: list[Any],
+            *,
+            model: Any,
+            blocked: bool = True,
+            **_: Any,
+        ) -> None:
+            """Initialize the token owner around closed-over kernel state."""
+            self.vars = vars
+            self.model = model
+            self.blocked = blocked
+            self.state = state
+            self.last_transition: Any = None
+
+        def step(
+            self,
+            current_point: dict[str, np.ndarray],
+        ) -> tuple[dict[str, np.ndarray], list[dict[str, object]]]:
+            """Apply structural MH, update data/masses, and seed the next HMC."""
+            source = self.state
+            transition, _ = _draw_structural_transition(
+                problem,
+                source,
+                rng=rng,
+            )
+            uniform = float(rng.random())
+            log_uniform = -math.inf if uniform == 0.0 else math.log(uniform)
+            next_state = accept_or_reject(
+                source,
+                transition,
+                log_uniform=log_uniform,
+            )
+            accepted = transition.valid and next_state is transition.candidate
+            (
+                dynamic_design,
+                alpha,
+                dirichlet_log_normalizer,
+            ) = _topology_arrays(problem, next_state)
+            _set_topology_data_atomically(
+                model,
+                dynamic_design,
+                alpha,
+                dirichlet_log_normalizer,
+            )
+            next_point = dict(current_point)
+            if accepted:
+                next_point["x"] = np.log(next_state.leaf_masses)
+            self.state = next_state
+            self.last_transition = transition
+            hmc_seed = int(
+                rng.integers(
+                    np.iinfo(np.uint64).max,
+                    dtype=np.uint64,
+                )
+            )
+            hmc.set_rng(np.random.Generator(np.random.PCG64(hmc_seed)))
+            return next_point, [
+                {
+                    "move": transition.move,
+                    "valid": transition.valid,
+                    "accepted": accepted,
+                    "log_acceptance_ratio": transition.log_acceptance_ratio,
+                    "invalid_reason": ("" if transition.reason is None else transition.reason),
+                    "hmc_seed": np.uint64(hmc_seed),
+                }
+            ]
+
+        @staticmethod
+        def competence(var: Any, has_grad: bool) -> Any:
+            """Declare compatibility only for the deliberately discrete token."""
+            del var, has_grad
+            return pm.step_methods.compound.Competence.COMPATIBLE
+
+    structural = _StructuralTilingStep(
+        vars=[model["topology_token"]],
+        model=model,
+    )
+    compound = pm.CompoundStep([structural, hmc])
+    compound.stop_tuning()
+    if compound.tune:
+        # PyMC 5.25 leaves CompoundStep.tune as an informational attribute;
+        # substeps are authoritative, but keeping it false avoids ambiguity.
+        compound.tune = False
+    if hmc.tune or hmc.adapt_step_size or hmc._step_rand is not None:
+        raise RuntimeError("compound HMC must be fully static before sampling.")
+    return model, compound, structural, point
+
+
+def _state_from_point(
+    problem: FullTilingProblem,
+    structural_state: FullTilingPosteriorState,
+    point: dict[str, np.ndarray],
+) -> FullTilingPosteriorState:
+    """Decode a PyMC endpoint through the complete scientific-state oracle.
+
+    Args:
+        problem: Scientific problem used to evaluate the decoded endpoint.
+        structural_state: Post-structural state supplying the authoritative
+            current tiling and fixed-block shape.
+        point: PyMC point containing length-``K`` log masses under ``x`` and,
+            when a fixed block exists, log fixed coefficients under ``y``.
+
+    Returns:
+        A newly rebuilt posterior state on ``structural_state``'s tiling, with
+        all predictions, residuals, and target components recomputed by the
+        scientific oracle.
+
+    Raises:
+        KeyError: If ``point`` omits a required coordinate.
+        TypeError: If decoded arrays cannot construct a scientific state.
+        ValueError: If decoded masses or coefficients have invalid shape,
+            support, or non-finite target terms.
+
+    Notes:
+        Exponentiation deliberately permits NumPy overflow or underflow; the
+        scientific-state constructor is the authoritative support check.
+    """
+    x = np.asarray(point["x"], dtype=np.float64)
+    with np.errstate(over="ignore", under="ignore", invalid="ignore"):
+        masses = np.exp(x)
+    if structural_state.fixed_coefficients.size:
+        y = np.asarray(point["y"], dtype=np.float64)
+        with np.errstate(over="ignore", under="ignore", invalid="ignore"):
+            fixed = np.exp(y)
+    else:
+        fixed = np.empty(0, dtype=np.float64)
+    allocation = TilingState(
+        structural_state.tiling_state.tiling,
+        masses,
+    )
+    return build_full_tiling_posterior_state(
+        problem,
+        allocation=allocation,
+        fixed_coefficients=fixed,
+    )
+
+
+def _run_segment(
+    problem: FullTilingProblem,
+    initial_state: FullTilingPosteriorState,
+    *,
+    iterations: int,
+    sweeps_completed: int,
+    settings: FullTilingPyMCHMCKernelSettings,
+    rng: np.random.Generator,
+    log_leaf_mass: ArrayLike | None = None,
+    log_fixed_coefficient: ArrayLike | None = None,
+) -> FullTilingPyMCHMCSamplingResult:
+    """Run one exact, boundary-inclusive compound-HMC segment.
+
+    Args:
+        problem: Fixed-``K`` posterior problem that owns ``initial_state``.
+        initial_state: Scientific state at the segment boundary.
+        iterations: Positive number of complete structural-then-HMC sweeps.
+        sweeps_completed: Non-negative global sweep offset preceding this
+            segment.
+        settings: Frozen kernel settings compatible with ``initial_state`` and
+            its fixed block.
+        rng: Authoritative PCG64-backed generator. It is advanced in place for
+            every structural proposal, decision, and HMC seed; its final state
+            is stored in the returned checkpoint.
+        log_leaf_mass: Optional authoritative boundary log-mass coordinates
+            for exact restart replay.
+        log_fixed_coefficient: Optional authoritative boundary log fixed
+            coordinates for exact restart replay.
+
+    Returns:
+        Boundary-inclusive trace, final scientific state, exact continuation
+        checkpoint, and separate kernel-setup and transition timings. State
+        arrays have ``iterations + 1`` rows, while per-sweep diagnostics have
+        ``iterations`` rows.
+
+    Raises:
+        ImportError: If the optional PyMC/PyTensor runtime is unavailable.
+        TypeError: If a state, coordinate, or reconstructed endpoint has an
+            incompatible type.
+        ValueError: If problem identity, fixed ``K``, position-scale width,
+            target support, or authoritative restart coordinates are invalid.
+        RuntimeError: If compound-step statistics are malformed, PyMC executes
+            a different leapfrog count, or an endpoint cannot be rebuilt.
+
+    Notes:
+        The input state is not mutated. The supplied RNG is intentionally
+        mutated, and replay requires restoring its exact checkpoint state
+        together with both authoritative log-coordinate arrays.
+    """
+    if initial_state.problem is not problem:
+        raise ValueError("initial_state must belong to the exact supplied problem.")
+    if initial_state.k != settings.fixed_k:
+        raise ValueError("initial_state K must match fixed kernel K.")
+    if initial_state.fixed_coefficients.size != len(settings.fixed_coefficient_position_scale):
+        raise ValueError("resolved fixed position scales must match the problem fixed block.")
+    if not math.isfinite(initial_state.log_target):
+        raise ValueError("initial_state must have finite target support.")
+
+    setup_start = time.perf_counter()
+    _, compound, structural, point = _build_compound_kernel(
+        problem,
+        initial_state,
+        settings,
+        rng,
+        log_leaf_mass=log_leaf_mass,
+        log_fixed_coefficient=log_fixed_coefficient,
+    )
+    kernel_setup_seconds = time.perf_counter() - setup_start
+    states = [initial_state]
+    log_leaf_mass_coordinates = [np.array(point["x"], dtype=np.float64, copy=True)]
+    log_fixed_coefficient_coordinates = [
+        (
+            np.array(point["y"], dtype=np.float64, copy=True)
+            if initial_state.fixed_coefficients.size
+            else np.empty(0, dtype=np.float64)
+        )
+    ]
+    structural_move: list[str] = []
+    structural_valid: list[bool] = []
+    structural_accepted: list[bool] = []
+    structural_log_ratio: list[float] = []
+    structural_reason: list[str] = []
+    hmc_accepted: list[bool] = []
+    hmc_accept: list[float] = []
+    hmc_diverging: list[bool] = []
+    hmc_energy: list[float] = []
+    hmc_energy_error: list[float] = []
+    hmc_step_size: list[float] = []
+    hmc_n_steps: list[int] = []
+    hmc_seed: list[np.uint64] = []
+
+    state = initial_state
+    transition_start = time.perf_counter()
+    for _ in range(iterations):
+        point, stats = compound.step(point)
+        if len(stats) != 2:
+            raise RuntimeError("compound sweep must return structural and HMC stats.")
+        structural_stats, hmc_stats = stats
+        state = _state_from_point(problem, structural.state, point)
+        structural.state = state
+        states.append(state)
+        log_leaf_mass_coordinates.append(np.array(point["x"], dtype=np.float64, copy=True))
+        log_fixed_coefficient_coordinates.append(
+            (
+                np.array(point["y"], dtype=np.float64, copy=True)
+                if state.fixed_coefficients.size
+                else np.empty(0, dtype=np.float64)
+            )
+        )
+
+        structural_move.append(str(structural_stats["move"]))
+        structural_valid.append(bool(structural_stats["valid"]))
+        structural_accepted.append(bool(structural_stats["accepted"]))
+        structural_log_ratio.append(float(structural_stats["log_acceptance_ratio"]))
+        structural_reason.append(str(structural_stats["invalid_reason"]))
+        hmc_accepted.append(bool(hmc_stats["accepted"]))
+        hmc_accept.append(float(hmc_stats["accept"]))
+        hmc_diverging.append(bool(hmc_stats["diverging"]))
+        hmc_energy.append(float(hmc_stats["energy"]))
+        hmc_energy_error.append(float(hmc_stats["energy_error"]))
+        hmc_step_size.append(float(hmc_stats["step_size"]))
+        completed_hmc_steps = int(hmc_stats["n_steps"])
+        if completed_hmc_steps != settings.leapfrog_steps:
+            raise RuntimeError("PyMC HMC did not execute the configured leapfrog count.")
+        hmc_n_steps.append(completed_hmc_steps)
+        hmc_seed.append(np.uint64(structural_stats["hmc_seed"]))
+    transition_seconds = time.perf_counter() - transition_start
+
+    state_sweep = np.arange(
+        sweeps_completed,
+        sweeps_completed + iterations + 1,
+        dtype=np.int64,
+    )
+    global_sweep = np.arange(
+        sweeps_completed + 1,
+        sweeps_completed + iterations + 1,
+        dtype=np.int64,
+    )
+    trace = FullTilingPyMCHMCTrace(
+        state_sweep=state_sweep,
+        rectangle_bounds=np.stack([_rectangle_bounds(item) for item in states]),
+        leaf_masses=np.stack([item.leaf_masses for item in states]),
+        fixed_coefficients=np.stack([item.fixed_coefficients for item in states]),
+        log_leaf_mass=np.stack(log_leaf_mass_coordinates),
+        log_fixed_coefficient=np.stack(log_fixed_coefficient_coordinates),
+        log_target=np.asarray([item.log_target for item in states]),
+        global_sweep=global_sweep,
+        structural_move=np.asarray(structural_move, dtype="U24"),
+        structural_valid=np.asarray(structural_valid, dtype=np.bool_),
+        structural_accepted=np.asarray(structural_accepted, dtype=np.bool_),
+        structural_log_acceptance_ratio=np.asarray(
+            structural_log_ratio,
+            dtype=np.float64,
+        ),
+        structural_invalid_reason=np.asarray(structural_reason, dtype="U96"),
+        hmc_accepted=np.asarray(hmc_accepted, dtype=np.bool_),
+        hmc_acceptance_probability=np.asarray(hmc_accept, dtype=np.float64),
+        hmc_diverging=np.asarray(hmc_diverging, dtype=np.bool_),
+        hmc_energy=np.asarray(hmc_energy, dtype=np.float64),
+        hmc_energy_error=np.asarray(hmc_energy_error, dtype=np.float64),
+        hmc_step_size=np.asarray(hmc_step_size, dtype=np.float64),
+        hmc_n_steps=np.asarray(hmc_n_steps, dtype=np.int64),
+        hmc_seed=np.asarray(hmc_seed, dtype=np.uint64),
+    )
+    checkpoint = FullTilingPyMCHMCCheckpoint(
+        problem=problem,
+        state=state,
+        log_leaf_mass=np.asarray(point["x"], dtype=np.float64),
+        log_fixed_coefficient=(
+            np.asarray(point["y"], dtype=np.float64)
+            if state.fixed_coefficients.size
+            else np.empty(0, dtype=np.float64)
+        ),
+        rng_state=PCG64State.from_generator(rng),
+        sweeps_completed=sweeps_completed + iterations,
+        kernel_settings=settings,
+        runtime_identity=full_tiling_pymc_hmc_runtime_identity(),
+    )
+    return FullTilingPyMCHMCSamplingResult(
+        trace=trace,
+        final_state=state,
+        checkpoint=checkpoint,
+        kernel_setup_seconds=kernel_setup_seconds,
+        transition_seconds=transition_seconds,
+    )
+
+
+def sample_full_tiling_pymc_hmc(
+    problem: FullTilingProblem,
+    initial_state: FullTilingPosteriorState,
+    config: FullTilingPyMCHMCConfig,
+) -> FullTilingPyMCHMCSamplingResult:
+    """Run a fresh mobile full-tiling compound HMC segment.
+
+    Args:
+        problem: Fixed-``K`` full-tiling posterior problem.
+        initial_state: State built for the exact problem object.
+        config: Fresh-chain sweep count, static HMC controls, position scales,
+            and optional master PCG64 seed. Exact replay from chain start
+            requires an explicit seed.
+
+    Returns:
+        Boundary-inclusive trace, final oracle state, and exact checkpoint.
+
+    Raises:
+        TypeError: If arguments have invalid public types.
+        ValueError: If problem identity, support, or resolved fixed position
+            scales are incompatible.
+        ImportError: If the optional PyMC runtime is unavailable.
+        RuntimeError: If PyTensor is not float64 or PyMC does not execute the
+            configured leapfrog count.
+    """
+    if not isinstance(problem, FullTilingProblem):
+        raise TypeError("problem must be a FullTilingProblem.")
+    if not isinstance(initial_state, FullTilingPosteriorState):
+        raise TypeError("initial_state must be a FullTilingPosteriorState.")
+    if not isinstance(config, FullTilingPyMCHMCConfig):
+        raise TypeError("config must be a FullTilingPyMCHMCConfig.")
+    fixed_position_scale = _resolve_fixed_position_scale(
+        config.fixed_coefficient_position_scale,
+        n_fixed=initial_state.fixed_coefficients.size,
+    )
+    settings = FullTilingPyMCHMCKernelSettings(
+        fixed_k=initial_state.k,
+        step_size=config.step_size,
+        leapfrog_steps=config.leapfrog_steps,
+        leaf_position_scale=config.leaf_position_scale,
+        fixed_coefficient_position_scale=fixed_position_scale,
+    )
+    return _run_segment(
+        problem,
+        initial_state,
+        iterations=config.iterations,
+        sweeps_completed=0,
+        settings=settings,
+        rng=np.random.Generator(np.random.PCG64(config.seed)),
+    )
+
+
+def continue_full_tiling_pymc_hmc(
+    problem: FullTilingProblem,
+    checkpoint: FullTilingPyMCHMCCheckpoint,
+    *,
+    iterations: int,
+) -> FullTilingPyMCHMCSamplingResult:
+    """Continue exactly from an in-memory compound HMC checkpoint.
+
+    Args:
+        problem: Exact problem object retained by the checkpoint.
+        checkpoint: Compatible post-HMC continuation boundary.
+        iterations: Positive number of additional compound sweeps.
+
+    Returns:
+        Boundary-inclusive continuation trace, final state, and next
+        checkpoint.
+
+    Raises:
+        TypeError: If arguments have invalid public types.
+        ValueError: If problem identity, schedule, dimensions, or support are
+            incompatible.
+        ImportError: If the optional PyMC runtime is unavailable.
+        RuntimeError: If PyTensor is not float64 or PyMC does not execute the
+            configured leapfrog count.
+    """
+    if not isinstance(problem, FullTilingProblem):
+        raise TypeError("problem must be a FullTilingProblem.")
+    if not isinstance(checkpoint, FullTilingPyMCHMCCheckpoint):
+        raise TypeError("checkpoint must be a FullTilingPyMCHMCCheckpoint.")
+    count = _positive_integer(iterations, name="iterations")
+    if checkpoint.problem is not problem:
+        raise ValueError("continuation requires the exact checkpoint problem.")
+    if checkpoint.schedule_id != FULL_TILING_PYMC_HMC_SCHEDULE_ID:
+        raise ValueError("checkpoint schedule is incompatible.")
+    if checkpoint.runtime_identity != full_tiling_pymc_hmc_runtime_identity():
+        raise ValueError("checkpoint runtime identity is incompatible.")
+    return _run_segment(
+        problem,
+        checkpoint.state,
+        iterations=count,
+        sweeps_completed=checkpoint.sweeps_completed,
+        settings=checkpoint.kernel_settings,
+        rng=checkpoint.rng_state.generator(),
+        log_leaf_mass=checkpoint.log_leaf_mass,
+        log_fixed_coefficient=checkpoint.log_fixed_coefficient,
+    )

--- a/openghg_inversions/experimental/rjmcmc/full_tiling_pymc_hmc.py
+++ b/openghg_inversions/experimental/rjmcmc/full_tiling_pymc_hmc.py
@@ -17,20 +17,22 @@ Thus accepted, rejected, and invalid structural attempts are all followed by
 exactly one HMC trajectory.
 
 The HMC kernel is deliberately static: no tuning, step-size randomization, or
-topology-dependent metric is allowed.  In-memory checkpoints retain the
-scientific state, exact unconstrained coordinates, immutable settings, sweep
-coordinate, and master PCG64 state.  Reconstructing and reseeding PyMC at every
-continuation boundary makes split execution exactly replayable without
-persisting mutable backend sampler state. Fresh initializer states instead
-pass through :func:`canonicalize_full_tiling_pymc_hmc_fresh_state` before draw
-zero so their physical values decode exactly from the authoritative log
-coordinates. This explicitly experimental module performs no durable file
-I/O.
+topology-dependent metric is allowed. Its leaf block has separate static
+position-covariance eigenscales for normalized-common total motion and
+orthogonal log-mass contrasts; fixed coefficients retain an ordered diagonal
+block. In-memory checkpoints retain the scientific state, exact unconstrained
+coordinates, immutable settings, sweep coordinate, and master PCG64 state.
+Reconstructing and reseeding PyMC at every continuation boundary makes split
+execution exactly replayable without persisting mutable backend sampler state.
+Fresh initializer states instead pass through
+:func:`canonicalize_full_tiling_pymc_hmc_fresh_state` before draw zero so their
+physical values decode exactly from the authoritative log coordinates. This
+explicitly experimental module performs no durable file I/O.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from importlib import import_module
 import math
 from numbers import Integral
@@ -62,14 +64,16 @@ BoolArray: TypeAlias = NDArray[np.bool_]
 StringArray: TypeAlias = NDArray[np.str_]
 UIntArray: TypeAlias = NDArray[np.uint64]
 
-FULL_TILING_PYMC_HMC_SCHEDULE_ID = "full_tiling_1_structure_1_static_pymc_hmc_v1"
+FULL_TILING_PYMC_HMC_SCHEDULE_ID = "full_tiling_1_structure_1_static_pymc_hmc_v2"
 """Versioned identity of the structural-then-HMC sweep."""
 
 FULL_TILING_PYMC_HMC_COORDINATE_LAYOUT_ID = "symmetric_log_leaf_mass_then_log_fixed_coefficient_v1"
 """Versioned ordering and interpretation of the HMC value coordinates."""
 
-FULL_TILING_PYMC_HMC_METRIC_SEMANTICS_ID = "pymc_position_covariance_momentum_precision_diagonal_v1"
-"""Versioned meaning of the diagonal passed to PyMC with ``is_cov=True``."""
+FULL_TILING_PYMC_HMC_METRIC_SEMANTICS_ID = (
+    "pymc_position_covariance_momentum_precision_normalized_common_contrast_projector_v2"
+)
+"""Versioned meaning of the full matrix passed to PyMC with ``is_cov=True``."""
 
 __all__ = [
     "FULL_TILING_PYMC_HMC_COORDINATE_LAYOUT_ID",
@@ -128,8 +132,8 @@ class FullTilingPyMCHMCRuntimeIdentity:
         pytensor_version: PyTensor version.
         pytensor_float_x: Required PyTensor floating-point default.
         coordinate_layout_id: Versioned unconstrained-coordinate ordering.
-        metric_semantics_id: Versioned interpretation of the PyMC potential
-            diagonal.
+        metric_semantics_id: Versioned interpretation of the PyMC position
+            covariance, equivalently momentum precision.
     """
 
     python_minor: str
@@ -317,13 +321,19 @@ class FullTilingPyMCHMCConfig:
             ``exp(log(epsilon))`` representation may move the effective value
             reported in the trace by one binary64 ULP.
         leapfrog_steps: Exact positive number of leapfrog steps per sweep.
-        leaf_position_scale: Shared positive PyMC position-covariance scale
-            for every symmetric log-leaf-mass coordinate. This is momentum
-            precision, not momentum covariance.
+        leaf_contrast_position_scale: Positive PyMC position-covariance scale
+            for leaf log-mass contrasts, equivalently momentum precision on
+            the contrast subspace.
         fixed_coefficient_position_scale: Shared positive PyMC
             position-covariance scale or a positive vector in deterministic
-            fixed-coefficient order.
+            fixed-coefficient order, equivalently momentum precision.
         seed: Optional non-negative seed for the sole NumPy PCG64 stream.
+        leaf_total_position_scale: Optional positive PyMC
+            position-covariance scale for the normalized common leaf
+            log-mass direction, equivalently momentum precision on that
+            direction. ``None`` resolves to
+            ``leaf_contrast_position_scale``. This new v2 setting is
+            keyword-only so legacy positional calls retain their meaning.
 
     Raises:
         TypeError: If integer or scalar settings have invalid types.
@@ -333,9 +343,10 @@ class FullTilingPyMCHMCConfig:
     iterations: int
     step_size: float
     leapfrog_steps: int
-    leaf_position_scale: float = 1.0
+    leaf_contrast_position_scale: float = 1.0
     fixed_coefficient_position_scale: float | tuple[float, ...] = 1.0
     seed: int | None = None
+    leaf_total_position_scale: float | None = field(default=None, kw_only=True)
 
     def __post_init__(self) -> None:
         """Normalize and validate problem-independent settings."""
@@ -356,12 +367,21 @@ class FullTilingPyMCHMCConfig:
         )
         object.__setattr__(
             self,
-            "leaf_position_scale",
+            "leaf_contrast_position_scale",
             _positive_float(
-                self.leaf_position_scale,
-                name="leaf_position_scale",
+                self.leaf_contrast_position_scale,
+                name="leaf_contrast_position_scale",
             ),
         )
+        if self.leaf_total_position_scale is not None:
+            object.__setattr__(
+                self,
+                "leaf_total_position_scale",
+                _positive_float(
+                    self.leaf_total_position_scale,
+                    name="leaf_total_position_scale",
+                ),
+            )
         object.__setattr__(
             self,
             "fixed_coefficient_position_scale",
@@ -388,21 +408,26 @@ class FullTilingPyMCHMCKernelSettings:
             PyMC value is recorded for every sweep and may differ by one
             binary64 ULP.
         leapfrog_steps: Exact number of leapfrog steps.
-        leaf_position_scale: Shared PyMC position-covariance diagonal for all
-            log leaf masses. The sampled momentum has reciprocal covariance.
+        leaf_contrast_position_scale: PyMC position-covariance eigenvalue on the
+            leaf log-mass contrast subspace, equivalently momentum precision.
         fixed_coefficient_position_scale: Resolved per-coefficient PyMC
-            position-covariance diagonal.
+            position-covariance diagonal, equivalently momentum precision.
+        leaf_total_position_scale: PyMC position-covariance eigenvalue on the
+            normalized common leaf log-mass direction, equivalently momentum
+            precision.
 
     Raises:
         TypeError: If an integer setting has an invalid type.
-        ValueError: If a mass, size, or count lies outside supported ranges.
+        ValueError: If a scale, trajectory length, dimension, or count lies
+            outside supported ranges.
     """
 
     fixed_k: int
     step_size: float
     leapfrog_steps: int
-    leaf_position_scale: float
+    leaf_contrast_position_scale: float
     fixed_coefficient_position_scale: tuple[float, ...]
+    leaf_total_position_scale: float
 
     def __post_init__(self) -> None:
         """Validate all resolved settings and finite trajectory length."""
@@ -419,12 +444,17 @@ class FullTilingPyMCHMCKernelSettings:
         object.__setattr__(self, "leapfrog_steps", steps)
         object.__setattr__(
             self,
-            "leaf_position_scale",
+            "leaf_contrast_position_scale",
             _positive_float(
-                self.leaf_position_scale,
-                name="leaf_position_scale",
+                self.leaf_contrast_position_scale,
+                name="leaf_contrast_position_scale",
             ),
         )
+        total_position_scale = _positive_float(
+            self.leaf_total_position_scale,
+            name="leaf_total_position_scale",
+        )
+        object.__setattr__(self, "leaf_total_position_scale", total_position_scale)
         masses = tuple(
             _positive_float(
                 value,
@@ -440,21 +470,79 @@ class FullTilingPyMCHMCKernelSettings:
         dimension_factor = (self.fixed_k + len(self.fixed_coefficient_position_scale)) ** 0.25
         if not math.isfinite(self.step_size * dimension_factor):
             raise ValueError("dimension-adjusted PyMC step scale must be finite.")
+        _build_position_scale_matrix(self)
+
+    @property
+    def position_scale_matrix(self) -> FloatArray:
+        """Return the permutation-invariant PyMC position covariance.
+
+        The leaf block is
+        ``g_contrast * (I - 11' / K) + g_total * (11' / K)``. It is followed
+        by the ordered fixed-coefficient diagonal, with an exactly zero
+        cross-block.
+
+        Returns:
+            Owned read-only symmetric positive-definite ``float64`` array of
+            shape ``(fixed_k + n_fixed, fixed_k + n_fixed)``.
+        """
+        return _build_position_scale_matrix(self)
 
     @property
     def position_scale_diagonal(self) -> FloatArray:
-        """Return the topology-neutral PyMC position-covariance diagonal.
+        """Return the diagonal of the PyMC position-covariance matrix.
+
+        This diagnostic projection does not contain the off-diagonal leaf
+        covariances when the total and contrast scales differ. It cannot
+        reconstruct the full matrix supplied to PyMC.
 
         Returns:
             Read-only float64 array of shape ``(fixed_k + n_fixed,)``, with
-            the exchangeable leaf block followed by fixed-coefficient order.
+            the leaf-block diagonal followed by fixed-coefficient order.
         """
-        result = np.asarray(
-            (self.leaf_position_scale,) * self.fixed_k + self.fixed_coefficient_position_scale,
-            dtype=np.float64,
-        )
+        result = np.diag(self.position_scale_matrix).copy()
         result.setflags(write=False)
         return result
+
+
+def _build_position_scale_matrix(
+    settings: FullTilingPyMCHMCKernelSettings,
+) -> FloatArray:
+    """Build and validate the full topology-neutral position covariance.
+
+    Args:
+        settings: Resolved positive leaf eigenscales and fixed diagonal.
+
+    Returns:
+        Owned read-only finite symmetric positive-definite matrix.
+
+    Raises:
+        ValueError: If binary64 construction does not produce a finite,
+            symmetric positive-definite matrix.
+    """
+    fixed_k = settings.fixed_k
+    dimension = fixed_k + len(settings.fixed_coefficient_position_scale)
+    common = np.full(
+        (fixed_k, fixed_k),
+        1.0 / fixed_k,
+        dtype=np.float64,
+    )
+    leaf_block = (
+        settings.leaf_contrast_position_scale * np.eye(fixed_k, dtype=np.float64)
+        + (settings.leaf_total_position_scale - settings.leaf_contrast_position_scale) * common
+    )
+    result = np.zeros((dimension, dimension), dtype=np.float64)
+    result[:fixed_k, :fixed_k] = leaf_block
+    if settings.fixed_coefficient_position_scale:
+        fixed_indices = np.arange(fixed_k, dimension)
+        result[fixed_indices, fixed_indices] = settings.fixed_coefficient_position_scale
+    if np.any(~np.isfinite(result)) or not np.array_equal(result, result.T):
+        raise ValueError("position scale matrix must be finite and symmetric.")
+    try:
+        np.linalg.cholesky(result)
+    except np.linalg.LinAlgError as error:
+        raise ValueError("position scale matrix must be positive definite.") from error
+    result.setflags(write=False)
+    return result
 
 
 @dataclass(frozen=True, slots=True)
@@ -481,6 +569,10 @@ class FullTilingPyMCHMCTrace:
         structural_accepted: Whether the topology/masses changed.
         structural_log_acceptance_ratio: Raw untruncated structural log ratio.
         structural_invalid_reason: Empty for valid proposals.
+        hmc_start_log_leaf_mass: Post-structure, pre-HMC leaf log masses in the
+            same canonical order as the corresponding post-HMC state.
+        hmc_start_log_fixed_coefficient: Post-structure, pre-HMC fixed
+            log-coefficient coordinates.
         hmc_accepted: Whether PyMC accepted the HMC endpoint.
         hmc_acceptance_probability: HMC Metropolis acceptance probability.
         hmc_diverging: Whether PyMC flagged the trajectory as divergent.
@@ -512,6 +604,8 @@ class FullTilingPyMCHMCTrace:
     structural_accepted: BoolArray
     structural_log_acceptance_ratio: FloatArray
     structural_invalid_reason: StringArray
+    hmc_start_log_leaf_mass: FloatArray
+    hmc_start_log_fixed_coefficient: FloatArray
     hmc_accepted: BoolArray
     hmc_acceptance_probability: FloatArray
     hmc_diverging: BoolArray
@@ -607,6 +701,30 @@ class FullTilingPyMCHMCTrace:
         for name in diagnostic_specs:
             if getattr(self, name).shape != (sweeps,):
                 raise ValueError(f"{name} must have one entry per sweep.")
+        object.__setattr__(
+            self,
+            "hmc_start_log_leaf_mass",
+            _readonly_array(
+                self.hmc_start_log_leaf_mass,
+                dtype=np.float64,
+                ndim=2,
+                name="hmc_start_log_leaf_mass",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "hmc_start_log_fixed_coefficient",
+            _readonly_array(
+                self.hmc_start_log_fixed_coefficient,
+                dtype=np.float64,
+                ndim=2,
+                name="hmc_start_log_fixed_coefficient",
+            ),
+        )
+        if self.hmc_start_log_leaf_mass.shape != (sweeps, fixed_k):
+            raise ValueError("hmc_start_log_leaf_mass must have shape (sweep, K).")
+        if self.hmc_start_log_fixed_coefficient.shape != (sweeps, self.fixed_coefficients.shape[1]):
+            raise ValueError("hmc_start_log_fixed_coefficient must have shape (sweep, n_fixed).")
         if draws != sweeps + 1 or not np.array_equal(
             self.state_sweep[1:],
             self.global_sweep,
@@ -628,6 +746,8 @@ class FullTilingPyMCHMCTrace:
             or np.any(self.structural_log_acceptance_ratio == np.inf)
             or np.any(self.structural_valid & (self.structural_invalid_reason != ""))
             or np.any(~self.structural_valid & (self.structural_invalid_reason == ""))
+            or np.any(~np.isfinite(self.hmc_start_log_leaf_mass))
+            or np.any(~np.isfinite(self.hmc_start_log_fixed_coefficient))
             or np.any(~np.isfinite(self.hmc_acceptance_probability))
             or np.any((self.hmc_acceptance_probability < 0.0) | (self.hmc_acceptance_probability > 1.0))
             or np.any(self.hmc_accepted & self.hmc_diverging)
@@ -1007,7 +1127,7 @@ def _build_compound_kernel(
         problem: Fixed-``K`` scientific posterior problem.
         state: Scientific initial state belonging to ``problem``.
         settings: Resolved static-HMC settings, including the exact leaf and
-            fixed-coordinate position-scale diagonal.
+            fixed-coordinate position-scale matrix.
         rng: Authoritative compound-chain generator. The returned structural
             step closes over this object and advances it for proposals,
             acceptance uniforms, and per-sweep HMC seeds.
@@ -1068,7 +1188,7 @@ def _build_compound_kernel(
     hmc = pm.HamiltonianMC(
         vars=continuous_rvs,
         model=model,
-        scaling=np.array(settings.position_scale_diagonal, copy=True),
+        scaling=np.array(settings.position_scale_matrix, copy=True),
         is_cov=True,
         step_scale=step_scale,
         path_length=settings.step_size * settings.leapfrog_steps,
@@ -1119,6 +1239,8 @@ def _build_compound_kernel(
             self.blocked = blocked
             self.state = state
             self.last_transition: Any = None
+            self.hmc_start_log_leaf_mass: FloatArray | None = None
+            self.hmc_start_log_fixed_coefficient: FloatArray | None = None
 
         def step(
             self,
@@ -1153,6 +1275,20 @@ def _build_compound_kernel(
             next_point = dict(current_point)
             if accepted:
                 next_point["x"] = np.log(next_state.leaf_masses)
+            self.hmc_start_log_leaf_mass = np.array(
+                next_point["x"],
+                dtype=np.float64,
+                copy=True,
+            )
+            self.hmc_start_log_fixed_coefficient = (
+                np.array(
+                    next_point["y"],
+                    dtype=np.float64,
+                    copy=True,
+                )
+                if next_state.fixed_coefficients.size
+                else np.empty(0, dtype=np.float64)
+            )
             self.state = next_state
             self.last_transition = transition
             hmc_seed = int(
@@ -1413,6 +1549,8 @@ def _run_segment(
     structural_accepted: list[bool] = []
     structural_log_ratio: list[float] = []
     structural_reason: list[str] = []
+    hmc_start_log_leaf_mass: list[FloatArray] = []
+    hmc_start_log_fixed_coefficient: list[FloatArray] = []
     hmc_accepted: list[bool] = []
     hmc_accept: list[float] = []
     hmc_diverging: list[bool] = []
@@ -1446,6 +1584,18 @@ def _run_segment(
         structural_accepted.append(bool(structural_stats["accepted"]))
         structural_log_ratio.append(float(structural_stats["log_acceptance_ratio"]))
         structural_reason.append(str(structural_stats["invalid_reason"]))
+        if structural.hmc_start_log_leaf_mass is None or structural.hmc_start_log_fixed_coefficient is None:
+            raise RuntimeError("structural step did not retain the pre-HMC coordinates.")
+        hmc_start_log_leaf_mass.append(
+            np.array(structural.hmc_start_log_leaf_mass, dtype=np.float64, copy=True)
+        )
+        hmc_start_log_fixed_coefficient.append(
+            np.array(
+                structural.hmc_start_log_fixed_coefficient,
+                dtype=np.float64,
+                copy=True,
+            )
+        )
         hmc_accepted.append(bool(hmc_stats["accepted"]))
         hmc_accept.append(float(hmc_stats["accept"]))
         hmc_diverging.append(bool(hmc_stats["diverging"]))
@@ -1486,6 +1636,10 @@ def _run_segment(
             dtype=np.float64,
         ),
         structural_invalid_reason=np.asarray(structural_reason, dtype="U96"),
+        hmc_start_log_leaf_mass=np.stack(hmc_start_log_leaf_mass),
+        hmc_start_log_fixed_coefficient=np.stack(
+            hmc_start_log_fixed_coefficient,
+        ),
         hmc_accepted=np.asarray(hmc_accepted, dtype=np.bool_),
         hmc_acceptance_probability=np.asarray(hmc_accept, dtype=np.float64),
         hmc_diverging=np.asarray(hmc_diverging, dtype=np.bool_),
@@ -1563,7 +1717,12 @@ def sample_full_tiling_pymc_hmc(
         fixed_k=initial_state.k,
         step_size=config.step_size,
         leapfrog_steps=config.leapfrog_steps,
-        leaf_position_scale=config.leaf_position_scale,
+        leaf_contrast_position_scale=config.leaf_contrast_position_scale,
+        leaf_total_position_scale=(
+            config.leaf_contrast_position_scale
+            if config.leaf_total_position_scale is None
+            else config.leaf_total_position_scale
+        ),
         fixed_coefficient_position_scale=fixed_position_scale,
     )
     canonical_state, log_leaf_mass, log_fixed_coefficient = canonicalize_full_tiling_pymc_hmc_fresh_state(

--- a/openghg_inversions/experimental/rjmcmc/full_tiling_pymc_hmc_io.py
+++ b/openghg_inversions/experimental/rjmcmc/full_tiling_pymc_hmc_io.py
@@ -15,6 +15,10 @@ summation order use the established full-tiling reconstruction tolerance;
 after that audit, the persisted immutable caches are restored exactly so
 continuation starts from the precise saved boundary.
 
+Schema version 2 records both leaf-metric eigenscales. Version 1 archives use
+the retired scalar diagonal leaf metric and are rejected explicitly; this
+module provides no converter.
+
 SHA-256 digests detect accidental corruption but do not authenticate an
 archive against a writer capable of replacing content and digests. Publication
 uses a synced same-directory temporary file and an atomic hard link, so an
@@ -63,7 +67,7 @@ FULL_TILING_PYMC_HMC_CHECKPOINT_SCHEMA_ID = (
 )
 """Stable identifier for the durable full-tiling PyMC HMC checkpoint schema."""
 
-FULL_TILING_PYMC_HMC_CHECKPOINT_SCHEMA_VERSION = 1
+FULL_TILING_PYMC_HMC_CHECKPOINT_SCHEMA_VERSION = 2
 """Current durable full-tiling PyMC HMC checkpoint schema version."""
 
 _STATE_ARRAY_NAMES = (
@@ -91,22 +95,23 @@ _STATE_LOG_FIELDS = (
     "log_fixed_coefficient_prior",
     "log_target",
 )
-_KERNEL_FIELDS_V1 = (
+_KERNEL_FIELDS_V2 = (
     "fixed_k",
     "step_size",
     "leapfrog_steps",
-    "leaf_position_scale",
+    "leaf_contrast_position_scale",
+    "leaf_total_position_scale",
     "fixed_coefficient_position_scale",
 )
 _KERNEL_METADATA_NAMES = frozenset(
     (
-        *_KERNEL_FIELDS_V1,
+        *_KERNEL_FIELDS_V2,
         "position_scale_semantics",
         "step_size_semantics",
     )
 )
 _STEP_SIZE_SEMANTICS = "requested_unscaled_integrator_step_size_v1"
-_RUNTIME_IDENTITY_FIELDS_V1 = (
+_RUNTIME_IDENTITY_FIELDS_V2 = (
     "python_minor",
     "platform_system",
     "platform_machine",
@@ -119,7 +124,7 @@ _RUNTIME_IDENTITY_FIELDS_V1 = (
 )
 _RUNTIME_IDENTITY_NAMES = frozenset(
     {
-        *_RUNTIME_IDENTITY_FIELDS_V1,
+        *_RUNTIME_IDENTITY_FIELDS_V2,
     }
 )
 _ARCHIVE_NAMES = frozenset((*_STATE_ARRAY_NAMES, "metadata", "metadata_sha256"))
@@ -246,7 +251,7 @@ def _finite_float(
 def _runtime_identity_metadata(
     identity: FullTilingPyMCHMCRuntimeIdentity,
 ) -> dict[str, str]:
-    """Return strict metadata for the frozen v1 runtime identity.
+    """Return strict metadata for the frozen v2 runtime identity.
 
     Args:
         identity: Exact immutable identity retained by the checkpoint.
@@ -267,7 +272,7 @@ def _runtime_identity_metadata(
         raise RuntimeError(
             "FullTilingPyMCHMCRuntimeIdentity changed without a durable checkpoint schema-version decision."
         )
-    result = {name: getattr(identity, name) for name in _RUNTIME_IDENTITY_FIELDS_V1}
+    result = {name: getattr(identity, name) for name in _RUNTIME_IDENTITY_FIELDS_V2}
     if any(not isinstance(value, str) or not value for value in result.values()):
         raise TypeError("runtime_identity fields must be non-empty strings.")
     return result
@@ -318,9 +323,9 @@ def _checkpoint_arrays(
 
 
 def _kernel_field_names() -> frozenset[str]:
-    """Return the frozen v1 setting fields or require a schema decision."""
+    """Return the frozen v2 setting fields or require a schema decision."""
     current = frozenset(field.name for field in fields(FullTilingPyMCHMCKernelSettings))
-    frozen = frozenset(_KERNEL_FIELDS_V1)
+    frozen = frozenset(_KERNEL_FIELDS_V2)
     if current != frozen:
         raise RuntimeError(
             "FullTilingPyMCHMCKernelSettings changed without a durable checkpoint schema-version decision."
@@ -350,7 +355,8 @@ def _kernel_metadata(
         "fixed_k": settings.fixed_k,
         "step_size": settings.step_size,
         "leapfrog_steps": settings.leapfrog_steps,
-        "leaf_position_scale": settings.leaf_position_scale,
+        "leaf_contrast_position_scale": settings.leaf_contrast_position_scale,
+        "leaf_total_position_scale": settings.leaf_total_position_scale,
         "fixed_coefficient_position_scale": list(settings.fixed_coefficient_position_scale),
         "position_scale_semantics": FULL_TILING_PYMC_HMC_METRIC_SEMANTICS_ID,
         "step_size_semantics": _STEP_SIZE_SEMANTICS,
@@ -449,10 +455,10 @@ def save_full_tiling_pymc_hmc_checkpoint(
 
     The archive retains authoritative ``log_leaf_mass`` and
     ``log_fixed_coefficient`` arrays in addition to their decoded scientific
-    coordinates. Kernel metadata identifies ``leaf_position_scale`` and
-    ``fixed_coefficient_position_scale`` as PyMC position-covariance
-    diagonals, equivalently momentum precisions, supplied with
-    ``is_cov=True``. The stored ``step_size`` is the requested unscaled
+    coordinates. Kernel metadata identifies the contrast and normalized-common
+    leaf eigenscales plus ``fixed_coefficient_position_scale`` as PyMC
+    position-covariance, equivalently momentum-precision, settings supplied
+    with ``is_cov=True``. The stored ``step_size`` is the requested unscaled
     integrator step; per-sweep effective values remain trace diagnostics and
     are not mutable continuation state.
 
@@ -693,9 +699,14 @@ def _kernel_settings_from_metadata(
             location="kernel.leapfrog_steps",
             minimum=1,
         ),
-        leaf_position_scale=_finite_float(
-            kernel["leaf_position_scale"],
-            location="kernel.leaf_position_scale",
+        leaf_contrast_position_scale=_finite_float(
+            kernel["leaf_contrast_position_scale"],
+            location="kernel.leaf_contrast_position_scale",
+            positive=True,
+        ),
+        leaf_total_position_scale=_finite_float(
+            kernel["leaf_total_position_scale"],
+            location="kernel.leaf_total_position_scale",
             positive=True,
         ),
         fixed_coefficient_position_scale=tuple(
@@ -737,11 +748,11 @@ def _runtime_identity_from_metadata(
     current = full_tiling_pymc_hmc_runtime_identity()
     _runtime_identity_metadata(current)
     persisted = FullTilingPyMCHMCRuntimeIdentity(
-        **{name: cast(str, runtime[name]) for name in _RUNTIME_IDENTITY_FIELDS_V1}
+        **{name: cast(str, runtime[name]) for name in _RUNTIME_IDENTITY_FIELDS_V2}
     )
     if persisted != current:
         mismatches = [
-            name for name in _RUNTIME_IDENTITY_FIELDS_V1 if getattr(persisted, name) != getattr(current, name)
+            name for name in _RUNTIME_IDENTITY_FIELDS_V2 if getattr(persisted, name) != getattr(current, name)
         ]
         raise ValueError(
             f"Full-tiling PyMC HMC checkpoint runtime identity does not match for {mismatches[0]}."
@@ -894,11 +905,17 @@ def load_full_tiling_pymc_hmc_checkpoint(
         raise TypeError("expected_run_manifest must be a mapping.")
     arrays = _load_archive_arrays(Path(path))
     metadata = _metadata_from_arrays(arrays)
-    if (
-        metadata["schema_id"] != FULL_TILING_PYMC_HMC_CHECKPOINT_SCHEMA_ID
-        or metadata["schema_version"] != FULL_TILING_PYMC_HMC_CHECKPOINT_SCHEMA_VERSION
-    ):
+    if metadata["schema_id"] != FULL_TILING_PYMC_HMC_CHECKPOINT_SCHEMA_ID:
         raise ValueError("Full-tiling PyMC HMC checkpoint schema is incompatible.")
+    schema_version = metadata["schema_version"]
+    if schema_version == 1:
+        raise ValueError(
+            "Full-tiling PyMC HMC checkpoint schema version 1 uses the retired "
+            "scalar diagonal leaf metric; schema version 2 is required and no "
+            "converter is provided."
+        )
+    if schema_version != FULL_TILING_PYMC_HMC_CHECKPOINT_SCHEMA_VERSION:
+        raise ValueError("Full-tiling PyMC HMC checkpoint schema version is incompatible.")
     runtime_identity = _runtime_identity_from_metadata(metadata["runtime_identity"])
     schedule_id = metadata["schedule_id"]
     if schedule_id != FULL_TILING_PYMC_HMC_SCHEDULE_ID:

--- a/openghg_inversions/experimental/rjmcmc/full_tiling_pymc_hmc_io.py
+++ b/openghg_inversions/experimental/rjmcmc/full_tiling_pymc_hmc_io.py
@@ -1,0 +1,1076 @@
+"""Strict durable checkpoint I/O for the mobile full-tiling PyMC HMC kernel.
+
+This module publishes create-only, atomic, no-pickle NPZ checkpoints for the
+experimental structural-then-static-HMC sampler. The schema preserves the
+canonical tiling, scientific coordinates, every posterior cache and log
+component, the authoritative symmetric log coordinates, exact PCG64 state,
+global sweep coordinate, and complete resolved HMC settings.
+
+Loading fails closed unless the caller supplies the same fingerprinted
+scientific problem and canonical run manifest and the current PyMC, PyTensor,
+NumPy, Python-minor, platform, precision, coordinate-layout, schedule, and
+kernel identities all match. It reconstructs the complete scientific state as
+an independent audit. Small cache differences caused only by floating-point
+summation order use the established full-tiling reconstruction tolerance;
+after that audit, the persisted immutable caches are restored exactly so
+continuation starts from the precise saved boundary.
+
+SHA-256 digests detect accidental corruption but do not authenticate an
+archive against a writer capable of replacing content and digests. Publication
+uses a synced same-directory temporary file and an atomic hard link, so an
+existing destination is never replaced.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import fields
+import errno
+from hashlib import sha256
+import hmac
+from math import isfinite
+import os
+from pathlib import Path
+import tempfile
+from typing import Any, TypeAlias, cast
+from zipfile import BadZipFile
+
+import numpy as np
+from numpy.typing import NDArray
+
+from . import full_tiling_io as _full_tiling_io
+from .full_tiling import LeafTiling, Rectangle, TilingState
+from .full_tiling_posterior import (
+    FullTilingPosteriorState,
+    FullTilingProblem,
+    build_full_tiling_posterior_state,
+)
+from .full_tiling_pymc_hmc import (
+    FULL_TILING_PYMC_HMC_METRIC_SEMANTICS_ID,
+    FULL_TILING_PYMC_HMC_SCHEDULE_ID,
+    FullTilingPyMCHMCCheckpoint,
+    FullTilingPyMCHMCKernelSettings,
+    FullTilingPyMCHMCRuntimeIdentity,
+    full_tiling_pymc_hmc_runtime_identity,
+)
+from .sampling import PCG64State
+
+PathLike: TypeAlias = str | os.PathLike[str]
+RunManifest: TypeAlias = Mapping[str, object]
+
+FULL_TILING_PYMC_HMC_CHECKPOINT_SCHEMA_ID = (
+    "openghg_inversions.experimental.rjmcmc.full_tiling_pymc_hmc_checkpoint"
+)
+"""Stable identifier for the durable full-tiling PyMC HMC checkpoint schema."""
+
+FULL_TILING_PYMC_HMC_CHECKPOINT_SCHEMA_VERSION = 1
+"""Current durable full-tiling PyMC HMC checkpoint schema version."""
+
+_STATE_ARRAY_NAMES = (
+    "rectangle_bounds",
+    "leaf_masses",
+    "fixed_coefficients",
+    "log_leaf_mass",
+    "log_fixed_coefficient",
+    "dynamic_prediction",
+    "fixed_prediction",
+    "prediction",
+    "residual",
+)
+_CACHE_ARRAY_NAMES = (
+    "dynamic_prediction",
+    "fixed_prediction",
+    "prediction",
+    "residual",
+)
+_STATE_LOG_FIELDS = (
+    "log_gaussian_likelihood",
+    "log_likelihood",
+    "log_root_prior",
+    "log_allocation_prior",
+    "log_fixed_coefficient_prior",
+    "log_target",
+)
+_KERNEL_FIELDS_V1 = (
+    "fixed_k",
+    "step_size",
+    "leapfrog_steps",
+    "leaf_position_scale",
+    "fixed_coefficient_position_scale",
+)
+_KERNEL_METADATA_NAMES = frozenset(
+    (
+        *_KERNEL_FIELDS_V1,
+        "position_scale_semantics",
+        "step_size_semantics",
+    )
+)
+_STEP_SIZE_SEMANTICS = "requested_unscaled_integrator_step_size_v1"
+_RUNTIME_IDENTITY_FIELDS_V1 = (
+    "python_minor",
+    "platform_system",
+    "platform_machine",
+    "numpy_version",
+    "pymc_version",
+    "pytensor_version",
+    "pytensor_float_x",
+    "coordinate_layout_id",
+    "metric_semantics_id",
+)
+_RUNTIME_IDENTITY_NAMES = frozenset(
+    {
+        *_RUNTIME_IDENTITY_FIELDS_V1,
+    }
+)
+_ARCHIVE_NAMES = frozenset((*_STATE_ARRAY_NAMES, "metadata", "metadata_sha256"))
+_METADATA_NAMES = frozenset(
+    {
+        "schema_id",
+        "schema_version",
+        "runtime_identity",
+        "schedule_id",
+        "problem_sha256",
+        "state_sha256",
+        "sweeps_completed",
+        "rng",
+        "kernel",
+        "state",
+        "run_manifest_json",
+        "run_manifest_sha256",
+        "array_sha256",
+    }
+)
+
+
+def _require_mapping(value: object, *, location: str) -> Mapping[str, object]:
+    """Return a string-keyed mapping or reject it.
+
+    Args:
+        value: Candidate decoded JSON value.
+        location: Field path included in validation errors.
+
+    Returns:
+        The validated mapping.
+
+    Raises:
+        ValueError: If the value is not a string-keyed mapping.
+    """
+    if not isinstance(value, Mapping) or any(not isinstance(key, str) for key in value):
+        raise ValueError(f"{location} must be a JSON object.")
+    return cast(Mapping[str, object], value)
+
+
+def _require_keys(
+    value: Mapping[str, object],
+    expected: frozenset[str],
+    *,
+    location: str,
+) -> None:
+    """Require exactly the declared mapping keys.
+
+    Args:
+        value: Mapping whose keys are checked.
+        expected: Complete allowed and required key set.
+        location: Field path included in validation errors.
+
+    Raises:
+        ValueError: If a key is missing or unexpected.
+    """
+    actual = frozenset(value)
+    if actual != expected:
+        raise ValueError(
+            f"{location} has an invalid field set; "
+            f"missing={sorted(expected - actual)}, "
+            f"unexpected={sorted(actual - expected)}."
+        )
+
+
+def _integer(
+    value: object,
+    *,
+    location: str,
+    minimum: int = 0,
+    maximum: int | None = None,
+) -> int:
+    """Return one bounded built-in integer metadata value.
+
+    Args:
+        value: Candidate decoded JSON scalar.
+        location: Field path included in validation errors.
+        minimum: Inclusive lower bound.
+        maximum: Optional inclusive upper bound.
+
+    Returns:
+        Validated built-in integer.
+
+    Raises:
+        ValueError: If the value is Boolean, non-integral, or out of bounds.
+    """
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{location} must be an integer.")
+    if value < minimum or (maximum is not None and value > maximum):
+        description = f"at least {minimum}" if maximum is None else f"between {minimum} and {maximum}"
+        raise ValueError(f"{location} must be {description}.")
+    return value
+
+
+def _finite_float(
+    value: object,
+    *,
+    location: str,
+    positive: bool = False,
+) -> float:
+    """Return one finite metadata float, optionally requiring positivity.
+
+    Args:
+        value: Candidate decoded JSON scalar.
+        location: Field path included in validation errors.
+        positive: Whether zero and negative values are invalid.
+
+    Returns:
+        Validated built-in float.
+
+    Raises:
+        ValueError: If the value is not a finite real scalar or violates the
+            requested positivity constraint.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{location} must be a finite real number.")
+    result = float(value)
+    if not isfinite(result) or (positive and result <= 0.0):
+        qualifier = "finite and positive" if positive else "finite"
+        raise ValueError(f"{location} must be {qualifier}.")
+    return result
+
+
+def _runtime_identity_metadata(
+    identity: FullTilingPyMCHMCRuntimeIdentity,
+) -> dict[str, str]:
+    """Return strict metadata for the frozen v1 runtime identity.
+
+    Args:
+        identity: Exact immutable identity retained by the checkpoint.
+
+    Returns:
+        Strict-JSON mapping of backend, platform, precision, coordinate, and
+        metric identities.
+
+    Raises:
+        TypeError: If ``identity`` has the wrong type or malformed fields.
+        RuntimeError: If the identity dataclass changed without a schema
+            version decision.
+    """
+    if not isinstance(identity, FullTilingPyMCHMCRuntimeIdentity):
+        raise TypeError("runtime_identity must be a FullTilingPyMCHMCRuntimeIdentity.")
+    current_fields = frozenset(field.name for field in fields(FullTilingPyMCHMCRuntimeIdentity))
+    if current_fields != _RUNTIME_IDENTITY_NAMES:
+        raise RuntimeError(
+            "FullTilingPyMCHMCRuntimeIdentity changed without a durable checkpoint schema-version decision."
+        )
+    result = {name: getattr(identity, name) for name in _RUNTIME_IDENTITY_FIELDS_V1}
+    if any(not isinstance(value, str) or not value for value in result.values()):
+        raise TypeError("runtime_identity fields must be non-empty strings.")
+    return result
+
+
+def _checkpoint_arrays(
+    checkpoint: FullTilingPyMCHMCCheckpoint,
+) -> dict[str, NDArray[Any]]:
+    """Return exact scientific, cache, and log-coordinate arrays."""
+    state = checkpoint.state
+    return {
+        "rectangle_bounds": np.asarray(
+            [
+                (
+                    leaf.row_start,
+                    leaf.row_stop,
+                    leaf.col_start,
+                    leaf.col_stop,
+                )
+                for leaf in state.tiling_state.tiling.leaves
+            ],
+            dtype=np.int64,
+        ),
+        "leaf_masses": np.asarray(state.leaf_masses, dtype=np.float64),
+        "fixed_coefficients": np.asarray(
+            state.fixed_coefficients,
+            dtype=np.float64,
+        ),
+        "log_leaf_mass": np.asarray(
+            checkpoint.log_leaf_mass,
+            dtype=np.float64,
+        ),
+        "log_fixed_coefficient": np.asarray(
+            checkpoint.log_fixed_coefficient,
+            dtype=np.float64,
+        ),
+        "dynamic_prediction": np.asarray(
+            state.dynamic_prediction,
+            dtype=np.float64,
+        ),
+        "fixed_prediction": np.asarray(
+            state.fixed_prediction,
+            dtype=np.float64,
+        ),
+        "prediction": np.asarray(state.prediction, dtype=np.float64),
+        "residual": np.asarray(state.residual, dtype=np.float64),
+    }
+
+
+def _kernel_field_names() -> frozenset[str]:
+    """Return the frozen v1 setting fields or require a schema decision."""
+    current = frozenset(field.name for field in fields(FullTilingPyMCHMCKernelSettings))
+    frozen = frozenset(_KERNEL_FIELDS_V1)
+    if current != frozen:
+        raise RuntimeError(
+            "FullTilingPyMCHMCKernelSettings changed without a durable checkpoint schema-version decision."
+        )
+    return frozen
+
+
+def _kernel_metadata(
+    settings: FullTilingPyMCHMCKernelSettings,
+) -> dict[str, object]:
+    """Return strict metadata for resolved static HMC settings.
+
+    Args:
+        settings: Fully resolved in-memory kernel settings.
+
+    Returns:
+        Strict finite JSON metadata including explicit PyMC mass and requested
+        step-size semantics.
+
+    Raises:
+        TypeError: If a setting has an unsupported runtime type.
+        RuntimeError: If the dataclass field set changed without a schema
+            version decision.
+    """
+    _kernel_field_names()
+    return {
+        "fixed_k": settings.fixed_k,
+        "step_size": settings.step_size,
+        "leapfrog_steps": settings.leapfrog_steps,
+        "leaf_position_scale": settings.leaf_position_scale,
+        "fixed_coefficient_position_scale": list(settings.fixed_coefficient_position_scale),
+        "position_scale_semantics": FULL_TILING_PYMC_HMC_METRIC_SEMANTICS_ID,
+        "step_size_semantics": _STEP_SIZE_SEMANTICS,
+    }
+
+
+def _checkpoint_metadata(
+    checkpoint: FullTilingPyMCHMCCheckpoint,
+    arrays: Mapping[str, NDArray[Any]],
+    *,
+    run_manifest_json: str,
+) -> dict[str, object]:
+    """Build strict metadata for one validated continuation boundary.
+
+    Args:
+        checkpoint: Exact validated sampler boundary.
+        arrays: Numeric arrays that will be persisted.
+        run_manifest_json: Canonical caller-owned run manifest.
+
+    Returns:
+        Strict finite JSON-compatible metadata with integrity digests.
+    """
+    state = checkpoint.state
+    rng = checkpoint.rng_state
+    return {
+        "schema_id": FULL_TILING_PYMC_HMC_CHECKPOINT_SCHEMA_ID,
+        "schema_version": FULL_TILING_PYMC_HMC_CHECKPOINT_SCHEMA_VERSION,
+        "runtime_identity": _runtime_identity_metadata(checkpoint.runtime_identity),
+        "schedule_id": checkpoint.schedule_id,
+        "problem_sha256": _full_tiling_io.full_tiling_problem_fingerprint(checkpoint.problem),
+        "state_sha256": _full_tiling_io.full_tiling_state_fingerprint(
+            checkpoint.problem,
+            state,
+        ),
+        "sweeps_completed": checkpoint.sweeps_completed,
+        "rng": {
+            "algorithm": rng.algorithm,
+            "state": rng.state,
+            "increment": rng.increment,
+            "has_uint32": rng.has_uint32,
+            "uinteger": rng.uinteger,
+        },
+        "kernel": _kernel_metadata(checkpoint.kernel_settings),
+        "state": {
+            "k": state.k,
+            "root_total": state.root_total,
+            **{name: getattr(state, name) for name in _STATE_LOG_FIELDS},
+        },
+        "run_manifest_json": run_manifest_json,
+        "run_manifest_sha256": sha256(run_manifest_json.encode("utf-8")).hexdigest(),
+        "array_sha256": {name: _full_tiling_io._array_sha256(name, array) for name, array in arrays.items()},
+    }
+
+
+def _fsync_parent_directory(path: Path) -> None:
+    """Persist one directory entry where directory fsync is supported.
+
+    Args:
+        path: Parent directory containing the new archive link.
+
+    Raises:
+        OSError: If opening or syncing fails for a supported reason.
+    """
+    unsupported = {
+        errno.EACCES,
+        errno.EBADF,
+        errno.EINVAL,
+        errno.EPERM,
+        getattr(errno, "ENOTSUP", errno.EINVAL),
+        getattr(errno, "EOPNOTSUPP", errno.EINVAL),
+    }
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        if exc.errno in unsupported:
+            return
+        raise
+    try:
+        try:
+            os.fsync(descriptor)
+        except OSError as exc:
+            if exc.errno not in unsupported:
+                raise
+    finally:
+        os.close(descriptor)
+
+
+def save_full_tiling_pymc_hmc_checkpoint(
+    path: PathLike,
+    checkpoint: FullTilingPyMCHMCCheckpoint,
+    *,
+    run_manifest: RunManifest,
+) -> None:
+    """Atomically publish one create-only PyMC HMC checkpoint.
+
+    The archive retains authoritative ``log_leaf_mass`` and
+    ``log_fixed_coefficient`` arrays in addition to their decoded scientific
+    coordinates. Kernel metadata identifies ``leaf_position_scale`` and
+    ``fixed_coefficient_position_scale`` as PyMC position-covariance
+    diagonals, equivalently momentum precisions, supplied with
+    ``is_cov=True``. The stored ``step_size`` is the requested unscaled
+    integrator step; per-sweep effective values remain trace diagnostics and
+    are not mutable continuation state.
+
+    Args:
+        path: New destination NPZ path whose parent directory already exists.
+        checkpoint: Exact in-memory full-tiling PyMC HMC boundary.
+        run_manifest: Caller-owned strict finite JSON manifest.
+
+    Raises:
+        TypeError: If the checkpoint or manifest has the wrong type.
+        ValueError: If the schedule or PCG64 state is incompatible, the state
+            or log coordinates are stale, or the manifest is invalid.
+        ImportError: If the checkpoint backend is unavailable.
+        RuntimeError: If PyTensor precision or the frozen settings schema is
+            incompatible.
+        FileExistsError: If ``path`` already exists.
+        OSError: If writing, linking, or durable syncing fails.
+
+    Notes:
+        The archive is written and synced under a temporary same-directory
+        name, then atomically hard-linked to the absent destination. Existing
+        checkpoint generations are never replaced.
+    """
+    if not isinstance(checkpoint, FullTilingPyMCHMCCheckpoint):
+        raise TypeError("checkpoint must be a FullTilingPyMCHMCCheckpoint.")
+    if checkpoint.schedule_id != FULL_TILING_PYMC_HMC_SCHEDULE_ID:
+        raise ValueError("checkpoint schedule is incompatible.")
+    if checkpoint.runtime_identity != full_tiling_pymc_hmc_runtime_identity():
+        raise ValueError("checkpoint runtime identity is incompatible.")
+    try:
+        checkpoint.rng_state.generator()
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError("checkpoint must contain a valid exact PCG64 continuation state.") from exc
+    _full_tiling_io._rebuild_and_validate_state(
+        checkpoint.problem,
+        checkpoint.state,
+        location="checkpoint state",
+    )
+    run_manifest_json = _full_tiling_io.canonical_full_tiling_run_manifest(run_manifest)
+    arrays = _checkpoint_arrays(checkpoint)
+    metadata = _checkpoint_metadata(
+        checkpoint,
+        arrays,
+        run_manifest_json=run_manifest_json,
+    )
+    metadata_bytes = _full_tiling_io._canonical_json(
+        metadata,
+        location="checkpoint metadata",
+    ).encode("utf-8")
+    archive_arrays = {
+        **arrays,
+        "metadata": np.frombuffer(metadata_bytes, dtype=np.uint8),
+        "metadata_sha256": np.frombuffer(
+            sha256(metadata_bytes).hexdigest().encode("ascii"),
+            dtype=np.uint8,
+        ),
+    }
+    destination = Path(path)
+    temporary_path: Path | None = None
+    try:
+        descriptor, temporary_name = tempfile.mkstemp(
+            prefix=f".{destination.name}.",
+            suffix=".tmp",
+            dir=destination.parent,
+        )
+        temporary_path = Path(temporary_name)
+        with os.fdopen(descriptor, "wb") as handle:
+            np.savez_compressed(handle, **archive_arrays)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.link(temporary_path, destination)
+        temporary_path.unlink()
+        temporary_path = None
+        _fsync_parent_directory(destination.parent)
+    finally:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+
+
+def _load_archive_arrays(path: Path) -> dict[str, NDArray[Any]]:
+    """Load the exact numeric archive field set with pickle disabled.
+
+    Args:
+        path: Existing checkpoint archive.
+
+    Returns:
+        Owned arrays indexed by required schema names.
+
+    Raises:
+        OSError: If the path cannot be opened.
+        ValueError: If the file is corrupt, is not NPZ, has wrong members, or
+            contains an object array.
+    """
+    try:
+        archive = np.load(path, allow_pickle=False)
+    except (FileNotFoundError, PermissionError):
+        raise
+    except (BadZipFile, EOFError, ValueError) as exc:
+        raise ValueError("Full-tiling PyMC HMC checkpoint archive is corrupt or unreadable.") from exc
+    if isinstance(archive, np.ndarray):
+        raise ValueError("Full-tiling PyMC HMC checkpoint must be an NPZ archive.")
+    try:
+        with archive:
+            archive_names = archive.files
+            if len(archive_names) != len(set(archive_names)):
+                raise ValueError("Full-tiling PyMC HMC checkpoint contains duplicate array members.")
+            names = frozenset(archive_names)
+            if names != _ARCHIVE_NAMES:
+                raise ValueError(
+                    "Full-tiling PyMC HMC checkpoint has an invalid array set; "
+                    f"missing={sorted(_ARCHIVE_NAMES - names)}, "
+                    f"unexpected={sorted(names - _ARCHIVE_NAMES)}."
+                )
+            try:
+                arrays = {name: np.array(archive[name], copy=True) for name in names}
+            except ValueError as exc:
+                raise ValueError(
+                    "Full-tiling PyMC HMC checkpoint arrays cannot require pickle or object dtype."
+                ) from exc
+    except ValueError:
+        raise
+    except (BadZipFile, EOFError) as exc:
+        raise ValueError("Full-tiling PyMC HMC checkpoint archive is corrupt or unreadable.") from exc
+    if any(array.dtype == np.dtype(object) for array in arrays.values()):
+        raise ValueError("Full-tiling PyMC HMC checkpoint arrays cannot use object dtype.")
+    return arrays
+
+
+def _metadata_from_arrays(
+    arrays: Mapping[str, NDArray[Any]],
+) -> dict[str, Any]:
+    """Validate the metadata digest and decode strict JSON.
+
+    Args:
+        arrays: Loaded archive arrays including metadata bytes and digest.
+
+    Returns:
+        Parsed metadata with the exact schema field set.
+
+    Raises:
+        ValueError: If byte layouts, checksums, JSON, or fields are malformed.
+    """
+    metadata_bytes = arrays["metadata"]
+    metadata_sha = arrays["metadata_sha256"]
+    if metadata_bytes.dtype != np.dtype(np.uint8) or metadata_bytes.ndim != 1:
+        raise ValueError("Checkpoint metadata must be a one-dimensional uint8 array.")
+    if metadata_sha.dtype != np.dtype(np.uint8) or metadata_sha.shape != (64,):
+        raise ValueError("Checkpoint metadata_sha256 must be a 64-byte uint8 array.")
+    try:
+        payload = metadata_bytes.tobytes().decode("utf-8")
+        supplied = metadata_sha.tobytes().decode("ascii")
+    except UnicodeDecodeError as exc:
+        raise ValueError("Checkpoint metadata is not valid UTF-8/ASCII.") from exc
+    expected = sha256(metadata_bytes.tobytes()).hexdigest()
+    if not hmac.compare_digest(supplied, expected):
+        raise ValueError("Checkpoint metadata SHA-256 checksum does not match.")
+    metadata = _full_tiling_io._parse_json_object(
+        payload,
+        location="checkpoint metadata",
+    )
+    _require_keys(metadata, _METADATA_NAMES, location="checkpoint metadata")
+    return metadata
+
+
+def _state_array(
+    arrays: Mapping[str, NDArray[Any]],
+    name: str,
+    *,
+    dtype: np.dtype[Any],
+    ndim: int,
+) -> NDArray[Any]:
+    """Validate one persisted state array's exact dtype and rank.
+
+    Args:
+        arrays: Loaded checkpoint arrays.
+        name: Required state-array name.
+        dtype: Exact required NumPy dtype.
+        ndim: Exact required number of dimensions.
+
+    Returns:
+        Validated owned array.
+
+    Raises:
+        ValueError: If dtype or rank differs from the schema.
+    """
+    array = arrays[name]
+    if array.dtype != dtype or array.ndim != ndim:
+        raise ValueError(f"Checkpoint {name} must be {ndim}-dimensional {dtype}.")
+    return array
+
+
+def _readonly_float_copy(values: NDArray[Any]) -> NDArray[np.float64]:
+    """Return one owned read-only ``float64`` array."""
+    result = np.array(values, dtype=np.float64, copy=True)
+    result.setflags(write=False)
+    return result
+
+
+def _kernel_settings_from_metadata(
+    value: object,
+) -> FullTilingPyMCHMCKernelSettings:
+    """Reconstruct exact resolved HMC settings from strict metadata.
+
+    Args:
+        value: Parsed candidate kernel metadata.
+
+    Returns:
+        Fully validated immutable kernel settings.
+
+    Raises:
+        ValueError: If fields, semantics, types, or values are incompatible.
+        RuntimeError: If the installed settings dataclass changed without a
+            schema version decision.
+    """
+    kernel = _require_mapping(value, location="kernel")
+    _kernel_field_names()
+    _require_keys(kernel, _KERNEL_METADATA_NAMES, location="kernel")
+    if kernel["position_scale_semantics"] != FULL_TILING_PYMC_HMC_METRIC_SEMANTICS_ID:
+        raise ValueError("Checkpoint HMC position-scale semantics are incompatible.")
+    if kernel["step_size_semantics"] != _STEP_SIZE_SEMANTICS:
+        raise ValueError("Checkpoint HMC step-size semantics are incompatible.")
+    fixed_position_scale = kernel["fixed_coefficient_position_scale"]
+    if not isinstance(fixed_position_scale, list):
+        raise ValueError("kernel.fixed_coefficient_position_scale must be a JSON array.")
+    return FullTilingPyMCHMCKernelSettings(
+        fixed_k=_integer(
+            kernel["fixed_k"],
+            location="kernel.fixed_k",
+            minimum=1,
+        ),
+        step_size=_finite_float(
+            kernel["step_size"],
+            location="kernel.step_size",
+            positive=True,
+        ),
+        leapfrog_steps=_integer(
+            kernel["leapfrog_steps"],
+            location="kernel.leapfrog_steps",
+            minimum=1,
+        ),
+        leaf_position_scale=_finite_float(
+            kernel["leaf_position_scale"],
+            location="kernel.leaf_position_scale",
+            positive=True,
+        ),
+        fixed_coefficient_position_scale=tuple(
+            _finite_float(
+                item,
+                location="kernel.fixed_coefficient_position_scale",
+                positive=True,
+            )
+            for item in fixed_position_scale
+        ),
+    )
+
+
+def _runtime_identity_from_metadata(
+    value: object,
+) -> FullTilingPyMCHMCRuntimeIdentity:
+    """Reconstruct and validate the exact continuation runtime identity.
+
+    Args:
+        value: Parsed candidate runtime-identity metadata.
+
+    Returns:
+        Immutable persisted identity after exact comparison with this process.
+
+    Raises:
+        ValueError: If fields or exact runtime identity do not match.
+        ImportError: If PyMC or PyTensor is unavailable.
+        RuntimeError: If PyTensor precision or the frozen identity schema is
+            incompatible.
+    """
+    runtime = _require_mapping(value, location="runtime_identity")
+    _require_keys(
+        runtime,
+        _RUNTIME_IDENTITY_NAMES,
+        location="runtime_identity",
+    )
+    if any(not isinstance(runtime[name], str) or not runtime[name] for name in _RUNTIME_IDENTITY_NAMES):
+        raise ValueError("Full-tiling PyMC HMC checkpoint runtime identity is malformed.")
+    current = full_tiling_pymc_hmc_runtime_identity()
+    _runtime_identity_metadata(current)
+    persisted = FullTilingPyMCHMCRuntimeIdentity(
+        **{name: cast(str, runtime[name]) for name in _RUNTIME_IDENTITY_FIELDS_V1}
+    )
+    if persisted != current:
+        mismatches = [
+            name for name in _RUNTIME_IDENTITY_FIELDS_V1 if getattr(persisted, name) != getattr(current, name)
+        ]
+        raise ValueError(
+            f"Full-tiling PyMC HMC checkpoint runtime identity does not match for {mismatches[0]}."
+        )
+    return persisted
+
+
+def _validate_manifest(
+    metadata: Mapping[str, object],
+    expected_run_manifest: RunManifest,
+) -> None:
+    """Require an intact canonical manifest equal to caller expectations.
+
+    Args:
+        metadata: Validated top-level checkpoint metadata.
+        expected_run_manifest: Exact caller-owned expected manifest.
+
+    Raises:
+        ValueError: If manifest metadata, checksum, or canonical content is
+            incompatible.
+    """
+    embedded_json = metadata["run_manifest_json"]
+    embedded_sha = metadata["run_manifest_sha256"]
+    if not isinstance(embedded_json, str) or not isinstance(embedded_sha, str):
+        raise ValueError("Checkpoint run manifest metadata is malformed.")
+    if not hmac.compare_digest(
+        sha256(embedded_json.encode("utf-8")).hexdigest(),
+        embedded_sha,
+    ):
+        raise ValueError("Checkpoint run manifest SHA-256 checksum does not match.")
+    expected_json = _full_tiling_io.canonical_full_tiling_run_manifest(expected_run_manifest)
+    if not hmac.compare_digest(embedded_json, expected_json):
+        raise ValueError("Checkpoint run manifest does not match expected canonical content.")
+
+
+def _validate_array_hashes(
+    arrays: Mapping[str, NDArray[Any]],
+    value: object,
+) -> None:
+    """Require every numeric array to match its exact-layout digest.
+
+    Args:
+        arrays: Loaded archive arrays.
+        value: Parsed candidate digest mapping.
+
+    Raises:
+        ValueError: If fields or any SHA-256 digest are invalid.
+    """
+    hashes = _require_mapping(value, location="array_sha256")
+    expected_names = frozenset(_STATE_ARRAY_NAMES)
+    if frozenset(hashes) != expected_names:
+        raise ValueError("Checkpoint array_sha256 has an invalid field set.")
+    for name in _STATE_ARRAY_NAMES:
+        supplied = hashes[name]
+        if not isinstance(supplied, str) or not hmac.compare_digest(
+            supplied,
+            _full_tiling_io._array_sha256(name, arrays[name]),
+        ):
+            raise ValueError(f"Checkpoint {name} SHA-256 checksum does not match.")
+
+
+def _rng_state_from_metadata(value: object) -> PCG64State:
+    """Reconstruct and validate the exact PCG64 continuation state.
+
+    Args:
+        value: Parsed candidate RNG metadata.
+
+    Returns:
+        Valid exact PCG64 state.
+
+    Raises:
+        ValueError: If fields, bounds, algorithm, or NumPy restoration fail.
+    """
+    rng = _require_mapping(value, location="rng")
+    _require_keys(
+        rng,
+        frozenset(("algorithm", "state", "increment", "has_uint32", "uinteger")),
+        location="rng",
+    )
+    if rng["algorithm"] != "PCG64":
+        raise ValueError("rng.algorithm must be exactly 'PCG64'.")
+    result = PCG64State(
+        state=_integer(
+            rng["state"],
+            location="rng.state",
+            maximum=(1 << 128) - 1,
+        ),
+        increment=_integer(
+            rng["increment"],
+            location="rng.increment",
+            maximum=(1 << 128) - 1,
+        ),
+        has_uint32=_integer(
+            rng["has_uint32"],
+            location="rng.has_uint32",
+            maximum=1,
+        ),
+        uinteger=_integer(
+            rng["uinteger"],
+            location="rng.uinteger",
+            maximum=(1 << 32) - 1,
+        ),
+        algorithm="PCG64",
+    )
+    try:
+        result.generator()
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError("Checkpoint PCG64 state is invalid.") from exc
+    return result
+
+
+def load_full_tiling_pymc_hmc_checkpoint(
+    path: PathLike,
+    problem: FullTilingProblem,
+    *,
+    expected_run_manifest: RunManifest,
+) -> FullTilingPyMCHMCCheckpoint:
+    """Load and independently validate a PyMC HMC continuation boundary.
+
+    The current runtime must exactly match the checkpoint's PyMC, PyTensor,
+    NumPy, Python-minor, platform, ``floatX``, symmetric-coordinate layout,
+    static-HMC semantics, and schedule identities. Scientific coordinates are
+    fully rebuilt against ``problem`` and audited before exact persisted
+    caches and authoritative log coordinates are attached to the returned
+    checkpoint.
+
+    Args:
+        path: Source NPZ archive.
+        problem: Equal reconstructed scientific problem for the resumed run.
+        expected_run_manifest: Exact caller-held manifest expected in the
+            archive.
+
+    Returns:
+        Valid checkpoint attached to ``problem`` with exact caches, log
+        coordinates, sweep count, settings, and PCG64 state restored.
+
+    Raises:
+        TypeError: If ``problem`` or the manifest has the wrong type.
+        ValueError: If archive schema, hashes, backend, problem, manifest,
+            topology, coordinates, caches, target terms, RNG, schedule, or
+            resolved HMC settings disagree.
+        ImportError: If PyMC or PyTensor is unavailable.
+        RuntimeError: If PyTensor precision or the frozen settings schema is
+            incompatible.
+        OSError: If the archive cannot be read.
+    """
+    if not isinstance(problem, FullTilingProblem):
+        raise TypeError("problem must be a FullTilingProblem.")
+    if not isinstance(expected_run_manifest, Mapping):
+        raise TypeError("expected_run_manifest must be a mapping.")
+    arrays = _load_archive_arrays(Path(path))
+    metadata = _metadata_from_arrays(arrays)
+    if (
+        metadata["schema_id"] != FULL_TILING_PYMC_HMC_CHECKPOINT_SCHEMA_ID
+        or metadata["schema_version"] != FULL_TILING_PYMC_HMC_CHECKPOINT_SCHEMA_VERSION
+    ):
+        raise ValueError("Full-tiling PyMC HMC checkpoint schema is incompatible.")
+    runtime_identity = _runtime_identity_from_metadata(metadata["runtime_identity"])
+    schedule_id = metadata["schedule_id"]
+    if schedule_id != FULL_TILING_PYMC_HMC_SCHEDULE_ID:
+        raise ValueError("Full-tiling PyMC HMC checkpoint schedule is incompatible.")
+    problem_sha = _full_tiling_io.full_tiling_problem_fingerprint(problem)
+    if metadata["problem_sha256"] != problem_sha:
+        raise ValueError("Full-tiling PyMC HMC checkpoint problem fingerprint does not match.")
+    _validate_manifest(metadata, expected_run_manifest)
+    _validate_array_hashes(arrays, metadata["array_sha256"])
+
+    rectangle_bounds = _state_array(
+        arrays,
+        "rectangle_bounds",
+        dtype=np.dtype(np.int64),
+        ndim=2,
+    )
+    leaf_masses = _state_array(
+        arrays,
+        "leaf_masses",
+        dtype=np.dtype(np.float64),
+        ndim=1,
+    )
+    fixed_coefficients = _state_array(
+        arrays,
+        "fixed_coefficients",
+        dtype=np.dtype(np.float64),
+        ndim=1,
+    )
+    log_leaf_mass = _state_array(
+        arrays,
+        "log_leaf_mass",
+        dtype=np.dtype(np.float64),
+        ndim=1,
+    )
+    log_fixed_coefficient = _state_array(
+        arrays,
+        "log_fixed_coefficient",
+        dtype=np.dtype(np.float64),
+        ndim=1,
+    )
+    caches = {
+        name: _state_array(
+            arrays,
+            name,
+            dtype=np.dtype(np.float64),
+            ndim=1,
+        )
+        for name in _CACHE_ARRAY_NAMES
+    }
+    state_metadata = _require_mapping(metadata["state"], location="state")
+    _require_keys(
+        state_metadata,
+        frozenset(("k", "root_total", *_STATE_LOG_FIELDS)),
+        location="state",
+    )
+    k = _integer(state_metadata["k"], location="state.k", minimum=1)
+    if rectangle_bounds.shape != (k, 4):
+        raise ValueError("Checkpoint rectangle_bounds must have shape (K, 4).")
+    if leaf_masses.shape != (k,) or log_leaf_mass.shape != (k,):
+        raise ValueError("Checkpoint leaf mass and log-coordinate arrays must have shape (K,).")
+    if log_fixed_coefficient.shape != fixed_coefficients.shape:
+        raise ValueError("Checkpoint fixed coefficients and log coordinates must have matching shapes.")
+    observation_shape = problem.observations.shape
+    if any(cache.shape != observation_shape for cache in caches.values()):
+        raise ValueError("Checkpoint posterior caches must match the observation shape.")
+    if np.any(~np.isfinite(log_leaf_mass)) or np.any(~np.isfinite(log_fixed_coefficient)):
+        raise ValueError("Checkpoint authoritative log coordinates must be finite.")
+    with np.errstate(over="ignore", under="ignore", invalid="ignore"):
+        if not np.array_equal(np.exp(log_leaf_mass), leaf_masses):
+            raise ValueError("Checkpoint log_leaf_mass does not exactly encode leaf_masses.")
+        if not np.array_equal(
+            np.exp(log_fixed_coefficient),
+            fixed_coefficients,
+        ):
+            raise ValueError("Checkpoint log_fixed_coefficient does not exactly encode fixed_coefficients.")
+    try:
+        rectangles = tuple(Rectangle(*(int(bound) for bound in row)) for row in rectangle_bounds.tolist())
+        allocation = TilingState(
+            LeafTiling(problem.shape, rectangles),
+            leaf_masses,
+        )
+        rebuilt = build_full_tiling_posterior_state(
+            problem,
+            allocation=allocation,
+            fixed_coefficients=fixed_coefficients,
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Checkpoint topology or state coordinates are invalid.") from exc
+
+    _full_tiling_io._validate_rebuilt_caches(
+        problem,
+        rebuilt,
+        caches,
+        location="Rebuilt checkpoint state",
+    )
+    expected_root_total = _finite_float(
+        state_metadata["root_total"],
+        location="state.root_total",
+        positive=True,
+    )
+    if rebuilt.root_total != expected_root_total:
+        raise ValueError("Rebuilt state root_total does not match checkpoint metadata.")
+    persisted_logs = {
+        name: _finite_float(
+            state_metadata[name],
+            location=f"state.{name}",
+        )
+        for name in _STATE_LOG_FIELDS
+    }
+    cache_consistent = _full_tiling_io._cache_consistent_state(
+        problem,
+        rebuilt,
+        caches,
+    )
+    _full_tiling_io._validate_cache_consistent_values(
+        cache_consistent,
+        caches,
+        persisted_logs,
+        location="Checkpoint state",
+    )
+    state = FullTilingPosteriorState(
+        problem=problem,
+        allocation=allocation,
+        fixed_coefficients=_readonly_float_copy(fixed_coefficients),
+        dynamic_prediction=_readonly_float_copy(caches["dynamic_prediction"]),
+        fixed_prediction=_readonly_float_copy(caches["fixed_prediction"]),
+        prediction=_readonly_float_copy(caches["prediction"]),
+        residual=_readonly_float_copy(caches["residual"]),
+        log_gaussian_likelihood=persisted_logs["log_gaussian_likelihood"],
+        log_likelihood=persisted_logs["log_likelihood"],
+        log_root_prior=persisted_logs["log_root_prior"],
+        log_allocation_prior=persisted_logs["log_allocation_prior"],
+        log_fixed_coefficient_prior=persisted_logs["log_fixed_coefficient_prior"],
+    )
+    if state.log_target != persisted_logs["log_target"]:
+        raise ValueError("Persisted state log_target is inconsistent with its components.")
+    supplied_state_sha = metadata["state_sha256"]
+    rebuilt_state_sha = _full_tiling_io.full_tiling_state_fingerprint(
+        problem,
+        state,
+    )
+    if not isinstance(supplied_state_sha, str) or not hmac.compare_digest(
+        supplied_state_sha,
+        rebuilt_state_sha,
+    ):
+        raise ValueError("Full-tiling PyMC HMC checkpoint state fingerprint does not match.")
+
+    settings = _kernel_settings_from_metadata(metadata["kernel"])
+    if settings.fixed_k != k:
+        raise ValueError("Checkpoint fixed K does not match the persisted state.")
+    if len(settings.fixed_coefficient_position_scale) != fixed_coefficients.size:
+        raise ValueError("Checkpoint fixed HMC position scales do not match the fixed block.")
+    rng_state = _rng_state_from_metadata(metadata["rng"])
+    return FullTilingPyMCHMCCheckpoint(
+        problem=problem,
+        state=state,
+        log_leaf_mass=_readonly_float_copy(log_leaf_mass),
+        log_fixed_coefficient=_readonly_float_copy(log_fixed_coefficient),
+        rng_state=rng_state,
+        sweeps_completed=_integer(
+            metadata["sweeps_completed"],
+            location="sweeps_completed",
+        ),
+        kernel_settings=settings,
+        runtime_identity=runtime_identity,
+        schedule_id=cast(str, schedule_id),
+    )
+
+
+__all__ = [
+    "FULL_TILING_PYMC_HMC_CHECKPOINT_SCHEMA_ID",
+    "FULL_TILING_PYMC_HMC_CHECKPOINT_SCHEMA_VERSION",
+    "load_full_tiling_pymc_hmc_checkpoint",
+    "save_full_tiling_pymc_hmc_checkpoint",
+]

--- a/tests/experimental/rjmcmc/test_full_tiling_pymc_hmc.py
+++ b/tests/experimental/rjmcmc/test_full_tiling_pymc_hmc.py
@@ -1,0 +1,988 @@
+"""Tests for the mobile full-tiling structural plus static PyMC HMC kernel."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+import math
+import os
+from pathlib import Path
+import subprocess
+import sys
+from typing import Literal
+
+import numpy as np
+import pytest
+import xarray as xr
+
+import openghg_inversions.experimental.rjmcmc.full_tiling_pymc_hmc as sampling
+from openghg_inversions.experimental.rjmcmc.core import lognormal_mu_sigma
+from openghg_inversions.experimental.rjmcmc.full_tiling import (
+    LeafTiling,
+    Rectangle,
+    TilingState,
+)
+from openghg_inversions.experimental.rjmcmc.full_tiling_posterior import (
+    FullTilingProblem,
+    FullTilingPosteriorState,
+    PosteriorTransitionTerms,
+    build_full_tiling_posterior_state,
+    full_tiling_problem_from_gamma_beta_adapter,
+    initialize_full_tiling_posterior_state,
+)
+from openghg_inversions.experimental.rjmcmc.gamma_beta_adapter import (
+    gamma_beta_problem_from_rhime_inputs,
+)
+
+_THIS_FILE = Path(__file__).resolve()
+_X64_CHILD_ENV = "OPENGHG_INVERSIONS_PYMC_HMC_X64_CHILD"
+_IS_X64_CHILD = os.environ.get(_X64_CHILD_ENV) == "1"
+_requires_x64_child = pytest.mark.skipif(
+    not _IS_X64_CHILD,
+    reason="PyMC runtime assertion executes in the isolated float64 child",
+)
+
+
+def _pytensor_flags_with_float64(flags: str) -> str:
+    """Return PyTensor flags with an unambiguous float64 configuration."""
+    retained = []
+    for item in flags.split(","):
+        stripped = item.strip()
+        if not stripped:
+            continue
+        name = stripped.split("=", 1)[0].strip()
+        if name not in {"floatX", "warn_float64"}:
+            retained.append(stripped)
+    return ",".join(("floatX=float64", "warn_float64=ignore", *retained))
+
+
+def _run_x64_test_file() -> None:
+    """Run all PyMC assertions in one fresh float64 subprocess."""
+    environment = os.environ.copy()
+    environment[_X64_CHILD_ENV] = "1"
+    environment["PYTENSOR_FLAGS"] = _pytensor_flags_with_float64(
+        environment.get("PYTENSOR_FLAGS", ""),
+    )
+    completed = subprocess.run(
+        [sys.executable, "-m", "pytest", "-q", str(_THIS_FILE)],
+        cwd=_THIS_FILE.parents[3],
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=180,
+        check=False,
+    )
+    assert completed.returncode == 0, (
+        "isolated full-tiling PyMC HMC tests failed\n"
+        f"stdout:\n{completed.stdout}\n"
+        f"stderr:\n{completed.stderr}"
+    )
+
+
+@pytest.mark.skipif(_IS_X64_CHILD, reason="parent-only subprocess dispatch")
+def test_pymc_runtime_cases_use_a_fresh_float64_subprocess() -> None:
+    """PyMC cases cannot inherit process-global float32 from RHIME tests."""
+    _run_x64_test_file()
+
+
+def _problem_state(
+    *,
+    k: int = 4,
+) -> tuple[FullTilingProblem, FullTilingPosteriorState]:
+    """Return a tiny non-degenerate problem with three fixed coefficients."""
+    sensitivity = np.arange(1.0, 49.0).reshape(3, 4, 4) / 40.0
+    fixed_design = np.arange(9.0).reshape(3, 3) / 20.0
+    fixed_offset = np.array([0.1, 0.2, 0.3])
+    dataset = xr.Dataset(
+        {
+            "fp_x_flux": (("nmeasure", "lat", "lon"), sensitivity),
+            "mf": ("nmeasure", np.array([1.2, 1.4, 1.8])),
+            "mf_error": ("nmeasure", np.full(3, 0.8)),
+            "outer": (("nmeasure", "outer_region"), fixed_design),
+            "boundary": ("nmeasure", fixed_offset),
+        },
+        coords={
+            "nmeasure": np.arange(3),
+            "lat": np.arange(4, dtype=float),
+            "lon": np.arange(4, dtype=float),
+            "outer_region": np.arange(3),
+        },
+    )
+    adapter = gamma_beta_problem_from_rhime_inputs(
+        dataset,
+        nominal_weight=np.arange(1.0, 17.0).reshape(4, 4),
+        k_min=1,
+        k_max=16,
+        concentration=4.0,
+        root_variance=0.25,
+        fixed_design_name="outer",
+        fixed_offset_name="boundary",
+        fixed_coefficient_prior_mean=np.array([0.8, 1.1, 1.5]),
+        fixed_coefficient_prior_sd=np.array([0.3, 0.4, 0.5]),
+    )
+    problem = full_tiling_problem_from_gamma_beta_adapter(
+        adapter,
+        concentration=4.0,
+    )
+    return problem, initialize_full_tiling_posterior_state(problem, k=k)
+
+
+def _nonuniform_state(
+    problem: FullTilingProblem,
+    state: FullTilingPosteriorState,
+) -> FullTilingPosteriorState:
+    """Return an arbitrary supported point with non-unit total mass."""
+    masses = np.linspace(0.3, 1.2, state.k, dtype=np.float64)
+    fixed = np.array([0.7, 1.3, 1.8], dtype=np.float64)
+    return build_full_tiling_posterior_state(
+        problem,
+        allocation=TilingState(state.tiling_state.tiling, masses),
+        fixed_coefficients=fixed,
+    )
+
+
+def _assert_states_equal(
+    actual: FullTilingPosteriorState,
+    expected: FullTilingPosteriorState,
+) -> None:
+    """Assert exact topology, coordinates, caches, and target equality."""
+    assert actual.problem is expected.problem
+    assert actual.tiling_state.tiling == expected.tiling_state.tiling
+    for name in (
+        "leaf_masses",
+        "fixed_coefficients",
+        "dynamic_prediction",
+        "fixed_prediction",
+        "prediction",
+        "residual",
+    ):
+        np.testing.assert_array_equal(getattr(actual, name), getattr(expected, name))
+    for name in (
+        "log_gaussian_likelihood",
+        "log_likelihood",
+        "log_root_prior",
+        "log_allocation_prior",
+        "log_fixed_coefficient_prior",
+        "log_target",
+    ):
+        assert getattr(actual, name) == getattr(expected, name)
+
+
+def _assert_results_equal(
+    actual: sampling.FullTilingPyMCHMCSamplingResult,
+    expected: sampling.FullTilingPyMCHMCSamplingResult,
+) -> None:
+    """Assert exact trace, state, settings, and PCG64 continuation equality."""
+    for name in actual.trace.__dataclass_fields__:
+        np.testing.assert_array_equal(
+            getattr(actual.trace, name),
+            getattr(expected.trace, name),
+        )
+    np.testing.assert_array_equal(actual.trace.hmc_seed, expected.trace.hmc_seed)
+    assert actual.trace.hmc_seed.dtype == np.dtype(np.uint64)
+    _assert_states_equal(actual.final_state, expected.final_state)
+    np.testing.assert_array_equal(
+        actual.checkpoint.log_leaf_mass,
+        expected.checkpoint.log_leaf_mass,
+    )
+    np.testing.assert_array_equal(
+        actual.checkpoint.log_fixed_coefficient,
+        expected.checkpoint.log_fixed_coefficient,
+    )
+    np.testing.assert_array_equal(
+        actual.trace.log_leaf_mass,
+        expected.trace.log_leaf_mass,
+    )
+    np.testing.assert_array_equal(
+        actual.trace.log_fixed_coefficient,
+        expected.trace.log_fixed_coefficient,
+    )
+    np.testing.assert_array_equal(
+        actual.trace.log_leaf_mass[-1],
+        actual.checkpoint.log_leaf_mass,
+    )
+    np.testing.assert_array_equal(
+        actual.trace.log_fixed_coefficient[-1],
+        actual.checkpoint.log_fixed_coefficient,
+    )
+    np.testing.assert_array_equal(
+        np.exp(actual.checkpoint.log_leaf_mass),
+        actual.checkpoint.state.leaf_masses,
+    )
+    np.testing.assert_array_equal(
+        np.exp(actual.checkpoint.log_fixed_coefficient),
+        actual.checkpoint.state.fixed_coefficients,
+    )
+    assert actual.checkpoint.rng_state == expected.checkpoint.rng_state
+    assert actual.checkpoint.sweeps_completed == expected.checkpoint.sweeps_completed
+    assert actual.checkpoint.kernel_settings == expected.checkpoint.kernel_settings
+    assert actual.checkpoint.runtime_identity == expected.checkpoint.runtime_identity
+    assert actual.checkpoint.runtime_identity == sampling.full_tiling_pymc_hmc_runtime_identity()
+
+
+def _config(*, iterations: int, seed: int = 761) -> sampling.FullTilingPyMCHMCConfig:
+    """Return a short frozen-HMC configuration used throughout the tests."""
+    return sampling.FullTilingPyMCHMCConfig(
+        iterations=iterations,
+        step_size=0.002,
+        leapfrog_steps=2,
+        leaf_position_scale=1.7,
+        fixed_coefficient_position_scale=(0.6, 1.1, 2.4),
+        seed=seed,
+    )
+
+
+@_requires_x64_child
+def test_compiled_transformed_target_includes_both_coordinate_jacobians() -> None:
+    """PyMC logp equals the scientific target plus mass and fixed Jacobians."""
+    problem, initial = _problem_state(k=4)
+    state = _nonuniform_state(problem, initial)
+    model = sampling.build_full_tiling_pymc_hmc_model(problem, state)
+    point = model.initial_point()
+    compiled = float(model.compile_logp()(point))
+    log_mass = np.log(state.leaf_masses)
+    log_total = float(np.logaddexp.reduce(log_mass))
+    mass_jacobian = float(log_mass.sum() - (state.k - 1) * log_total)
+    fixed_jacobian = float(np.log(state.fixed_coefficients).sum())
+
+    assert compiled - state.log_target == pytest.approx(
+        mass_jacobian + fixed_jacobian,
+        abs=2.0e-10,
+    )
+    assert compiled == pytest.approx(
+        state.log_target + mass_jacobian + fixed_jacobian,
+        abs=2.0e-10,
+    )
+
+
+@_requires_x64_child
+def test_compiled_target_matches_independent_closed_form_at_arbitrary_xy() -> None:
+    """An independent normalized density matches PyMC away from encoded state."""
+    problem, state = _problem_state(k=4)
+    model = sampling.build_full_tiling_pymc_hmc_model(problem, state)
+    point = model.initial_point()
+    x = np.array([-1.1, -0.6, -0.9, -0.35])
+    y = np.log(np.array([0.65, 1.25, 1.7]))
+    point["x"] = x
+    point["y"] = y
+
+    log_total = float(np.logaddexp.reduce(x))
+    total = math.exp(log_total)
+    log_share = x - log_total
+    prior = problem.base.prior
+    log_gamma = (
+        prior.root_shape * math.log(prior.root_rate)
+        - math.lgamma(prior.root_shape)
+        + (prior.root_shape - 1.0) * log_total
+        - prior.root_rate * total
+    )
+    alpha = problem.allocation_prior.leaf_alphas(state.tiling_state.tiling)
+    log_dirichlet = (
+        math.lgamma(float(alpha.sum()))
+        - sum(math.lgamma(float(value)) for value in alpha)
+        + float(np.dot(alpha - 1.0, log_share))
+    )
+    dynamic_design = np.column_stack(
+        [problem.design_column(leaf) for leaf in state.tiling_state.tiling.leaves],
+    )
+    fixed_block = problem.base.fixed_block
+    fixed_offset = problem.base.fixed_offset
+    assert fixed_block is not None
+    assert fixed_offset is not None
+    prediction = fixed_offset + dynamic_design @ np.exp(x) + fixed_block.design @ np.exp(y)
+    residual = (prediction - problem.observations) / problem.observation_sd
+    log_gaussian = (
+        -0.5 * float(np.dot(residual, residual))
+        - float(np.log(problem.observation_sd).sum())
+        - 0.5 * problem.observations.size * math.log(2.0 * math.pi)
+    )
+    log_likelihood = problem.base.likelihood_power * log_gaussian
+    log_fixed = 0.0
+    for coordinate, mean, sd in zip(
+        y,
+        fixed_block.coefficient_prior_mean,
+        fixed_block.coefficient_prior_sd,
+        strict=True,
+    ):
+        mu, sigma = lognormal_mu_sigma(float(mean), float(sd))
+        log_fixed += (
+            -0.5 * ((float(coordinate) - mu) / sigma) ** 2 - math.log(sigma) - 0.5 * math.log(2.0 * math.pi)
+        )
+    log_x_jacobian = float(x.sum() - (state.k - 1) * log_total)
+    expected = log_likelihood + log_gamma + log_dirichlet + log_fixed + log_x_jacobian
+
+    assert float(model.compile_logp()(point)) == pytest.approx(
+        expected,
+        rel=2.0e-12,
+        abs=2.0e-12,
+    )
+
+
+@_requires_x64_child
+def test_canonical_leaf_permutation_realigns_target_and_scalar_metric() -> None:
+    """Aligned topology arrays and log coordinates preserve target and metric."""
+    problem, initial = _problem_state(k=4)
+    state = _nonuniform_state(problem, initial)
+    model = sampling.build_full_tiling_pymc_hmc_model(problem, state)
+    point = model.initial_point()
+    logp = model.compile_logp()
+    canonical_logp = float(logp(point))
+    design, alpha, log_normalizer = sampling._topology_arrays(problem, state)
+    leaves = state.tiling_state.tiling.leaves
+    permutation = np.array([2, 0, 3, 1])
+    reordered_leaves = tuple(leaves[index] for index in permutation)
+    reordered_design = design[:, permutation]
+    reordered_alpha = alpha[permutation]
+    reordered_point = {name: np.array(value, copy=True) for name, value in point.items()}
+    reordered_point["x"] = reordered_point["x"][permutation]
+
+    assert reordered_leaves != leaves
+    for index, leaf in enumerate(reordered_leaves):
+        np.testing.assert_array_equal(
+            reordered_design[:, index],
+            problem.design_column(leaf),
+        )
+        assert reordered_alpha[index] == problem.allocation_prior.alpha(leaf)
+        assert np.exp(reordered_point["x"][index]) == state.tiling_state.mass(leaf)
+
+    mass_by_leaf = {
+        leaf: mass
+        for leaf, mass in zip(
+            reordered_leaves,
+            state.leaf_masses[permutation],
+            strict=True,
+        )
+    }
+    rebuilt = build_full_tiling_posterior_state(
+        problem,
+        allocation=TilingState(
+            state.tiling_state.tiling,
+            np.asarray([mass_by_leaf[leaf] for leaf in leaves]),
+        ),
+        fixed_coefficients=state.fixed_coefficients,
+    )
+    _assert_states_equal(rebuilt, state)
+
+    sampling._set_topology_data_atomically(
+        model,
+        reordered_design,
+        reordered_alpha,
+        log_normalizer,
+    )
+    assert float(logp(reordered_point)) == pytest.approx(
+        canonical_logp,
+        rel=0.0,
+        abs=2.0e-12,
+    )
+
+    settings = sampling.FullTilingPyMCHMCKernelSettings(
+        fixed_k=state.k,
+        step_size=0.01,
+        leapfrog_steps=2,
+        leaf_position_scale=2.5,
+        fixed_coefficient_position_scale=(0.4, 0.8, 1.6),
+    )
+    leaf_metric = settings.position_scale_diagonal[: state.k]
+    np.testing.assert_array_equal(leaf_metric[permutation], leaf_metric)
+
+
+@_requires_x64_child
+def test_compiled_gradient_matches_central_directional_difference() -> None:
+    """PyMC's gradient matches a stable finite difference inside support."""
+    problem, state = _problem_state(k=4)
+    model = sampling.build_full_tiling_pymc_hmc_model(problem, state)
+    point = model.initial_point()
+    point["x"] = np.array([-1.1, -0.6, -0.9, -0.35])
+    point["y"] = np.log(np.array([0.65, 1.25, 1.7]))
+    direction = np.array([0.3, -0.4, 0.2, 0.1, -0.25, 0.35, -0.15])
+    direction /= np.linalg.norm(direction)
+    gradient = np.asarray(
+        model.compile_dlogp(vars=[model["x"], model["y"]])(point),
+        dtype=np.float64,
+    )
+    step = 2.0e-6
+    plus = {name: np.array(value, copy=True) for name, value in point.items()}
+    minus = {name: np.array(value, copy=True) for name, value in point.items()}
+    plus["x"] += step * direction[: state.k]
+    minus["x"] -= step * direction[: state.k]
+    plus["y"] += step * direction[state.k :]
+    minus["y"] -= step * direction[state.k :]
+    logp = model.compile_logp()
+    finite_difference = (float(logp(plus)) - float(logp(minus))) / (2.0 * step)
+
+    assert float(np.dot(gradient, direction)) == pytest.approx(
+        finite_difference,
+        rel=2.0e-7,
+        abs=2.0e-7,
+    )
+
+
+@_requires_x64_child
+def test_model_rejects_unrepresentable_log_coordinates() -> None:
+    """Overflowing or underflowing log coordinates have negative-infinite logp."""
+    problem, state = _problem_state(k=4)
+    model = sampling.build_full_tiling_pymc_hmc_model(problem, state)
+    logp = model.compile_logp()
+    initial = model.initial_point()
+
+    assert math.isfinite(float(logp(initial)))
+    for name, value in (
+        ("x", -1000.0),
+        ("x", 1000.0),
+        ("y", -1000.0),
+        ("y", 1000.0),
+    ):
+        point = {key: np.array(item, copy=True) for key, item in initial.items()}
+        point[name][...] = value
+        assert float(logp(point)) == -math.inf
+
+
+@_requires_x64_child
+@pytest.mark.parametrize("outcome", ["accepted", "rejected", "invalid"])
+def test_every_structural_outcome_is_followed_by_one_hmc_transition(
+    monkeypatch: pytest.MonkeyPatch,
+    outcome: Literal["accepted", "rejected", "invalid"],
+) -> None:
+    """Accepted, rejected, and invalid structural attempts all run HMC once."""
+    problem, initial = _problem_state(k=4)
+    original_draw = sampling._draw_structural_transition
+    valid_transition = None
+    search_rng = np.random.default_rng(923)
+    for _ in range(100):
+        candidate, _ = original_draw(problem, initial, rng=search_rng)
+        if candidate.valid:
+            valid_transition = candidate
+            break
+    assert valid_transition is not None
+    transition = (
+        PosteriorTransitionTerms(
+            candidate=initial,
+            move="edge_flip",
+            delta_log_likelihood=0.0,
+            valid=False,
+            reason="forced invalid structural attempt",
+        )
+        if outcome == "invalid"
+        else valid_transition
+    )
+
+    monkeypatch.setattr(
+        sampling,
+        "_draw_structural_transition",
+        lambda *args, **kwargs: (transition, None),
+    )
+    original_accept = sampling.accept_or_reject
+
+    def controlled_accept(source, terms, *, log_uniform):
+        """Force the selected valid outcome while retaining invalid semantics."""
+        if outcome == "accepted":
+            return terms.candidate
+        if outcome == "rejected":
+            return source
+        return original_accept(source, terms, log_uniform=log_uniform)
+
+    monkeypatch.setattr(sampling, "accept_or_reject", controlled_accept)
+    result = sampling.sample_full_tiling_pymc_hmc(
+        problem,
+        initial,
+        _config(iterations=1),
+    )
+
+    assert result.trace.global_sweep.tolist() == [1]
+    assert result.trace.structural_valid.tolist() == [outcome != "invalid"]
+    assert result.trace.structural_accepted.tolist() == [outcome == "accepted"]
+    assert result.trace.hmc_n_steps.tolist() == [2]
+    assert result.trace.hmc_step_size.tolist() == pytest.approx([0.002])
+    expected_tiling = (
+        valid_transition.candidate.tiling_state.tiling
+        if outcome == "accepted"
+        else initial.tiling_state.tiling
+    )
+    assert result.final_state.tiling_state.tiling == expected_tiling
+
+
+@_requires_x64_child
+def test_hmc_preserves_topology_and_rebuilds_all_scientific_caches() -> None:
+    """Every HMC endpoint keeps its input tiling and closes through a full rebuild."""
+    problem, initial = _problem_state(k=4)
+    result = sampling.sample_full_tiling_pymc_hmc(
+        problem,
+        initial,
+        _config(iterations=3, seed=812),
+    )
+
+    np.testing.assert_array_equal(result.trace.state_sweep, np.arange(4))
+    np.testing.assert_array_equal(result.trace.global_sweep, np.arange(1, 4))
+    for before, after, accepted in zip(
+        result.trace.rectangle_bounds[:-1],
+        result.trace.rectangle_bounds[1:],
+        result.trace.structural_accepted,
+        strict=True,
+    ):
+        if not accepted:
+            np.testing.assert_array_equal(after, before)
+    for bounds, masses, fixed, log_target in zip(
+        result.trace.rectangle_bounds,
+        result.trace.leaf_masses,
+        result.trace.fixed_coefficients,
+        result.trace.log_target,
+        strict=True,
+    ):
+        tiling = LeafTiling(
+            problem.shape,
+            tuple(Rectangle(*(int(value) for value in row)) for row in bounds),
+        )
+        rebuilt_draw = build_full_tiling_posterior_state(
+            problem,
+            allocation=TilingState(tiling, masses),
+            fixed_coefficients=fixed,
+        )
+        assert rebuilt_draw.log_target == log_target
+    rebuilt = build_full_tiling_posterior_state(
+        problem,
+        allocation=result.final_state.tiling_state,
+        fixed_coefficients=result.final_state.fixed_coefficients,
+    )
+    _assert_states_equal(result.final_state, rebuilt)
+
+
+@_requires_x64_child
+def test_trace_preserves_authoritative_hmc_coordinates_read_only() -> None:
+    """Trace coordinates retain exact boundary points with fixed immutable shapes."""
+    problem, initial = _problem_state(k=4)
+    result = sampling.sample_full_tiling_pymc_hmc(
+        problem,
+        initial,
+        _config(iterations=2, seed=268),
+    )
+
+    assert result.trace.log_leaf_mass.shape == (3, 4)
+    assert result.trace.log_fixed_coefficient.shape == (3, 3)
+    np.testing.assert_array_equal(
+        np.exp(result.trace.log_leaf_mass),
+        result.trace.leaf_masses,
+    )
+    np.testing.assert_array_equal(
+        np.exp(result.trace.log_fixed_coefficient),
+        result.trace.fixed_coefficients,
+    )
+    np.testing.assert_array_equal(
+        result.trace.log_leaf_mass[-1],
+        result.checkpoint.log_leaf_mass,
+    )
+    np.testing.assert_array_equal(
+        result.trace.log_fixed_coefficient[-1],
+        result.checkpoint.log_fixed_coefficient,
+    )
+    assert math.isfinite(result.kernel_setup_seconds)
+    assert result.kernel_setup_seconds >= 0.0
+    assert math.isfinite(result.transition_seconds)
+    assert result.transition_seconds >= 0.0
+    for coordinates in (
+        result.trace.log_leaf_mass,
+        result.trace.log_fixed_coefficient,
+    ):
+        assert not coordinates.flags.writeable
+        with pytest.raises(ValueError):
+            coordinates[0, 0] = 0.0
+
+    with pytest.raises(ValueError, match="log_leaf_mass must have shape"):
+        replace(
+            result.trace,
+            log_leaf_mass=result.trace.log_leaf_mass[:, :-1],
+        )
+    with pytest.raises(
+        ValueError,
+        match="log_fixed_coefficient must match",
+    ):
+        replace(
+            result.trace,
+            log_fixed_coefficient=result.trace.log_fixed_coefficient[:, :-1],
+        )
+    with pytest.raises(ValueError, match="must be finite and non-negative"):
+        replace(result, kernel_setup_seconds=-1.0)
+
+
+@_requires_x64_child
+def test_seeded_replay_is_exact_including_pcg64_checkpoint() -> None:
+    """The same seed reproduces every state, diagnostic, and RNG bit exactly."""
+    problem, initial = _problem_state(k=4)
+    config = _config(iterations=3, seed=20260725)
+
+    first = sampling.sample_full_tiling_pymc_hmc(problem, initial, config)
+    replay = sampling.sample_full_tiling_pymc_hmc(problem, initial, config)
+
+    _assert_results_equal(first, replay)
+    np.testing.assert_array_equal(
+        first.trace.log_leaf_mass,
+        replay.trace.log_leaf_mass,
+    )
+    np.testing.assert_array_equal(
+        first.trace.log_fixed_coefficient,
+        replay.trace.log_fixed_coefficient,
+    )
+
+
+@_requires_x64_child
+def test_awkward_split_continuation_matches_uninterrupted_sampling() -> None:
+    """A one-plus-two split exactly matches a direct three-sweep execution."""
+    problem, initial = _problem_state(k=4)
+    direct = sampling.sample_full_tiling_pymc_hmc(
+        problem,
+        initial,
+        _config(iterations=3, seed=988),
+    )
+    first = sampling.sample_full_tiling_pymc_hmc(
+        problem,
+        initial,
+        _config(iterations=1, seed=988),
+    )
+    second = sampling.continue_full_tiling_pymc_hmc(
+        problem,
+        first.checkpoint,
+        iterations=2,
+    )
+
+    assert math.isfinite(second.kernel_setup_seconds)
+    assert second.kernel_setup_seconds >= 0.0
+    assert math.isfinite(second.transition_seconds)
+    assert second.transition_seconds >= 0.0
+    for name in direct.trace.__dataclass_fields__:
+        first_values = getattr(first.trace, name)
+        second_values = getattr(second.trace, name)
+        combined = (
+            np.concatenate((first_values, second_values[1:]), axis=0)
+            if name
+            in {
+                "state_sweep",
+                "rectangle_bounds",
+                "leaf_masses",
+                "fixed_coefficients",
+                "log_leaf_mass",
+                "log_fixed_coefficient",
+                "log_target",
+            }
+            else np.concatenate((first_values, second_values), axis=0)
+        )
+        np.testing.assert_array_equal(combined, getattr(direct.trace, name))
+    for name in ("log_leaf_mass", "log_fixed_coefficient"):
+        np.testing.assert_array_equal(
+            getattr(first.trace, name)[-1],
+            getattr(second.trace, name)[0],
+        )
+        np.testing.assert_array_equal(
+            np.concatenate(
+                (
+                    getattr(first.trace, name),
+                    getattr(second.trace, name)[1:],
+                ),
+                axis=0,
+            ),
+            getattr(direct.trace, name),
+        )
+    np.testing.assert_array_equal(
+        np.concatenate((first.trace.hmc_seed, second.trace.hmc_seed)),
+        direct.trace.hmc_seed,
+    )
+    _assert_states_equal(second.final_state, direct.final_state)
+    np.testing.assert_array_equal(
+        second.checkpoint.log_leaf_mass,
+        direct.checkpoint.log_leaf_mass,
+    )
+    np.testing.assert_array_equal(
+        second.checkpoint.log_fixed_coefficient,
+        direct.checkpoint.log_fixed_coefficient,
+    )
+    np.testing.assert_array_equal(
+        np.exp(second.checkpoint.log_leaf_mass),
+        second.final_state.leaf_masses,
+    )
+    np.testing.assert_array_equal(
+        np.exp(second.checkpoint.log_fixed_coefficient),
+        second.final_state.fixed_coefficients,
+    )
+    assert second.checkpoint.rng_state == direct.checkpoint.rng_state
+    assert second.checkpoint.sweeps_completed == direct.checkpoint.sweeps_completed == 3
+    assert second.checkpoint.runtime_identity == direct.checkpoint.runtime_identity
+
+
+def test_resolved_position_scale_is_fixed_and_topology_neutral() -> None:
+    """Leaf positions share one scale while fixed identities retain their entries."""
+    settings = sampling.FullTilingPyMCHMCKernelSettings(
+        fixed_k=4,
+        step_size=0.01,
+        leapfrog_steps=3,
+        leaf_position_scale=2.5,
+        fixed_coefficient_position_scale=(0.4, 0.8, 1.6),
+    )
+
+    np.testing.assert_array_equal(
+        settings.position_scale_diagonal,
+        np.array([2.5, 2.5, 2.5, 2.5, 0.4, 0.8, 1.6]),
+    )
+    assert not settings.position_scale_diagonal.flags.writeable
+
+
+@_requires_x64_child
+def test_hmc_is_frozen_with_exact_leapfrog_count_and_no_tuning() -> None:
+    """The constructed HMC step is static and reports the fixed path each sweep."""
+    problem, initial = _problem_state(k=4)
+    settings = sampling.FullTilingPyMCHMCKernelSettings(
+        fixed_k=4,
+        step_size=0.003,
+        leapfrog_steps=3,
+        leaf_position_scale=1.0,
+        fixed_coefficient_position_scale=(1.0, 1.0, 1.0),
+    )
+    _, compound, _, _ = sampling._build_compound_kernel(
+        problem,
+        initial,
+        settings,
+        np.random.default_rng(44),
+    )
+    hmc = compound.methods[1]
+
+    assert compound.tune is False
+    assert hmc.tune is False
+    assert hmc.adapt_step_size is False
+    assert hmc._step_rand is None
+    assert hmc.max_steps == 3
+    np.testing.assert_array_equal(
+        hmc.potential.v,
+        settings.position_scale_diagonal,
+    )
+    momentum = np.arange(1.0, 8.0)
+    np.testing.assert_array_equal(
+        hmc.potential.velocity(momentum),
+        settings.position_scale_diagonal * momentum,
+    )
+    assert hmc.potential.energy(momentum) == pytest.approx(
+        0.5
+        * float(
+            np.dot(
+                momentum,
+                settings.position_scale_diagonal * momentum,
+            )
+        ),
+    )
+    result = sampling.sample_full_tiling_pymc_hmc(
+        problem,
+        initial,
+        sampling.FullTilingPyMCHMCConfig(
+            iterations=3,
+            step_size=0.003,
+            leapfrog_steps=3,
+            seed=44,
+        ),
+    )
+    np.testing.assert_array_equal(result.trace.hmc_n_steps, np.full(3, 3))
+    np.testing.assert_allclose(
+        result.trace.hmc_step_size,
+        np.full(3, 0.003),
+        rtol=0.0,
+        atol=1.0e-18,
+    )
+
+
+@_requires_x64_child
+def test_divergent_hmc_returns_rejected_state_and_valid_checkpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-finite divergent trajectory is retained as a restartable rejection."""
+    problem, initial = _problem_state(k=4)
+    invalid = PosteriorTransitionTerms(
+        candidate=initial,
+        move="edge_flip",
+        delta_log_likelihood=0.0,
+        valid=False,
+        reason="forced invalid structural attempt",
+    )
+    monkeypatch.setattr(
+        sampling,
+        "_draw_structural_transition",
+        lambda *args, **kwargs: (invalid, None),
+    )
+
+    result = sampling.sample_full_tiling_pymc_hmc(
+        problem,
+        initial,
+        sampling.FullTilingPyMCHMCConfig(
+            iterations=1,
+            step_size=10.0,
+            leapfrog_steps=2,
+            seed=4,
+        ),
+    )
+
+    assert result.trace.hmc_diverging.tolist() == [True]
+    assert result.trace.hmc_accepted.tolist() == [False]
+    _assert_states_equal(result.final_state, initial)
+    np.testing.assert_array_equal(
+        np.exp(result.checkpoint.log_leaf_mass),
+        result.checkpoint.state.leaf_masses,
+    )
+    np.testing.assert_array_equal(
+        np.exp(result.checkpoint.log_fixed_coefficient),
+        result.checkpoint.state.fixed_coefficients,
+    )
+    assert isinstance(
+        result.checkpoint.rng_state.generator(),
+        np.random.Generator,
+    )
+
+
+@_requires_x64_child
+def test_leapfrog_count_survives_pymc_step_size_rounding() -> None:
+    """One-ULP step-size reconstruction still runs the requested path length."""
+    problem, initial = _problem_state(k=4)
+    result = sampling.sample_full_tiling_pymc_hmc(
+        problem,
+        initial,
+        sampling.FullTilingPyMCHMCConfig(
+            iterations=1,
+            step_size=0.005227487401508368,
+            leapfrog_steps=88,
+            seed=41,
+        ),
+    )
+
+    assert result.trace.hmc_n_steps.tolist() == [88]
+
+
+@pytest.mark.parametrize(
+    ("changes", "error", "message"),
+    [
+        ({"iterations": True}, TypeError, "iterations must be an integer"),
+        ({"iterations": 0}, ValueError, "iterations must be positive"),
+        ({"step_size": True}, TypeError, "step_size must be a real number"),
+        ({"step_size": math.inf}, ValueError, "step_size must be finite"),
+        ({"leapfrog_steps": 1.5}, TypeError, "leapfrog_steps must be an integer"),
+        ({"leapfrog_steps": 0}, ValueError, "leapfrog_steps must be positive"),
+        (
+            {"leaf_position_scale": 0.0},
+            ValueError,
+            "leaf_position_scale must be finite",
+        ),
+        (
+            {"fixed_coefficient_position_scale": (1.0, math.nan, 1.0)},
+            ValueError,
+            "fixed_coefficient_position_scale must be finite",
+        ),
+        ({"seed": -1}, ValueError, "seed must be non-negative"),
+    ],
+)
+def test_config_rejects_invalid_static_hmc_settings(
+    changes: dict[str, object],
+    error: type[Exception],
+    message: str,
+) -> None:
+    """Invalid scalar, count, mass, and seed settings fail at construction."""
+    values = {
+        "iterations": 2,
+        "step_size": 0.01,
+        "leapfrog_steps": 3,
+        "leaf_position_scale": 1.0,
+        "fixed_coefficient_position_scale": (1.0, 1.0, 1.0),
+        "seed": 4,
+    }
+    values.update(changes)
+
+    with pytest.raises(error, match=message):
+        sampling.FullTilingPyMCHMCConfig(**values)
+
+
+def test_sampling_rejects_fixed_position_scale_length_mismatch() -> None:
+    """Problem resolution rejects a fixed-scale vector of the wrong length."""
+    problem, initial = _problem_state(k=4)
+    config = sampling.FullTilingPyMCHMCConfig(
+        iterations=1,
+        step_size=0.01,
+        leapfrog_steps=2,
+        fixed_coefficient_position_scale=(1.0, 2.0),
+    )
+
+    with pytest.raises(ValueError, match="one entry per fixed coefficient"):
+        sampling.sample_full_tiling_pymc_hmc(problem, initial, config)
+
+
+@_requires_x64_child
+def test_checkpoint_rejects_problem_k_settings_and_schedule_mismatches() -> None:
+    """Continuation boundaries fail closed on all kernel-defining identities."""
+    problem, initial = _problem_state(k=4)
+    result = sampling.sample_full_tiling_pymc_hmc(
+        problem,
+        initial,
+        _config(iterations=1, seed=66),
+    )
+    checkpoint = result.checkpoint
+    other_problem, _ = _problem_state(k=4)
+
+    with pytest.raises(ValueError, match="exact checkpoint problem"):
+        sampling.continue_full_tiling_pymc_hmc(
+            other_problem,
+            checkpoint,
+            iterations=1,
+        )
+    with pytest.raises(ValueError, match="state K must match"):
+        replace(
+            checkpoint,
+            kernel_settings=replace(checkpoint.kernel_settings, fixed_k=3),
+        )
+    with pytest.raises(ValueError, match="fixed block must match"):
+        replace(
+            checkpoint,
+            kernel_settings=replace(
+                checkpoint.kernel_settings,
+                fixed_coefficient_position_scale=(1.0, 1.0),
+            ),
+        )
+    with pytest.raises(ValueError, match="log_leaf_mass must exactly encode"):
+        replace(
+            checkpoint,
+            log_leaf_mass=checkpoint.log_leaf_mass + 1.0e-6,
+        )
+    with pytest.raises(
+        ValueError,
+        match="log_fixed_coefficient must exactly encode",
+    ):
+        replace(
+            checkpoint,
+            log_fixed_coefficient=checkpoint.log_fixed_coefficient + 1.0e-6,
+        )
+    with pytest.raises(ValueError, match="runtime identity is incompatible"):
+        replace(
+            checkpoint,
+            runtime_identity=replace(
+                checkpoint.runtime_identity,
+                metric_semantics_id="future_metric_v2",
+            ),
+        )
+    with pytest.raises(ValueError, match="schedule is incompatible"):
+        replace(checkpoint, schedule_id="future_compound_hmc_v2")
+
+
+@_requires_x64_child
+def test_checkpoint_freezes_hmc_settings_for_continuation() -> None:
+    """Continuation retains the exact step, path, and position-scale settings."""
+    problem, initial = _problem_state(k=4)
+    first = sampling.sample_full_tiling_pymc_hmc(
+        problem,
+        initial,
+        _config(iterations=1, seed=17),
+    )
+    second = sampling.continue_full_tiling_pymc_hmc(
+        problem,
+        first.checkpoint,
+        iterations=1,
+    )
+
+    assert second.checkpoint.kernel_settings == first.checkpoint.kernel_settings
+    np.testing.assert_allclose(
+        second.trace.hmc_step_size,
+        np.array([first.checkpoint.kernel_settings.step_size]),
+        rtol=0.0,
+        atol=1.0e-18,
+    )
+    np.testing.assert_array_equal(
+        second.trace.hmc_n_steps,
+        np.array([first.checkpoint.kernel_settings.leapfrog_steps]),
+    )

--- a/tests/experimental/rjmcmc/test_full_tiling_pymc_hmc.py
+++ b/tests/experimental/rjmcmc/test_full_tiling_pymc_hmc.py
@@ -603,6 +603,97 @@ def test_trace_preserves_authoritative_hmc_coordinates_read_only() -> None:
 
 
 @_requires_x64_child
+def test_fresh_state_is_canonicalized_without_mutating_caller_boundary() -> None:
+    """Fresh sampling enforces exact ``exp(log_mass) == mass`` without mutation."""
+    problem, initialized = _problem_state(k=4)
+    leaf_masses = np.array(initialized.leaf_masses, copy=True)
+    fixed_coefficients = np.array(initialized.fixed_coefficients, copy=True)
+    leaf_masses[0] = np.float64(0.1)
+    fixed_coefficients[0] = np.float64(0.1)
+    supplied = build_full_tiling_posterior_state(
+        problem,
+        allocation=TilingState(initialized.tiling_state.tiling, leaf_masses),
+        fixed_coefficients=fixed_coefficients,
+    )
+    supplied_snapshot = build_full_tiling_posterior_state(
+        problem,
+        allocation=TilingState(
+            supplied.tiling_state.tiling,
+            np.array(supplied.leaf_masses, copy=True),
+        ),
+        fixed_coefficients=np.array(supplied.fixed_coefficients, copy=True),
+    )
+    authoritative_log_leaf_mass = np.log(supplied.leaf_masses)
+    authoritative_log_fixed = np.log(supplied.fixed_coefficients)
+    assert np.exp(authoritative_log_leaf_mass[0]) != supplied.leaf_masses[0]
+    assert np.exp(authoritative_log_fixed[0]) != supplied.fixed_coefficients[0]
+
+    canonical, log_leaf_mass, log_fixed = sampling.canonicalize_full_tiling_pymc_hmc_fresh_state(
+        problem,
+        supplied,
+    )
+    canonical_again, second_log_leaf_mass, second_log_fixed = (
+        sampling.canonicalize_full_tiling_pymc_hmc_fresh_state(
+            problem,
+            canonical,
+        )
+    )
+
+    _assert_states_equal(supplied, supplied_snapshot)
+    np.testing.assert_array_equal(log_leaf_mass, authoritative_log_leaf_mass)
+    np.testing.assert_array_equal(log_fixed, authoritative_log_fixed)
+    np.testing.assert_array_equal(canonical.leaf_masses, np.exp(log_leaf_mass))
+    np.testing.assert_array_equal(canonical.fixed_coefficients, np.exp(log_fixed))
+    _assert_states_equal(canonical_again, canonical)
+    np.testing.assert_array_equal(second_log_leaf_mass, log_leaf_mass)
+    np.testing.assert_array_equal(second_log_fixed, log_fixed)
+    rebuilt_boundary = build_full_tiling_posterior_state(
+        problem,
+        allocation=canonical.tiling_state,
+        fixed_coefficients=canonical.fixed_coefficients,
+    )
+    _assert_states_equal(canonical, rebuilt_boundary)
+
+    result = sampling.sample_full_tiling_pymc_hmc(
+        problem,
+        supplied,
+        _config(iterations=1, seed=611),
+    )
+
+    _assert_states_equal(supplied, supplied_snapshot)
+    np.testing.assert_array_equal(result.trace.log_leaf_mass[0], log_leaf_mass)
+    np.testing.assert_array_equal(result.trace.log_fixed_coefficient[0], log_fixed)
+    np.testing.assert_array_equal(result.trace.leaf_masses[0], np.exp(log_leaf_mass))
+    np.testing.assert_array_equal(
+        result.trace.fixed_coefficients[0],
+        np.exp(log_fixed),
+    )
+    assert result.trace.log_target[0] == rebuilt_boundary.log_target
+    np.testing.assert_array_equal(
+        result.checkpoint.log_leaf_mass,
+        result.trace.log_leaf_mass[-1],
+    )
+    np.testing.assert_array_equal(
+        result.checkpoint.log_fixed_coefficient,
+        result.trace.log_fixed_coefficient[-1],
+    )
+    np.testing.assert_array_equal(
+        np.exp(result.checkpoint.log_leaf_mass),
+        result.checkpoint.state.leaf_masses,
+    )
+    np.testing.assert_array_equal(
+        np.exp(result.checkpoint.log_fixed_coefficient),
+        result.checkpoint.state.fixed_coefficients,
+    )
+    rebuilt_checkpoint = build_full_tiling_posterior_state(
+        problem,
+        allocation=result.checkpoint.state.tiling_state,
+        fixed_coefficients=result.checkpoint.state.fixed_coefficients,
+    )
+    _assert_states_equal(result.checkpoint.state, rebuilt_checkpoint)
+
+
+@_requires_x64_child
 def test_seeded_replay_is_exact_including_pcg64_checkpoint() -> None:
     """The same seed reproduces every state, diagnostic, and RNG bit exactly."""
     problem, initial = _problem_state(k=4)

--- a/tests/experimental/rjmcmc/test_full_tiling_pymc_hmc.py
+++ b/tests/experimental/rjmcmc/test_full_tiling_pymc_hmc.py
@@ -225,7 +225,8 @@ def _config(*, iterations: int, seed: int = 761) -> sampling.FullTilingPyMCHMCCo
         iterations=iterations,
         step_size=0.002,
         leapfrog_steps=2,
-        leaf_position_scale=1.7,
+        leaf_contrast_position_scale=1.7,
+        leaf_total_position_scale=3.2,
         fixed_coefficient_position_scale=(0.6, 1.1, 2.4),
         seed=seed,
     )
@@ -318,7 +319,7 @@ def test_compiled_target_matches_independent_closed_form_at_arbitrary_xy() -> No
 
 
 @_requires_x64_child
-def test_canonical_leaf_permutation_realigns_target_and_scalar_metric() -> None:
+def test_canonical_leaf_permutation_realigns_target_and_full_metric() -> None:
     """Aligned topology arrays and log coordinates preserve target and metric."""
     problem, initial = _problem_state(k=4)
     state = _nonuniform_state(problem, initial)
@@ -378,11 +379,15 @@ def test_canonical_leaf_permutation_realigns_target_and_scalar_metric() -> None:
         fixed_k=state.k,
         step_size=0.01,
         leapfrog_steps=2,
-        leaf_position_scale=2.5,
+        leaf_contrast_position_scale=2.5,
+        leaf_total_position_scale=4.5,
         fixed_coefficient_position_scale=(0.4, 0.8, 1.6),
     )
-    leaf_metric = settings.position_scale_diagonal[: state.k]
-    np.testing.assert_array_equal(leaf_metric[permutation], leaf_metric)
+    leaf_metric = settings.position_scale_matrix[: state.k, : state.k]
+    np.testing.assert_array_equal(
+        leaf_metric[np.ix_(permutation, permutation)],
+        leaf_metric,
+    )
 
 
 @_requires_x64_child
@@ -492,6 +497,21 @@ def test_every_structural_outcome_is_followed_by_one_hmc_transition(
     assert result.trace.structural_accepted.tolist() == [outcome == "accepted"]
     assert result.trace.hmc_n_steps.tolist() == [2]
     assert result.trace.hmc_step_size.tolist() == pytest.approx([0.002])
+    assert result.trace.hmc_accepted.tolist() == [True]
+    if outcome == "accepted":
+        np.testing.assert_array_equal(
+            result.trace.hmc_start_log_leaf_mass[0],
+            np.log(valid_transition.candidate.leaf_masses),
+        )
+    else:
+        np.testing.assert_array_equal(
+            result.trace.hmc_start_log_leaf_mass[0],
+            result.trace.log_leaf_mass[0],
+        )
+    np.testing.assert_array_equal(
+        result.trace.hmc_start_log_fixed_coefficient[0],
+        result.trace.log_fixed_coefficient[0],
+    )
     expected_tiling = (
         valid_transition.candidate.tiling_state.tiling
         if outcome == "accepted"
@@ -512,6 +532,24 @@ def test_hmc_preserves_topology_and_rebuilds_all_scientific_caches() -> None:
 
     np.testing.assert_array_equal(result.trace.state_sweep, np.arange(4))
     np.testing.assert_array_equal(result.trace.global_sweep, np.arange(1, 4))
+    np.testing.assert_array_equal(
+        result.trace.hmc_start_log_fixed_coefficient,
+        result.trace.log_fixed_coefficient[:-1],
+    )
+    structurally_unchanged = ~result.trace.structural_accepted
+    np.testing.assert_array_equal(
+        result.trace.hmc_start_log_leaf_mass[structurally_unchanged],
+        result.trace.log_leaf_mass[:-1][structurally_unchanged],
+    )
+    hmc_rejected = ~result.trace.hmc_accepted
+    np.testing.assert_array_equal(
+        result.trace.hmc_start_log_leaf_mass[hmc_rejected],
+        result.trace.log_leaf_mass[1:][hmc_rejected],
+    )
+    np.testing.assert_array_equal(
+        result.trace.hmc_start_log_fixed_coefficient[hmc_rejected],
+        result.trace.log_fixed_coefficient[1:][hmc_rejected],
+    )
     for before, after, accepted in zip(
         result.trace.rectangle_bounds[:-1],
         result.trace.rectangle_bounds[1:],
@@ -557,6 +595,8 @@ def test_trace_preserves_authoritative_hmc_coordinates_read_only() -> None:
 
     assert result.trace.log_leaf_mass.shape == (3, 4)
     assert result.trace.log_fixed_coefficient.shape == (3, 3)
+    assert result.trace.hmc_start_log_leaf_mass.shape == (2, 4)
+    assert result.trace.hmc_start_log_fixed_coefficient.shape == (2, 3)
     np.testing.assert_array_equal(
         np.exp(result.trace.log_leaf_mass),
         result.trace.leaf_masses,
@@ -580,6 +620,8 @@ def test_trace_preserves_authoritative_hmc_coordinates_read_only() -> None:
     for coordinates in (
         result.trace.log_leaf_mass,
         result.trace.log_fixed_coefficient,
+        result.trace.hmc_start_log_leaf_mass,
+        result.trace.hmc_start_log_fixed_coefficient,
     ):
         assert not coordinates.flags.writeable
         with pytest.raises(ValueError):
@@ -597,6 +639,19 @@ def test_trace_preserves_authoritative_hmc_coordinates_read_only() -> None:
         replace(
             result.trace,
             log_fixed_coefficient=result.trace.log_fixed_coefficient[:, :-1],
+        )
+    with pytest.raises(ValueError, match="hmc_start_log_leaf_mass must have shape"):
+        replace(
+            result.trace,
+            hmc_start_log_leaf_mass=result.trace.hmc_start_log_leaf_mass[:, :-1],
+        )
+    with pytest.raises(
+        ValueError,
+        match="hmc_start_log_fixed_coefficient must have shape",
+    ):
+        replace(
+            result.trace,
+            hmc_start_log_fixed_coefficient=(result.trace.hmc_start_log_fixed_coefficient[:, :-1]),
         )
     with pytest.raises(ValueError, match="must be finite and non-negative"):
         replace(result, kernel_setup_seconds=-1.0)
@@ -796,21 +851,108 @@ def test_awkward_split_continuation_matches_uninterrupted_sampling() -> None:
     assert second.checkpoint.runtime_identity == direct.checkpoint.runtime_identity
 
 
-def test_resolved_position_scale_is_fixed_and_topology_neutral() -> None:
-    """Leaf positions share one scale while fixed identities retain their entries."""
+def test_position_scale_matrix_has_exact_total_contrast_formula_and_ownership() -> None:
+    """The resolved matrix exactly follows the projector formula and owns storage."""
     settings = sampling.FullTilingPyMCHMCKernelSettings(
         fixed_k=4,
         step_size=0.01,
         leapfrog_steps=3,
-        leaf_position_scale=2.5,
+        leaf_contrast_position_scale=2.5,
+        leaf_total_position_scale=4.5,
         fixed_coefficient_position_scale=(0.4, 0.8, 1.6),
+    )
+    common = np.full((4, 4), 0.25)
+    expected_leaf = 2.5 * (np.eye(4) - common) + 4.5 * common
+    expected = np.zeros((7, 7))
+    expected[:4, :4] = expected_leaf
+    expected[4:, 4:] = np.diag([0.4, 0.8, 1.6])
+
+    np.testing.assert_array_equal(
+        settings.position_scale_matrix,
+        expected,
+    )
+    first = settings.position_scale_matrix
+    second = settings.position_scale_matrix
+    assert first.flags.owndata
+    assert not first.flags.writeable
+    assert not np.shares_memory(first, second)
+
+
+def test_position_scale_matrix_is_spd_with_total_and_contrast_eigenvectors() -> None:
+    """Common, multiple contrasts, and fixed axes have their declared eigenvalues."""
+    settings = sampling.FullTilingPyMCHMCKernelSettings(
+        fixed_k=4,
+        step_size=0.01,
+        leapfrog_steps=3,
+        leaf_contrast_position_scale=2.5,
+        leaf_total_position_scale=4.5,
+        fixed_coefficient_position_scale=(0.4, 0.8),
+    )
+    matrix = settings.position_scale_matrix
+
+    np.testing.assert_array_equal(matrix, matrix.T)
+    assert np.all(np.linalg.eigvalsh(matrix) > 0.0)
+    for vector in (
+        np.array([1.0, -1.0, 0.0, 0.0, 0.0, 0.0]),
+        np.array([1.0, 1.0, -2.0, 0.0, 0.0, 0.0]),
+        np.array([1.0, 1.0, 1.0, -3.0, 0.0, 0.0]),
+    ):
+        np.testing.assert_allclose(matrix @ vector, 2.5 * vector, rtol=0.0, atol=1.0e-15)
+    total = np.array([1.0, 1.0, 1.0, 1.0, 0.0, 0.0])
+    np.testing.assert_allclose(matrix @ total, 4.5 * total, rtol=0.0, atol=1.0e-15)
+    np.testing.assert_array_equal(matrix[:4, 4:], np.zeros((4, 2)))
+    np.testing.assert_array_equal(matrix[4:, :4], np.zeros((2, 4)))
+    np.testing.assert_array_equal(matrix[4:, 4:], np.diag([0.4, 0.8]))
+
+
+@pytest.mark.parametrize("fixed_k", (5, 50, 250))
+def test_equal_leaf_scales_reduce_exactly_to_scalar_identity(fixed_k: int) -> None:
+    """Equal eigenscales give the exact legacy scalar metric at production K."""
+    equal = sampling.FullTilingPyMCHMCKernelSettings(
+        fixed_k=fixed_k,
+        step_size=0.01,
+        leapfrog_steps=1,
+        leaf_contrast_position_scale=3.0,
+        leaf_total_position_scale=3.0,
+        fixed_coefficient_position_scale=(),
     )
 
     np.testing.assert_array_equal(
-        settings.position_scale_diagonal,
-        np.array([2.5, 2.5, 2.5, 2.5, 0.4, 0.8, 1.6]),
+        equal.position_scale_matrix,
+        3.0 * np.eye(fixed_k),
     )
-    assert not settings.position_scale_diagonal.flags.writeable
+
+
+def test_singleton_leaf_metric_has_only_total_direction() -> None:
+    """At K=1 the contrast projector vanishes and only total scale remains."""
+    singleton = sampling.FullTilingPyMCHMCKernelSettings(
+        fixed_k=1,
+        step_size=0.01,
+        leapfrog_steps=1,
+        leaf_contrast_position_scale=99.0,
+        leaf_total_position_scale=7.0,
+        fixed_coefficient_position_scale=(),
+    )
+
+    np.testing.assert_array_equal(singleton.position_scale_matrix, np.array([[7.0]]))
+
+
+def test_config_preserves_legacy_positional_fixed_scale_and_seed_slots() -> None:
+    """The v2 total scale cannot silently reinterpret legacy positional calls."""
+    config = sampling.FullTilingPyMCHMCConfig(
+        2,
+        0.001,
+        1,
+        1.75,
+        0.5,
+        42,
+        leaf_total_position_scale=2.25,
+    )
+
+    assert config.leaf_contrast_position_scale == 1.75
+    assert config.fixed_coefficient_position_scale == 0.5
+    assert config.seed == 42
+    assert config.leaf_total_position_scale == 2.25
 
 
 @_requires_x64_child
@@ -821,7 +963,8 @@ def test_hmc_is_frozen_with_exact_leapfrog_count_and_no_tuning() -> None:
         fixed_k=4,
         step_size=0.003,
         leapfrog_steps=3,
-        leaf_position_scale=1.0,
+        leaf_contrast_position_scale=2.0,
+        leaf_total_position_scale=5.0,
         fixed_coefficient_position_scale=(1.0, 1.0, 1.0),
     )
     _, compound, _, _ = sampling._build_compound_kernel(
@@ -838,20 +981,20 @@ def test_hmc_is_frozen_with_exact_leapfrog_count_and_no_tuning() -> None:
     assert hmc._step_rand is None
     assert hmc.max_steps == 3
     np.testing.assert_array_equal(
-        hmc.potential.v,
-        settings.position_scale_diagonal,
+        hmc.potential._cov,
+        settings.position_scale_matrix,
     )
     momentum = np.arange(1.0, 8.0)
     np.testing.assert_array_equal(
         hmc.potential.velocity(momentum),
-        settings.position_scale_diagonal * momentum,
+        settings.position_scale_matrix @ momentum,
     )
     assert hmc.potential.energy(momentum) == pytest.approx(
         0.5
         * float(
             np.dot(
                 momentum,
-                settings.position_scale_diagonal * momentum,
+                settings.position_scale_matrix @ momentum,
             )
         ),
     )
@@ -906,6 +1049,14 @@ def test_divergent_hmc_returns_rejected_state_and_valid_checkpoint(
 
     assert result.trace.hmc_diverging.tolist() == [True]
     assert result.trace.hmc_accepted.tolist() == [False]
+    np.testing.assert_array_equal(
+        result.trace.hmc_start_log_leaf_mass,
+        result.trace.log_leaf_mass[1:],
+    )
+    np.testing.assert_array_equal(
+        result.trace.hmc_start_log_fixed_coefficient,
+        result.trace.log_fixed_coefficient[1:],
+    )
     _assert_states_equal(result.final_state, initial)
     np.testing.assert_array_equal(
         np.exp(result.checkpoint.log_leaf_mass),
@@ -939,6 +1090,32 @@ def test_leapfrog_count_survives_pymc_step_size_rounding() -> None:
     assert result.trace.hmc_n_steps.tolist() == [88]
 
 
+@_requires_x64_child
+def test_unspecified_total_scale_resolves_to_contrast_scale() -> None:
+    """The convenience default produces an isotropic leaf metric."""
+    problem, initial = _problem_state(k=4)
+    result = sampling.sample_full_tiling_pymc_hmc(
+        problem,
+        initial,
+        sampling.FullTilingPyMCHMCConfig(
+            iterations=1,
+            step_size=0.01,
+            leapfrog_steps=2,
+            leaf_contrast_position_scale=2.25,
+            leaf_total_position_scale=None,
+            seed=42,
+        ),
+    )
+
+    settings = result.checkpoint.kernel_settings
+    assert settings.leaf_contrast_position_scale == 2.25
+    assert settings.leaf_total_position_scale == 2.25
+    np.testing.assert_array_equal(
+        settings.position_scale_matrix[: initial.k, : initial.k],
+        2.25 * np.eye(initial.k),
+    )
+
+
 @pytest.mark.parametrize(
     ("changes", "error", "message"),
     [
@@ -949,9 +1126,14 @@ def test_leapfrog_count_survives_pymc_step_size_rounding() -> None:
         ({"leapfrog_steps": 1.5}, TypeError, "leapfrog_steps must be an integer"),
         ({"leapfrog_steps": 0}, ValueError, "leapfrog_steps must be positive"),
         (
-            {"leaf_position_scale": 0.0},
+            {"leaf_contrast_position_scale": 0.0},
             ValueError,
-            "leaf_position_scale must be finite",
+            "leaf_contrast_position_scale must be finite",
+        ),
+        (
+            {"leaf_total_position_scale": math.inf},
+            ValueError,
+            "leaf_total_position_scale must be finite",
         ),
         (
             {"fixed_coefficient_position_scale": (1.0, math.nan, 1.0)},
@@ -971,7 +1153,8 @@ def test_config_rejects_invalid_static_hmc_settings(
         "iterations": 2,
         "step_size": 0.01,
         "leapfrog_steps": 3,
-        "leaf_position_scale": 1.0,
+        "leaf_contrast_position_scale": 1.0,
+        "leaf_total_position_scale": 2.0,
         "fixed_coefficient_position_scale": (1.0, 1.0, 1.0),
         "seed": 4,
     }

--- a/tests/experimental/rjmcmc/test_full_tiling_pymc_hmc_io.py
+++ b/tests/experimental/rjmcmc/test_full_tiling_pymc_hmc_io.py
@@ -1,0 +1,534 @@
+"""Tests for strict durable full-tiling PyMC HMC checkpoints."""
+
+from __future__ import annotations
+
+from dataclasses import fields
+from hashlib import sha256
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+from typing import Any, Callable, cast
+
+import numpy as np
+import pytest
+
+from openghg_inversions.experimental.rjmcmc import full_tiling_io
+from openghg_inversions.experimental.rjmcmc.core import FixedDesignBlock
+from openghg_inversions.experimental.rjmcmc.dyadic_tree import CanonicalDyadicTree
+from openghg_inversions.experimental.rjmcmc.full_tiling_posterior import (
+    FullTilingPosteriorState,
+    FullTilingProblem,
+    initialize_full_tiling_posterior_state,
+)
+from openghg_inversions.experimental.rjmcmc.full_tiling_pymc_hmc import (
+    FullTilingPyMCHMCConfig,
+    FullTilingPyMCHMCSamplingResult,
+    continue_full_tiling_pymc_hmc,
+    sample_full_tiling_pymc_hmc,
+)
+from openghg_inversions.experimental.rjmcmc.full_tiling_pymc_hmc_io import (
+    load_full_tiling_pymc_hmc_checkpoint,
+    save_full_tiling_pymc_hmc_checkpoint,
+)
+from openghg_inversions.experimental.rjmcmc.gamma_beta_tree import (
+    GammaBetaTreePrior,
+    GammaBetaTreeProblem,
+    TreePartitionPrior,
+)
+
+_THIS_FILE = Path(__file__).resolve()
+_X64_CHILD_ENV = "OPENGHG_INVERSIONS_PYMC_HMC_IO_X64_CHILD"
+_IS_X64_CHILD = os.environ.get(_X64_CHILD_ENV) == "1"
+_requires_x64_child = pytest.mark.skipif(
+    not _IS_X64_CHILD,
+    reason="checkpoint assertion executes in the isolated float64 child",
+)
+_ARCHIVE_FIELDS = {
+    "rectangle_bounds",
+    "leaf_masses",
+    "fixed_coefficients",
+    "log_leaf_mass",
+    "log_fixed_coefficient",
+    "dynamic_prediction",
+    "fixed_prediction",
+    "prediction",
+    "residual",
+    "metadata",
+    "metadata_sha256",
+}
+
+
+def _pytensor_flags_with_float64(flags: str) -> str:
+    """Return PyTensor flags with an unambiguous float64 configuration."""
+    retained = []
+    for item in flags.split(","):
+        stripped = item.strip()
+        if not stripped:
+            continue
+        name = stripped.split("=", 1)[0].strip()
+        if name not in {"floatX", "warn_float64"}:
+            retained.append(stripped)
+    return ",".join(("floatX=float64", "warn_float64=ignore", *retained))
+
+
+def _run_x64_test_file() -> None:
+    """Run all checkpoint assertions in one fresh float64 subprocess."""
+    environment = os.environ.copy()
+    environment[_X64_CHILD_ENV] = "1"
+    environment["PYTENSOR_FLAGS"] = _pytensor_flags_with_float64(
+        environment.get("PYTENSOR_FLAGS", ""),
+    )
+    completed = subprocess.run(
+        [sys.executable, "-m", "pytest", "-q", str(_THIS_FILE)],
+        cwd=_THIS_FILE.parents[3],
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=180,
+        check=False,
+    )
+    assert completed.returncode == 0, (
+        "isolated full-tiling PyMC HMC checkpoint tests failed\n"
+        f"stdout:\n{completed.stdout}\n"
+        f"stderr:\n{completed.stderr}"
+    )
+
+
+@pytest.mark.skipif(_IS_X64_CHILD, reason="parent-only subprocess dispatch")
+def test_checkpoint_cases_use_a_fresh_float64_subprocess() -> None:
+    """Checkpoint cases cannot inherit process-global float32 from RHIME tests."""
+    _run_x64_test_file()
+
+
+def _problem(*, observation_shift: float = 0.0) -> FullTilingProblem:
+    """Build an independently reconstructible tiny posterior problem."""
+    tree = CanonicalDyadicTree.from_shape((2, 2))
+    prior = GammaBetaTreePrior.constant_concentration(
+        tree,
+        np.array([1.0, 2.0, 3.0, 4.0]),
+        concentration=3.0,
+        root_mean=3.0,
+        root_variance=1.0,
+    )
+    fixed_block = FixedDesignBlock(
+        design=np.array(
+            [
+                [0.2, 0.0],
+                [0.0, 0.1],
+                [0.3, 0.2],
+                [0.1, 0.4],
+            ],
+        ),
+        coefficient_prior_mean=np.array([1.0, 1.5]),
+        coefficient_prior_sd=np.array([0.5, 0.8]),
+    )
+    base = GammaBetaTreeProblem(
+        observations=np.full(4, observation_shift),
+        observation_sd=np.array([0.5, 0.7, 0.9, 1.1]),
+        sensitivity=np.eye(4),
+        prior=prior,
+        partition_prior=TreePartitionPrior.uniform_k(tree),
+        likelihood_power=0.25,
+        fixed_offset=np.array([0.1, 0.2, 0.3, 0.4]),
+        fixed_block=fixed_block,
+    )
+    return FullTilingProblem(base=base, concentration=3.0)
+
+
+def _manifest(*, revision: str = "0123456789abcdef") -> dict[str, object]:
+    """Return a strict finite caller-owned run manifest."""
+    return {
+        "chain": {"id": "chain-0", "seed": 481},
+        "code_revision": revision,
+        "input_sha256": "a" * 64,
+    }
+
+
+def _sample_boundary(problem: FullTilingProblem) -> FullTilingPyMCHMCSamplingResult:
+    """Return one short non-cycle-aligned exact checkpoint."""
+    initial = initialize_full_tiling_posterior_state(problem, k=3)
+    return sample_full_tiling_pymc_hmc(
+        problem,
+        initial,
+        FullTilingPyMCHMCConfig(
+            iterations=2,
+            step_size=0.002,
+            leapfrog_steps=2,
+            leaf_position_scale=1.4,
+            fixed_coefficient_position_scale=(0.7, 1.8),
+            seed=481,
+        ),
+    )
+
+
+def _assert_states_equal(
+    actual: FullTilingPosteriorState,
+    expected: FullTilingPosteriorState,
+) -> None:
+    """Assert exact coordinates, caches, and target components."""
+    assert actual.tiling_state.tiling == expected.tiling_state.tiling
+    for name in (
+        "leaf_masses",
+        "fixed_coefficients",
+        "dynamic_prediction",
+        "fixed_prediction",
+        "prediction",
+        "residual",
+    ):
+        np.testing.assert_array_equal(getattr(actual, name), getattr(expected, name))
+    for name in (
+        "log_gaussian_likelihood",
+        "log_likelihood",
+        "log_root_prior",
+        "log_allocation_prior",
+        "log_fixed_coefficient_prior",
+        "log_target",
+    ):
+        assert getattr(actual, name) == getattr(expected, name)
+
+
+def _assert_results_equal(
+    actual: FullTilingPyMCHMCSamplingResult,
+    expected: FullTilingPyMCHMCSamplingResult,
+) -> None:
+    """Assert exact traces, scientific states, and continuation metadata."""
+    for field in fields(actual.trace):
+        np.testing.assert_array_equal(
+            getattr(actual.trace, field.name),
+            getattr(expected.trace, field.name),
+        )
+    _assert_states_equal(actual.final_state, expected.final_state)
+    for name in ("log_leaf_mass", "log_fixed_coefficient"):
+        np.testing.assert_array_equal(
+            getattr(actual.checkpoint, name),
+            getattr(expected.checkpoint, name),
+        )
+    assert actual.checkpoint.rng_state == expected.checkpoint.rng_state
+    assert actual.checkpoint.sweeps_completed == expected.checkpoint.sweeps_completed
+    assert actual.checkpoint.kernel_settings == expected.checkpoint.kernel_settings
+    assert actual.checkpoint.runtime_identity == expected.checkpoint.runtime_identity
+
+
+def _rewrite_archive(
+    path: Path,
+    transform: Callable[[dict[str, np.ndarray[Any, Any]]], None],
+) -> None:
+    """Apply one test mutation and rewrite an NPZ archive."""
+    with np.load(path, allow_pickle=False) as archive:
+        arrays = {name: np.array(archive[name], copy=True) for name in archive.files}
+    transform(arrays)
+    with path.open("wb") as handle:
+        save = cast(Callable[..., None], np.savez_compressed)
+        save(handle, **arrays)
+
+
+def _rewrite_metadata(
+    path: Path,
+    transform: Callable[[dict[str, Any]], None],
+) -> None:
+    """Rewrite metadata and its outer digest for an internal mismatch test."""
+
+    def apply(arrays: dict[str, np.ndarray[Any, Any]]) -> None:
+        """Apply the mutation and recalculate the metadata digest."""
+        metadata = json.loads(arrays["metadata"].tobytes().decode("utf-8"))
+        transform(metadata)
+        payload = json.dumps(
+            metadata,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+        arrays["metadata"] = np.frombuffer(payload, dtype=np.uint8)
+        arrays["metadata_sha256"] = np.frombuffer(
+            sha256(payload).hexdigest().encode("ascii"),
+            dtype=np.uint8,
+        )
+
+    _rewrite_archive(path, apply)
+
+
+@_requires_x64_child
+def test_save_load_continue_matches_uninterrupted_checkpoint_exactly(
+    tmp_path: Path,
+) -> None:
+    """A durable equal-problem restart exactly reproduces direct continuation."""
+    source_problem = _problem()
+    restored_problem = _problem()
+    first = _sample_boundary(source_problem)
+    path = tmp_path / "checkpoint.npz"
+    manifest = _manifest()
+    save_full_tiling_pymc_hmc_checkpoint(
+        path,
+        first.checkpoint,
+        run_manifest=manifest,
+    )
+    loaded = load_full_tiling_pymc_hmc_checkpoint(
+        path,
+        restored_problem,
+        expected_run_manifest=manifest,
+    )
+    direct = continue_full_tiling_pymc_hmc(
+        source_problem,
+        first.checkpoint,
+        iterations=2,
+    )
+    resumed = continue_full_tiling_pymc_hmc(
+        restored_problem,
+        loaded,
+        iterations=2,
+    )
+
+    _assert_results_equal(resumed, direct)
+    _assert_states_equal(loaded.state, first.checkpoint.state)
+    np.testing.assert_array_equal(loaded.log_leaf_mass, first.checkpoint.log_leaf_mass)
+    np.testing.assert_array_equal(
+        loaded.log_fixed_coefficient,
+        first.checkpoint.log_fixed_coefficient,
+    )
+    assert loaded.rng_state == first.checkpoint.rng_state
+    assert loaded.kernel_settings == first.checkpoint.kernel_settings
+    assert loaded.runtime_identity == first.checkpoint.runtime_identity
+
+
+@_requires_x64_child
+def test_archive_is_no_pickle_exact_field_set_and_create_only(tmp_path: Path) -> None:
+    """Published archives have only numeric schema fields and are never replaced."""
+    result = _sample_boundary(_problem())
+    path = tmp_path / "checkpoint.npz"
+    save_full_tiling_pymc_hmc_checkpoint(
+        path,
+        result.checkpoint,
+        run_manifest=_manifest(),
+    )
+    original = path.read_bytes()
+
+    with np.load(path, allow_pickle=False) as archive:
+        assert set(archive.files) == _ARCHIVE_FIELDS
+        assert all(archive[name].dtype != np.dtype(object) for name in archive.files)
+    with pytest.raises(FileExistsError):
+        save_full_tiling_pymc_hmc_checkpoint(
+            path,
+            result.checkpoint,
+            run_manifest=_manifest(),
+        )
+    assert path.read_bytes() == original
+
+
+@_requires_x64_child
+def test_loader_rejects_wrong_manifest_and_problem(tmp_path: Path) -> None:
+    """Manifest content and scientific problem fingerprints fail closed."""
+    problem = _problem()
+    result = _sample_boundary(problem)
+    path = tmp_path / "checkpoint.npz"
+    save_full_tiling_pymc_hmc_checkpoint(
+        path,
+        result.checkpoint,
+        run_manifest=_manifest(),
+    )
+
+    with pytest.raises(ValueError, match="problem fingerprint does not match"):
+        load_full_tiling_pymc_hmc_checkpoint(
+            path,
+            _problem(observation_shift=0.1),
+            expected_run_manifest=_manifest(),
+        )
+    with pytest.raises(ValueError, match="manifest does not match"):
+        load_full_tiling_pymc_hmc_checkpoint(
+            path,
+            problem,
+            expected_run_manifest=_manifest(revision="different"),
+        )
+
+
+@_requires_x64_child
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("pymc_version", "0.0", "runtime identity does not match"),
+        ("coordinate_layout_id", "future_layout_v2", "runtime identity does not match"),
+        ("metric_semantics_id", "future_metric_v2", "runtime identity does not match"),
+    ],
+)
+def test_loader_rejects_runtime_and_layout_identity_tampering(
+    tmp_path: Path,
+    field: str,
+    value: str,
+    message: str,
+) -> None:
+    """Backend, coordinate-layout, and metric identities are exact."""
+    problem = _problem()
+    result = _sample_boundary(problem)
+    path = tmp_path / f"{field}.npz"
+    save_full_tiling_pymc_hmc_checkpoint(
+        path,
+        result.checkpoint,
+        run_manifest=_manifest(),
+    )
+    _rewrite_metadata(
+        path,
+        lambda metadata: metadata["runtime_identity"].__setitem__(field, value),
+    )
+
+    with pytest.raises(ValueError, match=message):
+        load_full_tiling_pymc_hmc_checkpoint(
+            path,
+            problem,
+            expected_run_manifest=_manifest(),
+        )
+
+
+@_requires_x64_child
+def test_loader_rejects_kernel_semantics_and_settings_tampering(
+    tmp_path: Path,
+) -> None:
+    """Position-scale semantics and fixed-K settings cannot be relabelled."""
+    problem = _problem()
+    result = _sample_boundary(problem)
+    semantics_path = tmp_path / "semantics.npz"
+    save_full_tiling_pymc_hmc_checkpoint(
+        semantics_path,
+        result.checkpoint,
+        run_manifest=_manifest(),
+    )
+    _rewrite_metadata(
+        semantics_path,
+        lambda metadata: metadata["kernel"].__setitem__(
+            "position_scale_semantics",
+            "future_position_scale_v2",
+        ),
+    )
+    with pytest.raises(ValueError, match="position-scale semantics are incompatible"):
+        load_full_tiling_pymc_hmc_checkpoint(
+            semantics_path,
+            problem,
+            expected_run_manifest=_manifest(),
+        )
+
+    settings_path = tmp_path / "settings.npz"
+    save_full_tiling_pymc_hmc_checkpoint(
+        settings_path,
+        result.checkpoint,
+        run_manifest=_manifest(),
+    )
+    _rewrite_metadata(
+        settings_path,
+        lambda metadata: metadata["kernel"].__setitem__("fixed_k", 2),
+    )
+    with pytest.raises(ValueError, match="fixed K does not match"):
+        load_full_tiling_pymc_hmc_checkpoint(
+            settings_path,
+            problem,
+            expected_run_manifest=_manifest(),
+        )
+
+
+@_requires_x64_child
+def test_loader_rejects_corruption_and_hash_tampering(tmp_path: Path) -> None:
+    """Unreadable archives and altered arrays fail their integrity gates."""
+    problem = _problem()
+    result = _sample_boundary(problem)
+    corrupt_path = tmp_path / "corrupt.npz"
+    corrupt_path.write_bytes(b"not an npz checkpoint")
+    with pytest.raises(ValueError, match="corrupt or unreadable"):
+        load_full_tiling_pymc_hmc_checkpoint(
+            corrupt_path,
+            problem,
+            expected_run_manifest=_manifest(),
+        )
+
+    hash_path = tmp_path / "hash.npz"
+    save_full_tiling_pymc_hmc_checkpoint(
+        hash_path,
+        result.checkpoint,
+        run_manifest=_manifest(),
+    )
+    _rewrite_archive(
+        hash_path,
+        lambda arrays: arrays["leaf_masses"].__setitem__(
+            0,
+            np.nextafter(arrays["leaf_masses"][0], np.inf),
+        ),
+    )
+    with pytest.raises(ValueError, match="leaf_masses SHA-256 checksum does not match"):
+        load_full_tiling_pymc_hmc_checkpoint(
+            hash_path,
+            problem,
+            expected_run_manifest=_manifest(),
+        )
+
+
+@_requires_x64_child
+def test_independent_cache_audit_rejects_forged_cache_hash(tmp_path: Path) -> None:
+    """A forged prediction digest cannot bypass the scientific rebuild audit."""
+    problem = _problem()
+    result = _sample_boundary(problem)
+    path = tmp_path / "cache.npz"
+    save_full_tiling_pymc_hmc_checkpoint(
+        path,
+        result.checkpoint,
+        run_manifest=_manifest(),
+    )
+
+    def forge_cache(arrays: dict[str, np.ndarray[Any, Any]]) -> None:
+        """Alter one cache and update both array and metadata digests."""
+        arrays["prediction"][0] += 1.0e-5
+        metadata = json.loads(arrays["metadata"].tobytes().decode("utf-8"))
+        metadata["array_sha256"]["prediction"] = full_tiling_io._array_sha256(
+            "prediction",
+            arrays["prediction"],
+        )
+        payload = json.dumps(
+            metadata,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+        arrays["metadata"] = np.frombuffer(payload, dtype=np.uint8)
+        arrays["metadata_sha256"] = np.frombuffer(
+            sha256(payload).hexdigest().encode("ascii"),
+            dtype=np.uint8,
+        )
+
+    _rewrite_archive(path, forge_cache)
+    with pytest.raises(ValueError, match="stale or inconsistent cached arrays"):
+        load_full_tiling_pymc_hmc_checkpoint(
+            path,
+            problem,
+            expected_run_manifest=_manifest(),
+        )
+
+
+@_requires_x64_child
+def test_loaded_arrays_restore_exact_caches_and_are_immutable(tmp_path: Path) -> None:
+    """Loading restores persisted caches exactly as independent read-only arrays."""
+    source_problem = _problem()
+    result = _sample_boundary(source_problem)
+    path = tmp_path / "immutable.npz"
+    save_full_tiling_pymc_hmc_checkpoint(
+        path,
+        result.checkpoint,
+        run_manifest=_manifest(),
+    )
+    loaded = load_full_tiling_pymc_hmc_checkpoint(
+        path,
+        _problem(),
+        expected_run_manifest=_manifest(),
+    )
+
+    for name in (
+        "leaf_masses",
+        "fixed_coefficients",
+        "dynamic_prediction",
+        "fixed_prediction",
+        "prediction",
+        "residual",
+    ):
+        actual = getattr(loaded.state, name)
+        np.testing.assert_array_equal(actual, getattr(result.checkpoint.state, name))
+        assert not actual.flags.writeable
+    for name in ("log_leaf_mass", "log_fixed_coefficient"):
+        actual = getattr(loaded, name)
+        np.testing.assert_array_equal(actual, getattr(result.checkpoint, name))
+        assert not actual.flags.writeable

--- a/tests/experimental/rjmcmc/test_full_tiling_pymc_hmc_io.py
+++ b/tests/experimental/rjmcmc/test_full_tiling_pymc_hmc_io.py
@@ -156,7 +156,8 @@ def _sample_boundary(problem: FullTilingProblem) -> FullTilingPyMCHMCSamplingRes
             iterations=2,
             step_size=0.002,
             leapfrog_steps=2,
-            leaf_position_scale=1.4,
+            leaf_contrast_position_scale=1.4,
+            leaf_total_position_scale=2.6,
             fixed_coefficient_position_scale=(0.7, 1.8),
             seed=481,
         ),
@@ -290,6 +291,113 @@ def test_save_load_continue_matches_uninterrupted_checkpoint_exactly(
     assert loaded.rng_state == first.checkpoint.rng_state
     assert loaded.kernel_settings == first.checkpoint.kernel_settings
     assert loaded.runtime_identity == first.checkpoint.runtime_identity
+
+
+@_requires_x64_child
+def test_v2_metadata_roundtrips_both_leaf_eigenscales(tmp_path: Path) -> None:
+    """Schema v2 persists and restores distinct contrast and total eigenscales."""
+    problem = _problem()
+    result = _sample_boundary(problem)
+    path = tmp_path / "metric-v2.npz"
+    save_full_tiling_pymc_hmc_checkpoint(
+        path,
+        result.checkpoint,
+        run_manifest=_manifest(),
+    )
+
+    with np.load(path, allow_pickle=False) as archive:
+        metadata = json.loads(archive["metadata"].tobytes().decode("utf-8"))
+    loaded = load_full_tiling_pymc_hmc_checkpoint(
+        path,
+        _problem(),
+        expected_run_manifest=_manifest(),
+    )
+
+    assert metadata["schema_version"] == 2
+    assert metadata["kernel"]["leaf_contrast_position_scale"] == 1.4
+    assert metadata["kernel"]["leaf_total_position_scale"] == 2.6
+    assert loaded.kernel_settings.leaf_contrast_position_scale == 1.4
+    assert loaded.kernel_settings.leaf_total_position_scale == 2.6
+
+
+@_requires_x64_child
+@pytest.mark.parametrize(
+    "field",
+    [
+        "leaf_contrast_position_scale",
+        "leaf_total_position_scale",
+    ],
+)
+def test_loader_rejects_leaf_eigenscale_tampering(
+    tmp_path: Path,
+    field: str,
+) -> None:
+    """Invalid tampering of either persisted leaf eigenscale fails closed."""
+    problem = _problem()
+    result = _sample_boundary(problem)
+    path = tmp_path / f"{field}.npz"
+    save_full_tiling_pymc_hmc_checkpoint(
+        path,
+        result.checkpoint,
+        run_manifest=_manifest(),
+    )
+    _rewrite_metadata(
+        path,
+        lambda metadata: metadata["kernel"].__setitem__(field, 0.0),
+    )
+
+    with pytest.raises(ValueError, match=rf"kernel\.{field} must be finite and positive"):
+        load_full_tiling_pymc_hmc_checkpoint(
+            path,
+            problem,
+            expected_run_manifest=_manifest(),
+        )
+
+
+@_requires_x64_child
+def test_loader_rejects_v1_schema_and_old_scalar_leaf_scale_key(
+    tmp_path: Path,
+) -> None:
+    """Old schema and scalar leaf-scale metadata cannot enter the v2 loader."""
+    problem = _problem()
+    result = _sample_boundary(problem)
+    schema_path = tmp_path / "schema-v1.npz"
+    save_full_tiling_pymc_hmc_checkpoint(
+        schema_path,
+        result.checkpoint,
+        run_manifest=_manifest(),
+    )
+    _rewrite_metadata(
+        schema_path,
+        lambda metadata: metadata.__setitem__("schema_version", 1),
+    )
+    with pytest.raises(ValueError, match="schema version 1 uses the retired scalar"):
+        load_full_tiling_pymc_hmc_checkpoint(
+            schema_path,
+            problem,
+            expected_run_manifest=_manifest(),
+        )
+
+    key_path = tmp_path / "old-leaf-scale-key.npz"
+    save_full_tiling_pymc_hmc_checkpoint(
+        key_path,
+        result.checkpoint,
+        run_manifest=_manifest(),
+    )
+
+    def use_old_scalar_key(metadata: dict[str, Any]) -> None:
+        """Replace the two v2 leaf scales with the rejected v1 scalar key."""
+        kernel = metadata["kernel"]
+        kernel["leaf_position_scale"] = kernel.pop("leaf_contrast_position_scale")
+        kernel.pop("leaf_total_position_scale")
+
+    _rewrite_metadata(key_path, use_old_scalar_key)
+    with pytest.raises(ValueError, match="kernel has an invalid field set"):
+        load_full_tiling_pymc_hmc_checkpoint(
+            key_path,
+            problem,
+            expected_run_manifest=_manifest(),
+        )
 
 
 @_requires_x64_child

--- a/tests/experimental/rjmcmc/test_full_tiling_pymc_hmc_native.py
+++ b/tests/experimental/rjmcmc/test_full_tiling_pymc_hmc_native.py
@@ -1,0 +1,819 @@
+"""Tests for the frozen-input mobile PyMC HMC native driver."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+import importlib.util
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+from types import ModuleType
+from typing import Any, Literal
+
+import numpy as np
+import pytest
+import xarray as xr
+
+
+_DRIVER_PATH = Path(__file__).parents[3] / "examples" / "rjmcmc" / "full_tiling_pymc_hmc_native.py"
+_X64_CHILD_ENV = "OPENGHG_INVERSIONS_PYMC_HMC_NATIVE_DRIVER_X64_CHILD"
+_IS_X64_CHILD = os.environ.get(_X64_CHILD_ENV) == "1"
+_requires_x64_child = pytest.mark.skipif(
+    not _IS_X64_CHILD,
+    reason="PyMC driver assertions execute in the isolated float64 child",
+)
+
+
+def _pytensor_flags_with_float64(flags: str, *, compiledir: Path) -> str:
+    """Return PyTensor flags with isolated float64 compilation."""
+    retained = []
+    for item in flags.split(","):
+        stripped = item.strip()
+        if not stripped:
+            continue
+        name = stripped.split("=", 1)[0].strip()
+        if name not in {"base_compiledir", "floatX", "warn_float64"}:
+            retained.append(stripped)
+    return ",".join(
+        (
+            "floatX=float64",
+            "warn_float64=ignore",
+            f"base_compiledir={compiledir}",
+            *retained,
+        )
+    )
+
+
+def _run_x64_test_file(tmp_path: Path) -> None:
+    """Run all PyMC driver assertions in one fresh float64 subprocess."""
+    environment = os.environ.copy()
+    environment[_X64_CHILD_ENV] = "1"
+    environment["PYTENSOR_FLAGS"] = _pytensor_flags_with_float64(
+        environment.get("PYTENSOR_FLAGS", ""),
+        compiledir=tmp_path / "pytensor",
+    )
+    environment["MPLCONFIGDIR"] = str(tmp_path / "matplotlib")
+    environment["XDG_CACHE_HOME"] = str(tmp_path / "cache")
+    completed = subprocess.run(
+        [sys.executable, "-m", "pytest", "-q", str(Path(__file__).resolve())],
+        cwd=Path(__file__).parents[3],
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=300,
+        check=False,
+    )
+    assert completed.returncode == 0, (
+        "isolated native PyMC HMC driver tests failed\n"
+        f"stdout:\n{completed.stdout}\n"
+        f"stderr:\n{completed.stderr}"
+    )
+
+
+@pytest.mark.skipif(_IS_X64_CHILD, reason="parent-only subprocess dispatch")
+def test_driver_cases_use_a_fresh_float64_subprocess(tmp_path: Path) -> None:
+    """Driver cases cannot inherit process-global float32 from other tests."""
+    _run_x64_test_file(tmp_path)
+
+
+@pytest.fixture(scope="module")
+def hmc_driver() -> ModuleType:
+    """Load the example driver without invoking its command-line entry point."""
+    specification = importlib.util.spec_from_file_location(
+        "full_tiling_pymc_hmc_native",
+        _DRIVER_PATH,
+    )
+    if specification is None or specification.loader is None:
+        raise RuntimeError("Could not load the native PyMC HMC example.")
+    module = importlib.util.module_from_spec(specification)
+    specification.loader.exec_module(module)
+    return module
+
+
+def _write_frozen_input(path: Path) -> None:
+    """Write a tiny exact-closure native dataset with six labelled outers."""
+    sensitivity = np.arange(1.0, 13.0).reshape(3, 2, 2)
+    outer = np.arange(18.0).reshape(3, 6) / 8.0
+    boundary = np.array([4.0, 5.0, 6.0])
+    dataset = xr.Dataset(
+        {
+            "fp_x_flux": (
+                ("lon", "nmeasure", "lat"),
+                sensitivity.transpose(2, 0, 1),
+            ),
+            "mf": (
+                "nmeasure",
+                boundary + sensitivity.sum(axis=(1, 2)) + outer.sum(axis=1),
+            ),
+            "mf_error": ("nmeasure", np.ones(3)),
+            "nominal_weight": (
+                ("lon", "lat"),
+                np.full((2, 2), 0.25).T,
+            ),
+            "outer_design": (("outer_region", "nmeasure"), outer.T),
+            "YaprioriBC": ("nmeasure", boundary),
+        },
+        coords={
+            "nmeasure": ["obs-a", "obs-b", "obs-c"],
+            "lat": [50.0, 51.0],
+            "lon": [-2.0, -1.0],
+            "outer_region": [f"region-{index}" for index in range(6)],
+        },
+    )
+    dataset.to_netcdf(path, engine="h5netcdf")
+
+
+def _arguments(
+    driver: ModuleType,
+    input_path: Path,
+    output_path: Path,
+    *,
+    extra: tuple[str, ...] = (),
+) -> list[str]:
+    """Return the complete explicit tiny-run CLI contract."""
+    calibration_path = input_path.with_name("calibration.json")
+    calibration = {
+        "schema": driver.CALIBRATION_SCHEMA,
+        "calibration_id": "tiny-static-hmc-calibration-v1",
+        "fixed_k": 2,
+        "input_sha256": driver._sha256_file(input_path),
+        "target": {
+            "concentration": 3.0,
+            "root_variance": 0.25,
+            "likelihood_power": 1.0,
+            "fixed_prior_mean": [1.0] * 6,
+            "fixed_prior_sd": [1.0] * 6,
+            "nominal_weight_policy": "positive-native-mass-v1",
+            "normalize_weights": True,
+        },
+        "kernel": {
+            "step_size": 0.001,
+            "leapfrog_steps": 1,
+            "coordinate_layout_id": (driver.FULL_TILING_PYMC_HMC_COORDINATE_LAYOUT_ID),
+            "metric_semantics_id": (driver.FULL_TILING_PYMC_HMC_METRIC_SEMANTICS_ID),
+            "leaf_position_scale": 1.75,
+            "fixed_coefficient_position_scale": [
+                0.5,
+                0.75,
+                1.0,
+                1.25,
+                1.5,
+                2.0,
+            ],
+        },
+        "evidence": {
+            "code_revision": "test-revision",
+            "robust_variance_estimator": (driver.ROBUST_VARIANCE_ESTIMATOR),
+            "clipping_bounds": [1.0e-4, 1.0e2],
+            "pilot_initializers": [
+                {
+                    "strategy": "largest-nominal",
+                    "seed": None,
+                    "sweeps": 100,
+                },
+                {
+                    "strategy": "random-recursive",
+                    "seed": 51003,
+                    "sweeps": 100,
+                },
+            ],
+            "candidate_grid": [{"step_size": 0.001, "leapfrog_steps": 1}],
+            "decision_statistics": [
+                {
+                    "step_size": 0.001,
+                    "leapfrog_steps": 1,
+                    "largest_nominal_mean_acceptance": 0.75,
+                    "random_recursive_mean_acceptance": 0.8,
+                    "divergences": 0,
+                    "finite": True,
+                    "median_log_displacement_per_leapfrog_step": 0.125,
+                    "selected": True,
+                }
+            ],
+            "source_artifact_sha256": {"tiny-nuts-reference": "b" * 64},
+        },
+    }
+    calibration_path.write_text(
+        driver._canonical_json(calibration),
+        encoding="utf-8",
+    )
+    values = [
+        "--input",
+        str(input_path),
+        "--output-directory",
+        str(output_path),
+        "--k",
+        "2",
+        "--sweeps",
+        "1",
+        "--seed",
+        "812",
+        "--chain-id",
+        "tiny-chain",
+        "--step-size",
+        "0.001",
+        "--leapfrog-steps",
+        "1",
+        "--leaf-position-scale",
+        "1.75",
+        "--fixed-coefficient-position-scale",
+        "0.5,0.75,1,1.25,1.5,2",
+        "--calibration-id",
+        "tiny-static-hmc-calibration-v1",
+        "--calibration-file",
+        str(calibration_path),
+        "--calibration-sha256",
+        driver._sha256_file(calibration_path),
+        "--concentration",
+        "3",
+        "--root-variance",
+        "0.25",
+        "--fixed-prior-mean",
+        "1",
+        "--fixed-prior-sd",
+        "1",
+        "--input-id",
+        "tiny-frozen-native-v1",
+        "--expected-input-sha256",
+        driver._sha256_file(input_path),
+        "--code-revision",
+        "test-revision",
+        "--nominal-weight-policy",
+        "positive-native-mass-v1",
+    ]
+    values.extend(extra)
+    return values
+
+
+def _replace_option(
+    arguments: list[str],
+    option: str,
+    replacement: str,
+) -> list[str]:
+    """Return CLI arguments with one option value replaced."""
+    changed = list(arguments)
+    changed[changed.index(option) + 1] = replacement
+    return changed
+
+
+def _json(path: Path) -> dict[str, Any]:
+    """Load one JSON artifact."""
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+@_requires_x64_child
+def test_dry_fresh_and_resumed_segments_are_exact_and_auditable(
+    tmp_path: Path,
+    hmc_driver: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A synthetic chain dry-runs, publishes in order, and resumes exactly.
+
+    The same immutable chain is also used to prove that calibration,
+    provenance, and static-HMC setting changes are rejected by checkpoint
+    manifest validation before any continuation output is published.
+    """
+    input_path = tmp_path / "frozen.nc"
+    dry_output = tmp_path / "dry-output"
+    fresh_output = tmp_path / "fresh-output"
+    resumed_output = tmp_path / "resumed-output"
+    _write_frozen_input(input_path)
+
+    dry_summary = hmc_driver.run(
+        hmc_driver.build_parser().parse_args(
+            [
+                *_arguments(hmc_driver, input_path, dry_output),
+                "--dry-run",
+            ]
+        )
+    )
+    assert dry_summary["status"] == "dry_run"
+    assert dry_summary["closure"] == {
+        "mass_coordinate_max_abs_error": 0.0,
+        "prior_mean_total_max_abs_error": 0.0,
+    }
+    assert (
+        abs(dry_summary["transformed_target_preflight"]["difference"])
+        <= dry_summary["transformed_target_preflight"]["absolute_tolerance"]
+    )
+    assert dry_summary["runtime_identity"]["pytensor_float_x"] == "float64"
+    assert not dry_output.exists()
+
+    publication_order: list[str] = []
+    original_write_text = hmc_driver._atomic_write_text
+    original_write_trace = hmc_driver._atomic_write_trace
+    original_save_checkpoint = hmc_driver.save_full_tiling_pymc_hmc_checkpoint
+
+    def recording_write_text(path: Path, text: str) -> None:
+        """Record JSON publication while preserving create-only writes."""
+        publication_order.append(path.name)
+        original_write_text(path, text)
+
+    def recording_write_trace(
+        dataset: xr.Dataset,
+        path: Path,
+        *,
+        engine: str,
+    ) -> None:
+        """Record trace publication while preserving the real NetCDF write."""
+        publication_order.append(path.name)
+        original_write_trace(dataset, path, engine=engine)
+
+    def recording_save_checkpoint(
+        path: Path,
+        checkpoint: Any,
+        *,
+        run_manifest: Any,
+    ) -> None:
+        """Record checkpoint publication while preserving strict checkpoint I/O."""
+        publication_order.append(path.name)
+        original_save_checkpoint(
+            path,
+            checkpoint,
+            run_manifest=run_manifest,
+        )
+
+    monkeypatch.setattr(
+        hmc_driver,
+        "_atomic_write_text",
+        recording_write_text,
+    )
+    monkeypatch.setattr(
+        hmc_driver,
+        "_atomic_write_trace",
+        recording_write_trace,
+    )
+    monkeypatch.setattr(
+        hmc_driver,
+        "save_full_tiling_pymc_hmc_checkpoint",
+        recording_save_checkpoint,
+    )
+
+    fresh_arguments = _arguments(
+        hmc_driver,
+        input_path,
+        fresh_output,
+    )
+    fresh_summary = hmc_driver.run(hmc_driver.build_parser().parse_args(fresh_arguments))
+    assert publication_order == [
+        hmc_driver.MANIFEST_FILENAME,
+        hmc_driver.TRACE_FILENAME,
+        hmc_driver.SUMMARY_FILENAME,
+        hmc_driver.CHECKPOINT_FILENAME,
+        hmc_driver.COMPLETION_FILENAME,
+    ]
+    assert {path.name for path in fresh_output.iterdir()} == {
+        hmc_driver.MANIFEST_FILENAME,
+        hmc_driver.TRACE_FILENAME,
+        hmc_driver.SUMMARY_FILENAME,
+        hmc_driver.CHECKPOINT_FILENAME,
+        hmc_driver.COMPLETION_FILENAME,
+    }
+    manifest = _json(fresh_output / hmc_driver.MANIFEST_FILENAME)
+    completion = _json(fresh_output / hmc_driver.COMPLETION_FILENAME)
+    assert manifest["schema"].endswith("native_manifest.v1")
+    assert manifest["initialization"]["seed"] is None
+    assert manifest["sampler"]["metric_semantics_id"] == (hmc_driver.FULL_TILING_PYMC_HMC_METRIC_SEMANTICS_ID)
+    assert manifest["sampler"]["leaf_position_scale"] == 1.75
+    assert manifest["sampler"]["fixed_coefficient_position_scale"] == [0.5, 0.75, 1.0, 1.25, 1.5, 2.0]
+    assert manifest["sampler"]["calibration"] == {
+        "schema": hmc_driver.CALIBRATION_SCHEMA,
+        "id": "tiny-static-hmc-calibration-v1",
+        "sha256": hmc_driver._sha256_file(input_path.with_name("calibration.json")),
+    }
+    assert "sampling_seconds" not in fresh_summary["performance"]
+    assert fresh_summary["performance"]["kernel_setup_and_compile_seconds"] >= 0.0
+    assert fresh_summary["performance"]["transition_sampling_seconds"] >= 0.0
+    assert fresh_summary["performance"]["sweeps_per_second"] is not None
+    assert (
+        fresh_summary["performance"]["leapfrog_steps_per_second"]
+        == fresh_summary["performance"]["sweeps_per_second"]
+    )
+    assert fresh_summary["run"] == {
+        "fixed_k": 2,
+        "schedule_id": hmc_driver.FULL_TILING_PYMC_HMC_SCHEDULE_ID,
+        "segment_sweeps": 1,
+        "segment_start_sweep": 0,
+        "segment_end_sweep": 1,
+        "retained_states": 2,
+        "durable_checkpoint": True,
+    }
+    assert completion["schema"].endswith("native_completion.v1")
+    assert completion["parent_checkpoint_sha256"] is None
+    assert completion["parent_completion_sha256"] is None
+    assert completion["parent_artifact_sha256"] is None
+    assert fresh_summary["lineage"]["parent_completion_sha256"] is None
+    assert fresh_summary["lineage"]["parent_artifact_sha256"] is None
+    assert completion["segment_start_sweep"] == 0
+    assert completion["segment_end_sweep"] == 1
+    assert set(completion["sha256"]) == {
+        hmc_driver.MANIFEST_FILENAME,
+        hmc_driver.TRACE_FILENAME,
+        hmc_driver.SUMMARY_FILENAME,
+        hmc_driver.CHECKPOINT_FILENAME,
+    }
+    for filename, digest in completion["sha256"].items():
+        assert hmc_driver._sha256_file(fresh_output / filename) == digest
+
+    with np.load(
+        fresh_output / hmc_driver.CHECKPOINT_FILENAME,
+        allow_pickle=False,
+    ) as checkpoint:
+        assert set(checkpoint.files) == {
+            "rectangle_bounds",
+            "leaf_masses",
+            "fixed_coefficients",
+            "log_leaf_mass",
+            "log_fixed_coefficient",
+            "dynamic_prediction",
+            "fixed_prediction",
+            "prediction",
+            "residual",
+            "metadata",
+            "metadata_sha256",
+        }
+        assert all(checkpoint[name].dtype != np.dtype(object) for name in checkpoint.files)
+        checkpoint_metadata = json.loads(checkpoint["metadata"].tobytes().decode("utf-8"))
+    assert checkpoint_metadata["schema_version"] == 1
+    assert checkpoint_metadata["sweeps_completed"] == 1
+    assert checkpoint_metadata["runtime_identity"]["pytensor_float_x"] == ("float64")
+    assert checkpoint_metadata["run_manifest_json"] == (hmc_driver._canonical_json(manifest).rstrip("\n"))
+
+    with xr.open_dataset(
+        fresh_output / hmc_driver.TRACE_FILENAME,
+        engine="h5netcdf",
+    ) as fresh_trace:
+        fresh_trace.load()
+        assert fresh_trace.attrs["schema"].endswith("native_trace.v1")
+        assert fresh_trace.attrs["manifest_sha256"] == (
+            hmc_driver._sha256_file(fresh_output / hmc_driver.MANIFEST_FILENAME)
+        )
+        assert fresh_trace.sizes == {
+            "draw": 2,
+            "region": 2,
+            "bound": 4,
+            "fixed_parameter": 6,
+            "observation": 3,
+            "sweep": 1,
+            "lat": 2,
+            "lon": 2,
+        }
+        np.testing.assert_array_equal(fresh_trace["sweep"], [1])
+        np.testing.assert_array_equal(
+            fresh_trace["state_sweep"],
+            [0, 1],
+        )
+        assert fresh_trace["hmc_seed"].dtype == np.dtype(np.uint64)
+        fresh_final_mass = fresh_trace["leaf_mass"].isel(draw=-1).values
+        fresh_final_fixed = fresh_trace["fixed_coefficient"].isel(draw=-1).values
+
+    checkpoint_path = fresh_output / hmc_driver.CHECKPOINT_FILENAME
+    mismatch_cases = (
+        (
+            "--calibration-id",
+            "different-calibration",
+            "Calibration v1 identity",
+        ),
+        ("--chain-id", "different-chain", "manifest does not match"),
+        ("--step-size", "0.002", "Calibration v1 identity"),
+    )
+    for option, replacement, message in mismatch_cases:
+        mismatch_output = tmp_path / option.removeprefix("--")
+        mismatched = _replace_option(
+            _arguments(
+                hmc_driver,
+                input_path,
+                mismatch_output,
+                extra=(
+                    "--resume-checkpoint",
+                    str(checkpoint_path),
+                ),
+            ),
+            option,
+            replacement,
+        )
+        with pytest.raises(ValueError, match=message):
+            hmc_driver.run(hmc_driver.build_parser().parse_args(mismatched))
+        assert not mismatch_output.exists()
+
+    parent_failure_cases = (
+        ("missing-completion", "missing"),
+        ("corrupt-summary", "corrupt"),
+        ("incompatible-completion", "incompatible"),
+    )
+    for case_name, mutation in parent_failure_cases:
+        parent_bundle = tmp_path / f"parent-{case_name}"
+        shutil.copytree(fresh_output, parent_bundle)
+        if mutation == "missing":
+            (parent_bundle / hmc_driver.COMPLETION_FILENAME).unlink()
+            expected_error = FileNotFoundError
+            message = "completion certificate"
+        elif mutation == "corrupt":
+            with (parent_bundle / hmc_driver.SUMMARY_FILENAME).open(
+                "a",
+                encoding="utf-8",
+            ) as handle:
+                handle.write("\n")
+            expected_error = ValueError
+            message = "SHA-256 does not match"
+        else:
+            certificate = _json(parent_bundle / hmc_driver.COMPLETION_FILENAME)
+            certificate["checkpoint"] = "different-checkpoint.npz"
+            (parent_bundle / hmc_driver.COMPLETION_FILENAME).write_text(
+                hmc_driver._canonical_json(certificate),
+                encoding="utf-8",
+            )
+            expected_error = ValueError
+            message = "checkpoint name is incompatible"
+        failed_output = tmp_path / f"child-{case_name}"
+        failed_arguments = _arguments(
+            hmc_driver,
+            input_path,
+            failed_output,
+            extra=(
+                "--resume-checkpoint",
+                str(parent_bundle / hmc_driver.CHECKPOINT_FILENAME),
+            ),
+        )
+        with pytest.raises(expected_error, match=message):
+            hmc_driver.run(hmc_driver.build_parser().parse_args(failed_arguments))
+        assert not failed_output.exists()
+
+    publication_order.clear()
+    resume_arguments = _arguments(
+        hmc_driver,
+        input_path,
+        resumed_output,
+        extra=("--resume-checkpoint", str(checkpoint_path)),
+    )
+    resumed_summary = hmc_driver.run(hmc_driver.build_parser().parse_args(resume_arguments))
+    assert (resumed_output / hmc_driver.MANIFEST_FILENAME).read_bytes() == (
+        fresh_output / hmc_driver.MANIFEST_FILENAME
+    ).read_bytes()
+    assert publication_order[-1] == hmc_driver.COMPLETION_FILENAME
+    assert resumed_summary["run"]["segment_start_sweep"] == 1
+    assert resumed_summary["run"]["segment_end_sweep"] == 2
+    resumed_completion = _json(resumed_output / hmc_driver.COMPLETION_FILENAME)
+    assert resumed_completion["parent_checkpoint_sha256"] == (hmc_driver._sha256_file(checkpoint_path))
+    parent_completion_sha256 = hmc_driver._sha256_file(fresh_output / hmc_driver.COMPLETION_FILENAME)
+    assert resumed_summary["lineage"]["parent_completion_sha256"] == (parent_completion_sha256)
+    assert resumed_summary["lineage"]["parent_artifact_sha256"] == completion["sha256"]
+    assert resumed_completion["parent_completion_sha256"] == (parent_completion_sha256)
+    assert resumed_completion["parent_artifact_sha256"] == completion["sha256"]
+    assert resumed_completion["segment_start_sweep"] == 1
+    assert resumed_completion["segment_end_sweep"] == 2
+    with xr.open_dataset(
+        resumed_output / hmc_driver.TRACE_FILENAME,
+        engine="h5netcdf",
+    ) as resumed_trace:
+        np.testing.assert_array_equal(resumed_trace["sweep"], [2])
+        np.testing.assert_array_equal(
+            resumed_trace["state_sweep"],
+            [1, 2],
+        )
+        np.testing.assert_array_equal(
+            resumed_trace["leaf_mass"].isel(draw=0),
+            fresh_final_mass,
+        )
+        np.testing.assert_array_equal(
+            resumed_trace["fixed_coefficient"].isel(draw=0),
+            fresh_final_fixed,
+        )
+
+
+@_requires_x64_child
+def test_driver_rejects_initialization_runtime_and_forbidden_outputs(
+    tmp_path: Path,
+    hmc_driver: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Initialization, runtime, and PARIS output safeguards fail before writes."""
+    input_path = tmp_path / "frozen.nc"
+    _write_frozen_input(input_path)
+    output_path = tmp_path / "output"
+
+    common = _arguments(hmc_driver, input_path, output_path)
+    with pytest.raises(ValueError, match="requires --initialization-seed"):
+        hmc_driver.run(
+            hmc_driver.build_parser().parse_args([*common, "--initialization", "random-recursive"])
+        )
+    with pytest.raises(ValueError, match="must differ"):
+        hmc_driver.run(
+            hmc_driver.build_parser().parse_args(
+                [
+                    *common,
+                    "--initialization",
+                    "random-recursive",
+                    "--initialization-seed",
+                    "812",
+                ]
+            )
+        )
+    malformed_calibration = _replace_option(
+        common,
+        "--calibration-sha256",
+        "not-a-sha256",
+    )
+    with pytest.raises(ValueError, match="64 hexadecimal"):
+        hmc_driver.run(hmc_driver.build_parser().parse_args(malformed_calibration))
+
+    missing_calibration = _replace_option(
+        _arguments(hmc_driver, input_path, output_path),
+        "--calibration-file",
+        str(tmp_path / "missing-calibration.json"),
+    )
+    with pytest.raises(FileNotFoundError, match="Calibration file"):
+        hmc_driver.run(hmc_driver.build_parser().parse_args(missing_calibration))
+
+    hash_mismatch = _arguments(hmc_driver, input_path, output_path)
+    calibration_path = Path(hash_mismatch[hash_mismatch.index("--calibration-file") + 1])
+    calibration_path.write_text(
+        calibration_path.read_text(encoding="utf-8") + " ",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="Calibration file SHA-256"):
+        hmc_driver.run(hmc_driver.build_parser().parse_args(hash_mismatch))
+
+    duplicate_member = _arguments(hmc_driver, input_path, output_path)
+    calibration_path.write_text(
+        '{"schema":"first","schema":"second"}\n',
+        encoding="utf-8",
+    )
+    duplicate_member = _replace_option(
+        duplicate_member,
+        "--calibration-sha256",
+        hmc_driver._sha256_file(calibration_path),
+    )
+    with pytest.raises(ValueError, match="Duplicate JSON object member"):
+        hmc_driver.run(hmc_driver.build_parser().parse_args(duplicate_member))
+
+    incompatible_identity = _arguments(
+        hmc_driver,
+        input_path,
+        output_path,
+    )
+    calibration = _json(calibration_path)
+    calibration["fixed_k"] = 3
+    calibration_path.write_text(
+        hmc_driver._canonical_json(calibration),
+        encoding="utf-8",
+    )
+    incompatible_identity = _replace_option(
+        incompatible_identity,
+        "--calibration-sha256",
+        hmc_driver._sha256_file(calibration_path),
+    )
+    with pytest.raises(ValueError, match="identity does not exactly match"):
+        hmc_driver.run(hmc_driver.build_parser().parse_args(incompatible_identity))
+    assert not output_path.exists()
+
+    common = _arguments(hmc_driver, input_path, output_path)
+    runtime = hmc_driver.full_tiling_pymc_hmc_runtime_identity()
+    monkeypatch.setattr(
+        hmc_driver,
+        "full_tiling_pymc_hmc_runtime_identity",
+        lambda: replace(runtime, pytensor_float_x="float32"),
+    )
+    with pytest.raises(RuntimeError, match="floatX must be exactly float64"):
+        hmc_driver.run(hmc_driver.build_parser().parse_args([*common, "--dry-run"]))
+    assert not output_path.exists()
+
+    paris_parent = tmp_path / "PARIS_inversions"
+    paris_parent.mkdir()
+    before = tuple(paris_parent.iterdir())
+    forbidden_output = paris_parent / "must-not-exist"
+    with pytest.raises(ValueError, match="PARIS_inversions"):
+        hmc_driver.run(
+            hmc_driver.build_parser().parse_args(
+                _arguments(
+                    hmc_driver,
+                    input_path,
+                    forbidden_output,
+                )
+            )
+        )
+    assert tuple(paris_parent.iterdir()) == before
+
+
+@_requires_x64_child
+def test_artifact_failures_never_publish_completion_certificate(
+    tmp_path: Path,
+    hmc_driver: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Coordinate-audit and checkpoint-stage failures leave bundles incomplete."""
+    input_path = tmp_path / "frozen.nc"
+    _write_frozen_input(input_path)
+    original_write_trace = hmc_driver._atomic_write_trace
+    original_save_checkpoint = hmc_driver.save_full_tiling_pymc_hmc_checkpoint
+
+    def corrupting_write_trace(
+        dataset: xr.Dataset,
+        path: Path,
+        *,
+        engine: Literal["h5netcdf", "netcdf4", "scipy"],
+    ) -> None:
+        """Corrupt one coordinate after publication to exercise reopen audit."""
+        original_write_trace(dataset, path, engine=engine)
+        with xr.open_dataset(path, engine=engine) as opened:
+            corrupted = opened.load()
+        corrupted = corrupted.assign_coords(draw=np.asarray(corrupted["draw"].values) + 1)
+        try:
+            corrupted.to_netcdf(path, engine=engine, mode="w")
+        finally:
+            corrupted.close()
+
+    coordinate_output = tmp_path / "coordinate-audit-failure"
+    monkeypatch.setattr(
+        hmc_driver,
+        "_atomic_write_trace",
+        corrupting_write_trace,
+    )
+    with pytest.raises(RuntimeError, match="coordinate draw does not match"):
+        hmc_driver.run(
+            hmc_driver.build_parser().parse_args(
+                _arguments(
+                    hmc_driver,
+                    input_path,
+                    coordinate_output,
+                )
+            )
+        )
+    assert coordinate_output.is_dir()
+    assert not (coordinate_output / hmc_driver.COMPLETION_FILENAME).exists()
+
+    def failing_save_checkpoint(*args: Any, **kwargs: Any) -> None:
+        """Inject a checkpoint publication failure."""
+        del args, kwargs
+        raise RuntimeError("injected checkpoint publication failure")
+
+    checkpoint_output = tmp_path / "checkpoint-failure"
+    monkeypatch.setattr(
+        hmc_driver,
+        "_atomic_write_trace",
+        original_write_trace,
+    )
+    monkeypatch.setattr(
+        hmc_driver,
+        "save_full_tiling_pymc_hmc_checkpoint",
+        failing_save_checkpoint,
+    )
+    with pytest.raises(RuntimeError, match="injected checkpoint"):
+        hmc_driver.run(
+            hmc_driver.build_parser().parse_args(
+                _arguments(
+                    hmc_driver,
+                    input_path,
+                    checkpoint_output,
+                )
+            )
+        )
+    assert checkpoint_output.is_dir()
+    assert not (checkpoint_output / hmc_driver.COMPLETION_FILENAME).exists()
+    monkeypatch.setattr(
+        hmc_driver,
+        "save_full_tiling_pymc_hmc_checkpoint",
+        original_save_checkpoint,
+    )
+
+
+def test_parser_and_kernel_settings_make_seed_and_metric_semantics_explicit(
+    tmp_path: Path,
+    hmc_driver: ModuleType,
+) -> None:
+    """The CLI requires a seed and resolves position-covariance diagonals."""
+    input_path = tmp_path / "frozen.nc"
+    _write_frozen_input(input_path)
+    arguments = _arguments(
+        hmc_driver,
+        input_path,
+        tmp_path / "output",
+    )
+    seed_index = arguments.index("--seed")
+    without_seed = arguments[:seed_index] + arguments[seed_index + 2 :]
+    with pytest.raises(SystemExit):
+        hmc_driver.build_parser().parse_args(without_seed)
+    calibration_index = arguments.index("--calibration-file")
+    without_calibration = arguments[:calibration_index] + arguments[calibration_index + 2 :]
+    with pytest.raises(SystemExit):
+        hmc_driver.build_parser().parse_args(without_calibration)
+
+    parsed = hmc_driver.build_parser().parse_args(arguments)
+    fixed_scales = hmc_driver._expand_values(
+        parsed.fixed_coefficient_position_scale,
+        size=6,
+        name="fixed_coefficient_position_scale",
+    )
+    settings = hmc_driver._requested_kernel_settings(
+        parsed,
+        fixed_scales,
+    )
+    np.testing.assert_array_equal(
+        settings.position_scale_diagonal,
+        [1.75, 1.75, 0.5, 0.75, 1.0, 1.25, 1.5, 2.0],
+    )
+    assert "position_covariance" in (hmc_driver.FULL_TILING_PYMC_HMC_METRIC_SEMANTICS_ID)
+    assert "momentum_precision" in (hmc_driver.FULL_TILING_PYMC_HMC_METRIC_SEMANTICS_ID)

--- a/tests/experimental/rjmcmc/test_full_tiling_pymc_hmc_native.py
+++ b/tests/experimental/rjmcmc/test_full_tiling_pymc_hmc_native.py
@@ -142,7 +142,7 @@ def _arguments(
     calibration_path = input_path.with_name("calibration.json")
     calibration = {
         "schema": driver.CALIBRATION_SCHEMA,
-        "calibration_id": "tiny-static-hmc-calibration-v1",
+        "calibration_id": "tiny-static-hmc-calibration-v2",
         "fixed_k": 2,
         "input_sha256": driver._sha256_file(input_path),
         "target": {
@@ -159,7 +159,8 @@ def _arguments(
             "leapfrog_steps": 1,
             "coordinate_layout_id": (driver.FULL_TILING_PYMC_HMC_COORDINATE_LAYOUT_ID),
             "metric_semantics_id": (driver.FULL_TILING_PYMC_HMC_METRIC_SEMANTICS_ID),
-            "leaf_position_scale": 1.75,
+            "leaf_contrast_position_scale": 1.75,
+            "leaf_total_position_scale": 2.25,
             "fixed_coefficient_position_scale": [
                 0.5,
                 0.75,
@@ -172,17 +173,22 @@ def _arguments(
         "evidence": {
             "code_revision": "test-revision",
             "robust_variance_estimator": (driver.ROBUST_VARIANCE_ESTIMATOR),
+            "leaf_metric_estimator": driver.LEAF_METRIC_ESTIMATOR,
             "clipping_bounds": [1.0e-4, 1.0e2],
-            "pilot_initializers": [
+            "development_initializers": [
                 {
-                    "strategy": "largest-nominal",
-                    "seed": None,
-                    "sweeps": 100,
+                    "role": "development-a",
+                    "strategy": "random-recursive",
+                    "seed": 41003,
+                    "sampler_seed": 71003,
+                    "sweeps": 200,
                 },
                 {
+                    "role": "development-b",
                     "strategy": "random-recursive",
-                    "seed": 51003,
-                    "sweeps": 100,
+                    "seed": 41004,
+                    "sampler_seed": 71004,
+                    "sweeps": 200,
                 },
             ],
             "candidate_grid": [{"step_size": 0.001, "leapfrog_steps": 1}],
@@ -190,14 +196,56 @@ def _arguments(
                 {
                     "step_size": 0.001,
                     "leapfrog_steps": 1,
-                    "largest_nominal_mean_acceptance": 0.75,
-                    "random_recursive_mean_acceptance": 0.8,
+                    "development_a_mean_acceptance": 0.75,
+                    "development_b_mean_acceptance": 0.8,
                     "divergences": 0,
                     "finite": True,
-                    "median_log_displacement_per_leapfrog_step": 0.125,
+                    "median_hmc_log_displacement_per_leapfrog_step": 0.125,
                     "selected": True,
                 }
             ],
+            "selected_validation": {
+                "step_size": 0.001,
+                "leapfrog_steps": 1,
+                "initializers": [
+                    {
+                        "role": "development-a",
+                        "strategy": "random-recursive",
+                        "seed": 41003,
+                        "sampler_seed": 72003,
+                        "sweeps": 500,
+                        "mean_acceptance": 0.75,
+                        "divergences": 0,
+                        "finite": True,
+                    },
+                    {
+                        "role": "development-b",
+                        "strategy": "random-recursive",
+                        "seed": 41004,
+                        "sampler_seed": 72004,
+                        "sweeps": 500,
+                        "mean_acceptance": 0.8,
+                        "divergences": 0,
+                        "finite": True,
+                    },
+                    {
+                        "role": "held-out",
+                        "strategy": "random-recursive",
+                        "seed": 41005,
+                        "sampler_seed": 72005,
+                        "sweeps": 500,
+                        "mean_acceptance": 0.78,
+                        "divergences": 0,
+                        "finite": True,
+                    },
+                ],
+            },
+            "excluded_production_topology_sha256": {
+                "metric_source": "c" * 64,
+                "development_a": "d" * 64,
+                "development_b": "e" * 64,
+                "held_out": "f" * 64,
+            },
             "source_artifact_sha256": {"tiny-nuts-reference": "b" * 64},
         },
     }
@@ -222,12 +270,14 @@ def _arguments(
         "0.001",
         "--leapfrog-steps",
         "1",
-        "--leaf-position-scale",
+        "--leaf-contrast-position-scale",
         "1.75",
+        "--leaf-total-position-scale",
+        "2.25",
         "--fixed-coefficient-position-scale",
         "0.5,0.75,1,1.25,1.5,2",
         "--calibration-id",
-        "tiny-static-hmc-calibration-v1",
+        "tiny-static-hmc-calibration-v2",
         "--calibration-file",
         str(calibration_path),
         "--calibration-sha256",
@@ -381,19 +431,21 @@ def test_dry_fresh_and_resumed_segments_are_exact_and_auditable(
     }
     manifest = _json(fresh_output / hmc_driver.MANIFEST_FILENAME)
     completion = _json(fresh_output / hmc_driver.COMPLETION_FILENAME)
-    assert manifest["schema"].endswith("native_manifest.v1")
+    assert manifest["schema"].endswith("native_manifest.v2")
     assert manifest["initialization"]["seed"] is None
     assert manifest["sampler"]["metric_semantics_id"] == (hmc_driver.FULL_TILING_PYMC_HMC_METRIC_SEMANTICS_ID)
-    assert manifest["sampler"]["leaf_position_scale"] == 1.75
+    assert manifest["sampler"]["leaf_contrast_position_scale"] == 1.75
+    assert manifest["sampler"]["leaf_total_position_scale"] == 2.25
     assert manifest["sampler"]["fixed_coefficient_position_scale"] == [0.5, 0.75, 1.0, 1.25, 1.5, 2.0]
     assert (
         manifest["initialization"]["state_sha256"] == fresh_summary["lineage"]["segment_start_state_sha256"]
     )
     assert manifest["sampler"]["calibration"] == {
         "schema": hmc_driver.CALIBRATION_SCHEMA,
-        "id": "tiny-static-hmc-calibration-v1",
+        "id": "tiny-static-hmc-calibration-v2",
         "sha256": hmc_driver._sha256_file(input_path.with_name("calibration.json")),
     }
+    assert fresh_summary["schema"].endswith("native_summary.v2")
     assert "sampling_seconds" not in fresh_summary["performance"]
     assert fresh_summary["performance"]["kernel_setup_and_compile_seconds"] >= 0.0
     assert fresh_summary["performance"]["transition_sampling_seconds"] >= 0.0
@@ -411,7 +463,7 @@ def test_dry_fresh_and_resumed_segments_are_exact_and_auditable(
         "retained_states": 2,
         "durable_checkpoint": True,
     }
-    assert completion["schema"].endswith("native_completion.v1")
+    assert completion["schema"].endswith("native_completion.v2")
     assert completion["parent_checkpoint_sha256"] is None
     assert completion["parent_completion_sha256"] is None
     assert completion["parent_artifact_sha256"] is None
@@ -447,7 +499,7 @@ def test_dry_fresh_and_resumed_segments_are_exact_and_auditable(
         }
         assert all(checkpoint[name].dtype != np.dtype(object) for name in checkpoint.files)
         checkpoint_metadata = json.loads(checkpoint["metadata"].tobytes().decode("utf-8"))
-    assert checkpoint_metadata["schema_version"] == 1
+    assert checkpoint_metadata["schema_version"] == 2
     assert checkpoint_metadata["sweeps_completed"] == 1
     assert checkpoint_metadata["runtime_identity"]["pytensor_float_x"] == ("float64")
     assert checkpoint_metadata["run_manifest_json"] == (hmc_driver._canonical_json(manifest).rstrip("\n"))
@@ -457,7 +509,7 @@ def test_dry_fresh_and_resumed_segments_are_exact_and_auditable(
         engine="h5netcdf",
     ) as fresh_trace:
         fresh_trace.load()
-        assert fresh_trace.attrs["schema"].endswith("native_trace.v1")
+        assert fresh_trace.attrs["schema"].endswith("native_trace.v2")
         assert fresh_trace.attrs["manifest_sha256"] == (
             hmc_driver._sha256_file(fresh_output / hmc_driver.MANIFEST_FILENAME)
         )
@@ -492,6 +544,8 @@ def test_dry_fresh_and_resumed_segments_are_exact_and_auditable(
             fresh_trace["fixed_coefficient"].isel(draw=0),
             np.exp(fresh_trace["log_fixed_coefficient"].isel(draw=0)),
         )
+        assert fresh_trace["hmc_start_log_leaf_mass"].shape == (1, 2)
+        assert fresh_trace["hmc_start_log_fixed_coefficient"].shape == (1, 6)
         assert fresh_trace["leaf_mass"].isel(draw=0, region=0).item() != 0.125
         assert fresh_trace["hmc_seed"].dtype == np.dtype(np.uint64)
         fresh_final_mass = fresh_trace["leaf_mass"].isel(draw=-1).values
@@ -502,10 +556,20 @@ def test_dry_fresh_and_resumed_segments_are_exact_and_auditable(
         (
             "--calibration-id",
             "different-calibration",
-            "Calibration v1 identity",
+            "Calibration v2 identity",
         ),
         ("--chain-id", "different-chain", "manifest does not match"),
-        ("--step-size", "0.002", "Calibration v1 identity"),
+        ("--step-size", "0.002", "Calibration v2 identity"),
+        (
+            "--leaf-contrast-position-scale",
+            "1.5",
+            "Calibration v2 identity",
+        ),
+        (
+            "--leaf-total-position-scale",
+            "2.5",
+            "Calibration v2 identity",
+        ),
     )
     for option, replacement, message in mismatch_cases:
         mismatch_output = tmp_path / option.removeprefix("--")
@@ -726,6 +790,188 @@ def test_driver_rejects_initialization_runtime_and_forbidden_outputs(
 
 
 @_requires_x64_child
+@pytest.mark.parametrize(
+    ("case", "message"),
+    (
+        ("legacy-schema", "retired diagonal metric"),
+        ("legacy-leaf-key", "identity does not exactly match"),
+        ("swapped-leaf-scales", "identity does not exactly match"),
+        ("development-seed-mismatch", "development seeds are incompatible"),
+        ("heldout-seed-equality", "must differ from development seeds"),
+        ("validation-sampler-seed-equality", "sampler seeds must be distinct"),
+        ("heldout-divergence", "does not pass the frozen acceptance gates"),
+        ("heldout-acceptance", "does not pass the frozen acceptance gates"),
+        ("heldout-nonfinite", "Non-standard JSON constant"),
+        ("heldout-failure", "does not pass the frozen acceptance gates"),
+        ("validation-candidate-mismatch", "does not match the selected decision"),
+        ("duplicate-excluded-topology", "topology hashes must be distinct"),
+    ),
+)
+def test_driver_rejects_invalid_v2_calibration_evidence(
+    tmp_path: Path,
+    hmc_driver: ModuleType,
+    case: str,
+    message: str,
+) -> None:
+    """Calibration v2 rejects retired metrics and invalid held-out evidence."""
+    input_path = tmp_path / "frozen.nc"
+    output_path = tmp_path / case
+    _write_frozen_input(input_path)
+    arguments = _arguments(hmc_driver, input_path, output_path)
+    calibration_path = Path(arguments[arguments.index("--calibration-file") + 1])
+    calibration = _json(calibration_path)
+    heldout = calibration["evidence"]["selected_validation"]["initializers"][2]
+
+    if case == "legacy-schema":
+        calibration["schema"] = hmc_driver.LEGACY_CALIBRATION_SCHEMA
+    elif case == "legacy-leaf-key":
+        kernel = calibration["kernel"]
+        kernel["leaf_position_scale"] = kernel.pop("leaf_contrast_position_scale")
+        kernel.pop("leaf_total_position_scale")
+    elif case == "swapped-leaf-scales":
+        kernel = calibration["kernel"]
+        kernel["leaf_contrast_position_scale"], kernel["leaf_total_position_scale"] = (
+            kernel["leaf_total_position_scale"],
+            kernel["leaf_contrast_position_scale"],
+        )
+    elif case == "development-seed-mismatch":
+        calibration["evidence"]["selected_validation"]["initializers"][1]["seed"] = 41006
+    elif case == "heldout-seed-equality":
+        heldout["seed"] = 41003
+    elif case == "validation-sampler-seed-equality":
+        heldout["sampler_seed"] = 72003
+    elif case == "heldout-divergence":
+        heldout["divergences"] = 1
+    elif case == "heldout-acceptance":
+        heldout["mean_acceptance"] = 0.91
+    elif case == "heldout-failure":
+        heldout["finite"] = False
+    elif case == "validation-candidate-mismatch":
+        calibration["evidence"]["selected_validation"]["step_size"] = 0.002
+    elif case == "duplicate-excluded-topology":
+        excluded = calibration["evidence"]["excluded_production_topology_sha256"]
+        excluded["held_out"] = excluded["development_a"]
+
+    calibration_text = hmc_driver._canonical_json(calibration)
+    if case == "heldout-nonfinite":
+        calibration_text = calibration_text.replace(
+            '"mean_acceptance":0.78',
+            '"mean_acceptance":NaN',
+        )
+    calibration_path.write_text(calibration_text, encoding="utf-8")
+    arguments = _replace_option(
+        arguments,
+        "--calibration-sha256",
+        hmc_driver._sha256_file(calibration_path),
+    )
+
+    with pytest.raises(ValueError, match=message):
+        hmc_driver.run(hmc_driver.build_parser().parse_args(arguments))
+    assert not output_path.exists()
+
+
+@_requires_x64_child
+def test_driver_rejects_excessive_leaf_metric_condition_ratio(
+    tmp_path: Path,
+    hmc_driver: ModuleType,
+) -> None:
+    """The production CLI bounds the total/contrast eigenscale ratio."""
+    input_path = tmp_path / "frozen.nc"
+    output_path = tmp_path / "invalid-metric-ratio"
+    _write_frozen_input(input_path)
+    arguments = _replace_option(
+        _arguments(hmc_driver, input_path, output_path),
+        "--leaf-total-position-scale",
+        "20000",
+    )
+
+    with pytest.raises(ValueError, match="maximum-to-minimum position-scale ratio"):
+        hmc_driver.run(hmc_driver.build_parser().parse_args(arguments))
+    assert not output_path.exists()
+
+
+@_requires_x64_child
+@pytest.mark.parametrize(
+    ("option", "value"),
+    (
+        ("--leaf-contrast-position-scale", "200"),
+        ("--leaf-total-position-scale", "200"),
+        ("--fixed-coefficient-position-scale", "0.5,0.75,1,1.25,1.5,200"),
+    ),
+)
+def test_driver_rejects_position_scales_outside_calibration_clipping_bounds(
+    tmp_path: Path,
+    hmc_driver: ModuleType,
+    option: str,
+    value: str,
+) -> None:
+    """Production scales must be possible outputs of the declared clipping rule."""
+    input_path = tmp_path / "frozen.nc"
+    output_path = tmp_path / f"invalid-scale-{option}"
+    _write_frozen_input(input_path)
+    arguments = _replace_option(
+        _arguments(hmc_driver, input_path, output_path),
+        option,
+        value,
+    )
+
+    with pytest.raises(ValueError, match="frozen clipping bounds"):
+        hmc_driver.run(hmc_driver.build_parser().parse_args(arguments))
+    assert not output_path.exists()
+
+
+@_requires_x64_child
+def test_driver_rejects_production_topology_seen_during_calibration(
+    tmp_path: Path,
+    hmc_driver: ModuleType,
+) -> None:
+    """Retained production starts must be disjoint from H2c topology seeds."""
+    input_path = tmp_path / "frozen.nc"
+    output_path = tmp_path / "reused-calibration-topology"
+    _write_frozen_input(input_path)
+    arguments = _replace_option(
+        _arguments(
+            hmc_driver,
+            input_path,
+            output_path,
+            extra=(
+                "--initialization",
+                "random-recursive",
+                "--initialization-seed",
+                "41050",
+            ),
+        ),
+        "--k",
+        "50",
+    )
+
+    with pytest.raises(ValueError, match="disjoint from H2c calibration topology seeds"):
+        hmc_driver.run(hmc_driver.build_parser().parse_args(arguments))
+    assert not output_path.exists()
+
+
+@_requires_x64_child
+def test_driver_rejects_exact_calibration_topology_hash_collision(
+    tmp_path: Path,
+    hmc_driver: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Actual topology identity, not only initializer seed, gates production."""
+    input_path = tmp_path / "frozen.nc"
+    output_path = tmp_path / "reused-calibration-topology-hash"
+    _write_frozen_input(input_path)
+    monkeypatch.setattr(
+        hmc_driver,
+        "_topology_sha256",
+        lambda bounds: "c" * 64,
+    )
+
+    with pytest.raises(ValueError, match="topology hash was used by H2c calibration"):
+        hmc_driver.run(hmc_driver.build_parser().parse_args(_arguments(hmc_driver, input_path, output_path)))
+    assert not output_path.exists()
+
+
+@_requires_x64_child
 def test_artifact_failures_never_publish_completion_certificate(
     tmp_path: Path,
     hmc_driver: ModuleType,
@@ -807,6 +1053,7 @@ def test_artifact_failures_never_publish_completion_certificate(
     )
 
 
+@_requires_x64_child
 def test_parser_and_kernel_settings_make_seed_and_metric_semantics_explicit(
     tmp_path: Path,
     hmc_driver: ModuleType,
@@ -827,6 +1074,21 @@ def test_parser_and_kernel_settings_make_seed_and_metric_semantics_explicit(
     without_calibration = arguments[:calibration_index] + arguments[calibration_index + 2 :]
     with pytest.raises(SystemExit):
         hmc_driver.build_parser().parse_args(without_calibration)
+    for option in (
+        "--leaf-contrast-position-scale",
+        "--leaf-total-position-scale",
+    ):
+        option_index = arguments.index(option)
+        without_metric_scale = arguments[:option_index] + arguments[option_index + 2 :]
+        with pytest.raises(SystemExit):
+            hmc_driver.build_parser().parse_args(without_metric_scale)
+    for option, value in (
+        ("--leaf-contrast-position-scale", "0"),
+        ("--leaf-total-position-scale", "-1"),
+    ):
+        nonpositive = _replace_option(arguments, option, value)
+        with pytest.raises(ValueError, match=f"{option} must be finite and positive"):
+            hmc_driver.run(hmc_driver.build_parser().parse_args(nonpositive))
 
     parsed = hmc_driver.build_parser().parse_args(arguments)
     fixed_scales = hmc_driver._expand_values(
@@ -838,9 +1100,23 @@ def test_parser_and_kernel_settings_make_seed_and_metric_semantics_explicit(
         parsed,
         fixed_scales,
     )
+    expected_matrix = np.diag([0.0, 0.0, 0.5, 0.75, 1.0, 1.25, 1.5, 2.0])
+    expected_matrix[:2, :2] = [[2.0, 0.25], [0.25, 2.0]]
+    np.testing.assert_array_equal(settings.position_scale_matrix, expected_matrix)
     np.testing.assert_array_equal(
         settings.position_scale_diagonal,
-        [1.75, 1.75, 0.5, 0.75, 1.0, 1.25, 1.5, 2.0],
+        [2.0, 2.0, 0.5, 0.75, 1.0, 1.25, 1.5, 2.0],
+    )
+    eigendirections = np.eye(8)
+    eigendirections[:, :2] = 0.0
+    eigendirections[:2, 0] = np.array([1.0, 1.0]) / np.sqrt(2.0)
+    eigendirections[:2, 1] = np.array([1.0, -1.0]) / np.sqrt(2.0)
+    eigenvalues = np.array([2.25, 1.75, 0.5, 0.75, 1.0, 1.25, 1.5, 2.0])
+    np.testing.assert_allclose(
+        settings.position_scale_matrix @ eigendirections,
+        eigendirections * eigenvalues,
+        rtol=0.0,
+        atol=np.finfo(np.float64).eps,
     )
     assert "position_covariance" in (hmc_driver.FULL_TILING_PYMC_HMC_METRIC_SEMANTICS_ID)
     assert "momentum_precision" in (hmc_driver.FULL_TILING_PYMC_HMC_METRIC_SEMANTICS_ID)

--- a/tests/experimental/rjmcmc/test_full_tiling_pymc_hmc_native.py
+++ b/tests/experimental/rjmcmc/test_full_tiling_pymc_hmc_native.py
@@ -94,7 +94,7 @@ def hmc_driver() -> ModuleType:
 
 
 def _write_frozen_input(path: Path) -> None:
-    """Write a tiny exact-closure native dataset with six labelled outers."""
+    """Write exact-closure data whose first fresh mass is not a log/exp fixed point."""
     sensitivity = np.arange(1.0, 13.0).reshape(3, 2, 2)
     outer = np.arange(18.0).reshape(3, 6) / 8.0
     boundary = np.array([4.0, 5.0, 6.0])
@@ -111,7 +111,12 @@ def _write_frozen_input(path: Path) -> None:
             "mf_error": ("nmeasure", np.ones(3)),
             "nominal_weight": (
                 ("lon", "lat"),
-                np.full((2, 2), 0.25).T,
+                np.array(
+                    [
+                        [1.0 / 16.0, 1.0 / 16.0],
+                        [1.0 / 4.0, 5.0 / 8.0],
+                    ],
+                ).T,
             ),
             "outer_design": (("outer_region", "nmeasure"), outer.T),
             "YaprioriBC": ("nmeasure", boundary),
@@ -270,11 +275,13 @@ def test_dry_fresh_and_resumed_segments_are_exact_and_auditable(
     hmc_driver: ModuleType,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A synthetic chain dry-runs, publishes in order, and resumes exactly.
+    """A fresh canonical boundary publishes in order and resumes unchanged.
 
-    The same immutable chain is also used to prove that calibration,
-    provenance, and static-HMC setting changes are rejected by checkpoint
-    manifest validation before any continuation output is published.
+    The fresh state is canonicalized before draw zero; the resumed state uses
+    stored authoritative coordinates unchanged. The same immutable chain also
+    proves that calibration, provenance, and static-HMC setting changes are
+    rejected by checkpoint manifest validation before continuation output is
+    published.
     """
     input_path = tmp_path / "frozen.nc"
     dry_output = tmp_path / "dry-output"
@@ -379,6 +386,9 @@ def test_dry_fresh_and_resumed_segments_are_exact_and_auditable(
     assert manifest["sampler"]["metric_semantics_id"] == (hmc_driver.FULL_TILING_PYMC_HMC_METRIC_SEMANTICS_ID)
     assert manifest["sampler"]["leaf_position_scale"] == 1.75
     assert manifest["sampler"]["fixed_coefficient_position_scale"] == [0.5, 0.75, 1.0, 1.25, 1.5, 2.0]
+    assert (
+        manifest["initialization"]["state_sha256"] == fresh_summary["lineage"]["segment_start_state_sha256"]
+    )
     assert manifest["sampler"]["calibration"] == {
         "schema": hmc_driver.CALIBRATION_SCHEMA,
         "id": "tiny-static-hmc-calibration-v1",
@@ -466,6 +476,23 @@ def test_dry_fresh_and_resumed_segments_are_exact_and_auditable(
             fresh_trace["state_sweep"],
             [0, 1],
         )
+        assert (
+            fresh_trace["log_target"].isel(draw=0).item()
+            == (fresh_summary["target"]["chain_initial_log_target"])
+        )
+        assert (
+            fresh_trace["log_target"].isel(draw=0).item()
+            == (fresh_summary["target"]["segment_initial_log_target"])
+        )
+        np.testing.assert_array_equal(
+            fresh_trace["leaf_mass"].isel(draw=0),
+            np.exp(fresh_trace["log_leaf_mass"].isel(draw=0)),
+        )
+        np.testing.assert_array_equal(
+            fresh_trace["fixed_coefficient"].isel(draw=0),
+            np.exp(fresh_trace["log_fixed_coefficient"].isel(draw=0)),
+        )
+        assert fresh_trace["leaf_mass"].isel(draw=0, region=0).item() != 0.125
         assert fresh_trace["hmc_seed"].dtype == np.dtype(np.uint64)
         fresh_final_mass = fresh_trace["leaf_mass"].isel(draw=-1).values
         fresh_final_fixed = fresh_trace["fixed_coefficient"].isel(draw=-1).values


### PR DESCRIPTION
## Summary

- add an experimental fixed-K full-tiling compound kernel that runs one existing topology transition followed by one native PyMC static-HMC transition
- preserve authoritative log-mass/log-coefficient coordinates, exact PCG64 replay, and strict no-pickle durable continuation
- add a frozen-input native driver with verified calibration evidence, certified parent-bundle lineage, audited NetCDF/checkpoint publication, and separated compilation/sampling timings
- add planning/background and a pinned HPC calibration plus real-data comparison plan

## Why

The fixed-basis NumPyro NUTS reference showed that the local continuous kernel was the dominant fixed-topology mixing bottleneck. This experiment tests whether joint HMC updates repair that bottleneck while the full-tiling topology remains mobile, without changing the scientific target.

This is a stacked draft based on `codex/rjmcmc-fixed-basis-nuts-reference` (`c5f908c`) so the review diff contains only the compound-HMC work.

## Validation

- focused experimental suite: `15 passed, 30 skipped`; PyMC-dependent skipped cases execute in isolated float64 child processes
- Ruff check and format check: passed
- Pyright on core, checkpoint I/O, and native driver: 0 errors
- independent final review: no blockers

The repository-wide tox matrix was intentionally not run for this experimental workstream. HPC calibration and stages H1-H5 remain the required real-data gate; no posterior claims are made by this draft.