### PR TITLE
Route multiple flux sources through RHIME sectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,8 +214,9 @@ RHIME terminology:
 - `species`: primary gas or tracer name used for object-store lookup and output naming.
 - `source`: OpenGHG metadata key used to retrieve flux data.
 - `flux_sources`: RHIME field containing requested OpenGHG flux `source` values.
-- `sector_sources`: optional mapping from RHIME sector names to OpenGHG flux `source` values.
-- `sector`: model component optimized separately, usually backed by one flux `source`.
+- `sector_sources`: optional one-to-one mapping from RHIME sector names to unique OpenGHG flux `source` values.
+- `sector_priors`: optional complete mapping from RHIME sector names to flux-scaling priors; omit it to use a shared `x_prior`.
+- `sector`: model component optimized separately, currently backed by one unique flux `source`.
 - `tracer`: additional species used to constrain the primary species through linked forward models.
 - `emissions_name`: legacy compatibility spelling only; use `flux_sources` in new RHIME configs.
 

--- a/docs/plans/issues_402_403_builder_strategy_design.md
+++ b/docs/plans/issues_402_403_builder_strategy_design.md
@@ -109,21 +109,24 @@ The current code already has most of the mathematical behavior:
 - Generic and PARIS postprocessing reconstruct sector fluxes and calculate
   physical totals from reconstructed fluxes rather than summed scale factors.
 
-The central acceptance item is still missing:
+The central acceptance item is now implemented, with some binary orchestration
+still visible at the runner boundary:
 
-- The loop implementation is hard-coded in
-  `build_rhime_multisector_model(...)`.
+- Standard and multisector declarations normalize into the same private
+  `_FluxPlan` representation before PyMC compilation.
 - Standard and multisector runners still select different builders and output
   paths through a `multisector` boolean.
 - `run_rhime_from_prepared_inputs(...)` is the correct new execution boundary,
   but it still requires model sector count, `split_by_sectors`, and the
   presence of `H.source` to encode the same binary mode.
-- The current builder consumes padded `H(region, nmeasure, source)` even though
-  the basis layer can represent ragged state spaces without padding.
+- Shared-basis sensitivity can remain `H(region, nmeasure, source)`;
+  source-specific bases remain gathered over
+  `(source, region_in_source)` and are selected into separate term designs
+  without padding.
 
-The conclusion is stronger than in the first note: #402 should remain open
-until a real internal compilation seam exists. A public strategy option is not
-required, but a private normalized linear-term boundary is.
+The private normalized linear-term boundary now exists. Remaining builder
+selection in the runner is orchestration around that common compiler, not a
+second mathematical implementation.
 
 ### Issue 403
 

--- a/docs/plans/issues_402_403_builder_strategy_design.md
+++ b/docs/plans/issues_402_403_builder_strategy_design.md
@@ -144,16 +144,16 @@ Important limitations and one correction:
   `ModelScenario` ability to combine several sources into one total prior flux.
 - Each `SectorSpec` contains exactly one `flux_source`. One optimized component
   cannot be backed by several sources.
-- `sector_sources` is not a strict one-to-one mapping. Multiple sectors may
-  point to the same source because validation compares sets of source values.
-  That can create separate, potentially non-identifiable states over the same
-  sensitivity. The actual invariant is "one source reference per sector", not
-  a bijection.
+- The narrow #403 implementation now treats `sector_sources` as one-to-one.
+  Duplicate source values are rejected because separate states over the same
+  sensitivity are generally non-identifiable. Broader cardinalities belong in
+  explicit component/state/term relations rather than this renaming adapter.
 - The canonical prepared coordinate is `source`, not `sector`. Renaming that
   coordinate to `sector` merely to satisfy the issue wording would make the
   architecture less clear.
-- Unknown or unused sector-prior keys should be treated deliberately rather
-  than silently becoming configuration debris.
+- `sector_priors`, when supplied, must contain exactly one prior for every
+  sector. Omitting it applies the shared `x_prior`; partial maps are rejected
+  rather than silently falling back after a typo.
 
 The original #403 acceptance criteria can be closed narrowly around the current
 one-source-per-sector case once its prepared-data contract and validation are

--- a/docs/usage/concrete_rhime_model.rst
+++ b/docs/usage/concrete_rhime_model.rst
@@ -113,6 +113,12 @@ The default priors are:
      - Normal with mean 0 and standard deviation 1
      - ``offset_latent`` and ``offset``
 
+This table describes the Python builder default used when ``x_prior`` is
+omitted. The shipped RHIME config template instead supplies an explicit
+``x_prior`` without ``reparameterise=True``. That config therefore creates
+``x`` directly, without ``x_latent``. Add ``"reparameterise": True`` to the
+config prior to request the API-default parameterization shown here.
+
 The important default model-data and deterministic names are:
 
 .. list-table::

--- a/docs/usage/rhime.rst
+++ b/docs/usage/rhime.rst
@@ -21,12 +21,19 @@ Terminology
 
 ``sector``
    Model component optimized separately in a multi-sector RHIME run. A sector
-   is usually backed by one flux ``source``.
+   is currently backed by one unique flux ``source``.
 
 ``sector_sources``
    Optional mapping from sector names to OpenGHG ``source`` values. Use this
    when sector labels such as ``FF`` or ``ocean`` differ from the source names
-   used to retrieve flux data.
+   used to retrieve flux data. The current multi-sector model requires a
+   one-to-one mapping: two independently optimized sectors cannot select the
+   same source.
+
+``sector_priors``
+   Optional mapping containing one flux-scaling prior for every sector. When
+   omitted, all sectors use the shared ``x_prior``. When supplied, missing and
+   unused sector keys are errors.
 
 ``tracer``
    Additional species used to constrain the primary species, normally with
@@ -78,6 +85,18 @@ Python API
            "ocean": {"pdf": "lognormal", "mean": 1.0, "stdev": 1.0},
        },
    )
+
+The canonical prepared sensitivity is ``H(region, nmeasure, source)``.
+``source`` remains the OpenGHG retrieval identity; sector names and priors live
+in the model specification and select ``H`` by source label. Source-coordinate
+order therefore does not determine sector routing. Prepared source-resolved
+sensitivities also carry ``source_region_count(source)`` so the current builder
+can reject padded source-specific state layouts explicitly.
+
+The current builder supports one distinct source and one independent state
+vector per sector. Source-specific bases must have compatible region counts.
+Ragged source-specific state blocks are rejected instead of being padded with
+unconstrained latent elements.
 
 Running Prepared Inputs
 -----------------------
@@ -166,7 +185,10 @@ New RHIME config files should use ``flux_sources``:
    output_name = "example"
 
 For multi-sector RHIME, use ``sector_sources`` when the optimized sector names
-are not the same strings as the OpenGHG source values.
+are not the same strings as the OpenGHG source values. Its values must match
+``flux_sources`` exactly and must be unique. If ``sector_priors`` is supplied,
+it must contain exactly the same sector keys as ``sector_sources``; otherwise
+omit it and use one shared ``x_prior``.
 
 .. code-block:: ini
 

--- a/docs/usage/rhime.rst
+++ b/docs/usage/rhime.rst
@@ -86,17 +86,21 @@ Python API
        },
    )
 
-The canonical prepared sensitivity is ``H(region, nmeasure, source)``.
+Shared-basis preparation uses ``H(region, nmeasure, source)``. When sources
+have different basis indexes, preparation instead keeps one gathered state
+dimension whose MultiIndex levels are ``(source, region_in_source)``. This is
+the same concat-gather representation used for ``nmeasure`` with
+``(site, time)`` levels: ragged values are concatenated rather than padded.
+Modern preparation preserves the state-dimension name supplied by the basis
+operator; it does not rename arbitrary state axes to ``region``.
+
 ``source`` remains the OpenGHG retrieval identity; sector names and priors live
 in the model specification and select ``H`` by source label. Source-coordinate
-order therefore does not determine sector routing. Prepared source-resolved
-sensitivities also carry ``source_region_count(source)`` so the current builder
-can reject padded source-specific state layouts explicitly.
-
-The current builder supports one distinct source and one independent state
-vector per sector. Source-specific bases must have compatible region counts.
-Ragged source-specific state blocks are rejected instead of being padded with
-unconstrained latent elements.
+order therefore does not determine sector routing. The current builder
+supports one distinct source and one independent state vector per sector.
+Rectangular legacy inputs may carry ``source_region_count(source)`` so padded
+layouts can be rejected; modern preparation does not create that compatibility
+metadata.
 
 Running Prepared Inputs
 -----------------------

--- a/docs/usage/rhime.rst
+++ b/docs/usage/rhime.rst
@@ -152,12 +152,15 @@ model, output, and sampler specifications:
 
 The prepared object is trusted canonical input: it must already contain the
 observation, error, sensitivity, and optional boundary-condition variables
-required by the selected model. A multisector run requires a ``source``
-dimension on ``prepared.inv_inputs["H"]`` and
-``run_spec.split_by_sectors=True``; a single-sector run requires neither. The
-sector count, prepared ``H`` layout, layout flag, and output settings are
-validated before model construction or sampling. Output side effects are still
-controlled by ``RhimeOutputSpec``.
+required by the selected model. A multisector run requires
+``run_spec.split_by_sectors=True`` and a source-resolved layout on
+``prepared.inv_inputs["H"]``. Shared-basis inputs may use a rectangular
+``source`` dimension. Source-specific, ragged state blocks use one gathered
+state dimension with a ``(source, region_in_source)`` MultiIndex. A scalar
+``source`` coordinate is provenance for a single-sector input, not a
+multisector layout. The sector count, prepared ``H`` layout, layout flag, and
+output settings are validated before model construction or sampling. Output
+side effects are still controlled by ``RhimeOutputSpec``.
 
 Model Construction
 ------------------

--- a/openghg_inversions/array_ops.py
+++ b/openghg_inversions/array_ops.py
@@ -41,14 +41,14 @@ an xarray issue, which now is written in terms of ``force_align``.
 
 from __future__ import annotations
 
-from collections.abc import Hashable, Iterable, Mapping, Sequence
-from typing import Any, Literal, overload, TypeVar
 import warnings
+from collections.abc import Hashable, Iterable, Mapping, Sequence
+from typing import Any, Literal, TypeVar, overload
 
-from dask.array.core import Array as DaskArray
 import numpy as np
 import pandas as pd
 import xarray as xr
+from dask.array.core import Array as DaskArray
 from sparse import COO, SparseArray
 from xarray.core.common import DataWithCoords, is_chunked_array  # type: ignore
 
@@ -297,20 +297,24 @@ def concat_gather_data_arrays(
     stack_dim: str | None = None,
     **concat_kwargs,
 ) -> xr.DataArray:
-    """Concatenate DataArrays by gathering along ragged coordinate.
+    """Concatenate DataArrays by gathering along a ragged coordinate.
 
     For example, if the keys are site codes and the ragged dimension is time,
-    then the "stacked dimension" will be the usual `nmeasure` coordinate.
+    then the stacked dimension is the usual ``nmeasure`` coordinate with
+    ``(site, time)`` levels. The same operation can gather source-specific
+    state blocks into ``(source, region_in_source)`` without rectangular
+    padding. Any alignment policy for dimensions other than ``ragged_dim``
+    should be passed explicitly through ``concat_kwargs``.
 
     Args:
-        da_dict: dictionary of DataArrays
-        key_dim: dimension name for the keys of the dictionary
-        ragged_dim: name of the ragged dimension
-        stack_dim: name for the "stacked" multi-index dimension
-        **concat_kwargs: arguments to pass to xr.concat
+        da_dict: DataArrays keyed by the values to record in ``key_dim``.
+        key_dim: Dimension name for the mapping keys.
+        ragged_dim: Name of the ragged dimension.
+        stack_dim: Name for the gathered MultiIndex dimension.
+        **concat_kwargs: Arguments passed to :func:`xarray.concat`.
 
     Returns:
-        Combined DataArray with new stacked dimension.
+        Combined DataArray with a new gathered dimension.
 
     """
     stack_dim = stack_dim or (key_dim + "_" + ragged_dim)
@@ -344,6 +348,52 @@ def concat_gather_data_arrays(
     da = da.assign_coords(xr_multiindex)
 
     return da
+
+
+def select_gathered_data_array(
+    da: xr.DataArray,
+    *,
+    key: Any,
+    key_dim: str,
+    ragged_dim: str,
+    stack_dim: str,
+) -> xr.DataArray:
+    """Select one key from a gathered DataArray and restore its ragged index.
+
+    This is the labelled inverse of one branch of
+    :func:`concat_gather_data_arrays`. The gathered dimension remains named
+    ``stack_dim``, but its ``(key_dim, ragged_dim)`` MultiIndex is reduced to
+    the selected ``ragged_dim`` labels.
+
+    Args:
+        da: DataArray containing a gathered MultiIndex dimension.
+        key: Key value to select from the gathered index.
+        key_dim: Name of the key level in the gathered MultiIndex.
+        ragged_dim: Name of the ragged level in the gathered MultiIndex.
+        stack_dim: Name of the gathered dimension.
+
+    Returns:
+        Selected DataArray indexed by the original ragged labels.
+
+    Raises:
+        TypeError: If the gathered dimension does not use a pandas MultiIndex.
+        ValueError: If the gathered levels or requested key are invalid.
+    """
+    index = da.indexes.get(stack_dim)
+    if not isinstance(index, pd.MultiIndex):
+        raise TypeError(f"Dimension {stack_dim!r} must have a pandas MultiIndex.")
+    if list(index.names) != [key_dim, ragged_dim]:
+        raise ValueError(
+            f"Dimension {stack_dim!r} must gather ({key_dim!r}, {ragged_dim!r}); "
+            f"found levels {list(index.names)!r}."
+        )
+    if key not in index.get_level_values(key_dim):
+        raise ValueError(f"Gathered dimension {stack_dim!r} does not contain {key_dim} value {key!r}.")
+
+    positions = np.flatnonzero(index.get_level_values(key_dim) == key)
+    selected = da.isel({stack_dim: positions}).reset_index(stack_dim)
+    selected = selected.drop_vars(key_dim)
+    return selected.set_index({stack_dim: ragged_dim})
 
 
 def concat_gather_datasets(

--- a/openghg_inversions/basis/_helpers.py
+++ b/openghg_inversions/basis/_helpers.py
@@ -194,10 +194,10 @@ def _legacy_multisource_h_if_needed(
     """Legacy adapter for gathered multi-source H.
 
     ``MultiSourceBucketBasisOperator.sensitivity`` returns a gathered MultiIndex
-    state dimension. Current multisector model builders and legacy output code
-    still expect separate ``region`` and ``source`` dimensions, so this converts
-    to legacy ``(region, time, source)`` shape at the wrapper boundary until
-    downstream code accepts gathered H.
+    state dimension. ``fixedbasisMCMC`` and its legacy output path still expect
+    separate ``region`` and ``source`` dimensions, so this converts to legacy
+    ``(region, time, source)`` shape only at that wrapper boundary. Modern RHIME
+    preparation must not call this adapter.
     """
     source_dim = "source"
     region_in_source_dim = "region_in_source"

--- a/openghg_inversions/basis/_helpers.py
+++ b/openghg_inversions/basis/_helpers.py
@@ -199,10 +199,27 @@ def _legacy_multisource_h_if_needed(
     source_dim = "source"
     region_in_source_dim = "region_in_source"
     if source_dim in sensitivity.dims:
+        if "region" in sensitivity.dims and "source_region_count" not in sensitivity.coords:
+            sensitivity = sensitivity.assign_coords(
+                source_region_count=(
+                    source_dim,
+                    [sensitivity.sizes["region"]] * sensitivity.sizes[source_dim],
+                )
+            )
         return sensitivity
     if state_dim not in sensitivity.dims or source_dim not in sensitivity.coords:
         return sensitivity
 
+    source_labels = [str(source) for source in sensitivity.coords[source_dim].values]
+    available_sources = list(dict.fromkeys(source_labels))
+    missing_sources = [source for source in flux_sources if source not in available_sources]
+    extra_sources = [source for source in available_sources if source not in flux_sources]
+    if missing_sources or extra_sources:
+        raise ValueError(
+            "Multi-source sensitivity does not match requested flux sources; "
+            f"missing source(s): {missing_sources!r}; extra source(s): {extra_sources!r}."
+        )
+    region_counts = {source: source_labels.count(source) for source in set(source_labels)}
     legacy_h = sensitivity.unstack(state_dim).fillna(0)
     if region_in_source_dim in legacy_h.dims:
         legacy_h = legacy_h.rename({region_in_source_dim: "region"})
@@ -210,6 +227,12 @@ def _legacy_multisource_h_if_needed(
         return sensitivity
 
     legacy_h = legacy_h.reindex({source_dim: flux_sources}).fillna(0)
+    legacy_h = legacy_h.assign_coords(
+        source_region_count=(
+            source_dim,
+            [region_counts.get(source, 0) for source in flux_sources],
+        )
+    )
     dim_order = ["region"]
     if "time" in legacy_h.dims:
         dim_order.append("time")

--- a/openghg_inversions/basis/_helpers.py
+++ b/openghg_inversions/basis/_helpers.py
@@ -226,6 +226,9 @@ def _legacy_multisource_h_if_needed(
             [source_coord.values, region_coord.values],
             names=[source_dim, region_in_source_dim],
         )
+        sensitivity = sensitivity.assign_coords(
+            xr.Coordinates.from_pandas_multiindex(state_index, state_dim)
+        )
     occupied = xr.DataArray(
         np.ones(sensitivity.sizes[state_dim], dtype=bool),
         dims=state_dim,

--- a/openghg_inversions/basis/_helpers.py
+++ b/openghg_inversions/basis/_helpers.py
@@ -1,9 +1,12 @@
 """Functions to create fit basis functiosn and apply to data."""
 
+import numpy as np
+import pandas as pd
 import xarray as xr
 
 from openghg_inversions.array_ops import get_xr_dummies, sparse_xr_dot, to_dense
 from openghg_inversions.basis.basis_functions import BasisFunctions
+
 from ._functions import basis_boundary_conditions
 
 
@@ -199,13 +202,6 @@ def _legacy_multisource_h_if_needed(
     source_dim = "source"
     region_in_source_dim = "region_in_source"
     if source_dim in sensitivity.dims:
-        if "region" in sensitivity.dims and "source_region_count" not in sensitivity.coords:
-            sensitivity = sensitivity.assign_coords(
-                source_region_count=(
-                    source_dim,
-                    [sensitivity.sizes["region"]] * sensitivity.sizes[source_dim],
-                )
-            )
         return sensitivity
     if state_dim not in sensitivity.dims or source_dim not in sensitivity.coords:
         return sensitivity
@@ -220,13 +216,28 @@ def _legacy_multisource_h_if_needed(
             f"missing source(s): {missing_sources!r}; extra source(s): {extra_sources!r}."
         )
     region_counts = {source: source_labels.count(source) for source in set(source_labels)}
-    legacy_h = sensitivity.unstack(state_dim).fillna(0)
+    state_index = sensitivity.indexes.get(state_dim)
+    if not isinstance(state_index, pd.MultiIndex):
+        source_coord = sensitivity.coords[source_dim]
+        region_coord = sensitivity.coords.get(region_in_source_dim)
+        if source_coord.dims != (state_dim,) or region_coord is None or region_coord.dims != (state_dim,):
+            return sensitivity
+        state_index = pd.MultiIndex.from_arrays(
+            [source_coord.values, region_coord.values],
+            names=[source_dim, region_in_source_dim],
+        )
+    occupied = xr.DataArray(
+        np.ones(sensitivity.sizes[state_dim], dtype=bool),
+        dims=state_dim,
+        coords=xr.Coordinates.from_pandas_multiindex(state_index, state_dim),
+    ).unstack(state_dim).notnull()
+    legacy_h = sensitivity.unstack(state_dim).where(occupied, 0.0)
     if region_in_source_dim in legacy_h.dims:
         legacy_h = legacy_h.rename({region_in_source_dim: "region"})
     if source_dim not in legacy_h.dims or "region" not in legacy_h.dims:
         return sensitivity
 
-    legacy_h = legacy_h.reindex({source_dim: flux_sources}).fillna(0)
+    legacy_h = legacy_h.sel({source_dim: flux_sources})
     legacy_h = legacy_h.assign_coords(
         source_region_count=(
             source_dim,

--- a/openghg_inversions/basis/operators.py
+++ b/openghg_inversions/basis/operators.py
@@ -645,6 +645,7 @@ class MultiSourceBucketBasisOperator(BasisOperator):
             key_dim=self.source_dim,
             ragged_dim=self.region_in_source_dim,
             stack_dim=self.meta.state_dim,
+            join="exact",
         )
 
         # chunking

--- a/openghg_inversions/config/templates/rhime_template.ini
+++ b/openghg_inversions/config/templates/rhime_template.ini
@@ -30,7 +30,7 @@ fp_height = None
 fp_species = None
 ; flux_sources gives the OpenGHG source values used to retrieve flux data.
 flux_sources = []
-; Optional mapping from sector labels to OpenGHG source values.
+; Optional one-to-one mapping from sector labels to unique OpenGHG source values.
 sector_sources = None
 bc_input = None
 
@@ -46,7 +46,8 @@ country_directory = None
 
 [RHIME.PDF]
 x_prior = {"pdf": "lognormal", "mean": 1.0, "stdev": 1.0}
-; In multi-sector RHIME, sector_priors are keyed by sector name.
+; In multi-sector RHIME, sector_priors must contain every sector key when supplied.
+; Leave this as None to apply the shared x_prior to every sector.
 sector_priors = None
 bc_prior = {"pdf": "truncatednormal", "mu": 1.0, "sigma": 0.05, "lower": 0.0}
 sigma_prior = {"pdf": "uniform", "lower": 0.1, "upper": 3.0}

--- a/openghg_inversions/inversion_data/preparation.py
+++ b/openghg_inversions/inversion_data/preparation.py
@@ -443,6 +443,39 @@ def _bc_basis_directory_arg(bc_basis_directory: str | Path | None) -> str | None
     return str(bc_basis_directory) if isinstance(bc_basis_directory, Path) else bc_basis_directory
 
 
+def _validate_multisector_sensitivity_sources(
+    sensitivity: xr.DataArray,
+    *,
+    site: str,
+    flux_sources: list[str],
+) -> xr.DataArray:
+    """Validate and order one site's source-resolved sensitivity."""
+    if "source" not in sensitivity.coords:
+        raise ValueError(
+            f"Site {site!r} sensitivity is missing the 'source' coordinate required for "
+            f"flux source(s) {flux_sources!r}."
+        )
+
+    source_labels = [str(source) for source in sensitivity.coords["source"].values]
+    available_sources = list(dict.fromkeys(source_labels))
+    duplicate_sources = (
+        [source for source in available_sources if source_labels.count(source) > 1]
+        if "source" in sensitivity.dims
+        else []
+    )
+    missing_sources = [source for source in flux_sources if source not in available_sources]
+    extra_sources = [source for source in available_sources if source not in flux_sources]
+    if duplicate_sources or missing_sources or extra_sources:
+        raise ValueError(
+            f"Site {site!r} sensitivity source layout does not match requested flux sources; "
+            f"missing source(s): {missing_sources!r}; extra source(s): {extra_sources!r}; "
+            f"duplicate source(s): {duplicate_sources!r}."
+        )
+    if "source" in sensitivity.dims:
+        return sensitivity.sel(source=flux_sources)
+    return sensitivity
+
+
 def _rhime_site_data_from_basis_functions(
     *,
     merged: _MergedInversionData,
@@ -478,6 +511,11 @@ def _rhime_site_data_from_basis_functions(
             sensitivity = sensitivity.rename({state_dim: "region"})
             state_dim = "region"
         if split_by_sectors:
+            sensitivity = _validate_multisector_sensitivity_sources(
+                sensitivity,
+                site=site,
+                flux_sources=flux_sources,
+            )
             sensitivity = _legacy_multisource_h_if_needed(
                 sensitivity,
                 state_dim=state_dim,
@@ -781,7 +819,8 @@ def prepare_rhime_inputs(
         output_name: Base output name used for data and basis artifacts.
         flux_sources: OpenGHG flux ``source`` values requested for the run.
         split_by_sectors: Whether to keep sector-resolved sensitivity inputs
-            with a ``source`` coordinate.
+            with a ``source`` provenance coordinate. Semantic sector names are
+            applied later by the model specification.
         use_tracer: Unsupported placeholder for tracer inversions, where an
             additional species constrains the primary species through linked
             forward models.

--- a/openghg_inversions/inversion_data/preparation.py
+++ b/openghg_inversions/inversion_data/preparation.py
@@ -25,7 +25,7 @@ import xarray as xr
 
 from openghg_inversions._timing import log_timing, timed, timer_seconds, timer_start
 from openghg_inversions.basis import basis_functions_wrapper, make_basis_functions
-from openghg_inversions.basis._helpers import _legacy_multisource_h_if_needed, bc_sensitivity
+from openghg_inversions.basis._helpers import bc_sensitivity
 from openghg_inversions.basis.basis_functions import BasisFunctions
 from openghg_inversions.filters import filtering
 from openghg_inversions.flux_sanitization import FluxNonFiniteCheck, sanitize_flux_nonfinite
@@ -507,27 +507,29 @@ def _rhime_site_data_from_basis_functions(
                 "Could not identify the RHIME sensitivity state dimension from "
                 f"sensitivity dims {sensitivity.dims!r} and fp_x_flux dims {fp_x_flux.dims!r}."
             )
-        if state_dim != "region" and state_dim in sensitivity.dims:
-            sensitivity = sensitivity.rename({state_dim: "region"})
-            state_dim = "region"
         if split_by_sectors:
             sensitivity = _validate_multisector_sensitivity_sources(
                 sensitivity,
                 site=site,
                 flux_sources=flux_sources,
             )
-            sensitivity = _legacy_multisource_h_if_needed(
-                sensitivity,
-                state_dim=state_dim,
-                flux_sources=flux_sources,
-            )
+        if "source" in sensitivity.coords and "source" not in sensitivity.dims:
+            fp_data[site] = fp_data[site].drop_vars(fp_x_flux_name)
+            orphan_dims = [
+                dim
+                for dim in fp_x_flux.dims
+                if dim in fp_data[site].dims
+                and all(dim not in variable.dims for variable in fp_data[site].data_vars.values())
+            ]
+            if orphan_dims:
+                fp_data[site] = fp_data[site].drop_dims(orphan_dims)
         fp_data[site]["H"] = sensitivity
         log_timing(
             "rhime.prepare_inputs.footprint_sensitivity",
             timer_seconds(timing_start),
             site=site,
             nmeasure=fp_data[site].sizes.get("time"),
-            regions=sensitivity.sizes.get("region"),
+            state_size=sensitivity.sizes.get(state_dim),
             sources=sensitivity.sizes.get("source"),
         )
 

--- a/openghg_inversions/inversion_inputs.py
+++ b/openghg_inversions/inversion_inputs.py
@@ -2,16 +2,39 @@
 
 import datetime as dt
 import numbers
-from typing import Any, Iterable, Literal
+from collections.abc import Iterable
+from typing import Any, Literal
 
 import numpy as np
 import pandas as pd
 import xarray as xr
 
-from openghg_inversions.array_ops import get_xr_dummies, concat_gather_datasets
+from openghg_inversions.array_ops import concat_gather_datasets, get_xr_dummies
 from openghg_inversions.model_error import percentile_error_method, residual_error_method, xr_setup_min_error
 
 DatetimeLike = str | dt.datetime | np.datetime64 | pd.Timestamp
+
+
+def _validate_per_site_dimension_names(
+    site_data: dict[str, xr.Dataset],
+    *,
+    ragged_dim: str,
+) -> None:
+    """Reject shared variables whose structural dimension names differ by site."""
+    if len(site_data) < 2:
+        return
+
+    shared_vars = set.intersection(*(set(dataset.data_vars) for dataset in site_data.values()))
+    for name in sorted(shared_vars):
+        layouts = {
+            site: frozenset(str(dim) for dim in dataset[name].dims if dim != ragged_dim)
+            for site, dataset in site_data.items()
+        }
+        if len(set(layouts.values())) > 1:
+            raise ValueError(
+                f"Per-site variable {name!r} must use the same non-{ragged_dim} dimensions "
+                f"before gathering; found {layouts!r}."
+            )
 
 
 def _compact_integer_index(values: np.ndarray) -> np.ndarray:
@@ -175,6 +198,7 @@ def add_min_error(
     else:
         min_error_data = min_error_data.rename("min_error")
 
+    assert isinstance(min_error_data, xr.DataArray)
     ds["min_error"] = xr.DataArray(min_error_data.data, dims=("nmeasure",), name="min_error")
     return ds
 
@@ -331,14 +355,23 @@ def make_inv_inputs(
             configuration is invalid.
     """
     sites = sites or [k for k in fp_data if not k.startswith(".")]
+    site_data = {k: v for k, v in fp_data.items() if k in sites}
+    _validate_per_site_dimension_names(site_data, ragged_dim="time")
 
-    ds = concat_gather_datasets(
-        {k: v for k, v in fp_data.items() if k in sites},
-        key_dim="site",
-        ragged_dim="time",
-        stack_dim="nmeasure",
-        missing_data_vars="drop",
-    )
+    try:
+        ds = concat_gather_datasets(
+            site_data,
+            key_dim="site",
+            ragged_dim="time",
+            stack_dim="nmeasure",
+            missing_data_vars="drop",
+            join="exact",
+        )
+    except xr.AlignmentError as exc:
+        raise ValueError(
+            "Per-site inversion inputs must have identical indexes on every non-time dimension "
+            "before gathering into nmeasure."
+        ) from exc
 
     # Check that we have variables for standard RHIME inversion (`inferpymc`).
     # Note that mf_prior_factor and mf_prior_upper_level_factor are only needed

--- a/openghg_inversions/models/_rhime_flux.py
+++ b/openghg_inversions/models/_rhime_flux.py
@@ -1,0 +1,321 @@
+"""Lower RHIME flux declarations into private PyMC compiler plans."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import pandas as pd
+import xarray as xr
+
+from openghg_inversions.array_ops import select_gathered_data_array
+from openghg_inversions.models._rhime_compiler import (
+    _FluxPlan,
+    _ForwardTermPlan,
+    _StatePlan,
+)
+
+
+@dataclass(frozen=True)
+class _ResolvedSectorBinding:
+    """Bind one semantic sector to prepared source data and backend naming."""
+
+    name: str
+    flux_source: str
+    variable_suffix: str
+
+
+def safe_pymc_name(value: str) -> str:
+    """Return a stable PyMC-safe suffix for a user-facing sector/source name."""
+    name = re.sub(r"\W+", "_", str(value).strip().lower()).strip("_")
+    return name or "sector"
+
+
+def _prepared_sources(design: xr.DataArray, *, observation_dim: str = "nmeasure") -> list[str]:
+    """Return ordered source labels from rectangular or gathered sensitivity."""
+    source_coord = design.coords.get("source")
+    if source_coord is None:
+        raise ValueError(
+            "Multi-sector RHIME requires inv_inputs['H'] to contain OpenGHG source labels."
+        )
+
+    source_labels = [str(value) for value in source_coord.values]
+    if "source" in design.dims:
+        duplicate_sources = list(
+            dict.fromkeys(source for source in source_labels if source_labels.count(source) > 1)
+        )
+        if duplicate_sources:
+            raise ValueError(
+                "Multi-sector RHIME requires unique inv_inputs['H'].source labels; "
+                f"duplicate source {duplicate_sources[0]!r}."
+            )
+        return source_labels
+
+    state_dims = [str(dim) for dim in design.dims if dim != observation_dim]
+    if len(state_dims) != 1 or source_coord.dims != (state_dims[0],):
+        raise ValueError(
+            "Gathered multi-sector H requires one state dimension carrying the 'source' coordinate."
+        )
+    state_index = design.indexes.get(state_dims[0])
+    if not isinstance(state_index, pd.MultiIndex) or "source" not in state_index.names:
+        raise ValueError(
+            "Gathered multi-sector H requires its state dimension to use a MultiIndex "
+            "containing a 'source' level."
+        )
+    if not state_index.is_unique:
+        duplicate = state_index[state_index.duplicated()][0]
+        raise ValueError(
+            "Gathered multi-sector H requires unique state labels; "
+            f"duplicate state {duplicate!r}."
+        )
+    return list(dict.fromkeys(source_labels))
+
+
+def _resolve_sector_bindings(
+    inv_inputs: xr.Dataset,
+    sectors: Sequence[str] | None,
+    *,
+    sector_sources: Mapping[str, str] | None,
+    sector_variable_suffixes: Mapping[str, str] | None,
+) -> tuple[_ResolvedSectorBinding, ...]:
+    """Resolve semantic sectors against prepared source provenance."""
+    available = _prepared_sources(inv_inputs["H"])
+    if sectors is None:
+        sectors = list(sector_sources) if sector_sources is not None else available
+    sector_names = [str(sector) for sector in sectors]
+
+    if len(sector_names) < 2:
+        raise ValueError("Multi-sector RHIME requires at least two sectors.")
+    duplicate_sectors = list(
+        dict.fromkeys(sector for sector in sector_names if sector_names.count(sector) > 1)
+    )
+    if duplicate_sectors:
+        raise ValueError(
+            f"Multi-sector RHIME requires unique sector names; duplicate sector {duplicate_sectors[0]!r}."
+        )
+    if any(not sector.strip() for sector in sector_names):
+        raise ValueError("Multi-sector RHIME requires non-empty sector names.")
+
+    source_by_sector = (
+        {str(sector): str(source) for sector, source in sector_sources.items()}
+        if sector_sources is not None
+        else {sector: sector for sector in sector_names}
+    )
+    suffix_by_sector = (
+        {str(sector): str(suffix) for sector, suffix in sector_variable_suffixes.items()}
+        if sector_variable_suffixes is not None
+        else {}
+    )
+
+    unused_mappings = [sector for sector in source_by_sector if sector not in sector_names]
+    if unused_mappings:
+        raise ValueError(f"`sector_sources` contains unused sector key(s): {unused_mappings!r}.")
+    missing_mappings = [sector for sector in sector_names if sector not in source_by_sector]
+    if missing_mappings:
+        raise ValueError(f"Sector(s) {missing_mappings!r} are missing from `sector_sources`.")
+
+    source_sectors: dict[str, list[str]] = {}
+    for sector in sector_names:
+        source_sectors.setdefault(source_by_sector[sector], []).append(sector)
+    duplicate_sources = {
+        source: mapped_sectors
+        for source, mapped_sectors in source_sectors.items()
+        if len(mapped_sectors) > 1
+    }
+    if duplicate_sources:
+        details = ", ".join(
+            f"source {source!r} is mapped by sectors {mapped_sectors!r}"
+            for source, mapped_sectors in duplicate_sources.items()
+        )
+        raise ValueError(
+            "Multi-sector RHIME requires a distinct source for each current sector; "
+            + details
+            + "."
+        )
+
+    missing = [
+        (sector, source_by_sector[sector])
+        for sector in sector_names
+        if source_by_sector[sector] not in available
+    ]
+    if missing:
+        details = ", ".join(f"sector {sector!r} -> source {source!r}" for sector, source in missing)
+        raise ValueError(
+            f"Source data required by {details} is not present in inv_inputs['H'].source; "
+            f"available source(s): {available!r}."
+        )
+
+    unused_suffixes = [sector for sector in suffix_by_sector if sector not in sector_names]
+    if unused_suffixes:
+        raise ValueError(
+            f"`sector_variable_suffixes` contains unused sector key(s): {unused_suffixes!r}."
+        )
+    bindings = tuple(
+        _ResolvedSectorBinding(
+            name=sector,
+            flux_source=source_by_sector[sector],
+            variable_suffix=suffix_by_sector.get(sector, safe_pymc_name(sector)),
+        )
+        for sector in sector_names
+    )
+    suffixes = [binding.variable_suffix for binding in bindings]
+    if len(suffixes) != len(set(suffixes)):
+        duplicate = next(suffix for suffix in suffixes if suffixes.count(suffix) > 1)
+        raise ValueError(
+            "Sector names must be unique after PyMC name sanitisation; "
+            f"duplicate sanitized name {duplicate!r}."
+        )
+    return bindings
+
+
+def _validate_unpadded_sector_design(
+    design: xr.DataArray,
+    *,
+    sector: str,
+    source: str,
+    observation_dim: str = "nmeasure",
+) -> None:
+    """Reject rectangular source layouts containing declared padding."""
+    state_dims = [str(dim) for dim in design.dims if dim != observation_dim]
+    if design.ndim != 2 or observation_dim not in design.dims or len(state_dims) != 1:
+        return
+
+    state_dim = state_dims[0]
+    source_region_count = design.coords.get("source_region_count")
+    if source_region_count is None:
+        return
+    declared_regions = int(source_region_count.item())
+    prepared_regions = design.sizes[state_dim]
+    if declared_regions != prepared_regions:
+        raise ValueError(
+            f"Sector {sector!r} -> source {source!r} declares {declared_regions} "
+            f"{state_dim} elements but prepared H has {prepared_regions}. Ragged "
+            "source-specific state blocks must use a gathered state coordinate."
+        )
+
+
+def _select_sector_design(
+    design: xr.DataArray,
+    *,
+    sector: str,
+    source: str,
+    variable_suffix: str,
+    observation_dim: str = "nmeasure",
+) -> xr.DataArray:
+    """Select one source design from rectangular or gathered sensitivity."""
+    available_sources = _prepared_sources(design, observation_dim=observation_dim)
+    if source not in available_sources:
+        raise ValueError(
+            f"Sector {sector!r} requires source {source!r}, but prepared H contains "
+            f"{available_sources!r}."
+        )
+
+    if "source" in design.dims:
+        selected = design.sel(source=source, drop=False)
+        _validate_unpadded_sector_design(
+            selected,
+            sector=sector,
+            source=source,
+            observation_dim=observation_dim,
+        )
+        return design.sel(source=source, drop=True)
+
+    state_dims = [str(dim) for dim in design.dims if dim != observation_dim]
+    state_dim = state_dims[0]
+    index = design.indexes.get(state_dim)
+    assert isinstance(index, pd.MultiIndex)
+    ragged_levels = [str(name) for name in index.names if name != "source"]
+    if len(ragged_levels) != 1:
+        raise ValueError(
+            f"Gathered H state dimension {state_dim!r} must contain exactly the "
+            f"'source' and one ragged-region level; found {list(index.names)!r}."
+        )
+
+    selected = select_gathered_data_array(
+        design,
+        key=source,
+        key_dim="source",
+        ragged_dim=ragged_levels[0],
+        stack_dim=state_dim,
+    )
+    return selected.rename({state_dim: f"{state_dim}_{variable_suffix}"})
+
+
+def _normalize_standard_flux_plan(inv_inputs: xr.Dataset, x_prior: Mapping[str, Any]) -> _FluxPlan:
+    """Normalize the standard flux component into a one-state linear plan."""
+    state_id = "flux"
+    return _FluxPlan(
+        states=(
+            _StatePlan(
+                state_id=state_id,
+                variable_name="x",
+                prior_args=x_prior,
+            ),
+        ),
+        terms=(
+            _ForwardTermPlan(
+                term_id=state_id,
+                state_id=state_id,
+                design=inv_inputs["H"],
+                data_name="hx",
+                deterministic_name="mu",
+                coefficient=1.0,
+            ),
+        ),
+    )
+
+
+def _normalize_multisector_flux_plan(
+    inv_inputs: xr.Dataset,
+    sector_bindings: Sequence[_ResolvedSectorBinding],
+    *,
+    sector_priors: Mapping[str, Mapping[str, Any]] | None,
+    x_prior: Mapping[str, Any] | None,
+    default_x_prior: Mapping[str, Any],
+) -> _FluxPlan:
+    """Normalize selected sector designs into separate state and term plans."""
+    sector_names = [binding.name for binding in sector_bindings]
+    if sector_priors is not None:
+        missing_priors = [sector for sector in sector_names if sector not in sector_priors]
+        unused_priors = [sector for sector in sector_priors if sector not in sector_names]
+        if missing_priors or unused_priors:
+            raise ValueError(
+                "`sector_priors` must define exactly one prior for every sector when supplied; "
+                f"missing sector prior(s): {missing_priors!r}; "
+                f"unused sector prior key(s): {unused_priors!r}."
+            )
+
+    states: list[_StatePlan] = []
+    terms: list[_ForwardTermPlan] = []
+    for binding in sector_bindings:
+        design = _select_sector_design(
+            inv_inputs["H"],
+            sector=binding.name,
+            source=binding.flux_source,
+            variable_suffix=binding.variable_suffix,
+        )
+        prior = (
+            sector_priors[binding.name]
+            if sector_priors is not None
+            else default_x_prior if x_prior is None else x_prior
+        )
+        states.append(
+            _StatePlan(
+                state_id=binding.name,
+                variable_name=f"x_{binding.variable_suffix}",
+                prior_args=dict(prior),
+            )
+        )
+        terms.append(
+            _ForwardTermPlan(
+                term_id=binding.name,
+                state_id=binding.name,
+                design=design,
+                data_name=f"hx_{binding.variable_suffix}",
+                deterministic_name=f"mu_{binding.variable_suffix}",
+                coefficient=1.0,
+            )
+        )
+    return _FluxPlan(states=tuple(states), terms=tuple(terms))

--- a/openghg_inversions/models/rhime.py
+++ b/openghg_inversions/models/rhime.py
@@ -357,14 +357,32 @@ def _resolve_sector_definitions(
     """
     if "source" not in inv_inputs["H"].dims:
         raise ValueError("Multi-sector RHIME requires inv_inputs['H'] to include a 'source' dimension.")
+    if "source" not in inv_inputs["H"].coords:
+        raise ValueError(
+            "Multi-sector RHIME requires inv_inputs['H'].source to contain OpenGHG source labels."
+        )
 
     available = [str(value) for value in inv_inputs["H"].coords["source"].values]
+    duplicate_available = [source for source in available if available.count(source) > 1]
+    if duplicate_available:
+        duplicate = next(iter(dict.fromkeys(duplicate_available)))
+        raise ValueError(
+            "Multi-sector RHIME requires unique inv_inputs['H'].source labels; "
+            f"duplicate source {duplicate!r}."
+        )
     if sectors is None:
         sectors = list(sector_sources) if sector_sources is not None else available
     sector_names = [str(sector) for sector in sectors]
 
     if len(sector_names) < 2:
         raise ValueError("Multi-sector RHIME requires at least two sectors.")
+    duplicate_sectors = [sector for sector in sector_names if sector_names.count(sector) > 1]
+    if duplicate_sectors:
+        duplicate = next(iter(dict.fromkeys(duplicate_sectors)))
+        raise ValueError(f"Multi-sector RHIME requires unique sector names; duplicate sector {duplicate!r}.")
+    empty_sectors = [sector for sector in sector_names if not sector.strip()]
+    if empty_sectors:
+        raise ValueError("Multi-sector RHIME requires non-empty sector names.")
 
     source_by_sector = (
         {str(sector): str(source) for sector, source in sector_sources.items()}
@@ -377,16 +395,47 @@ def _resolve_sector_definitions(
         else {}
     )
 
+    unused_mappings = [sector for sector in source_by_sector if sector not in sector_names]
+    if unused_mappings:
+        raise ValueError(f"`sector_sources` contains unused sector key(s): {unused_mappings!r}.")
     missing_mapping = [sector for sector in sector_names if sector not in source_by_sector]
     if missing_mapping:
         raise ValueError(f"Sector(s) {missing_mapping!r} are missing from `sector_sources`.")
 
+    source_sectors: dict[str, list[str]] = {}
+    for sector in sector_names:
+        source_sectors.setdefault(source_by_sector[sector], []).append(sector)
+    duplicate_sources = {
+        source: mapped_sectors
+        for source, mapped_sectors in source_sectors.items()
+        if len(mapped_sectors) > 1
+    }
+    if duplicate_sources:
+        details = ", ".join(
+            f"source {source!r} is mapped by sectors {mapped_sectors!r}"
+            for source, mapped_sectors in duplicate_sources.items()
+        )
+        raise ValueError(
+            "Multi-sector RHIME requires a distinct source for each current sector; " + details + "."
+        )
+
     missing = [
-        source_by_sector[sector] for sector in sector_names if source_by_sector[sector] not in available
+        (sector, source_by_sector[sector])
+        for sector in sector_names
+        if source_by_sector[sector] not in available
     ]
     if missing:
-        raise ValueError(f"Source value(s) {missing!r} are not present in inv_inputs['H'].source.")
+        details = ", ".join(f"sector {sector!r} -> source {source!r}" for sector, source in missing)
+        raise ValueError(
+            f"Source data required by {details} is not present in inv_inputs['H'].source; "
+            f"available source(s): {available!r}."
+        )
 
+    unused_suffixes = [sector for sector in suffix_by_sector if sector not in sector_names]
+    if unused_suffixes:
+        raise ValueError(
+            f"`sector_variable_suffixes` contains unused sector key(s): {unused_suffixes!r}."
+        )
     definitions = [
         (sector, source_by_sector[sector], suffix_by_sector.get(sector, safe_pymc_name(sector)))
         for sector in sector_names
@@ -413,6 +462,32 @@ def _sector_prior(
     return dict(DEFAULT_X_PRIOR if x_prior is None else x_prior)
 
 
+def _validate_sector_design(
+    design: xr.DataArray,
+    *,
+    sector: str,
+    source: str,
+    observation_dim: str = "nmeasure",
+) -> None:
+    """Reject source layouts that would create latent variables for padding."""
+    state_dims = [str(dim) for dim in design.dims if dim != observation_dim]
+    if design.ndim != 2 or observation_dim not in design.dims or len(state_dims) != 1:
+        return
+
+    state_dim = state_dims[0]
+    source_region_count = design.coords.get("source_region_count")
+    if source_region_count is not None:
+        declared_regions = int(source_region_count.item())
+        prepared_regions = design.sizes[state_dim]
+        if declared_regions == prepared_regions:
+            return
+        raise ValueError(
+            f"Sector {sector!r} -> source {source!r} declares {declared_regions} "
+            f"{state_dim} elements but prepared H has {prepared_regions}. Ragged "
+            "source-specific state blocks are not supported by this builder."
+        )
+
+
 def _normalize_multisector_flux_plan(
     inv_inputs: xr.Dataset,
     sector_definitions: Sequence[tuple[str, str, str]],
@@ -426,14 +501,28 @@ def _normalize_multisector_flux_plan(
         inv_inputs: Canonical inversion inputs containing source-resolved ``H``.
         sector_definitions: Ordered ``(sector, source, variable_suffix)`` values.
         sector_priors: Optional priors keyed by semantic sector ID.
-        x_prior: Optional shared fallback prior.
+        x_prior: Optional shared prior used when ``sector_priors`` is absent.
 
     Returns:
         Backend-neutral multisector flux plan with selected 2-D designs.
     """
+    sector_names = [sector for sector, _, _ in sector_definitions]
+    if sector_priors is not None:
+        missing_priors = [sector for sector in sector_names if sector not in sector_priors]
+        unused_priors = [sector for sector in sector_priors if sector not in sector_names]
+        if missing_priors or unused_priors:
+            raise ValueError(
+                "`sector_priors` must define exactly one prior for every sector when supplied; "
+                f"missing sector prior(s): {missing_priors!r}; "
+                f"unused sector prior key(s): {unused_priors!r}."
+            )
+
     states: list[_StatePlan] = []
     terms: list[_ForwardTermPlan] = []
     for sector, source, variable_suffix in sector_definitions:
+        design = inv_inputs["H"].sel(source=source).drop_vars("source", errors="ignore")
+        _validate_sector_design(design, sector=sector, source=source)
+        design = design.drop_vars("source_region_count", errors="ignore")
         states.append(
             _StatePlan(
                 state_id=sector,
@@ -445,7 +534,6 @@ def _normalize_multisector_flux_plan(
                 ),
             )
         )
-        design = inv_inputs["H"].sel(source=source).drop_vars("source", errors="ignore")
         terms.append(
             _ForwardTermPlan(
                 term_id=sector,
@@ -497,7 +585,9 @@ def build_rhime_multisector_model(
         sector_variable_suffixes: Optional mapping from sector label to
             PyMC-safe suffix used in ``x_<suffix>`` and ``mu_<suffix>`` names.
         sector_priors: Optional per-sector flux-scaling priors.
-        x_prior: Shared fallback flux-scaling prior.
+            When supplied, the mapping must contain exactly one entry for every
+            sector.
+        x_prior: Shared flux-scaling prior used when ``sector_priors`` is absent.
         bc_prior: Prior specification for boundary-condition scaling factors.
         sigma_prior: Prior specification for model-error terms.
         offset_prior: Prior specification for optional offsets.

--- a/openghg_inversions/models/rhime.py
+++ b/openghg_inversions/models/rhime.py
@@ -15,18 +15,20 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-import re
 from typing import Any
 
 import pymc as pm
 import xarray as xr
 
 from openghg_inversions.inversion_inputs import DatetimeLike
-from openghg_inversions.models._rhime_compiler import (
-    _FluxPlan,
-    _ForwardTermPlan,
-    _StatePlan,
-    _compile_loop_sum,
+from openghg_inversions.models._rhime_compiler import _compile_loop_sum, _FluxPlan
+from openghg_inversions.models._rhime_flux import (
+    _normalize_multisector_flux_plan,
+    _normalize_standard_flux_plan,
+    _resolve_sector_bindings,
+)
+from openghg_inversions.models._rhime_flux import (
+    safe_pymc_name as _safe_pymc_name,
 )
 from openghg_inversions.models.components import (
     add_inferpymc_likelihood_component,
@@ -41,6 +43,18 @@ DEFAULT_X_PRIOR: PriorArgs = {"pdf": "lognormal", "mean": 1.0, "stdev": 1.0, "re
 DEFAULT_BC_PRIOR: PriorArgs = {"pdf": "truncatednormal", "mu": 1.0, "sigma": 0.05, "lower": 0.0}
 DEFAULT_SIGMA_PRIOR: PriorArgs = {"pdf": "uniform", "lower": 0.1, "upper": 3.0}
 DEFAULT_OFFSET_PRIOR: PriorArgs = {"pdf": "normal", "mu": 0, "sigma": 1}
+
+
+def safe_pymc_name(value: str) -> str:
+    """Return a stable PyMC-safe suffix for a user-facing sector/source name.
+
+    Args:
+        value: User-facing sector or source name.
+
+    Returns:
+        Lowercase snake-case suffix safe to use in PyMC variable names.
+    """
+    return _safe_pymc_name(value)
 
 
 @dataclass(frozen=True)
@@ -104,19 +118,6 @@ class RhimeModelSpec:
     offset_args: dict[str, Any] | None = None
 
 
-def safe_pymc_name(value: str) -> str:
-    """Return a stable PyMC-safe suffix for a user-facing sector/source name.
-
-    Args:
-        value: User-facing sector or source name.
-
-    Returns:
-        Lowercase snake-case suffix safe to use in PyMC variable names.
-    """
-    name = re.sub(r"\W+", "_", str(value).strip().lower()).strip("_")
-    return name or "sector"
-
-
 def _prepare_builder_priors(
     *,
     x_prior: dict | None,
@@ -130,38 +131,6 @@ def _prepare_builder_priors(
     prepared_sigma_prior = DEFAULT_SIGMA_PRIOR.copy() if sigma_prior is None else sigma_prior.copy()
     prepared_offset_prior = DEFAULT_OFFSET_PRIOR.copy() if offset_prior is None else offset_prior.copy()
     return prepared_x_prior, prepared_bc_prior, prepared_sigma_prior, prepared_offset_prior
-
-
-def _normalize_standard_flux_plan(inv_inputs: xr.Dataset, x_prior: dict) -> _FluxPlan:
-    """Normalize the standard flux component into a one-state linear plan.
-
-    Args:
-        inv_inputs: Canonical inversion inputs containing ``H``.
-        x_prior: Prepared flux-scaling prior metadata.
-
-    Returns:
-        Backend-neutral standard flux plan.
-    """
-    state_id = "flux"
-    return _FluxPlan(
-        states=(
-            _StatePlan(
-                state_id=state_id,
-                variable_name="x",
-                prior_args=x_prior,
-            ),
-        ),
-        terms=(
-            _ForwardTermPlan(
-                term_id=state_id,
-                state_id=state_id,
-                design=inv_inputs["H"],
-                data_name="hx",
-                deterministic_name="mu",
-                coefficient=1.0,
-            ),
-        ),
-    )
 
 
 def _assemble_rhime_model(
@@ -342,211 +311,6 @@ def build_rhime_model_from_spec(inv_inputs: xr.Dataset, model_spec: RhimeModelSp
     )
 
 
-def _resolve_sector_definitions(
-    inv_inputs: xr.Dataset,
-    sectors: Sequence[str] | None,
-    *,
-    sector_sources: Mapping[str, str] | None,
-    sector_variable_suffixes: Mapping[str, str] | None,
-) -> list[tuple[str, str, str]]:
-    """Resolve model sectors against the flux ``source`` coordinate.
-
-    The input ``source`` coordinate records OpenGHG flux source metadata. The
-    returned sector definitions keep separately optimized sector labels,
-    OpenGHG source values, and PyMC variable suffixes together.
-    """
-    if "source" not in inv_inputs["H"].dims:
-        raise ValueError("Multi-sector RHIME requires inv_inputs['H'] to include a 'source' dimension.")
-    if "source" not in inv_inputs["H"].coords:
-        raise ValueError(
-            "Multi-sector RHIME requires inv_inputs['H'].source to contain OpenGHG source labels."
-        )
-
-    available = [str(value) for value in inv_inputs["H"].coords["source"].values]
-    duplicate_available = [source for source in available if available.count(source) > 1]
-    if duplicate_available:
-        duplicate = next(iter(dict.fromkeys(duplicate_available)))
-        raise ValueError(
-            "Multi-sector RHIME requires unique inv_inputs['H'].source labels; "
-            f"duplicate source {duplicate!r}."
-        )
-    if sectors is None:
-        sectors = list(sector_sources) if sector_sources is not None else available
-    sector_names = [str(sector) for sector in sectors]
-
-    if len(sector_names) < 2:
-        raise ValueError("Multi-sector RHIME requires at least two sectors.")
-    duplicate_sectors = [sector for sector in sector_names if sector_names.count(sector) > 1]
-    if duplicate_sectors:
-        duplicate = next(iter(dict.fromkeys(duplicate_sectors)))
-        raise ValueError(f"Multi-sector RHIME requires unique sector names; duplicate sector {duplicate!r}.")
-    empty_sectors = [sector for sector in sector_names if not sector.strip()]
-    if empty_sectors:
-        raise ValueError("Multi-sector RHIME requires non-empty sector names.")
-
-    source_by_sector = (
-        {str(sector): str(source) for sector, source in sector_sources.items()}
-        if sector_sources is not None
-        else {sector: sector for sector in sector_names}
-    )
-    suffix_by_sector = (
-        {str(sector): str(suffix) for sector, suffix in sector_variable_suffixes.items()}
-        if sector_variable_suffixes is not None
-        else {}
-    )
-
-    unused_mappings = [sector for sector in source_by_sector if sector not in sector_names]
-    if unused_mappings:
-        raise ValueError(f"`sector_sources` contains unused sector key(s): {unused_mappings!r}.")
-    missing_mapping = [sector for sector in sector_names if sector not in source_by_sector]
-    if missing_mapping:
-        raise ValueError(f"Sector(s) {missing_mapping!r} are missing from `sector_sources`.")
-
-    source_sectors: dict[str, list[str]] = {}
-    for sector in sector_names:
-        source_sectors.setdefault(source_by_sector[sector], []).append(sector)
-    duplicate_sources = {
-        source: mapped_sectors
-        for source, mapped_sectors in source_sectors.items()
-        if len(mapped_sectors) > 1
-    }
-    if duplicate_sources:
-        details = ", ".join(
-            f"source {source!r} is mapped by sectors {mapped_sectors!r}"
-            for source, mapped_sectors in duplicate_sources.items()
-        )
-        raise ValueError(
-            "Multi-sector RHIME requires a distinct source for each current sector; " + details + "."
-        )
-
-    missing = [
-        (sector, source_by_sector[sector])
-        for sector in sector_names
-        if source_by_sector[sector] not in available
-    ]
-    if missing:
-        details = ", ".join(f"sector {sector!r} -> source {source!r}" for sector, source in missing)
-        raise ValueError(
-            f"Source data required by {details} is not present in inv_inputs['H'].source; "
-            f"available source(s): {available!r}."
-        )
-
-    unused_suffixes = [sector for sector in suffix_by_sector if sector not in sector_names]
-    if unused_suffixes:
-        raise ValueError(
-            f"`sector_variable_suffixes` contains unused sector key(s): {unused_suffixes!r}."
-        )
-    definitions = [
-        (sector, source_by_sector[sector], suffix_by_sector.get(sector, safe_pymc_name(sector)))
-        for sector in sector_names
-    ]
-    suffixes = [suffix for _, _, suffix in definitions]
-    if len(suffixes) != len(set(suffixes)):
-        duplicate = next(suffix for suffix in suffixes if suffixes.count(suffix) > 1)
-        raise ValueError(
-            "Sector names must be unique after PyMC name sanitisation; "
-            f"duplicate sanitized name {duplicate!r}."
-        )
-    return definitions
-
-
-def _sector_prior(
-    sector: str,
-    *,
-    sector_priors: Mapping[str, dict] | None,
-    x_prior: dict | None,
-) -> dict:
-    """Resolve a sector prior, falling back to the shared flux-scaling prior."""
-    if sector_priors is not None and sector in sector_priors:
-        return dict(sector_priors[sector])
-    return dict(DEFAULT_X_PRIOR if x_prior is None else x_prior)
-
-
-def _validate_sector_design(
-    design: xr.DataArray,
-    *,
-    sector: str,
-    source: str,
-    observation_dim: str = "nmeasure",
-) -> None:
-    """Reject source layouts that would create latent variables for padding."""
-    state_dims = [str(dim) for dim in design.dims if dim != observation_dim]
-    if design.ndim != 2 or observation_dim not in design.dims or len(state_dims) != 1:
-        return
-
-    state_dim = state_dims[0]
-    source_region_count = design.coords.get("source_region_count")
-    if source_region_count is not None:
-        declared_regions = int(source_region_count.item())
-        prepared_regions = design.sizes[state_dim]
-        if declared_regions == prepared_regions:
-            return
-        raise ValueError(
-            f"Sector {sector!r} -> source {source!r} declares {declared_regions} "
-            f"{state_dim} elements but prepared H has {prepared_regions}. Ragged "
-            "source-specific state blocks are not supported by this builder."
-        )
-
-
-def _normalize_multisector_flux_plan(
-    inv_inputs: xr.Dataset,
-    sector_definitions: Sequence[tuple[str, str, str]],
-    *,
-    sector_priors: Mapping[str, dict] | None,
-    x_prior: dict | None,
-) -> _FluxPlan:
-    """Normalize selected sector designs into separate semantic state plans.
-
-    Args:
-        inv_inputs: Canonical inversion inputs containing source-resolved ``H``.
-        sector_definitions: Ordered ``(sector, source, variable_suffix)`` values.
-        sector_priors: Optional priors keyed by semantic sector ID.
-        x_prior: Optional shared prior used when ``sector_priors`` is absent.
-
-    Returns:
-        Backend-neutral multisector flux plan with selected 2-D designs.
-    """
-    sector_names = [sector for sector, _, _ in sector_definitions]
-    if sector_priors is not None:
-        missing_priors = [sector for sector in sector_names if sector not in sector_priors]
-        unused_priors = [sector for sector in sector_priors if sector not in sector_names]
-        if missing_priors or unused_priors:
-            raise ValueError(
-                "`sector_priors` must define exactly one prior for every sector when supplied; "
-                f"missing sector prior(s): {missing_priors!r}; "
-                f"unused sector prior key(s): {unused_priors!r}."
-            )
-
-    states: list[_StatePlan] = []
-    terms: list[_ForwardTermPlan] = []
-    for sector, source, variable_suffix in sector_definitions:
-        design = inv_inputs["H"].sel(source=source).drop_vars("source", errors="ignore")
-        _validate_sector_design(design, sector=sector, source=source)
-        design = design.drop_vars("source_region_count", errors="ignore")
-        states.append(
-            _StatePlan(
-                state_id=sector,
-                variable_name=f"x_{variable_suffix}",
-                prior_args=_sector_prior(
-                    sector,
-                    sector_priors=sector_priors,
-                    x_prior=x_prior,
-                ),
-            )
-        )
-        terms.append(
-            _ForwardTermPlan(
-                term_id=sector,
-                state_id=sector,
-                design=design,
-                data_name=f"hx_{variable_suffix}",
-                deterministic_name=f"mu_{variable_suffix}",
-                coefficient=1.0,
-            )
-        )
-    return _FluxPlan(states=tuple(states), terms=tuple(terms))
-
-
 def build_rhime_multisector_model(
     inv_inputs: xr.Dataset,
     *,
@@ -573,8 +337,10 @@ def build_rhime_multisector_model(
     contributions and is passed to the standard RHIME likelihood.
 
     Args:
-        inv_inputs: Canonical inversion-input dataset with
-            ``H(region, nmeasure, source)``.
+        inv_inputs: Canonical inversion-input dataset. Shared-basis inputs use
+            ``H(region, nmeasure, source)``. Source-specific bases use
+            ``H(state, nmeasure)`` with ``state`` gathered over
+            ``(source, region_in_source)``.
         sigma_alignment: Backend-neutral site and period alignment for sigma.
         sectors: Ordered model sector labels to optimize. Defaults to
             ``sector_sources`` keys when supplied, otherwise all
@@ -602,7 +368,7 @@ def build_rhime_multisector_model(
     Returns:
         Built PyMC model.
     """
-    sector_definitions = _resolve_sector_definitions(
+    sector_bindings = _resolve_sector_bindings(
         inv_inputs,
         sectors,
         sector_sources=sector_sources,
@@ -610,9 +376,10 @@ def build_rhime_multisector_model(
     )
     flux_plan = _normalize_multisector_flux_plan(
         inv_inputs,
-        sector_definitions,
+        sector_bindings,
         sector_priors=sector_priors,
         x_prior=x_prior,
+        default_x_prior=DEFAULT_X_PRIOR,
     )
     bc_prior = dict(DEFAULT_BC_PRIOR if bc_prior is None else bc_prior)
     sigma_prior = dict(DEFAULT_SIGMA_PRIOR if sigma_prior is None else sigma_prior)
@@ -640,8 +407,8 @@ def build_rhime_multisector_model_from_spec(
     """Build the shared-basis multi-sector RHIME model from a model spec.
 
     Args:
-        inv_inputs: Canonical inversion-input dataset with
-            ``H(region, nmeasure, source)``.
+        inv_inputs: Canonical inversion-input dataset using either rectangular
+            shared-basis or gathered source-specific sensitivity.
         model_spec: Normalized RHIME model specification.
 
     Returns:

--- a/openghg_inversions/postprocessing/make_outputs.py
+++ b/openghg_inversions/postprocessing/make_outputs.py
@@ -240,6 +240,9 @@ def _state_chunk_dim(trace: xr.Dataset, inv_out: InversionOutput) -> str:
         return "region"
     if "nx" in trace.dims:
         return "nx"
+    non_sample_dims = [str(dim) for dim in trace.dims if dim not in {"chain", "draw"}]
+    if len(non_sample_dims) == 1:
+        return non_sample_dims[0]
     raise ValueError(f"Could not find basis state dimension in trace dims {tuple(trace.dims)}.")
 
 

--- a/openghg_inversions/postprocessing/make_outputs.py
+++ b/openghg_inversions/postprocessing/make_outputs.py
@@ -297,12 +297,19 @@ def _sector_flux_trace_dataset(
 def _sector_scale_factor_stats(
     inv_out: InversionOutput,
     sector: OutputSector,
-    stats_args: dict,
+    *,
+    stats: list[str] | None,
+    stats_args: dict | None,
 ) -> xr.Dataset:
     """Return one sector's gridded scale-factor statistics."""
     trace = _sector_scale_trace(inv_out, sector)
     basis_functions = _sector_basis_functions(inv_out, sector, trace)
-    scale_stats = calculate_stats(trace, **stats_args)
+    sector_stats_args = _stats_args_with_defaults(
+        stats,
+        stats_args,
+        chunk_dim=_state_chunk_dim(trace, inv_out),
+    )
+    scale_stats = calculate_stats(trace, **sector_stats_args)
     result = reconstruct_scale_factor_stats(basis_functions, scale_stats)
     for data_var in result.data_vars:
         if data_var in scale_stats.data_vars:
@@ -509,19 +516,20 @@ def make_sector_flux_outputs(
         inv_out,
         report_flux_on_inversion_grid=report_flux_on_inversion_grid,
     )
-    sample_trace = _sector_scale_trace(inv_out, sectors[0])
-    scale_stats_args = _stats_args_with_defaults(
-        stats,
-        stats_args,
-        chunk_dim=_state_chunk_dim(sample_trace, inv_out),
-    )
     flux_stats_args = _stats_args_with_defaults(stats, stats_args)
 
     outputs = [calculate_stats(total_flux_trace, **flux_stats_args)]
     for sector, flux_trace in zip(sectors, sector_flux_traces, strict=True):
         outputs.append(calculate_stats(flux_trace, **flux_stats_args))
         if include_scale_factors:
-            outputs.append(_sector_scale_factor_stats(inv_out, sector, scale_stats_args))
+            outputs.append(
+                _sector_scale_factor_stats(
+                    inv_out,
+                    sector,
+                    stats=stats,
+                    stats_args=stats_args,
+                )
+            )
 
     result = _set_multisector_flux_attrs(xr.merge(outputs), inv_out, sectors).as_numpy()
     result = _copy_first_flux_nonfinite_metadata(result, [total_flux_trace, *sector_flux_traces])

--- a/openghg_inversions/rhime/params.py
+++ b/openghg_inversions/rhime/params.py
@@ -64,6 +64,17 @@ def as_list(value: str | Sequence[str] | None) -> list[str] | None:
     return [str(item) for item in value]
 
 
+def _duplicate_names(values: Sequence[str]) -> list[str]:
+    """Return duplicate names once each, preserving their first repeated order."""
+    seen: set[str] = set()
+    duplicates: list[str] = []
+    for value in values:
+        if value in seen and value not in duplicates:
+            duplicates.append(value)
+        seen.add(value)
+    return duplicates
+
+
 def resolve_flux_sources(
     *,
     flux_sources: str | Sequence[str] | None = None,
@@ -88,6 +99,12 @@ def resolve_flux_sources(
         resolved = as_list(emissions_name)
     if not resolved or any(source in {"", "None", "none"} for source in resolved):
         raise ValueError("At least one flux source must be supplied via `flux_sources`.")
+    duplicates = _duplicate_names(resolved)
+    if duplicates:
+        raise ValueError(
+            "`flux_sources` must contain unique OpenGHG source values; "
+            f"duplicate source(s): {duplicates!r}."
+        )
     return resolved
 
 
@@ -282,7 +299,18 @@ def normalise_sector_sources(
     """Copy optional sector-to-source mappings with string names."""
     if sector_sources is None:
         return None
-    return {str(sector): str(source) for sector, source in sector_sources.items()}
+    normalized = {str(sector): str(source) for sector, source in sector_sources.items()}
+    invalid = [
+        (sector, source)
+        for sector, source in normalized.items()
+        if not sector.strip() or not source.strip() or source in {"None", "none"}
+    ]
+    if invalid:
+        raise ValueError(
+            "`sector_sources` must map non-empty sector names to non-empty OpenGHG source values; "
+            f"invalid mapping(s): {invalid!r}."
+        )
+    return normalized
 
 
 def required_run_params() -> set[str]:
@@ -369,6 +397,38 @@ def _tuple_from_optional_sequence(value: Any) -> tuple[str | None, ...]:
     return (str(value),)
 
 
+def _validate_sector_source_mapping(
+    flux_sources: Sequence[str],
+    sector_sources: Mapping[str, str],
+) -> list[str]:
+    """Validate the current one-to-one sector/source routing contract."""
+    source_sectors: dict[str, list[str]] = {}
+    for sector, source in sector_sources.items():
+        source_sectors.setdefault(source, []).append(sector)
+    duplicate_sources = {
+        source: sector_names for source, sector_names in source_sectors.items() if len(sector_names) > 1
+    }
+    if duplicate_sources:
+        details = ", ".join(
+            f"source {source!r} is mapped by sectors {sector_names!r}"
+            for source, sector_names in duplicate_sources.items()
+        )
+        raise ValueError(
+            "`sector_sources` must map each current sector to a distinct OpenGHG source; " + details + "."
+        )
+
+    mapped_sources = list(sector_sources.values())
+    missing_sources = [source for source in flux_sources if source not in mapped_sources]
+    unrequested_sources = [source for source in mapped_sources if source not in flux_sources]
+    if missing_sources or unrequested_sources:
+        raise ValueError(
+            "`sector_sources` values must match `flux_sources`; "
+            f"missing source mapping(s): {missing_sources!r}; "
+            f"unrequested source value(s): {unrequested_sources!r}."
+        )
+    return mapped_sources
+
+
 def _make_model_spec(
     *,
     species: str,
@@ -395,15 +455,21 @@ def _make_model_spec(
     sectors = []
     used_suffixes: set[str] = set()
     if sector_sources is not None:
-        mapped_sources = list(dict.fromkeys(sector_sources.values()))
-        if set(mapped_sources) != set(flux_sources):
-            raise ValueError(
-                "`sector_sources` values must match `flux_sources` so RHIME can retrieve the "
-                "OpenGHG data used by each sector."
-            )
+        _validate_sector_source_mapping(flux_sources, sector_sources)
         sector_items = list(sector_sources.items())
     else:
         sector_items = [(source, source) for source in flux_sources]
+
+    sector_names = [name for name, _ in sector_items]
+    if sector_priors is not None:
+        missing_priors = [name for name in sector_names if name not in sector_priors]
+        unused_priors = [name for name in sector_priors if name not in sector_names]
+        if missing_priors or unused_priors:
+            raise ValueError(
+                "`sector_priors` must define exactly one prior for every sector when supplied; "
+                f"missing sector prior(s): {missing_priors!r}; "
+                f"unused sector prior key(s): {unused_priors!r}."
+            )
 
     for name, source in sector_items:
         suffix = safe_pymc_name(name)
@@ -413,9 +479,7 @@ def _make_model_spec(
                 f"duplicate sanitized name {suffix!r}."
             )
         used_suffixes.add(suffix)
-        prior = (
-            sector_priors[name] if sector_priors is not None and name in sector_priors else default_x_prior
-        )
+        prior = sector_priors[name] if sector_priors is not None else default_x_prior
         sectors.append(
             SectorSpec(
                 name=name,
@@ -460,13 +524,10 @@ def make_rhime_runner_setup(
     if not multisector and sector_sources is not None:
         raise ValueError("`sector_sources` is only supported by `run_rhime_multisector`.")
     data_flux_sources = (
-        list(dict.fromkeys(sector_sources.values())) if sector_sources is not None else flux_sources
+        _validate_sector_source_mapping(flux_sources, sector_sources)
+        if sector_sources is not None
+        else flux_sources
     )
-    if sector_sources is not None and set(data_flux_sources) != set(flux_sources):
-        raise ValueError(
-            "`sector_sources` values must match `flux_sources` so RHIME can retrieve the "
-            "OpenGHG data used by each sector."
-        )
     if multisector and len(data_flux_sources) < 2:
         raise ValueError("`run_rhime_multisector` requires at least two flux sources.")
     if not multisector and len(flux_sources) != 1:

--- a/openghg_inversions/rhime/runner.py
+++ b/openghg_inversions/rhime/runner.py
@@ -34,6 +34,7 @@ from pathlib import Path
 from typing import Any
 
 import arviz as az
+import pandas as pd
 import pymc as pm
 import xarray as xr
 
@@ -345,12 +346,19 @@ def run_rhime_from_prepared_inputs(
     if sector_count < 1:
         raise ValueError(f"`run_spec.model.sectors` must contain at least one sector; found {sector_count}.")
     multisector = sector_count > 1
-    prepared_is_multisector = "source" in prepared_inputs.inv_inputs["H"].coords
+    sensitivity = prepared_inputs.inv_inputs["H"]
+    source_coord = sensitivity.coords.get("source")
+    state_dims = [str(dim) for dim in sensitivity.dims if dim != "nmeasure"]
+    gathered_source = False
+    if source_coord is not None and len(state_dims) == 1 and source_coord.dims == (state_dims[0],):
+        source_index = sensitivity.indexes.get(state_dims[0])
+        gathered_source = isinstance(source_index, pd.MultiIndex) and "source" in source_index.names
+    prepared_is_multisector = "source" in sensitivity.dims or gathered_source
     if run_spec.split_by_sectors is not prepared_is_multisector:
         raise ValueError(
             "`run_spec.split_by_sectors` must agree with the prepared `H` layout: "
             f"split_by_sectors={run_spec.split_by_sectors}, "
-            f"source coordinate present={prepared_is_multisector}."
+            f"multisector source layout present={prepared_is_multisector}."
         )
     if run_spec.split_by_sectors is not multisector:
         raise ValueError(

--- a/openghg_inversions/rhime/runner.py
+++ b/openghg_inversions/rhime/runner.py
@@ -145,6 +145,65 @@ def _run_spec_with_prepared_inputs(
     )
 
 
+def _validate_multisector_basis_layout(
+    basis_functions: BasisFunctions,
+    model_spec: RhimeModelSpec,
+    inv_inputs: xr.Dataset,
+) -> None:
+    """Reject padded ragged bases unsupported by the current sector builder."""
+    operator = basis_functions.operator
+    design = inv_inputs["H"]
+    if "region" not in design.dims or "region" not in design.coords:
+        return
+    prepared_index = design.get_index("region")
+    operator_for_source = getattr(operator, "operator_for_source", None)
+    if not callable(operator_for_source):
+        state_dim = operator.meta.state_dim
+        basis_index = operator.basis_matrix.get_index(state_dim)
+        if not basis_index.equals(prepared_index):
+            sector_sources = [
+                (sector.name, sector.flux_source) for sector in model_spec.sectors
+            ]
+            raise ValueError(
+                "Retained shared basis state coordinates do not match prepared H.region for "
+                f"sector/source mapping(s) {sector_sources!r}: basis has {len(basis_index)} "
+                f"elements, prepared H has {len(prepared_index)}."
+            )
+        return
+
+    region_layouts: list[tuple[str, str, int, bool]] = []
+    for sector in model_spec.sectors:
+        try:
+            source_operator: Any = operator_for_source(sector.flux_source)
+        except ValueError as exc:
+            raise ValueError(
+                f"Sector {sector.name!r} requires source {sector.flux_source!r}, "
+                "but the retained basis has no matching source-specific basis."
+            ) from exc
+        state_dim = source_operator.meta.state_dim
+        basis_index = source_operator.basis_matrix.get_index(state_dim)
+        region_layouts.append(
+            (
+                sector.name,
+                sector.flux_source,
+                len(basis_index),
+                basis_index.equals(prepared_index),
+            )
+        )
+
+    if any(not coordinates_match for _, _, _, coordinates_match in region_layouts):
+        details = ", ".join(
+            f"sector {sector!r} -> source {source!r}: {count} regions"
+            + ("" if coordinates_match else " with coordinates differing from H.region")
+            for sector, source, count, coordinates_match in region_layouts
+        )
+        raise ValueError(
+            "Multi-sector RHIME currently requires compatible basis dimensions across sectors; "
+            f"prepared H has {len(prepared_index)} regions; {details}. Ragged or inconsistent "
+            "source-specific state blocks are not supported by this builder."
+        )
+
+
 def _execute_prepared_rhime(
     *,
     prepared: RhimePreparedInputs,
@@ -158,6 +217,11 @@ def _execute_prepared_rhime(
     build_and_sample_start = timer_start()
     timing_start = timer_start()
     if multisector:
+        _validate_multisector_basis_layout(
+            prepared.basis_functions,
+            run_spec.model,
+            prepared.inv_inputs,
+        )
         model = build_rhime_multisector_model_from_spec(prepared.inv_inputs, run_spec.model)
     else:
         model = build_rhime_model_from_spec(prepared.inv_inputs, run_spec.model)
@@ -356,11 +420,12 @@ def run_rhime_multisector(
             override values read from this file.
         **kwargs: RHIME run parameters using snake-case names. Multi-sector
             runs require at least two ``flux_sources`` and may include
-            ``sector_priors`` keyed by sector name. When model sector labels
-            differ from OpenGHG source values, pass ``sector_sources`` as a
-            mapping from sector name to one value in ``flux_sources``. Legacy
-            ``emissions_name`` is accepted only as a compatibility alias when
-            ``flux_sources`` is absent.
+            a complete ``sector_priors`` mapping keyed by sector name. When
+            model sector labels differ from OpenGHG source values, pass
+            ``sector_sources`` as a one-to-one mapping from sector name to one
+            unique value in ``flux_sources``. Legacy ``emissions_name`` is
+            accepted only as a compatibility alias when ``flux_sources`` is
+            absent.
 
     Returns:
         Modern RHIME result containing canonical inputs, InferenceData, specs,

--- a/openghg_inversions/rhime/runner.py
+++ b/openghg_inversions/rhime/runner.py
@@ -64,6 +64,7 @@ from openghg_inversions.models import (
     build_rhime_model_from_spec,
     build_rhime_multisector_model_from_spec,
 )
+from openghg_inversions.models._rhime_flux import _select_sector_design
 from openghg_inversions.postprocessing.inversion_output import InversionOutput
 
 __all__ = [
@@ -150,57 +151,55 @@ def _validate_multisector_basis_layout(
     model_spec: RhimeModelSpec,
     inv_inputs: xr.Dataset,
 ) -> None:
-    """Reject padded ragged bases unsupported by the current sector builder."""
-    operator = basis_functions.operator
+    """Require retained basis indexes to match each prepared sector design."""
     design = inv_inputs["H"]
-    if "region" not in design.dims or "region" not in design.coords:
-        return
-    prepared_index = design.get_index("region")
-    operator_for_source = getattr(operator, "operator_for_source", None)
-    if not callable(operator_for_source):
-        state_dim = operator.meta.state_dim
-        basis_index = operator.basis_matrix.get_index(state_dim)
-        if not basis_index.equals(prepared_index):
-            sector_sources = [
-                (sector.name, sector.flux_source) for sector in model_spec.sectors
-            ]
-            raise ValueError(
-                "Retained shared basis state coordinates do not match prepared H.region for "
-                f"sector/source mapping(s) {sector_sources!r}: basis has {len(basis_index)} "
-                f"elements, prepared H has {len(prepared_index)}."
-            )
-        return
 
-    region_layouts: list[tuple[str, str, int, bool]] = []
+    region_layouts: list[tuple[str, str, int, int, bool]] = []
     for sector in model_spec.sectors:
         try:
-            source_operator: Any = operator_for_source(sector.flux_source)
-        except ValueError as exc:
+            source_basis = basis_functions.for_source(sector.flux_source)
+        except (KeyError, ValueError) as exc:
             raise ValueError(
                 f"Sector {sector.name!r} requires source {sector.flux_source!r}, "
                 "but the retained basis has no matching source-specific basis."
             ) from exc
+        source_operator = source_basis.operator
         state_dim = source_operator.meta.state_dim
         basis_index = source_operator.basis_matrix.get_index(state_dim)
+        sector_design = _select_sector_design(
+            design,
+            sector=sector.name,
+            source=sector.flux_source,
+            variable_suffix=sector.variable_suffix,
+        )
+        prepared_state_dims = [str(dim) for dim in sector_design.dims if dim != "nmeasure"]
+        if len(prepared_state_dims) != 1:
+            raise ValueError(
+                f"Sector {sector.name!r} -> source {sector.flux_source!r} must have exactly "
+                f"one prepared state dimension; found {prepared_state_dims!r}."
+            )
+        prepared_index = sector_design.get_index(prepared_state_dims[0])
         region_layouts.append(
             (
                 sector.name,
                 sector.flux_source,
                 len(basis_index),
+                len(prepared_index),
                 basis_index.equals(prepared_index),
             )
         )
 
-    if any(not coordinates_match for _, _, _, coordinates_match in region_layouts):
+    if any(not coordinates_match for _, _, _, _, coordinates_match in region_layouts):
         details = ", ".join(
-            f"sector {sector!r} -> source {source!r}: {count} regions"
-            + ("" if coordinates_match else " with coordinates differing from H.region")
-            for sector, source, count, coordinates_match in region_layouts
+            f"sector {sector!r} -> source {source!r}: basis has {basis_count} regions, "
+            f"prepared H has {prepared_count}"
+            + ("" if coordinates_match else " with different coordinates")
+            for sector, source, basis_count, prepared_count, coordinates_match in region_layouts
         )
         raise ValueError(
-            "Multi-sector RHIME currently requires compatible basis dimensions across sectors; "
-            f"prepared H has {len(prepared_index)} regions; {details}. Ragged or inconsistent "
-            "source-specific state blocks are not supported by this builder."
+            "Retained source-specific basis state coordinates do not match prepared H; "
+            + details
+            + "."
         )
 
 
@@ -346,12 +345,12 @@ def run_rhime_from_prepared_inputs(
     if sector_count < 1:
         raise ValueError(f"`run_spec.model.sectors` must contain at least one sector; found {sector_count}.")
     multisector = sector_count > 1
-    prepared_is_multisector = "source" in prepared_inputs.inv_inputs["H"].dims
+    prepared_is_multisector = "source" in prepared_inputs.inv_inputs["H"].coords
     if run_spec.split_by_sectors is not prepared_is_multisector:
         raise ValueError(
             "`run_spec.split_by_sectors` must agree with the prepared `H` layout: "
             f"split_by_sectors={run_spec.split_by_sectors}, "
-            f"source dimension present={prepared_is_multisector}."
+            f"source coordinate present={prepared_is_multisector}."
         )
     if run_spec.split_by_sectors is not multisector:
         raise ValueError(

--- a/tests/postprocessing/test_make_outputs.py
+++ b/tests/postprocessing/test_make_outputs.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Callable, cast
 
+import arviz as az
 import numpy as np
 import pytest
 import xarray as xr
@@ -93,6 +94,59 @@ def test_multisector_flux_outputs_support_source_specific_basis(
     assert "flux_total_posterior_mode" in outputs
     assert float(outputs["flux_total_posterior_mean"].item()) == 2.0
     assert _flux_nonfinite_metadata(outputs).policy == NONFINITE_POLICY_ZERO_FILL
+
+
+def test_multisector_mode_kde_scale_factors_use_each_sector_state_dimension(
+    multisector_postprocessing_inv_out: Callable[..., InversionOutput],
+) -> None:
+    """Ragged sector scale-factor modes chunk each sector along its own state dimension."""
+    ff_basis = xr.DataArray(
+        [[1, 2]],
+        dims=("lat", "lon"),
+        coords={"lat": [0.0], "lon": [0.0, 1.0]},
+    )
+    ocean_basis = xr.DataArray(
+        [[1, 1]],
+        dims=("lat", "lon"),
+        coords={"lat": [0.0], "lon": [0.0, 1.0]},
+    )
+    flux = xr.DataArray(
+        np.ones((2, 1, 2)),
+        dims=("source", "lat", "lon"),
+        coords={
+            "source": ["ff-inventory", "ocean-inventory"],
+            "lat": [0.0],
+            "lon": [0.0, 1.0],
+        },
+        attrs={"units": "mol/m2/s"},
+    )
+    basis_functions = BasisFunctions.from_multi_source_flat_basis(
+        basis_flat={
+            "ff-inventory": ff_basis,
+            "ocean-inventory": ocean_basis,
+        },
+        flux=flux,
+        operator_kwargs={"state_dim": "state"},
+    )
+    inv_out = multisector_postprocessing_inv_out(basis_functions)
+    inv_out.trace = az.from_dict(
+        posterior={
+            "x_ff": np.array([[[1.0, 2.0], [1.5, 2.5], [2.0, 3.0], [2.5, 3.5]]]),
+            "x_ocean": np.array([[[0.5], [1.0], [1.5], [2.0]]]),
+        },
+        coords={"state_ff": [0, 1], "state_ocean": [0]},
+        dims={"x_ff": ["state_ff"], "x_ocean": ["state_ocean"]},
+    )
+
+    outputs = make_flux_outputs(
+        inv_out,
+        stats=["mode_kde"],
+        include_scale_factors=True,
+        report_flux_on_inversion_grid=False,
+    )
+
+    assert "scaling_ff_posterior_mode" in outputs
+    assert "scaling_ocean_posterior_mode" in outputs
 
 
 def test_multisector_flux_trace_materialization_is_optional(

--- a/tests/test_array_ops.py
+++ b/tests/test_array_ops.py
@@ -6,8 +6,10 @@ import xarray as xr
 
 from openghg_inversions.array_ops import (
     align_to_multi_index_level_values,
+    concat_gather_data_arrays,
     concat_gather_datatree,
     concat_gather_datasets,
+    select_gathered_data_array,
 )
 
 
@@ -154,6 +156,44 @@ def test_align_to_multi_index_level_values_with_other_level_as_dim_warns():
         )
 
     xr.testing.assert_equal(da_stack.a, da_aligned.a)
+
+
+def test_select_gathered_data_array_restores_ragged_labels_and_values() -> None:
+    """Selecting a gathered key should retain represented values, including NaNs."""
+    time = pd.date_range("2020-01-01", periods=2, freq="1h")
+    gathered = concat_gather_data_arrays(
+        {
+            "ff": xr.DataArray(
+                [[1.0, np.nan], [2.0, 3.0]],
+                dims=("region", "time"),
+                coords={"region": [10, 11], "time": time},
+            ),
+            "ocean": xr.DataArray(
+                [[4.0, 5.0]],
+                dims=("region", "time"),
+                coords={"region": [20], "time": time},
+            ),
+        },
+        key_dim="source",
+        ragged_dim="region",
+        stack_dim="state",
+        join="exact",
+    )
+
+    selected = select_gathered_data_array(
+        gathered,
+        key="ff",
+        key_dim="source",
+        ragged_dim="region",
+        stack_dim="state",
+    )
+
+    expected = xr.DataArray(
+        [[1.0, np.nan], [2.0, 3.0]],
+        dims=("state", "time"),
+        coords={"state": [10, 11], "time": time},
+    )
+    xr.testing.assert_identical(selected, expected)
 
 
 @pytest.mark.parametrize("use_datatree", [False, True], ids=["datasets", "datatree"])

--- a/tests/test_basis_functions.py
+++ b/tests/test_basis_functions.py
@@ -42,7 +42,11 @@ from openghg_inversions.basis.operators import (
     BucketBasisOperator,
     MultiSourceBucketBasisOperator,
 )
-from openghg_inversions.basis._helpers import apply_fp_basis_functions, fp_sensitivity
+from openghg_inversions.basis._helpers import (
+    _legacy_multisource_h_if_needed,
+    apply_fp_basis_functions,
+    fp_sensitivity,
+)
 from openghg_inversions.flux_sanitization import (
     FluxNonFiniteMetadata,
     NONFINITE_CHECKED_COMPUTED,
@@ -1414,6 +1418,32 @@ def test_basisfunctions_interpolate_trace_with_chain_dim():
 # --------------------------------------------------------------------------------------
 # Multi-source equivalence: gathered MultiIndex vs legacy padded H conversion
 # --------------------------------------------------------------------------------------
+def test_legacy_multisource_adapter_only_zero_fills_structural_padding() -> None:
+    """Legacy rectangularization must preserve NaNs in represented state cells."""
+    state_index = pd.MultiIndex.from_tuples(
+        [("ff", 0), ("ff", 1), ("ocean", 0)],
+        names=["source", "region_in_source"],
+    )
+    sensitivity = xr.DataArray(
+        [[1.0, 2.0], [np.nan, 4.0], [5.0, 6.0]],
+        dims=("state", "time"),
+        coords={
+            **xr.Coordinates.from_pandas_multiindex(state_index, "state"),
+            "time": [0, 1],
+        },
+    )
+
+    result = _legacy_multisource_h_if_needed(
+        sensitivity,
+        state_dim="state",
+        flux_sources=["ff", "ocean"],
+    )
+
+    assert np.isnan(result.sel(source="ff", region=1, time=0))
+    assert result.sel(source="ocean", region=1, time=0).item() == 0.0
+    assert result.coords["source_region_count"].to_dict()["data"] == [2, 1]
+
+
 def test_multisource_sensitivity_matches_legacy_padded_conversion_smoke():
     """Smoke test: gathered multi-source sensitivity matches legacy padded->gathered conversion.
 

--- a/tests/test_basis_functions.py
+++ b/tests/test_basis_functions.py
@@ -1418,17 +1418,27 @@ def test_basisfunctions_interpolate_trace_with_chain_dim():
 # --------------------------------------------------------------------------------------
 # Multi-source equivalence: gathered MultiIndex vs legacy padded H conversion
 # --------------------------------------------------------------------------------------
-def test_legacy_multisource_adapter_only_zero_fills_structural_padding() -> None:
+@pytest.mark.parametrize("use_multiindex", [True, False], ids=["multiindex", "auxiliary-coordinates"])
+def test_legacy_multisource_adapter_only_zero_fills_structural_padding(use_multiindex: bool) -> None:
     """Legacy rectangularization must preserve NaNs in represented state cells."""
     state_index = pd.MultiIndex.from_tuples(
         [("ff", 0), ("ff", 1), ("ocean", 0)],
         names=["source", "region_in_source"],
     )
+    state_coords: dict = (
+        dict(xr.Coordinates.from_pandas_multiindex(state_index, "state"))
+        if use_multiindex
+        else {
+            "state": [0, 1, 2],
+            "source": ("state", ["ff", "ff", "ocean"]),
+            "region_in_source": ("state", [0, 1, 0]),
+        }
+    )
     sensitivity = xr.DataArray(
         [[1.0, 2.0], [np.nan, 4.0], [5.0, 6.0]],
         dims=("state", "time"),
         coords={
-            **xr.Coordinates.from_pandas_multiindex(state_index, "state"),
+            **state_coords,
             "time": [0, 1],
         },
     )

--- a/tests/test_inversion_inputs.py
+++ b/tests/test_inversion_inputs.py
@@ -293,6 +293,55 @@ def test_make_inv_inputs_drops_non_shared_data_vars():
     assert "sigma_freq_index" not in result
 
 
+def test_make_inv_inputs_rejects_mismatched_gathered_state_indexes() -> None:
+    """Site gathering must not outer-align different source/region state layouts."""
+    fp_data = {
+        "AAA": _make_minimal_fp_site(mf_base=10.0, include_inlet_height=False),
+        "BBB": _make_minimal_fp_site(mf_base=20.0, include_inlet_height=False),
+    }
+    state_indexes = {
+        "AAA": pd.MultiIndex.from_tuples(
+            [("ff", 0), ("ff", 1), ("ocean", 0)],
+            names=["source", "region_in_source"],
+        ),
+        "BBB": pd.MultiIndex.from_tuples(
+            [("ff", 0), ("ocean", 0)],
+            names=["source", "region_in_source"],
+        ),
+    }
+    for site, state_index in state_indexes.items():
+        time = fp_data[site].coords["time"]
+        fp_data[site]["H"] = xr.DataArray(
+            np.ones((len(state_index), time.size)),
+            dims=("state", "time"),
+            coords={
+                **xr.Coordinates.from_pandas_multiindex(state_index, "state"),
+                "time": time,
+            },
+        )
+
+    with pytest.raises(ValueError, match="identical indexes on every non-time dimension"):
+        make_inv_inputs(fp_data=fp_data, sites=["AAA", "BBB"], min_error=0.0)
+
+
+def test_make_inv_inputs_rejects_mismatched_state_dimension_names() -> None:
+    """Site gathering must not broadcast differently named state dimensions."""
+    fp_data = {
+        "AAA": _make_minimal_fp_site(mf_base=10.0, include_inlet_height=False),
+        "BBB": _make_minimal_fp_site(mf_base=20.0, include_inlet_height=False),
+    }
+    for site, state_dim in (("AAA", "state"), ("BBB", "region")):
+        time = fp_data[site].coords["time"]
+        fp_data[site]["H"] = xr.DataArray(
+            np.ones((2, time.size)),
+            dims=(state_dim, "time"),
+            coords={state_dim: [0, 1], "time": time},
+        )
+
+    with pytest.raises(ValueError, match="variable 'H'.*same non-time dimensions"):
+        make_inv_inputs(fp_data=fp_data, sites=["AAA", "BBB"], min_error=0.0)
+
+
 def test_make_inv_inputs_raises_if_required_var_would_be_dropped():
     """`make_inv_inputs` should still fail clearly if a required var is not shared."""
     fp_data = {

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -1265,7 +1265,9 @@ def test_run_rhime_from_prepared_inputs_routes_without_preparation(
         split_by_sectors=sector_count > 1,
     )
     inv_inputs = _minimal_output_inv_inputs()
-    if sector_count == 2:
+    if sector_count == 1:
+        inv_inputs["H"] = inv_inputs["H"].assign_coords(source=sectors[0].flux_source)
+    else:
         inv_inputs["H"] = xr.concat(
             [inv_inputs["H"].expand_dims(source=[sector.flux_source]) for sector in model_spec.sectors],
             dim="source",

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -865,6 +865,112 @@ def test_build_rhime_multisector_model_selects_sources_by_label(
     np.testing.assert_allclose(model["hx_ocean"].get_value(), expected_ocean.values)
 
 
+def test_build_rhime_multisector_model_accepts_gathered_ragged_states(
+    multisector_inv_inputs: xr.Dataset,
+    builder_args: dict,
+) -> None:
+    """Source-specific state blocks remain gathered until model normalization."""
+    state_index = pd.MultiIndex.from_tuples(
+        [
+            ("ff-inventory", 0),
+            ("ff-inventory", 1),
+            ("ocean-inventory", 0),
+            ("ocean-inventory", 1),
+            ("ocean-inventory", 2),
+        ],
+        names=["source", "region_in_source"],
+    )
+    nmeasure = multisector_inv_inputs.sizes["nmeasure"]
+    values = np.arange(len(state_index) * nmeasure, dtype=float).reshape(len(state_index), nmeasure)
+    inv_inputs = multisector_inv_inputs.drop_vars("H")
+    inv_inputs = inv_inputs.drop_dims([dim for dim in ("region", "source") if dim in inv_inputs.dims])
+    inv_inputs["H"] = xr.DataArray(
+        values,
+        dims=("state", "nmeasure"),
+        coords={
+            **xr.Coordinates.from_pandas_multiindex(state_index, "state"),
+            "nmeasure": multisector_inv_inputs.coords["nmeasure"],
+        },
+    )
+
+    model = build_rhime_multisector_model(
+        inv_inputs,
+        sectors=["FF", "ocean"],
+        sector_sources={"FF": "ff-inventory", "ocean": "ocean-inventory"},
+        sector_priors={
+            "FF": {"pdf": "normal", "mu": 1.0, "sigma": 0.2},
+            "ocean": {"pdf": "normal", "mu": 1.0, "sigma": 0.3},
+        },
+        **builder_args,
+    )
+
+    np.testing.assert_allclose(model["hx_ff"].get_value(), values[:2].T)
+    np.testing.assert_allclose(model["hx_ocean"].get_value(), values[2:].T)
+    assert model.named_vars_to_dims["x_ff"] == ("state_ff",)
+    assert model.named_vars_to_dims["x_ocean"] == ("state_ocean",)
+
+
+def test_build_rhime_multisector_model_rejects_ungathered_source_state(
+    multisector_inv_inputs: xr.Dataset,
+    builder_args: dict,
+) -> None:
+    """Source labels on a state axis require the canonical gathered MultiIndex."""
+    nmeasure = multisector_inv_inputs.sizes["nmeasure"]
+    inv_inputs = multisector_inv_inputs.drop_vars("H")
+    inv_inputs = inv_inputs.drop_dims([dim for dim in ("region", "source") if dim in inv_inputs.dims])
+    inv_inputs["H"] = xr.DataArray(
+        np.ones((2, nmeasure)),
+        dims=("state", "nmeasure"),
+        coords={
+            "state": [0, 1],
+            "source": ("state", ["ff-inventory", "ocean-inventory"]),
+            "nmeasure": multisector_inv_inputs.coords["nmeasure"],
+        },
+    )
+
+    with pytest.raises(ValueError, match="MultiIndex containing a 'source' level"):
+        build_rhime_multisector_model(
+            inv_inputs,
+            sectors=["FF", "ocean"],
+            sector_sources={"FF": "ff-inventory", "ocean": "ocean-inventory"},
+            **builder_args,
+        )
+
+
+def test_build_rhime_multisector_model_rejects_duplicate_gathered_states(
+    multisector_inv_inputs: xr.Dataset,
+    builder_args: dict,
+) -> None:
+    """Gathered scientific state coordinates must identify unique coefficients."""
+    state_index = pd.MultiIndex.from_tuples(
+        [
+            ("ff-inventory", 0),
+            ("ff-inventory", 0),
+            ("ocean-inventory", 0),
+        ],
+        names=["source", "region_in_source"],
+    )
+    nmeasure = multisector_inv_inputs.sizes["nmeasure"]
+    inv_inputs = multisector_inv_inputs.drop_vars("H")
+    inv_inputs = inv_inputs.drop_dims([dim for dim in ("region", "source") if dim in inv_inputs.dims])
+    inv_inputs["H"] = xr.DataArray(
+        np.ones((len(state_index), nmeasure)),
+        dims=("state", "nmeasure"),
+        coords={
+            **xr.Coordinates.from_pandas_multiindex(state_index, "state"),
+            "nmeasure": multisector_inv_inputs.coords["nmeasure"],
+        },
+    )
+
+    with pytest.raises(ValueError, match="unique state labels.*duplicate state.*ff-inventory"):
+        build_rhime_multisector_model(
+            inv_inputs,
+            sectors=["FF", "ocean"],
+            sector_sources={"FF": "ff-inventory", "ocean": "ocean-inventory"},
+            **builder_args,
+        )
+
+
 def test_build_rhime_multisector_model_rejects_duplicate_prepared_sources(
     multisector_inv_inputs: xr.Dataset,
     builder_args: dict,
@@ -2365,8 +2471,10 @@ def test_rhime_prepared_inputs_contract_exposes_only_modern_fields() -> None:
         assert not hasattr(prepared, legacy_attr)
 
 
-def test_prepared_multisector_runner_rejects_ragged_source_specific_basis_layout() -> None:
-    """Prepared-input execution rejects padded state layouts before model construction."""
+def test_prepared_multisector_runner_accepts_gathered_source_specific_basis_layout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Prepared-input validation accepts exact ragged source/state coordinates."""
     basis_ff = xr.DataArray(
         [[0, 0], [1, 1]],
         dims=("lat", "lon"),
@@ -2394,6 +2502,7 @@ def test_prepared_multisector_runner_rejects_ragged_source_specific_basis_layout
     model_spec = RhimeModelSpec(
         species="ch4",
         domain="EUROPE",
+        use_bc=False,
         sectors=(
             SectorSpec("FF", "ff-inventory", {"pdf": "normal", "mu": 1.0, "sigma": 0.2}, "ff"),
             SectorSpec(
@@ -2404,16 +2513,22 @@ def test_prepared_multisector_runner_rejects_ragged_source_specific_basis_layout
             ),
         ),
     )
-    inv_inputs = _minimal_output_inv_inputs().drop_dims("region")
-    inv_inputs["H"] = xr.DataArray(
-        np.ones((3, 1, 2)),
-        dims=("region", "nmeasure", "source"),
+    fp_x_flux = xr.DataArray(
+        np.ones((2, 2, 2, 1)),
+        dims=("source", "lat", "lon", "time"),
         coords={
-            "region": [0, 1, 2],
-            "nmeasure": inv_inputs.coords["nmeasure"],
             "source": ["ff-inventory", "ocean-inventory"],
+            "lat": [0.0, 1.0],
+            "lon": [0.0, 1.0],
+            "time": [0],
         },
     )
+    inv_inputs = _minimal_output_inv_inputs().drop_dims("region")
+    inv_inputs["min_error"] = xr.zeros_like(inv_inputs["mf"])
+    inv_inputs["H"] = basis_functions.sensitivity(fp_x_flux).rename(time="nmeasure").assign_coords(
+        nmeasure=inv_inputs.coords["nmeasure"]
+    )
+
     prepared = RhimePreparedInputs(
         inv_inputs=inv_inputs,
         basis_functions=basis_functions,
@@ -2430,13 +2545,21 @@ def test_prepared_multisector_runner_rejects_ragged_source_specific_basis_layout
         output=RhimeOutputSpec(output_format="none"),
         split_by_sectors=True,
     )
+    monkeypatch.setattr(
+        RhimeSampler,
+        "sample",
+        lambda self, model: _minimal_output_idata(),
+    )
+    monkeypatch.setattr(
+        rhime_module,
+        "make_multisector_output_bundle",
+        lambda **kwargs: rhime_outputs.RhimeOutputBundle(),
+    )
 
-    with pytest.raises(
-        ValueError,
-        match="prepared H has 3 regions.*sector 'FF' -> source 'ff-inventory': 2 regions.*"
-        "sector 'ocean' -> source 'ocean-inventory': 3 regions",
-    ):
-        run_rhime_from_prepared_inputs(prepared_inputs=prepared, run_spec=run_spec)
+    result = run_rhime_from_prepared_inputs(prepared_inputs=prepared, run_spec=run_spec)
+
+    assert result.model.named_vars_to_dims["x_ff"] == ("region_ff",)
+    assert result.model.named_vars_to_dims["x_ocean"] == ("region_ocean",)
 
 
 def test_multisector_runner_rejects_shared_basis_h_layout_mismatch() -> None:
@@ -2468,7 +2591,10 @@ def test_multisector_runner_rejects_shared_basis_h_layout_mismatch() -> None:
         },
     )
 
-    with pytest.raises(ValueError, match="Retained shared basis.*basis has 1 elements.*H has 2"):
+    with pytest.raises(
+        ValueError,
+        match="Retained source-specific basis.*basis has 1 regions.*prepared H has 2",
+    ):
         rhime_module._validate_multisector_basis_layout(
             _fake_basis_functions(),
             model_spec,
@@ -2516,10 +2642,7 @@ def test_prepare_rhime_inputs_multisector_keeps_source_dimension(
     assert isinstance(prepared.basis_functions, BasisFunctions)
     assert "source" in prepared.inv_inputs["H"].dims
     assert list(prepared.inv_inputs["H"].coords["source"].values) == flux_sources
-    assert list(prepared.inv_inputs["H"].coords["source_region_count"].values) == [
-        prepared.inv_inputs.sizes["region"],
-        prepared.inv_inputs.sizes["region"],
-    ]
+    assert "source_region_count" not in prepared.inv_inputs["H"].coords
 
 
 def test_multisector_sensitivity_sources_fail_before_site_gathering() -> None:
@@ -2571,6 +2694,60 @@ def test_multisector_sensitivity_sources_fail_before_site_gathering() -> None:
             bc_basis_case="NESW",
             bc_basis_directory=None,
         )
+
+
+def test_multisector_site_preparation_keeps_gathered_source_state() -> None:
+    """Modern preparation must not rectangularize ragged source-specific state."""
+    time = pd.date_range("2019-01-01", periods=2, freq="h")
+    state_index = pd.MultiIndex.from_tuples(
+        [("ff-inventory", 0), ("ff-inventory", 1), ("ocean-inventory", 0)],
+        names=["source", "region_in_source"],
+    )
+    sensitivity = xr.DataArray(
+        np.ones((3, 2)),
+        dims=("state", "time"),
+        coords={
+            **xr.Coordinates.from_pandas_multiindex(state_index, "state"),
+            "time": time,
+        },
+    )
+    fp_x_flux = xr.DataArray(
+        np.ones((2, 2)),
+        dims=("source", "time"),
+        coords={
+            "source": ["ff-inventory", "ocean-inventory"],
+            "time": time,
+        },
+        name="fp_x_flux_sectoral",
+    )
+
+    class GatheredBasis:
+        def sensitivity(self, _: xr.DataArray) -> xr.DataArray:
+            return sensitivity
+
+    merged = prep_module._MergedInversionData(
+        fp_all={"TAC": xr.Dataset({"fp_x_flux_sectoral": fp_x_flux})},
+        sites=["TAC"],
+        averaging_period=["1H"],
+    )
+
+    prepared = prep_module._rhime_site_data_from_basis_functions(
+        merged=merged,
+        basis_functions=cast(BasisFunctions, GatheredBasis()),
+        domain="EUROPE",
+        split_by_sectors=True,
+        flux_sources=["ff-inventory", "ocean-inventory"],
+        use_bc=False,
+        bc_basis_case="NESW",
+        bc_basis_directory=None,
+    )
+
+    xr.testing.assert_identical(prepared["TAC"]["H"], sensitivity.rename("H"))
+    assert "source" not in prepared["TAC"]["H"].dims
+    assert list(prepared["TAC"]["H"].indexes["state"].names) == [
+        "source",
+        "region_in_source",
+    ]
 
 
 def test_fixedbasis_preparation_adds_anchored_legacy_sigma_index(
@@ -2634,7 +2811,7 @@ def test_prepare_rhime_inputs_uses_basis_sensitivity_without_legacy_side_channel
         coords={"state": [0], "time": site_data.time},
         name="H",
     )
-    expected_sensitivity = sensitivity.rename({"state": "region"})
+    expected_sensitivity = sensitivity
     basis_functions = _SpyBasisFunctions(sensitivity)
     captured_fp_data_keys: set[str] = set()
 

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -841,6 +841,154 @@ def test_build_rhime_multisector_model_uses_sector_names_for_variables(
     np.testing.assert_allclose(prior["mu"], prior["mu_ff"] + prior["mu_ocean"])
 
 
+def test_build_rhime_multisector_model_selects_sources_by_label(
+    multisector_inv_inputs: xr.Dataset,
+    builder_args: dict,
+) -> None:
+    """Sector routing is independent of the prepared source-coordinate order."""
+    reversed_inputs = multisector_inv_inputs.sel(source=["sector-2", "total-ukghg-edgar7"])
+
+    model = build_rhime_multisector_model(
+        reversed_inputs,
+        sectors=["FF", "ocean"],
+        sector_sources={"FF": "total-ukghg-edgar7", "ocean": "sector-2"},
+        sector_priors={
+            "FF": {"pdf": "normal", "mu": 1.0, "sigma": 0.2},
+            "ocean": {"pdf": "normal", "mu": 1.0, "sigma": 0.3},
+        },
+        **builder_args,
+    )
+
+    expected_ff = reversed_inputs["H"].sel(source="total-ukghg-edgar7").transpose("nmeasure", "region")
+    expected_ocean = reversed_inputs["H"].sel(source="sector-2").transpose("nmeasure", "region")
+    np.testing.assert_allclose(model["hx_ff"].get_value(), expected_ff.values)
+    np.testing.assert_allclose(model["hx_ocean"].get_value(), expected_ocean.values)
+
+
+def test_build_rhime_multisector_model_rejects_duplicate_prepared_sources(
+    multisector_inv_inputs: xr.Dataset,
+    builder_args: dict,
+) -> None:
+    """Duplicate source coordinates fail before label selection becomes ambiguous."""
+    duplicate_sources = multisector_inv_inputs.sel(
+        source=["total-ukghg-edgar7", "total-ukghg-edgar7"]
+    )
+
+    with pytest.raises(ValueError, match="duplicate source 'total-ukghg-edgar7'"):
+        build_rhime_multisector_model(duplicate_sources, **builder_args)
+
+
+def test_build_rhime_multisector_model_rejects_padded_source_regions(
+    multisector_inv_inputs: xr.Dataset,
+    builder_args: dict,
+) -> None:
+    """Direct builders reject latent state elements introduced only by padding."""
+    region_count = multisector_inv_inputs.sizes["region"]
+    padded_inputs = multisector_inv_inputs.assign_coords(
+        source_region_count=(
+            "source",
+            [region_count - 1, region_count],
+        )
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            f"Sector 'FF' -> source 'total-ukghg-edgar7' declares {region_count - 1} "
+            f"region elements.*prepared H has {region_count}"
+        ),
+    ):
+        build_rhime_multisector_model(
+            padded_inputs,
+            sectors=["FF", "ocean"],
+            sector_sources={"FF": "total-ukghg-edgar7", "ocean": "sector-2"},
+            **builder_args,
+        )
+
+
+def test_build_rhime_multisector_model_allows_prior_only_regions(
+    multisector_inv_inputs: xr.Dataset,
+    builder_args: dict,
+) -> None:
+    """Zero sensitivity is not mistaken for padding when layout metadata matches."""
+    region_count = multisector_inv_inputs.sizes["region"]
+    inv_inputs = multisector_inv_inputs.assign_coords(
+        source_region_count=("source", [region_count, region_count])
+    ).copy(deep=True)
+    inv_inputs["H"].loc[{"source": "total-ukghg-edgar7", "region": 0}] = 0
+
+    model = build_rhime_multisector_model(
+        inv_inputs,
+        sectors=["FF", "ocean"],
+        sector_sources={"FF": "total-ukghg-edgar7", "ocean": "sector-2"},
+        **builder_args,
+    )
+
+    assert "x_ff" in model.named_vars
+
+
+def test_build_rhime_multisector_model_rejects_duplicate_sector_source_mappings(
+    multisector_inv_inputs: xr.Dataset,
+    builder_args: dict,
+) -> None:
+    """Independent sector states cannot select the same source sensitivity."""
+    with pytest.raises(ValueError, match="source 'total-ukghg-edgar7'.*\\['FF', 'other'\\]"):
+        build_rhime_multisector_model(
+            multisector_inv_inputs,
+            sectors=["FF", "other"],
+            sector_sources={"FF": "total-ukghg-edgar7", "other": "total-ukghg-edgar7"},
+            **builder_args,
+        )
+
+
+def test_build_rhime_multisector_model_names_sector_and_missing_source(
+    multisector_inv_inputs: xr.Dataset,
+    builder_args: dict,
+) -> None:
+    """Missing prepared data errors retain semantic sector and source identities."""
+    with pytest.raises(ValueError, match="sector 'FF' -> source 'missing-inventory'"):
+        build_rhime_multisector_model(
+            multisector_inv_inputs,
+            sectors=["FF", "ocean"],
+            sector_sources={"FF": "missing-inventory", "ocean": "sector-2"},
+            **builder_args,
+        )
+
+
+@pytest.mark.parametrize(
+    ("sector_priors", "error_fragment"),
+    [
+        (
+            {"FF": {"pdf": "normal", "mu": 1.0, "sigma": 0.2}},
+            "missing sector prior\\(s\\): \\['ocean'\\]",
+        ),
+        (
+            {
+                "FF": {"pdf": "normal", "mu": 1.0, "sigma": 0.2},
+                "ocean": {"pdf": "normal", "mu": 1.0, "sigma": 0.3},
+                "typo": {"pdf": "normal", "mu": 1.0, "sigma": 0.4},
+            },
+            "unused sector prior key\\(s\\): \\['typo'\\]",
+        ),
+    ],
+)
+def test_build_rhime_multisector_model_requires_exact_sector_prior_keys(
+    multisector_inv_inputs: xr.Dataset,
+    builder_args: dict,
+    sector_priors: dict[str, dict[str, Any]],
+    error_fragment: str,
+) -> None:
+    """Explicit per-sector priors must be complete and contain no unused keys."""
+    with pytest.raises(ValueError, match=error_fragment):
+        build_rhime_multisector_model(
+            multisector_inv_inputs,
+            sectors=["FF", "ocean"],
+            sector_sources={"FF": "total-ukghg-edgar7", "ocean": "sector-2"},
+            sector_priors=sector_priors,
+            **builder_args,
+        )
+
+
 def test_build_rhime_multisector_model_rejects_reparameterized_name_collisions(
     multisector_inv_inputs: xr.Dataset,
     builder_args: dict,
@@ -1388,8 +1536,10 @@ def test_rhime_runner_setup_builds_specs_before_preparation(tmp_path: Path) -> N
         "output_format": "none",
         "x_prior": {"pdf": "normal", "mu": 1.0, "sigma": 0.5},
         "sector_priors": {
+            "FF": {"pdf": "normal", "mu": 1.0, "sigma": 0.5},
             "GPP": {"pdf": "normal", "mu": 0.7, "sigma": 0.2},
             "TER": {"pdf": "normal", "mu": 1.3, "sigma": 0.3},
+            "ocean": {"pdf": "normal", "mu": 1.0, "sigma": 0.5},
         },
         "sigma_freq": "8D",
         "draws": "7",
@@ -2067,6 +2217,76 @@ def test_run_rhime_multisector_rejects_duplicate_sanitized_sector_names() -> Non
         )
 
 
+def test_resolve_flux_sources_rejects_duplicates() -> None:
+    """Repeated retrieval identities are rejected before OpenGHG access."""
+    with pytest.raises(ValueError, match="duplicate source.*ff-inventory"):
+        resolve_flux_sources(flux_sources=["ff-inventory", "ff-inventory"])
+
+
+def test_run_rhime_multisector_rejects_duplicate_sector_source_mappings() -> None:
+    """Current independent sector states require distinct source sensitivities."""
+    with pytest.raises(ValueError, match="source 'ff-inventory'.*\\['FF', 'other'\\]"):
+        rhime_module._make_rhime_runner_setup(
+            params={
+                "species": "ch4",
+                "sites": ["TAC"],
+                "averaging_period": ["1h"],
+                "domain": "EUROPE",
+                "start_date": "2019-01-01",
+                "end_date": "2019-01-02",
+                "output_name": "test",
+                "output_format": "none",
+                "flux_sources": ["ff-inventory"],
+                "sector_sources": {
+                    "FF": "ff-inventory",
+                    "other": "ff-inventory",
+                },
+            },
+            multisector=True,
+        )
+
+
+@pytest.mark.parametrize(
+    ("sector_priors", "error_fragment"),
+    [
+        (
+            {"FF": {"pdf": "normal", "mu": 1.0, "sigma": 0.2}},
+            "missing sector prior\\(s\\): \\['ocean'\\]",
+        ),
+        (
+            {
+                "FF": {"pdf": "normal", "mu": 1.0, "sigma": 0.2},
+                "ocean": {"pdf": "normal", "mu": 1.0, "sigma": 0.3},
+                "oecam": {"pdf": "normal", "mu": 1.0, "sigma": 0.4},
+            },
+            "unused sector prior key\\(s\\): \\['oecam'\\]",
+        ),
+    ],
+)
+def test_run_rhime_multisector_rejects_inexact_sector_prior_keys(
+    sector_priors: dict[str, dict[str, Any]],
+    error_fragment: str,
+) -> None:
+    """Missing and unused sector prior keys fail before data preparation."""
+    with pytest.raises(ValueError, match=error_fragment):
+        rhime_module._make_rhime_runner_setup(
+            params={
+                "species": "ch4",
+                "sites": ["TAC"],
+                "averaging_period": ["1h"],
+                "domain": "EUROPE",
+                "start_date": "2019-01-01",
+                "end_date": "2019-01-02",
+                "output_name": "test",
+                "output_format": "none",
+                "flux_sources": ["ff-inventory", "ocean-inventory"],
+                "sector_sources": {"FF": "ff-inventory", "ocean": "ocean-inventory"},
+                "sector_priors": sector_priors,
+            },
+            multisector=True,
+        )
+
+
 def test_new_rhime_docs_use_flux_sources_for_examples() -> None:
     """New RHIME docs keep legacy names out of config/API examples."""
     rhime_doc = Path("docs/usage/rhime.rst").read_text(encoding="utf-8")
@@ -2145,6 +2365,117 @@ def test_rhime_prepared_inputs_contract_exposes_only_modern_fields() -> None:
         assert not hasattr(prepared, legacy_attr)
 
 
+def test_prepared_multisector_runner_rejects_ragged_source_specific_basis_layout() -> None:
+    """Prepared-input execution rejects padded state layouts before model construction."""
+    basis_ff = xr.DataArray(
+        [[0, 0], [1, 1]],
+        dims=("lat", "lon"),
+        coords={"lat": [0.0, 1.0], "lon": [0.0, 1.0]},
+    )
+    basis_ocean = xr.DataArray(
+        [[0, 1], [2, 2]],
+        dims=("lat", "lon"),
+        coords={"lat": [0.0, 1.0], "lon": [0.0, 1.0]},
+    )
+    flux = xr.DataArray(
+        np.ones((2, 2, 2)),
+        dims=("source", "lat", "lon"),
+        coords={
+            "source": ["ff-inventory", "ocean-inventory"],
+            "lat": [0.0, 1.0],
+            "lon": [0.0, 1.0],
+        },
+    )
+    basis_functions = BasisFunctions.from_multi_source_flat_basis(
+        basis_flat={"ff-inventory": basis_ff, "ocean-inventory": basis_ocean},
+        flux=flux,
+        operator_kwargs={"state_dim": "region"},
+    )
+    model_spec = RhimeModelSpec(
+        species="ch4",
+        domain="EUROPE",
+        sectors=(
+            SectorSpec("FF", "ff-inventory", {"pdf": "normal", "mu": 1.0, "sigma": 0.2}, "ff"),
+            SectorSpec(
+                "ocean",
+                "ocean-inventory",
+                {"pdf": "normal", "mu": 1.0, "sigma": 0.3},
+                "ocean",
+            ),
+        ),
+    )
+    inv_inputs = _minimal_output_inv_inputs().drop_dims("region")
+    inv_inputs["H"] = xr.DataArray(
+        np.ones((3, 1, 2)),
+        dims=("region", "nmeasure", "source"),
+        coords={
+            "region": [0, 1, 2],
+            "nmeasure": inv_inputs.coords["nmeasure"],
+            "source": ["ff-inventory", "ocean-inventory"],
+        },
+    )
+    prepared = RhimePreparedInputs(
+        inv_inputs=inv_inputs,
+        basis_functions=basis_functions,
+        sites=("TAC",),
+        averaging_period=("1H",),
+        basis_artifact_source="generated",
+    )
+    run_spec = RhimeRunSpec(
+        start_date="2019-01-01",
+        end_date="2019-01-02",
+        sites=("TAC",),
+        averaging_period=("1H",),
+        model=model_spec,
+        output=RhimeOutputSpec(output_format="none"),
+        split_by_sectors=True,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="prepared H has 3 regions.*sector 'FF' -> source 'ff-inventory': 2 regions.*"
+        "sector 'ocean' -> source 'ocean-inventory': 3 regions",
+    ):
+        run_rhime_from_prepared_inputs(prepared_inputs=prepared, run_spec=run_spec)
+
+
+def test_multisector_runner_rejects_shared_basis_h_layout_mismatch() -> None:
+    """Retained shared-basis coordinates must match the prepared design state."""
+    model_spec = RhimeModelSpec(
+        species="ch4",
+        domain="EUROPE",
+        sectors=(
+            SectorSpec("FF", "ff-inventory", {"pdf": "normal", "mu": 1.0, "sigma": 0.2}, "ff"),
+            SectorSpec(
+                "ocean",
+                "ocean-inventory",
+                {"pdf": "normal", "mu": 1.0, "sigma": 0.3},
+                "ocean",
+            ),
+        ),
+    )
+    inv_inputs = xr.Dataset(
+        {
+            "H": (
+                ("region", "nmeasure", "source"),
+                np.ones((2, 1, 2)),
+            )
+        },
+        coords={
+            "region": [0, 1],
+            "nmeasure": [0],
+            "source": ["ff-inventory", "ocean-inventory"],
+        },
+    )
+
+    with pytest.raises(ValueError, match="Retained shared basis.*basis has 1 elements.*H has 2"):
+        rhime_module._validate_multisector_basis_layout(
+            _fake_basis_functions(),
+            model_spec,
+            inv_inputs,
+        )
+
+
 def test_prepare_rhime_inputs_single_sector_reloads_merged_data(
     tac_ch4_data_args, merged_data_dir, merged_data_file_name, default_bc_basis_directory
 ) -> None:
@@ -2184,7 +2515,62 @@ def test_prepare_rhime_inputs_multisector_keeps_source_dimension(
     assert prepared.basis_artifact_source == "generated"
     assert isinstance(prepared.basis_functions, BasisFunctions)
     assert "source" in prepared.inv_inputs["H"].dims
-    assert set(prepared.inv_inputs["H"].coords["source"].values) == set(flux_sources)
+    assert list(prepared.inv_inputs["H"].coords["source"].values) == flux_sources
+    assert list(prepared.inv_inputs["H"].coords["source_region_count"].values) == [
+        prepared.inv_inputs.sizes["region"],
+        prepared.inv_inputs.sizes["region"],
+    ]
+
+
+def test_multisector_sensitivity_sources_fail_before_site_gathering() -> None:
+    """Gathered sensitivity is validated before missing sources can be synthesized."""
+    time = pd.date_range("2019-01-01", periods=2, freq="h")
+    state_index = pd.MultiIndex.from_tuples(
+        [("ff-inventory", 0)],
+        names=["source", "region_in_source"],
+    )
+    sensitivity = xr.DataArray(
+        np.ones((1, 2)),
+        dims=("state", "time"),
+        coords={
+            **xr.Coordinates.from_pandas_multiindex(state_index, "state"),
+            "time": time,
+        },
+    )
+    fp_x_flux = xr.DataArray(
+        np.ones((2, 2)),
+        dims=("time", "source"),
+        coords={
+            "time": time,
+            "source": ["ff-inventory", "ocean-inventory"],
+        },
+        name="fp_x_flux_sectoral",
+    )
+
+    class MissingSourceBasis:
+        def sensitivity(self, _: xr.DataArray) -> xr.DataArray:
+            return sensitivity
+
+    merged = prep_module._MergedInversionData(
+        fp_all={"TAC": xr.Dataset({"fp_x_flux_sectoral": fp_x_flux})},
+        sites=["TAC"],
+        averaging_period=["1H"],
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Site 'TAC'.*missing source\\(s\\): \\['ocean-inventory'\\]",
+    ):
+        prep_module._rhime_site_data_from_basis_functions(
+            merged=merged,
+            basis_functions=cast(BasisFunctions, MissingSourceBasis()),
+            domain="EUROPE",
+            split_by_sectors=True,
+            flux_sources=["ff-inventory", "ocean-inventory"],
+            use_bc=False,
+            bc_basis_case="NESW",
+            bc_basis_directory=None,
+        )
 
 
 def test_fixedbasis_preparation_adds_anchored_legacy_sigma_index(
@@ -4401,7 +4787,10 @@ def test_run_rhime_multisector_api_smoke(
             "chains": 1,
             "reload_merged_data": False,
             "output_format": "none",
-            "x_prior": {"pdf": "normal", "mu": 1.0, "sigma": 1.0},
+            "sector_priors": {
+                "FF": {"pdf": "uniform", "lower": 0.8, "upper": 1.0},
+                "ocean": {"pdf": "uniform", "lower": 1.1, "upper": 1.3},
+            },
             "bc_prior": {"pdf": "normal", "mu": 1.0, "sigma": 1.0},
             "sigma_prior": {"pdf": "uniform", "lower": 0.1, "upper": 10.0},
             "sample_kwargs": {"random_seed": 123, "compute_convergence_checks": False},
@@ -4416,6 +4805,16 @@ def test_run_rhime_multisector_api_smoke(
     assert not hasattr(result, "basis_objects")
     assert result.run_spec.split_by_sectors is True
     assert [sector.name for sector in result.model_spec.sectors] == ["FF", "ocean"]
+    assert result.model_spec.sectors[0].x_prior == {
+        "pdf": "uniform",
+        "lower": 0.8,
+        "upper": 1.0,
+    }
+    assert result.model_spec.sectors[1].x_prior == {
+        "pdf": "uniform",
+        "lower": 1.1,
+        "upper": 1.3,
+    }
     posterior = cast(Any, result.idata).posterior
     assert "x_ff" in posterior
     assert "x_ocean" in posterior


### PR DESCRIPTION
## Summary

- enforce the current one-to-one mapping between requested flux sources and RHIME model sectors
- route source-resolved sensitivities by coordinate label rather than source order
- lower standard and multisector declarations through one private PyMC flux-plan boundary
- encapsulate source/sector normalization in `models/_rhime_flux.py` and keep basis selection behind `BasisFunctions.for_source(...)`
- keep source-specific state blocks gathered as `(source, region_in_source)` instead of padding them into rectangular arrays
- use the same concat-gather operation for `nmeasure <-> (site, time)` and state layouts, with exact structural alignment across sites
- preserve genuine NaNs; only the explicitly legacy `fixedbasisMCMC` adapter zero-fills positions proven absent by an unstack occupancy mask
- reject malformed/duplicate gathered states, incompatible per-site state dimensions/indexes, padded legacy layouts, and ambiguous source mappings
- document the concrete shared-basis and ragged source-specific RHIME input contracts

Closes #403.

This is a stacked draft based on #529 (`agent/402-builder-strategy-seam`) so the review diff contains only the #403 work. The implementation deliberately defers grouped-source aggregation, virtual sectors, fixed components, tracer-specific model structures, and a public semantic-model schema to the existing follow-up design issues. It keeps sources as acquisition provenance and sectors as model semantics so those additions do not have to preserve the current one-to-one restriction.

## Validation

- changed-area suite: 242 passed, 1 deselected
- final focused scientific/layout regressions: 32 passed, 1 deselected
- changed-file Ruff check: passed
- scoped Pyright: 0 errors
- `git diff --check`: passed
- independent architecture and scientific/xarray reviews: all actionable findings addressed

`tox -p --parallel-no-spinner` was attempted. Its repository-wide lint environment stops on 222 existing findings outside this change, and the fresh test environment could not provision dependencies because PyPI DNS was unavailable. Tests were run from the existing project environment instead.

## Checklist

- [x] Closes #403
- [x] Tests added and passing
- [x] Documentation and tutorials updated/added
- [ ] Added an entry to `CHANGELOG.md`
- [x] No new requirements are needed