### PR TITLE
Check country file before HBMCMC run

### DIFF
--- a/openghg_inversions/hbmcmc/run_hbmcmc.py
+++ b/openghg_inversions/hbmcmc/run_hbmcmc.py
@@ -364,6 +364,13 @@ def main(argv: list[str] | None = None) -> None:
     with timed("run_hbmcmc.validation"):
         validate_rhime_params(rhime_params)
 
+    country_file = rhime_params.get("country_file")
+    if country_file is not None and str(country_file).strip():
+        country_file_path = Path(country_file)
+        if not country_file_path.exists():
+            raise FileNotFoundError(f"Configured country_file does not exist: {country_file_path}")
+
+    # TODO(#423): Validate BC and saved fp-basis files, including glob matches and readability.
     with timed("run_hbmcmc.config_copy"):
         output.copy_config_file(str(config_file), param=param, **command_line_args)
 

--- a/tests/test_run_hbmcmc_shim.py
+++ b/tests/test_run_hbmcmc_shim.py
@@ -255,3 +255,29 @@ def test_run_hbmcmc_main_validates_rhime_params_before_copying_config(
                 '{"unknown_rhime_option": true}',
             ]
         )
+
+
+def test_run_hbmcmc_main_checks_country_file_before_copying_or_running(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A configured missing country file fails before output side effects."""
+    config_file = tmp_path / "hbmcmc.ini"
+    missing_country_file = tmp_path / "missing_country_file.nc"
+    _fixedbasis_config(config_file)
+    config_file.write_text(
+        config_file.read_text(encoding="utf-8")
+        + f'\n[INPUT.BASIS_CASE]\ncountry_file = "{missing_country_file}"\n',
+        encoding="utf-8",
+    )
+
+    def fail_copy_config_file(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("Config copy should happen only after country-file validation.")
+
+    def fail_run_rhime(**kwargs: Any) -> None:
+        raise AssertionError("RHIME should run only after country-file validation.")
+
+    monkeypatch.setattr(run_hbmcmc.output, "copy_config_file", fail_copy_config_file)
+    monkeypatch.setattr(run_hbmcmc, "run_rhime", fail_run_rhime)
+
+    with pytest.raises(FileNotFoundError, match="country_file"):
+        run_hbmcmc.main(["-c", str(config_file)])


### PR DESCRIPTION
## Summary of changes

- Check an explicitly configured `country_file` exists in `run_hbmcmc.py` before config-copy or RHIME side effects.
- Raise a clear `FileNotFoundError` for a missing file.
- Defer broader BC and saved FP-basis artifact validation to #423.

## Why

A missing country file was otherwise discovered only after expensive inversion work. This provides a minimal early failure for the directly configured file path.

## Validation

- `uv run pytest tests/test_run_hbmcmc_shim.py`
- `uv run ruff check openghg_inversions/hbmcmc/run_hbmcmc.py tests/test_run_hbmcmc_shim.py`
- `uv run ruff format --check openghg_inversions/hbmcmc/run_hbmcmc.py tests/test_run_hbmcmc_shim.py`
- `uv run pyright openghg_inversions/hbmcmc/run_hbmcmc.py tests/test_run_hbmcmc_shim.py`

## Checklist

- [x] Closes #93
- [x] Tests added and passing
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry to the `CHANGELOG.md` file
- [ ] Added any new requirements to `requirements.txt`