### PR TITLE
Fail fast when tox lacks a PyTensor C++ compiler

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,3 +42,19 @@ tox -e py310-openghgCur -- tests/test_array_ops.py
 If a machine has limited cores, set `PYTEST_XDIST_WORKERS=1` or run tox
 serially. Automated agents should run tox without allocating a PTY and use
 `--parallel-no-spinner` for parallel runs.
+
+The tox test environments fail before pytest when the effective
+`pytensor.config.cxx` is empty. On Rocky Linux and Blue Pebble, the launcher
+first tries the `gcc/12.3.0-sknc` module in the same shell that starts pytest.
+The default `PYTENSOR_COMPILER_BOOTSTRAP=auto` mode targets Rocky Linux or
+recognized Blue Pebble hostnames. Use `PYTENSOR_COMPILER_MODULE` and
+`PYTENSOR_MODULE_INIT` (default `/etc/profile.d/modules.sh`) for different
+module setups, `PYTENSOR_COMPILER_BOOTSTRAP=always` to enable module loading on
+other hosts, or `PYTENSOR_FLAGS='cxx=/path/to/g++'` to select a compiler
+directly. Setting `PYTENSOR_COMPILER_BOOTSTRAP=never` disables module loading
+but keeps the fail-fast compiler check.
+
+For cluster test runs, prefer a writable node-local PyTensor cache such as
+`base_compiledir=${TMPDIR:-/tmp}/pytensor-${USER}`. Add it as a
+comma-separated `PYTENSOR_FLAGS` entry without discarding existing flags or
+defining `base_compiledir` twice.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## Code changes
 
+- Added a tox PyTensor compiler preflight that automatically loads
+  `gcc/12.3.0-sknc` on Rocky Linux or recognized Blue Pebble hosts when the
+  compiler setting is empty, supports configurable module/compiler overrides,
+  and fails before pytest when `pytensor.config.cxx` remains empty instead of
+  allowing extremely slow C++-free PyMC test runs.
+
 - Reset retained posterior draw labels after burn-in before attaching predictive
   groups in both modern RHIME and fixed-basis sampling, and preserve the
   discarded burn count through trace and `InversionOutput` round trips.

--- a/README.md
+++ b/README.md
@@ -427,6 +427,44 @@ tox -p --parallel-no-spinner
 This is the required local check before pushing a draft pull request. GitHub
 Actions runs current, previous, and devel OpenGHG test jobs independently.
 
+Before pytest starts, each tox test environment checks the effective
+`pytensor.config.cxx` value. If it is empty on Rocky Linux or Blue Pebble, the
+test launcher tries to load the `gcc/12.3.0-sknc` environment module in the
+same shell that starts pytest, then checks PyTensor again. The launcher exits
+quickly with setup guidance if PyTensor still has no configured compiler,
+avoiding extremely slow C++-free PyMC test runs.
+
+Override the compiler module or module initialization script when a cluster
+uses different names. The defaults are `gcc/12.3.0-sknc` and
+`/etc/profile.d/modules.sh`, respectively:
+
+```bash
+PYTENSOR_COMPILER_MODULE=gcc/13.2.0 tox -e py310-openghgCur
+PYTENSOR_MODULE_INIT=/path/to/modules/init/bash tox -e py310-openghgCur
+```
+
+`PYTENSOR_COMPILER_BOOTSTRAP=auto` is the default: it attempts module loading
+on Rocky Linux or recognized Blue Pebble hostnames. Set it to `always` to try
+module loading on another host, or to `never` to disable automatic module
+loading while retaining the compiler preflight. A compiler can also be selected
+directly, for example:
+
+```bash
+PYTENSOR_FLAGS='cxx=/path/to/g++' tox -e py310-openghgCur
+```
+
+On a cluster compute node, a writable node-local PyTensor compilation cache
+also avoids shared-filesystem contention. Preserve any existing
+comma-separated `PYTENSOR_FLAGS` entries when adding it:
+
+```bash
+PYTENSOR_FLAGS="${PYTENSOR_FLAGS:+${PYTENSOR_FLAGS},}base_compiledir=${TMPDIR:-/tmp}/pytensor-${USER}" \
+  tox -e py310-openghgCur
+```
+
+If `PYTENSOR_FLAGS` already defines `base_compiledir`, update that entry
+instead of adding the same key twice.
+
 For final review or release-sensitive dependency changes, run the full
 compatibility matrix:
 

--- a/scripts/run_pytest_with_pytensor_compiler.sh
+++ b/scripts/run_pytest_with_pytensor_compiler.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# Ensure PyTensor has a non-empty compiler setting before starting pytest.
+
+set -euo pipefail
+
+readonly default_compiler_module="gcc/12.3.0-sknc"
+readonly compiler_module="${PYTENSOR_COMPILER_MODULE:-${default_compiler_module}}"
+readonly module_init="${PYTENSOR_MODULE_INIT:-/etc/profile.d/modules.sh}"
+readonly bootstrap_mode="${PYTENSOR_COMPILER_BOOTSTRAP:-auto}"
+
+pytensor_cxx() {
+    python -c 'import pytensor; print(pytensor.config.cxx or "", end="")'
+}
+
+is_rocky_linux() {
+    [[ -r /etc/os-release ]] || return 1
+
+    (
+        # shellcheck disable=SC1091
+        source /etc/os-release
+        [[ "${ID:-}" == "rocky" || " ${ID_LIKE:-} " == *" rocky "* ]]
+    )
+}
+
+is_blue_pebble() {
+    local host_name="${HOSTNAME:-}"
+
+    if [[ -z "${host_name}" ]] && command -v hostname >/dev/null 2>&1; then
+        host_name="$(hostname -s 2>/dev/null || true)"
+    fi
+
+    case "${host_name}" in
+        [Bb][Pp]1* | *[Bb][Ll][Uu][Ee][Pp][Ee][Bb][Bb][Ll][Ee]* | *[Bb][Ll][Uu][Ee]-[Pp][Ee][Bb][Bb][Ll][Ee]*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+load_compiler_module() {
+    if ! type module >/dev/null 2>&1 && [[ -r "${module_init}" ]]; then
+        # shellcheck disable=SC1090
+        source "${module_init}"
+    fi
+
+    if ! type module >/dev/null 2>&1; then
+        echo "PyTensor has no configured C++ compiler, and the environment-module command is unavailable." >&2
+        echo "Set PYTENSOR_MODULE_INIT to the module init script, or set PYTENSOR_FLAGS=cxx=/path/to/g++." >&2
+        return 1
+    fi
+
+    echo "PyTensor has no configured C++ compiler; loading module ${compiler_module}." >&2
+    if ! module load "${compiler_module}"; then
+        echo "Failed to load compiler module ${compiler_module}." >&2
+        echo "Set PYTENSOR_COMPILER_MODULE to an available GCC module, or set PYTENSOR_FLAGS=cxx=/path/to/g++." >&2
+        return 1
+    fi
+}
+
+if [[ -z "$(pytensor_cxx)" ]]; then
+    case "${bootstrap_mode}" in
+        auto)
+            if is_rocky_linux || is_blue_pebble; then
+                load_compiler_module
+            fi
+            ;;
+        always)
+            load_compiler_module
+            ;;
+        never)
+            ;;
+        *)
+            echo "Invalid PYTENSOR_COMPILER_BOOTSTRAP=${bootstrap_mode}; expected auto, always, or never." >&2
+            exit 2
+            ;;
+    esac
+
+    if [[ -z "$(pytensor_cxx)" ]]; then
+        echo "PyTensor still has no configured C++ compiler; refusing to start pytest." >&2
+        echo "Set PYTENSOR_FLAGS=cxx=/path/to/g++, or configure PYTENSOR_COMPILER_MODULE and PYTENSOR_MODULE_INIT." >&2
+        echo "Set PYTENSOR_COMPILER_BOOTSTRAP=always to enable module loading on another host." >&2
+        exit 2
+    fi
+fi
+
+python -c 'import arviz'
+exec "$@"

--- a/tests/test_tox_compiler.py
+++ b/tests/test_tox_compiler.py
@@ -1,0 +1,233 @@
+"""Regression tests for the tox PyTensor compiler preflight launcher."""
+
+from __future__ import annotations
+
+import os
+import platform
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+LAUNCHER = Path(__file__).parents[1] / "scripts" / "run_pytest_with_pytensor_compiler.sh"
+
+
+def _write_executable(path: Path, content: str) -> None:
+    """Create or replace an executable test helper script.
+
+    Args:
+        path: Destination path for the helper script.
+        content: Complete script contents to write.
+
+    Raises:
+        OSError: If the file cannot be written or its permissions cannot be
+            changed to ``0755``.
+    """
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _is_rocky_linux() -> bool:
+    """Return whether the test host identifies as Rocky Linux."""
+    try:
+        release = platform.freedesktop_os_release()
+    except OSError:
+        return False
+    return release.get("ID") == "rocky" or "rocky" in release.get("ID_LIKE", "").split()
+
+
+@pytest.fixture
+def launcher_env(tmp_path: Path) -> tuple[dict[str, str], Path, Path, Path, Path]:
+    """Provide isolated fake Python, module, and child-command executables.
+
+    The fake ``python`` reports compiler state for PyTensor probes and records
+    the separate ArviZ import. The module function can optionally export a
+    compiler into the launcher's shell, while the child command records its
+    arguments without starting pytest.
+
+    Args:
+        tmp_path: Pytest-managed directory for the fake commands and output
+            records.
+
+    Returns:
+        The isolated environment, child-command path, child-argument record,
+        event-log path, and module-log path. Record paths may not exist until
+        the launcher invokes their corresponding fake commands.
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    event_log = tmp_path / "events.log"
+    module_log = tmp_path / "module.log"
+    module_init_sourced = tmp_path / "module-init-sourced"
+    child_args = tmp_path / "child-args"
+
+    _write_executable(
+        bin_dir / "python",
+        """#!/bin/bash
+case "${2:-}" in
+    *pytensor*)
+        printf 'pytensor\\n' >> "${FAKE_EVENT_LOG}"
+        printf '%s' "${FAKE_PYTENSOR_CXX:-}"
+        ;;
+    *arviz*)
+        printf 'arviz\\n' >> "${FAKE_EVENT_LOG}"
+        ;;
+    *)
+        printf 'unexpected python invocation: %s\\n' "$*" >&2
+        exit 99
+        ;;
+esac
+""",
+    )
+    child_command = tmp_path / "record-child"
+    _write_executable(
+        child_command,
+        """#!/bin/bash
+printf '%s\\n' "$@" > "${FAKE_CHILD_ARGS}"
+exit "${FAKE_CHILD_EXIT:-0}"
+""",
+    )
+    module_init = tmp_path / "modules.sh"
+    module_init.write_text(
+        """printf 'sourced\\n' > "${FAKE_MODULE_INIT_SOURCED}"
+module() {
+    printf '%s\\n' "$*" > "${FAKE_MODULE_LOG}"
+    if [[ "${FAKE_MODULE_CONFIGURES_CXX:-0}" == "1" ]]; then
+        export FAKE_PYTENSOR_CXX=g++
+    fi
+}
+"""
+    )
+
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("PYTENSOR_") and not key.startswith("BASH_FUNC_module")
+    }
+    env.update(
+        {
+            "PATH": str(bin_dir),
+            "HOSTNAME": "unrelated-test-host",
+            "FAKE_CHILD_ARGS": str(child_args),
+            "FAKE_EVENT_LOG": str(event_log),
+            "FAKE_MODULE_INIT_SOURCED": str(module_init_sourced),
+            "FAKE_MODULE_LOG": str(module_log),
+            "PYTENSOR_MODULE_INIT": str(module_init),
+        }
+    )
+    return env, child_command, child_args, event_log, module_log
+
+
+def test_launcher_forwards_arguments_and_child_status(
+    launcher_env: tuple[dict[str, str], Path, Path, Path, Path],
+) -> None:
+    """An effective compiler lets the exact pytest command run unchanged."""
+    env, child_command, child_args, event_log, _ = launcher_env
+    env.update({"FAKE_PYTENSOR_CXX": "g++", "FAKE_CHILD_EXIT": "7"})
+    arguments = ["-k", "alpha or beta", "tests/a path/test_example.py"]
+
+    result = subprocess.run(
+        ["/bin/bash", str(LAUNCHER), str(child_command), *arguments],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 7
+    assert child_args.read_text().splitlines() == arguments
+    assert event_log.read_text().splitlines() == ["pytensor", "arviz"]
+
+
+def test_launcher_bootstraps_default_module_on_blue_pebble(
+    launcher_env: tuple[dict[str, str], Path, Path, Path, Path],
+) -> None:
+    """Blue Pebble auto mode loads the default module and rechecks PyTensor."""
+    env, child_command, child_args, event_log, module_log = launcher_env
+    env.update({"HOSTNAME": "bp1-test", "FAKE_MODULE_CONFIGURES_CXX": "1"})
+
+    result = subprocess.run(
+        ["/bin/bash", str(LAUNCHER), str(child_command), "tests/test_array_ops.py"],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert module_log.read_text().splitlines() == ["load gcc/12.3.0-sknc"]
+    assert event_log.read_text().splitlines() == ["pytensor", "pytensor", "arviz"]
+    assert child_args.read_text().splitlines() == ["tests/test_array_ops.py"]
+
+
+def test_launcher_uses_configured_module_in_always_mode(
+    launcher_env: tuple[dict[str, str], Path, Path, Path, Path],
+) -> None:
+    """Explicit bootstrap uses the configured module on an unrelated host."""
+    env, child_command, _, _, module_log = launcher_env
+    env.update(
+        {
+            "PYTENSOR_COMPILER_BOOTSTRAP": "always",
+            "PYTENSOR_COMPILER_MODULE": "gcc/custom",
+            "FAKE_MODULE_CONFIGURES_CXX": "1",
+        }
+    )
+
+    result = subprocess.run(
+        ["/bin/bash", str(LAUNCHER), str(child_command)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert module_log.read_text().splitlines() == ["load gcc/custom"]
+
+
+def test_launcher_fails_before_pytest_when_recheck_has_no_compiler(
+    launcher_env: tuple[dict[str, str], Path, Path, Path, Path],
+) -> None:
+    """A successful module command cannot bypass the compiler recheck."""
+    env, child_command, child_args, event_log, module_log = launcher_env
+    env["PYTENSOR_COMPILER_BOOTSTRAP"] = "always"
+
+    result = subprocess.run(
+        ["/bin/bash", str(LAUNCHER), str(child_command)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert module_log.read_text().splitlines() == ["load gcc/12.3.0-sknc"]
+    assert event_log.read_text().splitlines() == ["pytensor", "pytensor"]
+    assert not child_args.exists()
+    assert "still has no configured C++ compiler" in result.stderr
+    assert "PYTENSOR_FLAGS=cxx=/path/to/g++" in result.stderr
+
+
+@pytest.mark.skipif(_is_rocky_linux(), reason="Rocky Linux is an automatic compiler-bootstrap target")
+def test_launcher_does_not_load_modules_automatically_on_unrelated_host(
+    launcher_env: tuple[dict[str, str], Path, Path, Path, Path],
+) -> None:
+    """Auto mode fails early without attempting modules on unrelated hosts."""
+    env, child_command, child_args, event_log, module_log = launcher_env
+    module_init_sourced = Path(env["FAKE_MODULE_INIT_SOURCED"])
+
+    result = subprocess.run(
+        ["/bin/bash", str(LAUNCHER), str(child_command)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert event_log.read_text().splitlines() == ["pytensor", "pytensor"]
+    assert not module_init_sourced.exists()
+    assert not module_log.exists()
+    assert not child_args.exists()
+    assert "PYTENSOR_COMPILER_BOOTSTRAP=always" in result.stderr

--- a/tox.ini
+++ b/tox.ini
@@ -16,15 +16,20 @@ description =
 # Use the non-lockfile uv runner so factor-specific OpenGHG deps are honored.
 runner = uv-venv-runner
 package = uv-editable
+allowlist_externals =
+    bash
+pass_env =
+    PYTENSOR_COMPILER_BOOTSTRAP
+    PYTENSOR_COMPILER_MODULE
+    PYTENSOR_FLAGS
+    PYTENSOR_MODULE_INIT
 deps =
     pytest
     pytest-xdist
     openghgDev: git+https://github.com/openghg/openghg.git@devel
     openghgPrev: {env:OPENGHG_PREV_SPEC:openghg==0.18.0}
-commands_pre =
-    openghgCur,openghgPrev,openghgDev: python -c "import arviz"
 commands =
-    pytest -n {env:PYTEST_XDIST_WORKERS:2} --dist=loadscope {posargs:tests}
+    bash {tox_root}/scripts/run_pytest_with_pytensor_compiler.sh pytest -n {env:PYTEST_XDIST_WORKERS:2} --dist=loadscope {posargs:tests}
 
 [testenv:lint]
 description = "Run linters."


### PR DESCRIPTION
* **Summary of changes**

Adds a compiler-aware tox launcher for the PyMC test environments. Before pytest starts, it checks the effective `pytensor.config.cxx` value. When that setting is empty on Rocky Linux or a recognized Blue Pebble host, the launcher sources the environment-modules initialization and tries `gcc/12.3.0-sknc` in the same shell that starts pytest. It then rechecks PyTensor and fails quickly with actionable guidance if the setting remains empty.

The launcher preserves the existing pytest/xdist arguments and ArviZ compatibility import. Environment variables allow other clusters to override the bootstrap mode, compiler module, module initialization script, or PyTensor compiler setting. The testing documentation also recommends a writable node-local PyTensor compilation cache.

Root cause: without a C++ compiler, PyTensor falls back to Python implementations. The real PyMC inversion tests near the end of the loadscope-distributed suite can then take more than 15 minutes each, making tox appear stalled at 97%.

* **Validation**

- `tox -e py310-openghgCur -- tests/test_tox_compiler.py -q` — 5 passed
- `uv run pytest --noconftest tests/test_tox_compiler.py -q` — 5 passed
- `uv run ruff check tests/test_tox_compiler.py`
- `uv run ruff format --check tests/test_tox_compiler.py`
- `uv run pyright tests/test_tox_compiler.py`
- `shellcheck scripts/run_pytest_with_pytensor_compiler.sh`
- `bash -n scripts/run_pytest_with_pytensor_compiler.sh`
- `tox c -e py310-openghgCur`
- `tox -p --parallel-no-spinner` — `py310-openghgCur` passed; the overall command remains non-zero because the existing repository-wide lint environment reports 217 unrelated Ruff violations

* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx
- [x] Tests added and passing
- [x] Documentation and tutorials updated/added
- [x] Added an entry to the `CHANGELOG.md` file
- [ ] Added any new requirements to `requirements.txt` (not applicable; no requirements added)