### PR TITLE
Add connected basis region strategies

### DIFF
--- a/openghg_inversions/basis/algorithms/__init__.py
+++ b/openghg_inversions/basis/algorithms/__init__.py
@@ -1,16 +1,12 @@
 """Algorithms for computing basis functions."""
 
-from ._contrast import (
-    ContrastScoreSplitAcceptance,
-    SplitContrastScore,
-    contrast_tau_from_multiplier_cv,
-    split_contrast_score,
-)
 from ._constrained import (
     AllocationMode,
     AllSplitAcceptancePolicies,
-    AxisParallelSplitStep,
     AxisAlignedWeightedSplitStrategy,
+    AxisParallelSplitStep,
+    ConnectedComponentPartitionStep,
+    ConnectedComponentSplitStrategy,
     GreedyAxisParallelSplitStrategy,
     InertialSplitStep,
     LatLonGridGeometry,
@@ -28,14 +24,22 @@ from ._constrained import (
     intersect_region_class_layers,
     region_constrained_basis,
 )
+from ._contrast import (
+    ContrastScoreSplitAcceptance,
+    SplitContrastScore,
+    contrast_tau_from_multiplier_cv,
+    split_contrast_score,
+)
 from ._quadtree import get_quadtree_basis as quadtree_algorithm
 from ._weighted import nregion_landsea_basis as weighted_algorithm
 
 __all__ = [
-    "AllocationMode",
     "AllSplitAcceptancePolicies",
-    "AxisParallelSplitStep",
+    "AllocationMode",
     "AxisAlignedWeightedSplitStrategy",
+    "AxisParallelSplitStep",
+    "ConnectedComponentPartitionStep",
+    "ConnectedComponentSplitStrategy",
     "ContrastScoreSplitAcceptance",
     "GreedyAxisParallelSplitStrategy",
     "InertialSplitStep",
@@ -44,11 +48,12 @@ __all__ = [
     "MinChildTargetWeightShare",
     "MinChildWeightShare",
     "NbasisAllocation",
-    "SplitAcceptance",
-    "SplitStrategy",
     "PartitionStep",
+    "SplitAcceptance",
     "SplitAcceptancePolicy",
+    "SplitContrastScore",
     "SplitGeometry",
+    "SplitStrategy",
     "TargetSplitAcceptancePolicy",
     "allocate_nbasis_by_class",
     "contrast_tau_from_multiplier_cv",
@@ -56,6 +61,5 @@ __all__ = [
     "quadtree_algorithm",
     "region_constrained_basis",
     "split_contrast_score",
-    "SplitContrastScore",
     "weighted_algorithm",
 ]

--- a/openghg_inversions/basis/algorithms/_constrained.py
+++ b/openghg_inversions/basis/algorithms/_constrained.py
@@ -37,6 +37,7 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 import xarray as xr
+from scipy import ndimage
 
 from ._weighted import bucket_value_split
 
@@ -617,6 +618,74 @@ class InertialSplitStep:
         return [left, right]
 
 
+def _connected_node_components(
+    nodes: GridPartition,
+    shape: tuple[int, int],
+    *,
+    connectivity: int,
+) -> list[GridPartition]:
+    """Return deterministic connected components for grid nodes."""
+    if not nodes:
+        return []
+    if connectivity not in (1, 2):
+        raise ValueError("connectivity must be 1 (edge) or 2 (edge and corner).")
+
+    mask = np.zeros(shape, dtype=bool)
+    rows, columns = zip(*nodes, strict=True)
+    mask[np.asarray(rows), np.asarray(columns)] = True
+    labels, count = ndimage.label(
+        mask,
+        structure=ndimage.generate_binary_structure(2, connectivity),
+    )
+    return [
+        list(zip(*np.where(labels == component), strict=True))
+        for component in range(1, int(count) + 1)
+    ]
+
+
+@dataclass(frozen=True)
+class ConnectedComponentPartitionStep:
+    """Make every child from another partition step spatially connected.
+
+    This wrapper is useful for partition steps such as
+    :class:`InertialSplitStep`, whose one-dimensional projection can assign
+    spatially disconnected cells to the same child. Each proposed child is
+    decomposed into deterministic connected components before the greedy
+    orchestrator accepts it.
+
+    Attributes:
+        split_step: Partition step whose children should be made connected.
+        connectivity: Two-dimensional neighbourhood definition. ``1`` uses
+            edge-sharing (four-neighbour) connectivity and ``2`` additionally
+            includes corner-sharing (eight-neighbour) connectivity.
+    """
+
+    split_step: PartitionStep
+    connectivity: int = 1
+
+    def __post_init__(self) -> None:
+        """Validate the requested two-dimensional connectivity."""
+        if self.connectivity not in (1, 2):
+            raise ValueError("connectivity must be 1 (edge) or 2 (edge and corner).")
+
+    def __call__(
+        self,
+        nodes: GridPartition,
+        weights: np.ndarray,
+    ) -> list[GridPartition]:
+        """Split once, then separate disconnected pieces of every child."""
+        children = self.split_step(nodes, weights)
+        return [
+            component
+            for child in children
+            for component in _connected_node_components(
+                child,
+                weights.shape,
+                connectivity=self.connectivity,
+            )
+        ]
+
+
 @dataclass(frozen=True)
 class GreedyAxisParallelSplitStrategy:
     """Class-local greedy repeated-bisection strategy.
@@ -673,6 +742,105 @@ class GreedyAxisParallelSplitStrategy:
             split_acceptance=self.split_acceptance,
         )
         return _labels_from_node_partition(partition, weights.shape)
+
+
+@dataclass
+class ConnectedComponentSplitStrategy:
+    """Allocate and split each connected piece of a class independently.
+
+    A disconnected class requires at least one label per connected component.
+    If ``target_regions`` is below that geographic minimum, the effective
+    target is raised rather than assigning one label to disconnected cells.
+    Targets above the minimum are allocated across components by weight, with
+    the existing area fallback for all-zero weights.
+
+    Attributes:
+        split_strategy: Class-local strategy applied separately to each
+            connected component.
+        connectivity: Two-dimensional neighbourhood definition. ``1`` uses
+            edge-sharing (four-neighbour) connectivity and ``2`` additionally
+            includes corner-sharing (eight-neighbour) connectivity.
+        diagnostics: Per-call requested, minimum, effective, and actual region
+            counts.
+    """
+
+    split_strategy: SplitStrategy
+    connectivity: int = 1
+    diagnostics: list[dict[str, int]] = field(default_factory=list, init=False)
+
+    def __post_init__(self) -> None:
+        """Validate the requested two-dimensional connectivity."""
+        if self.connectivity not in (1, 2):
+            raise ValueError("connectivity must be 1 (edge) or 2 (edge and corner).")
+
+    def __call__(
+        self,
+        weights: np.ndarray,
+        class_mask: np.ndarray,
+        target_regions: int,
+    ) -> np.ndarray:
+        """Return connected labels, raising the target to the geographic minimum."""
+        if target_regions < 1:
+            raise ValueError("target_regions must be at least 1.")
+        if weights.shape != class_mask.shape or weights.ndim != 2:
+            raise ValueError("weights and class_mask must be aligned two-dimensional arrays.")
+        if not class_mask.any():
+            return np.zeros(weights.shape, dtype=np.int64)
+
+        component_labels, component_count = ndimage.label(
+            class_mask,
+            structure=ndimage.generate_binary_structure(2, self.connectivity),
+        )
+        effective_target = min(
+            max(int(target_regions), int(component_count)),
+            int(class_mask.sum()),
+        )
+        dims = ("row", "column")
+        coordinates = {
+            "row": np.arange(weights.shape[0]),
+            "column": np.arange(weights.shape[1]),
+        }
+        allocation = allocate_nbasis_by_class(
+            xr.DataArray(weights, dims=dims, coords=coordinates),
+            xr.DataArray(component_labels, dims=dims, coords=coordinates),
+            effective_target,
+            allocation="weight",
+            min_regions_per_class=1,
+            unmapped_values=(0,),
+        )
+
+        labels = np.zeros(weights.shape, dtype=np.int64)
+        next_region = 1
+        for component in range(1, int(component_count) + 1):
+            component_mask = component_labels == component
+            local_labels = self.split_strategy(
+                weights,
+                component_mask,
+                allocation[component],
+            )
+            if not np.array_equal(local_labels > 0, component_mask):
+                raise RuntimeError("Connected split strategy did not preserve class coverage.")
+            for local_region in _positive_labels(local_labels):
+                region_mask = local_labels == local_region
+                _component_labels, region_component_count = ndimage.label(
+                    region_mask,
+                    structure=ndimage.generate_binary_structure(2, self.connectivity),
+                )
+                if int(region_component_count) != 1:
+                    raise RuntimeError("Connected split strategy produced a disconnected label.")
+                labels[region_mask] = next_region
+                next_region += 1
+
+        actual_regions = next_region - 1
+        self.diagnostics.append(
+            {
+                "requested_target": int(target_regions),
+                "connected_component_minimum": int(component_count),
+                "effective_target": int(effective_target),
+                "actual_regions": int(actual_regions),
+            }
+        )
+        return labels
 
 
 @dataclass(frozen=True)
@@ -1837,16 +2005,18 @@ def _labels_dataarray(labels: np.ndarray, weights: xr.DataArray) -> xr.DataArray
 
 
 __all__ = [
-    "AllocationMode",
     "AllSplitAcceptancePolicies",
-    "AxisParallelSplitStep",
+    "AllocationMode",
     "AxisAlignedWeightedSplitStrategy",
+    "AxisParallelSplitStep",
+    "ConnectedComponentPartitionStep",
+    "ConnectedComponentSplitStrategy",
     "GreedyAxisParallelSplitStrategy",
     "InertialSplitStep",
     "LatLonGridGeometry",
     "MaxChildPCAEccentricity",
-    "MinChildWeightShare",
     "MinChildTargetWeightShare",
+    "MinChildWeightShare",
     "NbasisAllocation",
     "PartitionStep",
     "SplitAcceptance",

--- a/tests/test_constrained_basis_algorithm.py
+++ b/tests/test_constrained_basis_algorithm.py
@@ -1,10 +1,13 @@
 import numpy as np
 import pytest
 import xarray as xr
+from scipy import ndimage
 
 from openghg_inversions.basis.algorithms import (
     AllSplitAcceptancePolicies,
     AxisParallelSplitStep,
+    ConnectedComponentPartitionStep,
+    ConnectedComponentSplitStrategy,
     ContrastScoreSplitAcceptance,
     GreedyAxisParallelSplitStrategy,
     InertialSplitStep,
@@ -282,6 +285,103 @@ def test_greedy_axis_parallel_strategy_hits_target_region_count():
     labels = GreedyAxisParallelSplitStrategy()(weights, class_mask, target_regions=5)
 
     assert set(np.unique(labels)) == {1, 2, 3, 4, 5}
+
+
+class CheckerboardSplitStep:
+    """Split nodes into parity groups that are disconnected by edges."""
+
+    def __call__(
+        self,
+        nodes: list[tuple[int, int]],
+        _weights: np.ndarray,
+    ) -> list[list[tuple[int, int]]]:
+        even = [node for node in nodes if sum(node) % 2 == 0]
+        odd = [node for node in nodes if sum(node) % 2 == 1]
+        return [even, odd]
+
+
+def test_connected_component_partition_step_splits_disconnected_children():
+    """Partition-step children are decomposed into deterministic components."""
+    nodes = [(0, 0), (0, 1), (1, 0), (1, 1)]
+    step = ConnectedComponentPartitionStep(
+        CheckerboardSplitStep(),
+        connectivity=1,
+    )
+
+    children = step(nodes, np.ones((2, 2), dtype=float))
+
+    assert children == [[(0, 0)], [(1, 1)], [(0, 1)], [(1, 0)]]
+
+
+def test_connected_strategy_raises_target_to_disconnected_class_minimum():
+    """Disconnected class pieces receive distinct labels below the minimum target."""
+    weights = np.asarray(
+        [
+            [1.0, 0.0, 0.0],
+            [1.0, 0.0, 2.0],
+            [0.0, 0.0, 2.0],
+        ]
+    )
+    class_mask = weights > 0
+    strategy = ConnectedComponentSplitStrategy(
+        GreedyAxisParallelSplitStrategy(),
+        connectivity=1,
+    )
+
+    labels = strategy(weights, class_mask, target_regions=1)
+
+    np.testing.assert_array_equal(labels > 0, class_mask)
+    assert set(np.unique(labels)) == {0, 1, 2}
+    assert strategy.diagnostics == [
+        {
+            "requested_target": 1,
+            "connected_component_minimum": 2,
+            "effective_target": 2,
+            "actual_regions": 2,
+        }
+    ]
+
+
+def test_connected_strategy_four_and_eight_neighbour_diagonal_adjacency():
+    """Connectivity controls whether diagonally adjacent cells share a label."""
+    weights = np.eye(2, dtype=float)
+    class_mask = weights > 0
+    four_neighbour = ConnectedComponentSplitStrategy(
+        GreedyAxisParallelSplitStrategy(),
+        connectivity=1,
+    )
+    eight_neighbour = ConnectedComponentSplitStrategy(
+        GreedyAxisParallelSplitStrategy(),
+        connectivity=2,
+    )
+
+    four_labels = four_neighbour(weights, class_mask, target_regions=1)
+    eight_labels = eight_neighbour(weights, class_mask, target_regions=1)
+
+    assert int(four_labels.max()) == 2
+    assert int(eight_labels.max()) == 1
+
+
+def test_connected_strategy_zero_weight_components_use_area_fallback():
+    """All-zero component weights still receive the requested allocation."""
+    weights = np.zeros((2, 4), dtype=float)
+    class_mask = np.asarray(
+        [
+            [True, True, False, True],
+            [True, True, False, True],
+        ]
+    )
+    strategy = ConnectedComponentSplitStrategy(
+        GreedyAxisParallelSplitStrategy(),
+        connectivity=1,
+    )
+
+    labels = strategy(weights, class_mask, target_regions=3)
+
+    np.testing.assert_array_equal(labels > 0, class_mask)
+    assert np.array_equal(np.unique(labels), np.asarray([0, 1, 2, 3]))
+    for region in (1, 2, 3):
+        assert ndimage.label(labels == region)[1] == 1
 
 
 def test_axis_parallel_split_uses_lat_lon_geometry_for_axis_choice():


### PR DESCRIPTION
## Summary

- add `ConnectedComponentPartitionStep` to decompose proposed partition children into deterministic connected components
- add `ConnectedComponentSplitStrategy` to allocate region targets across disconnected class components before splitting
- support four-neighbour and eight-neighbour connectivity, geographic-minimum target increases, zero-weight area fallback, and per-call allocation diagnostics
- export both strategies from `openghg_inversions.basis.algorithms`
- port focused tests from the verification-games implementation

## Why

Region-constrained classes and inertial projection splits can assign the same basis label to spatially disconnected cells. Repairing labels only after basis generation can greatly inflate the state dimension. Enforcing connectivity during component allocation and each partition step preserves compact bases while guaranteeing the configured connectivity definition.

This moves the reusable implementation out of verification-games and into OpenGHG Inversions, leaving verification-games responsible only for composing the strategies with its domain-specific masks and geometry.

## Validation

- `tox -e py310-openghgCur -- tests/test_basis_functions.py tests/test_constrained_basis_algorithm.py` — 143 passed
- `uv run pytest tests/test_constrained_basis_algorithm.py` — 77 passed
- `tox -e lint -- --ignore PLR0124 openghg_inversions/basis/algorithms/_constrained.py openghg_inversions/basis/algorithms/__init__.py tests/test_constrained_basis_algorithm.py` — passed (`PLR0124` is a pre-existing warning in the test helper)
- `git diff --check` — passed

The full `tox -p` run reached 97% of 589 tests but remained in CPU-heavy numerical tests for more than an hour and was stopped. Its lint environment also traversed unrelated untracked files in the shared worktree; scoped lint on every changed file passes.