### PR TITLE
Add experimental Ramsden multi-gas model

### DIFF
--- a/docs/experimental/index.rst
+++ b/docs/experimental/index.rst
@@ -1,0 +1,34 @@
+Experimental code
+=================
+
+The :mod:`openghg_inversions.experimental` namespace contains runnable model
+variants and integration prototypes that are useful for scientific comparison
+and future API design, but are not part of the stable public API.
+
+.. warning::
+
+   Experimental modules may change or be removed without a deprecation period.
+   Their inputs and results should be treated as research interfaces rather
+   than production contracts. Importing the namespace does not retrieve data or
+   start sampling.
+
+Experimental code is kept separate from production model builders so that it
+can:
+
+* preserve scientifically useful historical behavior;
+* test requirements for planned generic interfaces;
+* use current preparation, coordinate, prior, and sampling infrastructure; and
+* carry focused tests and validation evidence without changing stable results.
+
+Available experiments
+---------------------
+
+The first experiment is the Ramsden et al. (2022) methane/ethane shared-state
+model. It ports the paper-shaped two-gas likelihood to the modern RHIME stack
+without restoring the obsolete historical loader, sampler, or output system.
+
+.. toctree::
+   :maxdepth: 2
+
+   ramsden2022
+   ramsden2022_validation

--- a/docs/experimental/ramsden2022.rst
+++ b/docs/experimental/ramsden2022.rst
@@ -1,0 +1,169 @@
+Ramsden methane/ethane model
+============================
+
+Status
+------
+
+The :mod:`openghg_inversions.experimental.ramsden2022` module implements the
+shared-state methane/ethane model described by `Ramsden et al. (2022)
+<https://doi.org/10.5194/acp-22-3911-2022>`_. It is intended for historical
+comparison and as a requirements fixture for future generic linked-tracer
+work. It is not a stable public API.
+
+The model starts at the prepared-input boundary. It accepts two canonical
+RHIME-style datasets and uses the current PyMC model components and
+:class:`~openghg_inversions.rhime.sampling.RhimeSampler`. It deliberately does
+not port the historical ACRG/OpenGHG retrieval layer, pickle cache,
+configuration parser, custom Metropolis-Hastings sampler, isotope extensions,
+or bespoke country/NetCDF post-processing.
+
+Scientific model
+----------------
+
+For fossil-fuel and non-fossil methane scaling states, the two observation
+models are
+
+.. math::
+
+   \mu_{\mathrm{CH_4}} =
+       H_{\mathrm{CH_4,FF}} x_{\mathrm{FF}}
+       + H_{\mathrm{CH_4,nonFF}} x_{\mathrm{nonFF}}
+       + H_{\mathrm{bc,CH_4}} b_{\mathrm{CH_4}},
+
+.. math::
+
+   \mu_{\mathrm{C_2H_6}} =
+       H_{\mathrm{C_2H_6,FF}} (R x_{\mathrm{FF}})
+       + H_{\mathrm{bc,C_2H_6}} b_{\mathrm{C_2H_6}}.
+
+The fossil-fuel scaling state is shared between channels. Non-fossil methane
+does not contribute to the ethane likelihood. The channels can have different
+sites, timestamps, observation counts, boundary states, and absolute
+model-error states.
+
+For channel :math:`g`, the observation standard deviation is
+
+.. math::
+
+   \epsilon_g =
+       \max\left(
+           \sqrt{\sigma_{\mathrm{measurement},g}^2
+                 + \sigma_{\mathrm{model},g}^2},
+           \epsilon_{\min,g}
+       \right).
+
+Set ``min_error`` to zero for the paper-shaped likelihood. A positive value
+retains the modern RHIME numerical floor intentionally.
+
+Prepared inputs
+---------------
+
+Each channel dataset must use the canonical names below. The two observation
+axes can differ, but every coupled sector must use exactly matching labelled
+state coordinates.
+
+.. list-table:: Required channel variables
+   :header-rows: 1
+   :widths: 20 25 55
+
+   * - Variable
+     - Required dimensions
+     - Meaning
+   * - ``H``
+     - observation, state, source
+     - Labelled design matrix mapping scaling states into observation space.
+   * - ``mf``
+     - observation
+     - Measured mole fraction in the channel's declared numeric units.
+   * - ``mf_error``
+     - observation
+     - Measurement contribution to likelihood uncertainty.
+   * - ``min_error``
+     - observation
+     - Optional positive floor applied after combining measurement and model
+       uncertainty.
+   * - ``site_indicator``
+     - observation
+     - Integer site index used to align site-level model error.
+   * - ``H_bc``
+     - observation, boundary state
+     - Boundary design; required when the channel enables boundary scaling.
+
+If state labels are positional numbers, retain and pass both
+:class:`~openghg_inversions.basis.basis_functions.BasisFunctions` objects.
+The builder then verifies the spatial maps instead of assuming that two
+``0..N-1`` indexes describe the same regions.
+
+Ratio contracts
+---------------
+
+The model supports two explicit ratio conventions:
+
+Direct physical ratio
+   ``reference_ratio=None`` means the tracer design is ratio-free. The
+   sampled or fixed value is the dimensionless molar emission ratio, moles of
+   tracer divided by moles of primary gas.
+
+Historical multiplier
+   A positive ``reference_ratio`` means the tracer design already contains
+   that ratio. The sampled or fixed value is a multiplier, and the model
+   exposes
+
+   .. math::
+
+      R_{\mathrm{physical}} =
+          R_{\mathrm{reference}} R_{\mathrm{multiplier}}.
+
+The independent ``tracer_design_reference_ratios`` mapping records what is
+already present in every tracer design. The builder rejects inconsistent
+declarations to prevent applying a ratio twice or omitting it.
+
+Units
+-----
+
+The builder validates supported unit declarations by mole-fraction scale but
+does not convert numeric values. Observations, measurement errors, minimum
+errors, forward designs, and model-error prior values must already share each
+channel's declared scale.
+
+For the retained Ramsden case, methane values are numeric ``ppb`` and ethane
+values numeric ``ppt``. The paper prints the ethane model-error bounds as ppb,
+but its figures, retained data, and historical configuration support ppt.
+
+API reference
+-------------
+
+.. autoclass:: openghg_inversions.experimental.ramsden2022.RamsdenPreparedInputs
+   :members:
+   :no-index:
+
+.. autoclass:: openghg_inversions.experimental.ramsden2022.RamsdenChannelSpec
+   :members:
+   :no-index:
+
+.. autoclass:: openghg_inversions.experimental.ramsden2022.RamsdenSectorSpec
+   :members:
+   :no-index:
+
+.. autoclass:: openghg_inversions.experimental.ramsden2022.RamsdenModelSpec
+   :members:
+   :no-index:
+
+.. autoclass:: openghg_inversions.experimental.ramsden2022.RamsdenResult
+   :members:
+   :no-index:
+
+.. autofunction:: openghg_inversions.experimental.ramsden2022.build_ramsden_model
+   :no-index:
+
+.. autofunction:: openghg_inversions.experimental.ramsden2022.run_ramsden_from_prepared_inputs
+   :no-index:
+
+Design history
+--------------
+
+The detailed historical comparison and porting decision is retained in
+`adding_multi_gas_model_historical_comparison.md
+<https://github.com/openghg/openghg_inversions/blob/codex/ramsden-2022-multigas/docs/plans/adding_multi_gas_model_historical_comparison.md>`_.
+It documents the behavior preserved from the old branch, the behavior
+deliberately excluded, and known historical correctness defects.

--- a/docs/experimental/ramsden2022_validation.rst
+++ b/docs/experimental/ramsden2022_validation.rst
@@ -1,0 +1,452 @@
+Ramsden real-data validation
+============================
+
+Outcome
+-------
+
+The experimental implementation at model commit ``f0d27d7`` closely
+reproduces the retained original January 2019 inversion. The annualized UK
+fossil-fuel methane posterior mean changes by only 0.96%, all 49 regional 95%
+posterior intervals overlap, and the regional fossil-fuel posterior-mean
+correlation is 0.980.
+
+Observation-space posterior latent means are also nearly identical. The
+original-versus-modern correlations are 0.9983 for methane and 0.999963 for
+ethane.
+
+The validation also reproduces the principal scientific warning in the
+original analysis: both ethane model-error parameters concentrate at their
+50 ppt upper bound. Modern ethane 90% posterior-predictive coverage is only
+32.9% at MHD and 40.4% at TAC. This supports the implementation as a faithful,
+runnable historical comparison; it does not establish that the current
+ethane likelihood is scientifically production-ready.
+
+What was tested
+---------------
+
+The validation used retained real-data observations and sensitivity matrices
+for January 2019:
+
+.. list-table:: Final validation configuration
+   :header-rows: 1
+   :widths: 28 72
+
+   * - Item
+     - Configuration
+   * - Code
+     - Experimental model at ``f0d27d7``.
+   * - Period
+     - 1--31 January 2019, nominal four-hour observations.
+   * - Methane observations
+     - 331 values at MHD, TAC, RGL, BSD, and HFD; numeric units ppb.
+   * - Ethane observations
+     - 117 values at MHD and TAC; numeric units ppt.
+   * - Spatial state
+     - 49 retained quadtree basis regions, with identical reconstructed maps
+       for both channels.
+   * - Methane design
+     - Fossil and non-fossil source terms plus four boundary terms.
+   * - Ethane design
+     - Fossil source term only plus four boundary terms.
+   * - Coupling
+     - Shared 49-region fossil methane scaling state; no non-fossil ethane
+       contribution.
+   * - Likelihood
+     - Independent Gaussian channels with measurement error plus inferred
+       absolute site-month model error; ``min_error=0``.
+   * - Sampler
+     - Four NumPyro NUTS chains; 1,000 tuning and 1,000 retained draws per
+       chain; target acceptance 0.9.
+
+Priors followed the paper's printed specification:
+
+* fossil and non-fossil scaling:
+  zero-truncated Gaussian with mean 1 and standard deviation 0.5;
+* methane model error: ``Uniform(10, 50)`` ppb by site and month;
+* ethane model error: ``Uniform(20, 50)`` ppt by site and month;
+* methane boundary scaling:
+  zero-truncated Gaussian with mean 1 and standard deviation 0.05;
+* ethane boundary scaling:
+  zero-truncated Gaussian with mean 1 and standard deviation 0.5; and
+* physical molar ethane:methane ratio:
+  ``0.075 * Uniform(0.1, 2.7)`` independently by region.
+
+Terminology and truth
+---------------------
+
+This is a real-data inversion. There is no known state-space or flux truth and
+no flux-recovery score.
+
+The closest comparator is the retained original January 2019 posterior. It
+uses the same retained observations, designs, basis state, and month, but a
+historical sampler and a different effective methane model-error prior.
+
+The paper is a second, less direct comparator. It reports monthly inversions
+summarized as annual 2015--2019 UK totals. January's annualized flux rate and
+an annual result are not like-for-like.
+
+Observation-space bias and RMSE below compare deterministic posterior latent
+means with retained observations. Posterior-predictive coverage instead uses
+simulated posterior observations and includes likelihood uncertainty. Neither
+kind of observation-space agreement demonstrates emission accuracy.
+
+Input provenance and limitations
+--------------------------------
+
+The retained output supplied observations, timestamps, source-separated
+designs, boundary designs, site stacking, state ordering, and the gridded
+basis representation. Its provenance identifies:
+
+* UKGHG/EDGAR fossil and non-fossil methane sources;
+* an ethane fossil inventory already scaled by the reference ratio 0.075;
+* a zero non-fossil ethane contribution; and
+* a 49-region sensitivity-driven quadtree basis.
+
+The exact historical measurement-error arrays were not retained. Methane
+within-bin variability and ethane repeatability were reconstructed from frozen
+observation products. One missing TAC ethane repeatability value was filled
+with that site's positive median. This is the main input-level limitation on a
+strict original-versus-modern comparison.
+
+The available current OpenGHG object store did not contain usable footprint
+and observation products for rebuilding this historical case. The validation
+therefore converted the retained designs into canonical prepared datasets
+rather than rerunning modern retrieval and preparation.
+
+Sampling diagnostics
+--------------------
+
+The final four-chain run completed both likelihoods and posterior-predictive
+generation with zero divergences.
+
+.. list-table:: Modern sampling diagnostics
+   :header-rows: 1
+   :widths: 45 30
+
+   * - Diagnostic
+     - Value
+   * - Maximum unrounded R-hat
+     - 1.0051
+   * - Minimum bulk effective sample size
+     - 1,447
+   * - Minimum tail effective sample size
+     - 556
+   * - Mean acceptance probability
+     - 0.941
+   * - Maximum tree depth
+     - 8
+   * - Divergences
+     - 0
+
+The paper used an adaptive random-walk Metropolis-Hastings sampler, discarded
+the first 50%, and retained every 100th subsequent sample. It did not report
+chain count, R-hat, effective sample sizes, or equivalent modern convergence
+diagnostics, so convergence cannot be compared directly.
+
+Flux-space results
+------------------
+
+The retained per-region UK prior-flux weights were recovered by dividing each
+stored regional posterior flux trace by its scaling trace and taking the
+median over draws. Their sums exactly reproduce the stored fossil and
+non-fossil country priors. Applying the same weights to the modern posterior is
+valid because basis-map and state ordering were checked exactly.
+
+The table reports annualized January methane flux rates in Tg CH4 yr-1, not
+twelve-month annual totals.
+
+.. list-table:: Annualized January UK methane flux
+   :header-rows: 1
+   :widths: 22 28 28 22
+
+   * - Sector
+     - Retained original mean (95% interval)
+     - Modern mean (95% interval)
+     - Change in mean
+   * - Fossil fuel
+     - 0.28094 (0.21625--0.35400)
+     - 0.27825 (0.21405--0.35210)
+     - -0.96%
+   * - Non-fossil
+     - 1.57795 (1.34910--1.80753)
+     - 1.65733 (1.41293--1.89559)
+     - +5.03%
+   * - Total
+     - 1.85888 (1.61077--2.10658)
+     - 1.93557 (1.69621--2.17447)
+     - +4.13%
+
+The fossil-fuel aggregate, which is the quantity the added ethane channel is
+intended to constrain, is reproduced within 1%. The larger aggregate change is
+in the methane-only non-fossil sector.
+
+Regional state results
+----------------------
+
+The following metrics compare posterior summaries for the same 49 basis
+regions. Scaling states and ratio multipliers are dimensionless.
+
+.. list-table:: Regional state comparison
+   :header-rows: 1
+   :widths: 34 22 18 26
+
+   * - Parameter
+     - Correlation of posterior means
+     - RMSE of posterior means
+     - Regions with overlapping 95% intervals
+   * - Fossil methane scaling
+     - 0.9799
+     - 0.1409
+     - 49/49
+   * - Non-fossil methane scaling
+     - 0.8889
+     - 0.1444
+     - 49/49
+   * - Ratio multiplier
+     - 0.9369
+     - 0.2087
+     - 49/49
+
+The physical molar ratio means moles of ethane divided by moles of
+fossil-fuel methane. Because the retained ethane design already contains
+0.075, it equals ``0.075 * ratio_multiplier``.
+
+.. list-table:: Physical ethane:methane ratio
+   :header-rows: 1
+   :widths: 52 24 24
+
+   * - Summary
+     - Retained original
+     - Modern
+   * - Unweighted mean over all region-draw values
+     - 0.08209
+     - 0.08320
+   * - UK fossil-methane-flux-weighted mean
+     - 0.08969
+     - 0.09121
+   * - Weighted 95% interval
+     - 0.07061--0.11703
+     - 0.07125--0.11663
+
+The weighted mean changes by 1.7%.
+
+Observation-space results
+-------------------------
+
+The table compares deterministic posterior latent means with observations.
+Methane bias and RMSE are in ppb; ethane values are in ppt.
+
+.. list-table:: Site-level posterior latent-mean fit
+   :header-rows: 1
+   :widths: 16 18 33 33
+
+   * - Gas
+     - Site
+     - Retained original bias, RMSE
+     - Modern bias, RMSE
+   * - CH4
+     - MHD
+     - -1.610, 6.561
+     - -1.883, 7.242
+   * - CH4
+     - TAC
+     - -2.498, 9.929
+     - -2.702, 10.163
+   * - CH4
+     - RGL
+     - -3.402, 15.198
+     - -2.041, 14.480
+   * - CH4
+     - BSD
+     - -0.629, 5.530
+     - +0.393, 5.292
+   * - CH4
+     - HFD
+     - +0.867, 10.640
+     - +0.564, 10.406
+   * - C2H6
+     - MHD
+     - -3.267, 229.104
+     - -3.982, 229.018
+   * - C2H6
+     - TAC
+     - +11.159, 165.840
+     - +11.510, 165.908
+
+Overall methane RMSE changes from 10.126 to 10.004 ppb, and overall ethane
+RMSE from 206.038 to 206.003 ppt. Pointwise original-versus-modern latent-mean
+correlations are 0.99831 for methane and 0.999963 for ethane.
+
+Modern 90% posterior-predictive coverage is 93.3--100% across methane sites,
+32.9% for ethane at MHD, and 40.4% for ethane at TAC. Historical coverage
+cannot be computed on the same definition because the retained file does not
+contain equivalent likelihood-level predictive draws or the original
+measurement-error vector.
+
+Model-error and boundary results
+--------------------------------
+
+The four boundary states for each channel are numerically close. They are not
+assigned compass names here because the retained boundary-column ordering
+cannot be established safely from the output alone.
+
+.. list-table:: Boundary posterior means
+   :header-rows: 1
+   :widths: 18 41 41
+
+   * - Channel
+     - Retained original
+     - Modern
+   * - CH4
+     - 1.00177, 1.00357, 0.95488, 0.99873
+     - 1.00065, 1.00294, 0.96018, 0.99906
+   * - C2H6
+     - 1.10707, 1.19605, 0.00531, 0.80497
+     - 1.10547, 1.18075, 0.00531, 0.80432
+
+Monthly site-level absolute model-error means are:
+
+.. list-table:: Absolute model-error posterior means
+   :header-rows: 1
+   :widths: 24 38 38
+
+   * - Channel and site order
+     - Retained original
+     - Modern
+   * - CH4: MHD, TAC, RGL, BSD, HFD (ppb)
+     - 6.591, 7.861, 4.686, 4.090, 9.108
+     - 10.218, 10.628, 10.365, 10.286, 10.685
+   * - C2H6: MHD, TAC (ppt)
+     - 49.964, 49.898
+     - 49.964, 49.896
+
+The methane values are not like-for-like: the modern validation imposed the
+paper's printed 10 ppb lower bound, whereas the retained implementation used a
+zero lower bound. Both implementations give virtually identical ethane model
+error and press the 50 ppt upper bound.
+
+Primary figure
+--------------
+
+.. figure:: ../validation/ramsden2022_pr543_validation_comparison.svg
+   :alt: Grouped comparisons of UK methane flux rates and site-level methane
+         and ethane posterior latent-mean RMSE.
+   :width: 100%
+   :align: center
+
+   Panel A compares annualized UK methane flux rates in Tg CH4 yr-1. Error bars
+   are 95% posterior intervals. Retained-original and modern bars represent
+   January states; hatched paper bars are annual 2019 values shown only for
+   scale. Panels B and C compare deterministic posterior latent-mean RMSE by
+   site for methane in ppb and ethane in ppt.
+
+Comparison with Ramsden et al. (2022)
+-------------------------------------
+
+The modern regional posterior-mean physical ratios span 0.0386--0.1997, with
+median 0.0674. This is inside the paper's 2015--2019 regional range 0.009--0.2
+and is consistent in scale with the independent ratios quoted there:
+approximately 0.06 for UK gas leaks and 0.088 (0.04--0.18) for sampled North
+Sea plumes. Those external observations are sparse and local, so this is
+context rather than a validation score.
+
+The paper's annual 2019 methane estimates and the modern January annualized
+state are:
+
+.. list-table:: Paper context versus the modern January state
+   :header-rows: 1
+   :widths: 26 37 37
+
+   * - Sector
+     - Paper annual 2019
+     - Modern January annualized state
+   * - Fossil fuel
+     - 0.25 (0.23--0.28)
+     - 0.278 (0.214--0.352)
+   * - Non-fossil
+     - 1.90 (1.78--2.04)
+     - 1.657 (1.413--1.896)
+   * - Total
+     - 2.15 (2.03--2.28)
+     - 1.936 (1.696--2.174)
+
+Units are Tg CH4 yr-1 and intervals are 95% posterior intervals. All interval
+pairs overlap, but seasonal and annual averaging prevent a stronger
+reproduction claim.
+
+The paper also reports that adding ethane lowers fossil emissions by about 15%
+relative to a methane-only inversion and reduces fossil interval width by 15%
+on average and up to 35%. The present validation has no matched methane-only
+counterfactual, so those claims were not tested.
+
+Paper inconsistencies affecting interpretation
+-----------------------------------------------
+
+Three inconsistencies in the paper matter for exact reproduction:
+
+#. The methods state a methane model-error prior of ``Uniform(10, 50)`` ppb,
+   but the results report an overall mean of 7.75 ppb and say 75% of site-month
+   means lie between 5 and 10 ppb. Those results are impossible under the
+   printed prior. The retained ``Uniform(0, 50)`` implementation resolves the
+   contradiction.
+#. The paper prints the ethane model-error bounds in ppb, while its ethane
+   figures use pmol mol-1, equivalent to ppt. The retained data and
+   configuration also support ppt.
+#. The text describes one fixed-ratio sensitivity case as April 2019, while
+   the corresponding figure caption says May 2015.
+
+Implementation differences
+--------------------------
+
+The modern port preserves the paper-shaped equations, not the historical
+software stack:
+
+* PyMC/NumPyro NUTS and ArviZ replace the custom adaptive random-walk sampler
+  and bespoke output format.
+* Prepared canonical datasets replace the historical loaders, cache, and
+  configuration parser.
+* Source labels, state indexes, basis maps, unit scales, ratio provenance, and
+  boundary configuration are validated explicitly.
+* The direct physical ratio and the multiplier of a pre-scaled tracer design
+  are represented separately.
+* The module does not reproduce historical gridded/country post-processing.
+
+The historical generalized branch also contains documented correctness
+problems, including a stale boundary proposal state, brittle posterior slicing,
+and omission of the sampled ratio from ethane gridded/country output. The
+comparison therefore uses explicit state variables, methane aggregate fluxes,
+boundary states, physical ratios, and observation latent means rather than the
+suspect stored national ethane result.
+
+Assessment and follow-up
+------------------------
+
+The evidence supports computational fidelity of the modern forward model and
+posterior target for this retained January case:
+
+* fossil UK methane flux is reproduced within 1%;
+* all regional 95% posterior intervals overlap;
+* fossil and ratio spatial patterns agree strongly;
+* boundary states and observation-space latent means are nearly identical; and
+* the distinctive ethane model-error ceiling is reproduced.
+
+It does not establish full reproduction of the paper. That would require:
+
+* all 60 monthly inversions for 2015--2019;
+* the exact original measurement-error inputs;
+* a matched methane-only counterfactual; and
+* the paper's annual aggregation and uncertainty comparison.
+
+The low ethane posterior-predictive coverage should remain visible in any
+future milestone work. A generic linked-tracer API should preserve the
+successful shared-state and ratio contracts while making data preparation,
+unit provenance, predictive diagnostics, and tracer-aware output explicit.
+
+Reference
+---------
+
+A. E. Ramsden et al. (2022), "Quantifying fossil fuel methane emissions using
+observations of atmospheric ethane and an uncertain emission ratio",
+*Atmospheric Chemistry and Physics* 22, 3911--3929,
+`doi:10.5194/acp-22-3911-2022
+<https://doi.org/10.5194/acp-22-3911-2022>`_.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,4 +29,5 @@ Releases are tagged with a `DOI <https://doi.org/10.5281/zenodo.10650595>`_.
    :caption: Contents:
 
    usage/usage
+   experimental/index
    reference/modules

--- a/docs/plans/adding_multi_gas_model_historical_comparison.md
+++ b/docs/plans/adding_multi_gas_model_historical_comparison.md
@@ -1,0 +1,235 @@
+# `adding_multi_gas_model`: historical comparison and modern port
+
+## Decision
+
+Do not merge or cherry-pick `origin/adding_multi_gas_model`. The branch is four
+commits ahead of its 2023 base but more than 1,500 commits behind the current
+`devel` branch. Its useful scientific behavior is now represented by the
+isolated experimental module
+`openghg_inversions.experimental.ramsden2022`.
+
+The experimental module ports only the Ramsden et al. (2022) methane/ethane
+model:
+
+- one labelled methane scaling state per sector;
+- the same fossil-fuel state contributes to methane and ethane likelihoods;
+- ethane has no non-fossil contribution;
+- the ethane:methane ratio can be fixed, scalar, or spatially varying;
+- methane and ethane retain independent sites, times, boundary states, and
+  absolute model-error terms;
+- sampling uses the current `RhimeSampler`.
+
+It deliberately does not port the branch's ACRG/OpenGHG loaders, pickle cache,
+custom Metropolis-Hastings sampler, configuration parser, isotope extensions,
+or bespoke NetCDF/country postprocessing.
+
+The paper is:
+
+> Ramsden, A. E. et al. (2022), "Quantifying fossil fuel methane emissions
+> using observations of atmospheric ethane and an uncertain emission ratio",
+> *Atmospheric Chemistry and Physics* 22, 3911-3929,
+> <https://doi.org/10.5194/acp-22-3911-2022>.
+
+## Model comparison
+
+For fossil-fuel (`FF`) and non-fossil (`nonFF`) methane states, the paper model
+is
+
+```text
+mu_CH4 =
+    H_CH4,FF @ x_FF
+  + H_CH4,nonFF @ x_nonFF
+  + Hbc_CH4 @ bc_CH4
+
+mu_C2H6 =
+    H_C2H6,FF @ (R * x_FF)
+  + Hbc_C2H6 @ bc_C2H6
+```
+
+The gas likelihoods are conditionally independent. Model error is absolute in
+each gas's observation units:
+
+```text
+epsilon_g = max(
+    sqrt(measurement_error_g**2 + sigma_g(site, period)**2),
+    min_error_g,
+)
+```
+
+This is not the same as modern standard RHIME's enhancement-proportional error
+term, so the experimental builder has a small namespaced two-channel
+likelihood rather than calling the current single-channel likelihood helper
+twice. Set `min_error=0` in prepared inputs for an exact comparison with the
+paper; a nonzero value intentionally retains the modern RHIME safety floor.
+Sigma priors are required explicitly, as are boundary priors for channels with
+boundary states; the experimental API does not silently substitute modern
+RHIME defaults for the paper's settings.
+
+### Direct ratio versus historical multiplier
+
+The paper samples the direct molar ratio `R`. In contrast, the historical
+branch constructs ethane sensitivity from an inventory that already contains
+a reference ratio (0.075 in the supplied configuration) and samples a
+dimensionless multiplier around that inventory:
+
+```text
+R_physical = 0.075 * ratio_multiplier
+```
+
+The new `RamsdenSectorSpec` makes this distinction explicit:
+
+- `reference_ratio=None`: `tracer.H` must be ratio-free and the sampled/fixed
+  value is the direct emission ratio;
+- `reference_ratio=<positive value>`: `tracer.H` must already contain that
+  ratio and the sampled/fixed value is a dimensionless multiplier. The model
+  exposes both `ratio_multiplier_<sector>` and
+  `emission_ratio_<sector>`.
+
+Sampled ratios must use priors with non-negative support, and sectors must bind
+unique primary and tracer sensitivity sources so that duplicate,
+non-identifiable states fail during validation.
+
+`RamsdenPreparedInputs.tracer_design_reference_ratios` independently records
+which reference ratio, if any, is already present in every tracer design. The
+builder requires those values to agree with the model spec. This prevents a
+ratio from being silently applied twice.
+
+## Why the historical branch cannot be run unchanged
+
+The branch is not only dependency-old; it contains correctness defects that
+make it unsuitable as a production fallback:
+
+- imports refer to removed modules and obsolete OpenGHG/ACRG APIs;
+- pseudo-data setup references an undefined emissions-uncertainty variable;
+- site/time matching checks site and timestamp membership separately rather
+  than matching `(site, time)` pairs;
+- the real-data boundary proposal can score stale proposed state from another
+  parameter update, violating the intended Metropolis transition;
+- posterior modelled-observation slicing mixes burn-in and posterior draws and
+  can create inconsistent output dimensions;
+- ethane gridded/country outputs omit the sampled ratio multiplier;
+- basis counts and sector layouts are inferred positionally without labelled
+  alignment;
+- there are no multi-gas tests.
+
+The old code remains useful as a source for equations and tiny repaired
+synthetic-oracle comparisons.
+
+## Relationship to milestones 10 and 11
+
+Milestone 10 ("high-resolution RHIME and parallel extension hooks") includes
+issue #410, which calls for isolated model variants using the modern
+run-spec/preparation/builder/result pattern and explicitly avoids new model
+logic in `hbmcmc`.
+
+Milestone 11 ("linked CO2/O2 tracer inversion") will provide the durable,
+general contracts that this experiment intentionally does not invent:
+
+- serialisable primary/tracer coupling specs (#411);
+- channel-aware preparation and shared-state model construction (#412);
+- tracer-aware postprocessing and outputs (#413).
+
+The Ramsden module is therefore a running historical comparison and a
+requirements fixture for milestone 11, not the proposed final generic tracer
+API. It has a dedicated result carrier and does not alter `RhimeResult` or
+`InversionOutput`.
+
+## Prepared-input usage
+
+Both datasets use the canonical RHIME variable names (`H`, `mf`, `mf_error`,
+`min_error`, `site_indicator`, and optional `H_bc`). They can have different
+observation axes but coupled sector designs must have exactly matching labelled
+state coordinates. Retain and pass both `BasisFunctions` objects when using
+ordinary numeric region labels; the builder then compares the actual spatial
+basis maps rather than treating two `0..N-1` indexes as proof of alignment.
+
+```python
+from openghg_inversions.experimental.ramsden2022 import (
+    RamsdenChannelSpec,
+    RamsdenModelSpec,
+    RamsdenPreparedInputs,
+    RamsdenSectorSpec,
+    run_ramsden_from_prepared_inputs,
+)
+from openghg_inversions.rhime import RhimeSampler
+
+spec = RamsdenModelSpec(
+    primary=RamsdenChannelSpec(
+        species="ch4",
+        observation_units="ppb",
+        sigma_prior={"pdf": "uniform", "lower": 10.0, "upper": 50.0},
+        sigma_frequency="monthly",
+        use_bc=True,
+        bc_prior={
+            "pdf": "truncatednormal",
+            "mu": 1.0,
+            "sigma": 0.05,
+            "lower": 0.0,
+        },
+    ),
+    tracer=RamsdenChannelSpec(
+        species="c2h6",
+        observation_units="ppt",
+        sigma_prior={"pdf": "uniform", "lower": 20.0, "upper": 50.0},
+        sigma_frequency="monthly",
+        use_bc=True,
+        bc_prior={
+            "pdf": "truncatednormal",
+            "mu": 1.0,
+            "sigma": 0.5,
+            "lower": 0.0,
+        },
+    ),
+    sectors=(
+        RamsdenSectorSpec(
+            name="fossil_fuel",
+            primary_flux_source="ch4_ff",
+            tracer_flux_source="c2h6_ff_r0075",
+            x_prior={
+                "pdf": "truncatednormal",
+                "mu": 1.0,
+                "sigma": 0.5,
+                "lower": 0.0,
+            },
+            ratio_prior={"pdf": "uniform", "lower": 0.1, "upper": 2.7},
+            ratio_resolution="spatial",
+            reference_ratio=0.075,
+        ),
+        RamsdenSectorSpec(
+            name="non_fossil",
+            primary_flux_source="ch4_nonff",
+            x_prior={
+                "pdf": "truncatednormal",
+                "mu": 1.0,
+                "sigma": 0.5,
+                "lower": 0.0,
+            },
+        ),
+    ),
+)
+
+result = run_ramsden_from_prepared_inputs(
+    prepared_inputs=RamsdenPreparedInputs(
+        primary=prepared_ch4.inv_inputs,
+        tracer=prepared_c2h6.inv_inputs,
+        tracer_design_reference_ratios={"c2h6_ff_r0075": 0.075},
+        primary_basis_functions=prepared_ch4.basis_functions,
+        tracer_basis_functions=prepared_c2h6.basis_functions,
+    ),
+    model_spec=spec,
+    sampler=RhimeSampler(
+        draws=1000,
+        tune=1000,
+        chains=4,
+        nuts_sampler="numpyro",
+        sample_posterior_predictive=("y_ch4", "y_c2h6"),
+    ),
+)
+```
+
+The builder compares supported mole-fraction unit declarations on `mf` (and on
+other arrays when present) with `observation_units`. The caller remains
+responsible for expressing numeric sigma-prior values and unitless forward
+designs on that same scale. In particular, the paper labels the ethane
+model-error values as ppb, while the historical data/configuration strongly
+indicate ppt; this should not be hidden behind an implicit conversion.

--- a/docs/validation/ramsden2022_pr543_validation_comparison.svg
+++ b/docs/validation/ramsden2022_pr543_validation_comparison.svg
@@ -1,0 +1,988 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="872.39952pt" height="620.39952pt" viewBox="0 0 872.39952 620.39952" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <title>PR #543 Ramsden CH4/C2H6 real-data validation comparison</title>
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title>PR #543 Ramsden CH4/C2H6 real-data validation comparison</dc:title>
+    <dc:date>2026-07-30T09:12:29.163446</dc:date>
+    <dc:description>Grouped comparisons of UK methane flux rates and site-level posterior latent-mean RMSE.</dc:description>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 620.39952 
+L 872.39952 620.39952 
+L 872.39952 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 45.203125 310.843859 
+L 865.19952 310.843859 
+L 865.19952 42.835792 
+L 45.203125 42.835792 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 82.475688 310.843859 
+L 148.2508 310.843859 
+L 148.2508 281.31716 
+L 82.475688 281.31716 
+z
+" clip-path="url(#p5ae1ac2510)" style="fill: #6b7280; opacity: 0.82"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 356.538655 310.843859 
+L 422.313767 310.843859 
+L 422.313767 144.999733 
+L 356.538655 144.999733 
+z
+" clip-path="url(#p5ae1ac2510)" style="fill: #6b7280; opacity: 0.82"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 630.601621 310.843859 
+L 696.376733 310.843859 
+L 696.376733 115.473033 
+L 630.601621 115.473033 
+z
+" clip-path="url(#p5ae1ac2510)" style="fill: #6b7280; opacity: 0.82"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 148.2508 310.843859 
+L 214.025912 310.843859 
+L 214.025912 281.599926 
+L 148.2508 281.599926 
+z
+" clip-path="url(#p5ae1ac2510)" style="fill: #0072b2; opacity: 0.82"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 422.313767 310.843859 
+L 488.088878 310.843859 
+L 488.088878 136.656936 
+L 422.313767 136.656936 
+z
+" clip-path="url(#p5ae1ac2510)" style="fill: #0072b2; opacity: 0.82"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 696.376733 310.843859 
+L 762.151845 310.843859 
+L 762.151845 107.413003 
+L 696.376733 107.413003 
+z
+" clip-path="url(#p5ae1ac2510)" style="fill: #0072b2; opacity: 0.82"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 214.025912 310.843859 
+L 279.801024 310.843859 
+L 279.801024 284.568559 
+L 214.025912 284.568559 
+z
+" clip-path="url(#p5ae1ac2510)" style="fill: url(#h73640ae1db); opacity: 0.82"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 488.088878 310.843859 
+L 553.86399 310.843859 
+L 553.86399 111.151574 
+L 488.088878 111.151574 
+z
+" clip-path="url(#p5ae1ac2510)" style="fill: url(#h73640ae1db); opacity: 0.82"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 762.151845 310.843859 
+L 827.926957 310.843859 
+L 827.926957 84.876274 
+L 762.151845 84.876274 
+z
+" clip-path="url(#p5ae1ac2510)" style="fill: url(#h73640ae1db); opacity: 0.82"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="ma73fc2b0cb" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#ma73fc2b0cb" x="181.138356" y="310.843859" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="181.138356" y="325.442297" transform="rotate(-0 181.138356 325.442297)">Fossil fuel</text>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#ma73fc2b0cb" x="455.201322" y="310.843859" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="455.201322" y="325.442297" transform="rotate(-0 455.201322 325.442297)">Non-fossil</text>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#ma73fc2b0cb" x="729.264289" y="310.843859" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="729.264289" y="325.442297" transform="rotate(-0 729.264289 325.442297)">Total</text>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_4">
+      <path d="M 45.203125 310.843859 
+L 865.19952 310.843859 
+" clip-path="url(#p5ae1ac2510)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.22; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_5">
+      <defs>
+       <path id="m0a37ce209b" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m0a37ce209b" x="45.203125" y="310.843859" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="38.203125" y="314.643078" transform="rotate(-0 38.203125 314.643078)">0.0</text>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_6">
+      <path d="M 45.203125 258.293258 
+L 865.19952 258.293258 
+" clip-path="url(#p5ae1ac2510)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.22; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#m0a37ce209b" x="45.203125" y="258.293258" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="38.203125" y="262.092477" transform="rotate(-0 38.203125 262.092477)">0.5</text>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_8">
+      <path d="M 45.203125 205.742657 
+L 865.19952 205.742657 
+" clip-path="url(#p5ae1ac2510)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.22; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m0a37ce209b" x="45.203125" y="205.742657" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="38.203125" y="209.541875" transform="rotate(-0 38.203125 209.541875)">1.0</text>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_10">
+      <path d="M 45.203125 153.192055 
+L 865.19952 153.192055 
+" clip-path="url(#p5ae1ac2510)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.22; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#m0a37ce209b" x="45.203125" y="153.192055" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="38.203125" y="156.991274" transform="rotate(-0 38.203125 156.991274)">1.5</text>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_12">
+      <path d="M 45.203125 100.641454 
+L 865.19952 100.641454 
+" clip-path="url(#p5ae1ac2510)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.22; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#m0a37ce209b" x="45.203125" y="100.641454" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="38.203125" y="104.440673" transform="rotate(-0 38.203125 104.440673)">2.0</text>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_14">
+      <path d="M 45.203125 48.090853 
+L 865.19952 48.090853 
+" clip-path="url(#p5ae1ac2510)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.22; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#m0a37ce209b" x="45.203125" y="48.090853" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="38.203125" y="51.890071" transform="rotate(-0 38.203125 51.890071)">2.5</text>
+     </g>
+    </g>
+    <g id="text_10">
+     <!-- Tg CH$_4$ yr$^{-1}$ -->
+     <g transform="translate(16.2 206.289826) rotate(-90)">
+      <text>
+       <tspan x="0" y="-0.064063" style="font-size: 10px; font-family: 'DejaVu Sans'">T</tspan>
+       <tspan x="6.108398" y="-0.064063" style="font-size: 10px; font-family: 'DejaVu Sans'">g</tspan>
+       <tspan x="12.456055" y="-0.064063" style="font-size: 10px; font-family: 'DejaVu Sans'"> </tspan>
+       <tspan x="15.634766" y="-0.064063" style="font-size: 10px; font-family: 'DejaVu Sans'">C</tspan>
+       <tspan x="22.617188" y="-0.064063" style="font-size: 10px; font-family: 'DejaVu Sans'">H</tspan>
+       <tspan x="34.959473" y="-0.064063" style="font-size: 10px; font-family: 'DejaVu Sans'"> </tspan>
+       <tspan x="38.138184" y="-0.064063" style="font-size: 10px; font-family: 'DejaVu Sans'">y</tspan>
+       <tspan x="44.056152" y="-0.064063" style="font-size: 10px; font-family: 'DejaVu Sans'">r</tspan>
+       <tspan x="30.232422" y="1.576562" style="font-size: 7px; font-family: 'DejaVu Sans'">4</tspan>
+       <tspan x="48.263184" y="-3.892188" style="font-size: 7px; font-family: 'DejaVu Sans'">−</tspan>
+       <tspan x="54.128418" y="-3.892188" style="font-size: 7px; font-family: 'DejaVu Sans'">1</tspan>
+      </text>
+     </g>
+    </g>
+   </g>
+   <g id="LineCollection_1">
+    <path d="M 115.363244 288.115773 
+L 115.363244 273.638384 
+" clip-path="url(#p5ae1ac2510)" style="fill: none; stroke: #000000; stroke-width: 1.5"/>
+    <path d="M 389.426211 169.052175 
+L 389.426211 120.870259 
+" clip-path="url(#p5ae1ac2510)" style="fill: none; stroke: #000000; stroke-width: 1.5"/>
+    <path d="M 663.489177 141.549777 
+L 663.489177 89.439564 
+" clip-path="url(#p5ae1ac2510)" style="fill: none; stroke: #000000; stroke-width: 1.5"/>
+   </g>
+   <g id="line2d_16">
+    <defs>
+     <path id="m7633417eff" d="M 4 0 
+L -4 -0 
+" style="stroke: #000000"/>
+    </defs>
+    <g clip-path="url(#p5ae1ac2510)">
+     <use xlink:href="#m7633417eff" x="115.363244" y="288.115773" style="fill: #1f77b4; stroke: #000000"/>
+     <use xlink:href="#m7633417eff" x="389.426211" y="169.052175" style="fill: #1f77b4; stroke: #000000"/>
+     <use xlink:href="#m7633417eff" x="663.489177" y="141.549777" style="fill: #1f77b4; stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_17">
+    <g clip-path="url(#p5ae1ac2510)">
+     <use xlink:href="#m7633417eff" x="115.363244" y="273.638384" style="fill: #1f77b4; stroke: #000000"/>
+     <use xlink:href="#m7633417eff" x="389.426211" y="120.870259" style="fill: #1f77b4; stroke: #000000"/>
+     <use xlink:href="#m7633417eff" x="663.489177" y="89.439564" style="fill: #1f77b4; stroke: #000000"/>
+    </g>
+   </g>
+   <g id="LineCollection_2">
+    <path d="M 181.138356 288.347336 
+L 181.138356 273.838172 
+" clip-path="url(#p5ae1ac2510)" style="fill: none; stroke: #000000; stroke-width: 1.5"/>
+    <path d="M 455.201322 162.343107 
+L 455.201322 111.615013 
+" clip-path="url(#p5ae1ac2510)" style="fill: none; stroke: #000000; stroke-width: 1.5"/>
+    <path d="M 729.264289 132.569779 
+L 729.264289 82.304832 
+" clip-path="url(#p5ae1ac2510)" style="fill: none; stroke: #000000; stroke-width: 1.5"/>
+   </g>
+   <g id="line2d_18">
+    <g clip-path="url(#p5ae1ac2510)">
+     <use xlink:href="#m7633417eff" x="181.138356" y="288.347336" style="fill: #1f77b4; stroke: #000000"/>
+     <use xlink:href="#m7633417eff" x="455.201322" y="162.343107" style="fill: #1f77b4; stroke: #000000"/>
+     <use xlink:href="#m7633417eff" x="729.264289" y="132.569779" style="fill: #1f77b4; stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_19">
+    <g clip-path="url(#p5ae1ac2510)">
+     <use xlink:href="#m7633417eff" x="181.138356" y="273.838172" style="fill: #1f77b4; stroke: #000000"/>
+     <use xlink:href="#m7633417eff" x="455.201322" y="111.615013" style="fill: #1f77b4; stroke: #000000"/>
+     <use xlink:href="#m7633417eff" x="729.264289" y="82.304832" style="fill: #1f77b4; stroke: #000000"/>
+    </g>
+   </g>
+   <g id="LineCollection_3">
+    <path d="M 246.913468 286.670583 
+L 246.913468 281.415523 
+" clip-path="url(#p5ae1ac2510)" style="fill: none; stroke: #000000; stroke-width: 1.5"/>
+    <path d="M 520.976434 123.763719 
+L 520.976434 96.437406 
+" clip-path="url(#p5ae1ac2510)" style="fill: none; stroke: #000000; stroke-width: 1.5"/>
+    <path d="M 795.039401 97.488418 
+L 795.039401 71.213117 
+" clip-path="url(#p5ae1ac2510)" style="fill: none; stroke: #000000; stroke-width: 1.5"/>
+   </g>
+   <g id="line2d_20">
+    <g clip-path="url(#p5ae1ac2510)">
+     <use xlink:href="#m7633417eff" x="246.913468" y="286.670583" style="fill: #1f77b4; stroke: #000000"/>
+     <use xlink:href="#m7633417eff" x="520.976434" y="123.763719" style="fill: #1f77b4; stroke: #000000"/>
+     <use xlink:href="#m7633417eff" x="795.039401" y="97.488418" style="fill: #1f77b4; stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_21">
+    <g clip-path="url(#p5ae1ac2510)">
+     <use xlink:href="#m7633417eff" x="246.913468" y="281.415523" style="fill: #1f77b4; stroke: #000000"/>
+     <use xlink:href="#m7633417eff" x="520.976434" y="96.437406" style="fill: #1f77b4; stroke: #000000"/>
+     <use xlink:href="#m7633417eff" x="795.039401" y="71.213117" style="fill: #1f77b4; stroke: #000000"/>
+    </g>
+   </g>
+   <g id="patch_12">
+    <path d="M 45.203125 310.843859 
+L 45.203125 42.835792 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 45.203125 310.843859 
+L 865.19952 310.843859 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_11">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="115.363244" y="268.974634" transform="rotate(-0 115.363244 268.974634)">0.28</text>
+   </g>
+   <g id="text_12">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="389.426211" y="116.206509" transform="rotate(-0 389.426211 116.206509)">1.58</text>
+   </g>
+   <g id="text_13">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="663.489177" y="84.775814" transform="rotate(-0 663.489177 84.775814)">1.86</text>
+   </g>
+   <g id="text_14">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="181.138356" y="269.174422" transform="rotate(-0 181.138356 269.174422)">0.28</text>
+   </g>
+   <g id="text_15">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="455.201322" y="106.951263" transform="rotate(-0 455.201322 106.951263)">1.66</text>
+   </g>
+   <g id="text_16">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="729.264289" y="77.641082" transform="rotate(-0 729.264289 77.641082)">1.94</text>
+   </g>
+   <g id="text_17">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="246.913468" y="276.751773" transform="rotate(-0 246.913468 276.751773)">0.25</text>
+   </g>
+   <g id="text_18">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="520.976434" y="91.773656" transform="rotate(-0 520.976434 91.773656)">1.90</text>
+   </g>
+   <g id="text_19">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="795.039401" y="66.549367" transform="rotate(-0 795.039401 66.549367)">2.15</text>
+   </g>
+   <g id="text_20">
+    <text style="font-size: 12px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="455.201323" y="36.835792" transform="rotate(-0 455.201323 36.835792)">A. UK methane flux-rate comparison</text>
+   </g>
+   <g id="legend_1">
+    <g id="patch_14">
+     <path d="M 54.203125 59.43423 
+L 74.203125 59.43423 
+L 74.203125 52.43423 
+L 54.203125 52.43423 
+z
+" style="fill: #6b7280; opacity: 0.82"/>
+    </g>
+    <g id="text_21">
+     <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="82.203125" y="59.43423" transform="rotate(-0 82.203125 59.43423)">Retained original — January annualized state</text>
+    </g>
+    <g id="patch_15">
+     <path d="M 327.60625 59.43423 
+L 347.60625 59.43423 
+L 347.60625 52.43423 
+L 327.60625 52.43423 
+z
+" style="fill: #0072b2; opacity: 0.82"/>
+    </g>
+    <g id="text_22">
+     <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="355.60625" y="59.43423" transform="rotate(-0 355.60625 59.43423)">Modern — January annualized state</text>
+    </g>
+    <g id="patch_16">
+     <path d="M 553.657813 59.43423 
+L 573.657813 59.43423 
+L 573.657813 52.43423 
+L 553.657813 52.43423 
+z
+" style="fill: url(#h73640ae1db); opacity: 0.82"/>
+    </g>
+    <g id="text_23">
+     <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="581.657813" y="59.43423" transform="rotate(-0 581.657813 59.43423)">Ramsden et al. — annual 2019</text>
+    </g>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_17">
+    <path d="M 45.203125 581.810602 
+L 426.67851 581.810602 
+L 426.67851 348.760109 
+L 45.203125 348.760109 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 62.542915 581.810602 
+L 81.121262 581.810602 
+L 81.121262 491.866821 
+L 62.542915 491.866821 
+z
+" clip-path="url(#p336a2f33f2)" style="fill: #6b7280; opacity: 0.82"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 139.952693 581.810602 
+L 158.53104 581.810602 
+L 158.53104 445.695406 
+L 139.952693 445.695406 
+z
+" clip-path="url(#p336a2f33f2)" style="fill: #6b7280; opacity: 0.82"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 217.362471 581.810602 
+L 235.940817 581.810602 
+L 235.940817 373.463462 
+L 217.362471 373.463462 
+z
+" clip-path="url(#p336a2f33f2)" style="fill: #6b7280; opacity: 0.82"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 294.772249 581.810602 
+L 313.350595 581.810602 
+L 313.350595 506.000648 
+L 294.772249 506.000648 
+z
+" clip-path="url(#p336a2f33f2)" style="fill: #6b7280; opacity: 0.82"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 372.182026 581.810602 
+L 390.760373 581.810602 
+L 390.760373 435.948412 
+L 372.182026 435.948412 
+z
+" clip-path="url(#p336a2f33f2)" style="fill: #6b7280; opacity: 0.82"/>
+   </g>
+   <g id="patch_23">
+    <path d="M 81.121262 581.810602 
+L 99.699609 581.810602 
+L 99.699609 482.531092 
+L 81.121262 482.531092 
+z
+" clip-path="url(#p336a2f33f2)" style="fill: #0072b2; opacity: 0.82"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 158.53104 581.810602 
+L 177.109386 581.810602 
+L 177.109386 442.487534 
+L 158.53104 442.487534 
+z
+" clip-path="url(#p336a2f33f2)" style="fill: #0072b2; opacity: 0.82"/>
+   </g>
+   <g id="patch_25">
+    <path d="M 235.940817 581.810602 
+L 254.519164 581.810602 
+L 254.519164 383.306418 
+L 235.940817 383.306418 
+z
+" clip-path="url(#p336a2f33f2)" style="fill: #0072b2; opacity: 0.82"/>
+   </g>
+   <g id="patch_26">
+    <path d="M 313.350595 581.810602 
+L 331.928942 581.810602 
+L 331.928942 509.263355 
+L 313.350595 509.263355 
+z
+" clip-path="url(#p336a2f33f2)" style="fill: #0072b2; opacity: 0.82"/>
+   </g>
+   <g id="patch_27">
+    <path d="M 390.760373 581.810602 
+L 409.33872 581.810602 
+L 409.33872 439.156283 
+L 390.760373 439.156283 
+z
+" clip-path="url(#p336a2f33f2)" style="fill: #0072b2; opacity: 0.82"/>
+   </g>
+   <g id="matplotlib.axis_3">
+    <g id="xtick_4">
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#ma73fc2b0cb" x="81.121262" y="581.810602" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_24">
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="81.121262" y="596.40904" transform="rotate(-0 81.121262 596.40904)">MHD</text>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_23">
+      <g>
+       <use xlink:href="#ma73fc2b0cb" x="158.53104" y="581.810602" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_25">
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="158.53104" y="596.40904" transform="rotate(-0 158.53104 596.40904)">TAC</text>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#ma73fc2b0cb" x="235.940817" y="581.810602" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_26">
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="235.940817" y="596.40904" transform="rotate(-0 235.940817 596.40904)">RGL</text>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_25">
+      <g>
+       <use xlink:href="#ma73fc2b0cb" x="313.350595" y="581.810602" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_27">
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="313.350595" y="596.40904" transform="rotate(-0 313.350595 596.40904)">BSD</text>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#ma73fc2b0cb" x="390.760373" y="581.810602" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_28">
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="390.760373" y="596.40904" transform="rotate(-0 390.760373 596.40904)">HFD</text>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_7">
+     <g id="line2d_27">
+      <path d="M 45.203125 581.810602 
+L 426.67851 581.810602 
+" clip-path="url(#p336a2f33f2)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.22; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_28">
+      <g>
+       <use xlink:href="#m0a37ce209b" x="45.203125" y="581.810602" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_29">
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="38.203125" y="585.609821" transform="rotate(-0 38.203125 585.609821)">0</text>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_29">
+      <path d="M 45.203125 554.392897 
+L 426.67851 554.392897 
+" clip-path="url(#p336a2f33f2)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.22; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#m0a37ce209b" x="45.203125" y="554.392897" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_30">
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="38.203125" y="558.192116" transform="rotate(-0 38.203125 558.192116)">2</text>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_31">
+      <path d="M 45.203125 526.975192 
+L 426.67851 526.975192 
+" clip-path="url(#p336a2f33f2)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.22; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_32">
+      <g>
+       <use xlink:href="#m0a37ce209b" x="45.203125" y="526.975192" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_31">
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="38.203125" y="530.774411" transform="rotate(-0 38.203125 530.774411)">4</text>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_33">
+      <path d="M 45.203125 499.557487 
+L 426.67851 499.557487 
+" clip-path="url(#p336a2f33f2)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.22; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_34">
+      <g>
+       <use xlink:href="#m0a37ce209b" x="45.203125" y="499.557487" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_32">
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="38.203125" y="503.356706" transform="rotate(-0 38.203125 503.356706)">6</text>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_35">
+      <path d="M 45.203125 472.139782 
+L 426.67851 472.139782 
+" clip-path="url(#p336a2f33f2)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.22; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_36">
+      <g>
+       <use xlink:href="#m0a37ce209b" x="45.203125" y="472.139782" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_33">
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="38.203125" y="475.939001" transform="rotate(-0 38.203125 475.939001)">8</text>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_37">
+      <path d="M 45.203125 444.722077 
+L 426.67851 444.722077 
+" clip-path="url(#p336a2f33f2)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.22; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_38">
+      <g>
+       <use xlink:href="#m0a37ce209b" x="45.203125" y="444.722077" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_34">
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="38.203125" y="448.521296" transform="rotate(-0 38.203125 448.521296)">10</text>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_39">
+      <path d="M 45.203125 417.304372 
+L 426.67851 417.304372 
+" clip-path="url(#p336a2f33f2)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.22; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_40">
+      <g>
+       <use xlink:href="#m0a37ce209b" x="45.203125" y="417.304372" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_35">
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="38.203125" y="421.103591" transform="rotate(-0 38.203125 421.103591)">12</text>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_41">
+      <path d="M 45.203125 389.886667 
+L 426.67851 389.886667 
+" clip-path="url(#p336a2f33f2)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.22; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_42">
+      <g>
+       <use xlink:href="#m0a37ce209b" x="45.203125" y="389.886667" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_36">
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="38.203125" y="393.685886" transform="rotate(-0 38.203125 393.685886)">14</text>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_43">
+      <path d="M 45.203125 362.468962 
+L 426.67851 362.468962 
+" clip-path="url(#p336a2f33f2)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.22; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_44">
+      <g>
+       <use xlink:href="#m0a37ce209b" x="45.203125" y="362.468962" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_37">
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="38.203125" y="366.268181" transform="rotate(-0 38.203125 366.268181)">16</text>
+     </g>
+    </g>
+    <g id="text_38">
+     <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="19.398438" y="465.285356" transform="rotate(-90 19.398438 465.285356)">ppb</text>
+    </g>
+   </g>
+   <g id="patch_28">
+    <path d="M 45.203125 581.810602 
+L 45.203125 348.760109 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_29">
+    <path d="M 45.203125 581.810602 
+L 426.67851 581.810602 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_39">
+    <text style="font-size: 12px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="235.940817" y="342.760109" transform="rotate(-0 235.940817 342.760109)">B. CH4 posterior latent-mean RMSE</text>
+   </g>
+   <g id="legend_2">
+    <g id="patch_30">
+     <path d="M 54.203125 365.358547 
+L 74.203125 365.358547 
+L 74.203125 358.358547 
+L 54.203125 358.358547 
+z
+" style="fill: #6b7280; opacity: 0.82"/>
+    </g>
+    <g id="text_40">
+     <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="82.203125" y="365.358547" transform="rotate(-0 82.203125 365.358547)">Retained original</text>
+    </g>
+    <g id="patch_31">
+     <path d="M 187.076563 365.358547 
+L 207.076563 365.358547 
+L 207.076563 358.358547 
+L 187.076563 358.358547 
+z
+" style="fill: #0072b2; opacity: 0.82"/>
+    </g>
+    <g id="text_41">
+     <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="215.076563" y="365.358547" transform="rotate(-0 215.076563 365.358547)">Modern</text>
+    </g>
+   </g>
+  </g>
+  <g id="axes_3">
+   <g id="patch_32">
+    <path d="M 483.724135 581.810602 
+L 865.19952 581.810602 
+L 865.19952 348.760109 
+L 483.724135 348.760109 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="patch_33">
+    <path d="M 501.063925 581.810602 
+L 557.301083 581.810602 
+L 557.301083 368.239402 
+L 501.063925 368.239402 
+z
+" clip-path="url(#p5d7545750e)" style="fill: #6b7280; opacity: 0.82"/>
+   </g>
+   <g id="patch_34">
+    <path d="M 735.385415 581.810602 
+L 791.622572 581.810602 
+L 791.622572 427.214227 
+L 735.385415 427.214227 
+z
+" clip-path="url(#p5d7545750e)" style="fill: #6b7280; opacity: 0.82"/>
+   </g>
+   <g id="patch_35">
+    <path d="M 557.301083 581.810602 
+L 613.53824 581.810602 
+L 613.53824 368.319571 
+L 557.301083 368.319571 
+z
+" clip-path="url(#p5d7545750e)" style="fill: #0072b2; opacity: 0.82"/>
+   </g>
+   <g id="patch_36">
+    <path d="M 791.622572 581.810602 
+L 847.85973 581.810602 
+L 847.85973 427.150838 
+L 791.622572 427.150838 
+z
+" clip-path="url(#p5d7545750e)" style="fill: #0072b2; opacity: 0.82"/>
+   </g>
+   <g id="matplotlib.axis_5">
+    <g id="xtick_9">
+     <g id="line2d_45">
+      <g>
+       <use xlink:href="#ma73fc2b0cb" x="557.301083" y="581.810602" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_42">
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="557.301083" y="596.40904" transform="rotate(-0 557.301083 596.40904)">MHD</text>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_46">
+      <g>
+       <use xlink:href="#ma73fc2b0cb" x="791.622572" y="581.810602" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_43">
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="791.622572" y="596.40904" transform="rotate(-0 791.622572 596.40904)">TAC</text>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_6">
+    <g id="ytick_16">
+     <g id="line2d_47">
+      <path d="M 483.724135 581.810602 
+L 865.19952 581.810602 
+" clip-path="url(#p5d7545750e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.22; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_48">
+      <g>
+       <use xlink:href="#m0a37ce209b" x="483.724135" y="581.810602" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_44">
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="476.724135" y="585.609821" transform="rotate(-0 476.724135 585.609821)">0</text>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_49">
+      <path d="M 483.724135 535.200504 
+L 865.19952 535.200504 
+" clip-path="url(#p5d7545750e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.22; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_50">
+      <g>
+       <use xlink:href="#m0a37ce209b" x="483.724135" y="535.200504" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_45">
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="476.724135" y="538.999723" transform="rotate(-0 476.724135 538.999723)">50</text>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_51">
+      <path d="M 483.724135 488.590405 
+L 865.19952 488.590405 
+" clip-path="url(#p5d7545750e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.22; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_52">
+      <g>
+       <use xlink:href="#m0a37ce209b" x="483.724135" y="488.590405" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_46">
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="476.724135" y="492.389624" transform="rotate(-0 476.724135 492.389624)">100</text>
+     </g>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_53">
+      <path d="M 483.724135 441.980307 
+L 865.19952 441.980307 
+" clip-path="url(#p5d7545750e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.22; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_54">
+      <g>
+       <use xlink:href="#m0a37ce209b" x="483.724135" y="441.980307" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_47">
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="476.724135" y="445.779525" transform="rotate(-0 476.724135 445.779525)">150</text>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_55">
+      <path d="M 483.724135 395.370208 
+L 865.19952 395.370208 
+" clip-path="url(#p5d7545750e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.22; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_56">
+      <g>
+       <use xlink:href="#m0a37ce209b" x="483.724135" y="395.370208" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_48">
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="476.724135" y="399.169427" transform="rotate(-0 476.724135 399.169427)">200</text>
+     </g>
+    </g>
+    <g id="ytick_21">
+     <g id="line2d_57">
+      <path d="M 483.724135 348.760109 
+L 865.19952 348.760109 
+" clip-path="url(#p5d7545750e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.22; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_58">
+      <g>
+       <use xlink:href="#m0a37ce209b" x="483.724135" y="348.760109" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_49">
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="476.724135" y="352.559328" transform="rotate(-0 476.724135 352.559328)">250</text>
+     </g>
+    </g>
+    <g id="text_50">
+     <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="451.556947" y="465.285356" transform="rotate(-90 451.556947 465.285356)">ppt</text>
+    </g>
+   </g>
+   <g id="patch_37">
+    <path d="M 483.724135 581.810602 
+L 483.724135 348.760109 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_38">
+    <path d="M 483.724135 581.810602 
+L 865.19952 581.810602 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_51">
+    <text style="font-size: 12px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="674.461827" y="342.760109" transform="rotate(-0 674.461827 342.760109)">C. C2H6 posterior latent-mean RMSE</text>
+   </g>
+   <g id="legend_3">
+    <g id="patch_39">
+     <path d="M 492.724135 365.358547 
+L 512.724135 365.358547 
+L 512.724135 358.358547 
+L 492.724135 358.358547 
+z
+" style="fill: #6b7280; opacity: 0.82"/>
+    </g>
+    <g id="text_52">
+     <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="520.724135" y="365.358547" transform="rotate(-0 520.724135 365.358547)">Retained original</text>
+    </g>
+    <g id="patch_40">
+     <path d="M 625.597572 365.358547 
+L 645.597572 365.358547 
+L 645.597572 358.358547 
+L 625.597572 358.358547 
+z
+" style="fill: #0072b2; opacity: 0.82"/>
+    </g>
+    <g id="text_53">
+     <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="653.597572" y="365.358547" transform="rotate(-0 653.597572 365.358547)">Modern</text>
+    </g>
+   </g>
+  </g>
+  <g id="text_54">
+   <text style="font-weight: 700; font-size: 15px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="436.19976" y="18.597656" transform="rotate(-0 436.19976 18.597656)">PR #543 Ramsden CH4/C2H6 real-data validation</text>
+  </g>
+  <g id="text_55">
+   <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="436.19976" y="611.327801" transform="rotate(-0 436.19976 611.327801)">Panel A error bars are 95% posterior intervals. The annual paper result is contextual, not like-for-like with January. Panels B–C compare deterministic posterior latent-mean RMSE.</text>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p5ae1ac2510">
+   <rect x="45.203125" y="42.835792" width="819.996395" height="268.008067"/>
+  </clipPath>
+  <clipPath id="p336a2f33f2">
+   <rect x="45.203125" y="348.760109" width="381.475385" height="233.050493"/>
+  </clipPath>
+  <clipPath id="p5d7545750e">
+   <rect x="483.724135" y="348.760109" width="381.475385" height="233.050493"/>
+  </clipPath>
+ </defs>
+ <defs>
+  <pattern id="h73640ae1db" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+   <rect x="0" y="0" width="73" height="73" fill="#d55e00"/>
+   <path d="M -36 36 
+L 36 -36 
+M -30 42 
+L 42 -30 
+M -24 48 
+L 48 -24 
+M -18 54 
+L 54 -18 
+M -12 60 
+L 60 -12 
+M -6 66 
+L 66 -6 
+M 0 72 
+L 72 0 
+M 6 78 
+L 78 6 
+M 12 84 
+L 84 12 
+M 18 90 
+L 90 18 
+M 24 96 
+L 96 24 
+M 30 102 
+L 102 30 
+M 36 108 
+L 108 36 
+" style="fill: #000000; stroke: #000000; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
+  </pattern>
+ </defs>
+</svg>

--- a/openghg_inversions/experimental/__init__.py
+++ b/openghg_inversions/experimental/__init__.py
@@ -1,0 +1,8 @@
+"""Experimental inversion models built on the modern OpenGHG stack.
+
+The current entry point is :mod:`openghg_inversions.experimental.ramsden2022`,
+an isolated methane/ethane shared-state model. Modules in this package are
+outside the stable public API, and compatibility is not guaranteed while their
+contracts are evaluated. Importing the package performs no retrieval or
+sampling.
+"""

--- a/openghg_inversions/experimental/ramsden2022/__init__.py
+++ b/openghg_inversions/experimental/ramsden2022/__init__.py
@@ -1,0 +1,35 @@
+"""Historical Ramsden et al. (2022) methane/ethane inversion.
+
+This experimental module preserves the paper's shared-state two-gas model
+without porting the obsolete data loading, custom Metropolis-Hastings sampler,
+or postprocessing from ``origin/adding_multi_gas_model``. Pass independently
+prepared, canonical RHIME datasets to :func:`build_ramsden_model` to build a
+PyMC graph or :func:`run_ramsden_from_prepared_inputs` to build and sample it.
+The gases may use different observation axes, but coupled sector state
+coordinates must match exactly.
+
+Ratios may either be direct molar ratios applied to a ratio-free tracer design
+or multipliers applied to a design that already includes a declared reference
+ratio. Values must already share each channel's declared observation units;
+the module validates supported unit declarations but does not convert values.
+"""
+
+from .model import (
+    RamsdenChannelSpec,
+    RamsdenModelSpec,
+    RamsdenPreparedInputs,
+    RamsdenResult,
+    RamsdenSectorSpec,
+    build_ramsden_model,
+    run_ramsden_from_prepared_inputs,
+)
+
+__all__ = [
+    "RamsdenChannelSpec",
+    "RamsdenModelSpec",
+    "RamsdenPreparedInputs",
+    "RamsdenResult",
+    "RamsdenSectorSpec",
+    "build_ramsden_model",
+    "run_ramsden_from_prepared_inputs",
+]

--- a/openghg_inversions/experimental/ramsden2022/model.py
+++ b/openghg_inversions/experimental/ramsden2022/model.py
@@ -1,0 +1,899 @@
+"""Modern PyMC implementation of the Ramsden et al. (2022) two-gas model.
+
+The implementation is deliberately prepared-input first. Each gas is supplied
+as a canonical RHIME-style :class:`xarray.Dataset`, normally obtained from a
+``RhimePreparedInputs.inv_inputs`` object. Data retrieval and postprocessing
+remain outside this historical comparison module.
+
+For primary-gas sector ``s`` with state ``x_s`` the forward models are
+
+``mu_primary = sum_s(H_primary,s @ x_s)``
+
+and, for sectors that emit the tracer,
+
+``mu_tracer = sum_s(H_tracer,s @ (R_s * x_s))``.
+
+The two gases may have different sites, timestamps, and observation counts.
+Their conditional likelihoods are independent and use the paper's absolute
+model-error definition, ``sqrt(measurement_error**2 + sigma**2)``.
+
+Use :func:`build_ramsden_model` to construct the graph without sampling and
+:func:`run_ramsden_from_prepared_inputs` to sample it. Coupled primary/tracer
+designs must have exactly matching labelled state coordinates. A ratio may be
+applied directly to a ratio-free tracer design, or interpreted as a multiplier
+when the design already includes an explicit reference ratio. Boundary states
+are optional and independent by gas. The caller is responsible for consistent
+units; this module performs no retrieval, conversion, or postprocessing.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+import math
+from typing import Any, Literal
+
+import arviz as az
+import numpy as np
+import pandas as pd
+import pymc as pm
+import pytensor.tensor as pt
+from pytensor.tensor.variable import TensorVariable
+import xarray as xr
+
+from openghg_inversions.basis.basis_functions import BasisFunctions
+from openghg_inversions.inversion_inputs import DatetimeLike
+from openghg_inversions.models._rhime_flux import _select_sector_design
+from openghg_inversions.models.components import add_linear_component, add_model_data
+from openghg_inversions.models.coords import CoordRegistry, add_coords, attach_coord_registry
+from openghg_inversions.models.priors import parse_prior
+from openghg_inversions.models.rhime import safe_pymc_name
+from openghg_inversions.rhime.sampling import RhimeSampler
+from openghg_inversions.sigma import SigmaAlignment
+
+RatioResolution = Literal["scalar", "spatial"]
+
+
+@dataclass(frozen=True)
+class RamsdenPreparedInputs:
+    """Canonical primary-gas and tracer inputs for one joint inversion.
+
+    Each dataset requires ``H``, ``mf``, ``mf_error``, ``min_error``, and
+    ``site_indicator`` on ``nmeasure``; ``H_bc`` is required when that
+    channel's boundary component is enabled. Observation axes may differ.
+    Coupled sector designs must have exactly matching labelled state
+    coordinates and, for positional numeric labels, retained basis objects.
+
+    Args:
+        primary: Canonical RHIME-style dataset for the primary gas.
+        tracer: Canonical RHIME-style dataset for the tracer gas. Its ``H``
+            matrix must use the same labelled state layout as ``primary.H``.
+        tracer_design_reference_ratios: Reference ratio already included in
+            each tracer ``H`` source, keyed by tracer source label. Use
+            ``None`` for a ratio-free design. These declarations are checked
+            against each sector specification to prevent applying a ratio
+            twice or omitting it.
+        primary_basis_functions: Retained basis used to construct ``primary.H``.
+            Required together with ``tracer_basis_functions`` when state
+            labels are positional numbers.
+        tracer_basis_functions: Retained basis used to construct ``tracer.H``.
+            Its source-specific spatial map must equal the primary map for
+            every coupled sector.
+    """
+
+    primary: xr.Dataset
+    tracer: xr.Dataset
+    tracer_design_reference_ratios: Mapping[str, float | None]
+    primary_basis_functions: BasisFunctions | None = None
+    tracer_basis_functions: BasisFunctions | None = None
+
+
+@dataclass(frozen=True)
+class RamsdenChannelSpec:
+    """Likelihood and boundary settings for one observed gas.
+
+    Args:
+        species: Gas name used to namespace model variables.
+        observation_units: Units shared by observations, measurement errors,
+            minimum errors, forward-model outputs, and the model-error prior.
+            Supported dataset unit attributes are checked by mol/mol scale;
+            values are not converted.
+        sigma_prior: PyMC prior mapping accepted by
+            :func:`~openghg_inversions.models.priors.parse_prior` for absolute
+            model error. The prior is expanded by site and period, not
+            multiplied by the modelled enhancement.
+        sigma_per_site: Whether model error is independent by observation site.
+        sigma_frequency: Optional pandas-compatible frequency for model-error
+            periods.
+        sigma_frequency_anchor: Optional anchor for fixed-duration periods.
+        use_bc: Whether this channel has an independent boundary component.
+        bc_prior: Prior mapping for the state that scales this channel's
+            ``H_bc`` design.
+    """
+
+    species: str
+    observation_units: str
+    sigma_prior: dict[str, Any]
+    sigma_per_site: bool = True
+    sigma_frequency: str | None = None
+    sigma_frequency_anchor: DatetimeLike | None = None
+    use_bc: bool = False
+    bc_prior: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class RamsdenSectorSpec:
+    """Shared primary-gas state and optional tracer coupling for one sector.
+
+    Args:
+        name: Semantic sector name.
+        primary_flux_source: Source-provenance label selected from
+            ``primary.H``.
+        x_prior: Prior mapping for the primary-gas scaling state. It must
+            broadcast to the selected state dimension.
+        tracer_flux_source: Source-provenance label selected from ``tracer.H``.
+            ``None`` means this sector contributes no tracer, as for the
+            non-fossil methane sector in Ramsden et al. (2022).
+        ratio_prior: Prior for a sampled direct emission ratio or historical
+            ratio multiplier. Exactly one of ``ratio_prior`` and
+            ``fixed_ratio`` is required for a tracer-emitting sector. The
+            distribution must have non-negative support.
+        fixed_ratio: Fixed direct emission ratio or historical multiplier.
+        ratio_resolution: ``"spatial"`` creates one sampled/fixed ratio value
+            per state element, so its prior must broadcast to that state;
+            ``"scalar"`` shares one value across the sector.
+        reference_ratio: ``None`` selects the paper's direct-ratio contract:
+            ``tracer.H`` must be ratio-free and the ratio parameter is applied
+            directly. A positive value selects historical compatibility:
+            ``tracer.H`` must already include this reference ratio, the sampled
+            parameter is a dimensionless multiplier, and
+            ``emission_ratio = reference_ratio * ratio_multiplier`` is exposed
+            for interpretation. Direct and reference ratios are dimensionless
+            molar ratios (moles tracer per mole primary).
+    """
+
+    name: str
+    primary_flux_source: str
+    x_prior: dict[str, Any]
+    tracer_flux_source: str | None = None
+    ratio_prior: dict[str, Any] | None = None
+    fixed_ratio: float | None = None
+    ratio_resolution: RatioResolution = "spatial"
+    reference_ratio: float | None = None
+
+
+@dataclass(frozen=True)
+class RamsdenModelSpec:
+    """Complete specification for the historical two-gas model.
+
+    Args:
+        primary: Primary-gas likelihood settings.
+        tracer: Tracer-gas likelihood settings.
+        sectors: Ordered primary sectors. At least one sector must also emit
+            the tracer. Sanitized channel names must be distinct, and sanitized
+            sector names must be non-empty and unique.
+    """
+
+    primary: RamsdenChannelSpec
+    tracer: RamsdenChannelSpec
+    sectors: tuple[RamsdenSectorSpec, ...]
+
+
+@dataclass(frozen=True)
+class RamsdenResult:
+    """Result returned by :func:`run_ramsden_from_prepared_inputs`.
+
+    Args:
+        prepared_inputs: Labelled inputs consumed by the model.
+        model_spec: Historical model specification.
+        model: Built PyMC model.
+        idata: Joint inference data preserving shared-state/ratio covariance
+            and the two namespaced likelihood and predictive variables.
+        sampler: Modern RHIME sampler used for the run.
+    """
+
+    prepared_inputs: RamsdenPreparedInputs
+    model_spec: RamsdenModelSpec
+    model: pm.Model
+    idata: az.InferenceData
+    sampler: RhimeSampler
+
+
+@dataclass(frozen=True)
+class _SectorDesigns:
+    """Validated primary and optional tracer designs for one sector."""
+
+    primary: xr.DataArray
+    tracer: xr.DataArray | None
+    state_dim: str
+
+
+def _channel_suffix(spec: RamsdenChannelSpec) -> str:
+    """Return a stable non-empty namespace suffix for one gas."""
+    suffix = safe_pymc_name(spec.species)
+    if not suffix:
+        raise ValueError("Ramsden channel species names must contain at least one letter or digit.")
+    return suffix
+
+
+def _validate_channel_spec(spec: RamsdenChannelSpec, *, label: str) -> None:
+    """Validate one gas-channel specification."""
+    if not spec.species.strip():
+        raise ValueError(f"Ramsden {label} species must be non-empty.")
+    if not spec.observation_units.strip():
+        raise ValueError(f"Ramsden {label} observation_units must be non-empty.")
+    if _mole_fraction_unit_scale(spec.observation_units) is None:
+        raise ValueError(
+            f"Ramsden {label} observation_units {spec.observation_units!r} are not a supported "
+            "mole-fraction unit."
+        )
+    if spec.use_bc and spec.bc_prior is None:
+        raise ValueError(f"Ramsden {label} bc_prior must be explicit when use_bc=True.")
+
+
+def _mole_fraction_unit_scale(units: object) -> float | None:
+    """Return the mol/mol scale represented by a supported unit declaration."""
+    if isinstance(units, (float, int)) and not isinstance(units, bool):
+        scale = float(units)
+        return scale if math.isfinite(scale) and scale > 0 else None
+    if not isinstance(units, str):
+        return None
+
+    normalized = units.strip().lower().replace("μ", "u").replace("µ", "u")
+    try:
+        numeric_scale = float(normalized)
+    except ValueError:
+        pass
+    else:
+        return numeric_scale if math.isfinite(numeric_scale) and numeric_scale > 0 else None
+
+    aliases = {
+        "mol/mol": 1.0,
+        "mol mol-1": 1.0,
+        "mol mol^-1": 1.0,
+        "ppm": 1e-6,
+        "umol/mol": 1e-6,
+        "ppb": 1e-9,
+        "nmol/mol": 1e-9,
+        "ppt": 1e-12,
+        "pmol/mol": 1e-12,
+    }
+    if normalized in aliases:
+        return aliases[normalized]
+
+    pieces = normalized.split(maxsplit=1)
+    if len(pieces) == 2 and pieces[1] in {"mol/mol", "mol mol-1", "mol mol^-1"}:
+        try:
+            scale = float(pieces[0])
+        except ValueError:
+            return None
+        return scale if math.isfinite(scale) and scale > 0 else None
+    return None
+
+
+def _validate_sector_spec(sector: RamsdenSectorSpec) -> None:
+    """Validate one shared-sector and ratio declaration."""
+    if not sector.name.strip():
+        raise ValueError("Ramsden sector names must be non-empty.")
+    if not sector.primary_flux_source.strip():
+        raise ValueError(f"Ramsden sector {sector.name!r} requires a primary_flux_source.")
+    if sector.ratio_resolution not in ("scalar", "spatial"):
+        raise ValueError(f"Ramsden sector {sector.name!r} ratio_resolution must be 'scalar' or 'spatial'.")
+
+    has_prior = sector.ratio_prior is not None
+    has_fixed = sector.fixed_ratio is not None
+    if sector.tracer_flux_source is None:
+        if has_prior or has_fixed or sector.reference_ratio is not None:
+            raise ValueError(f"Non-tracer Ramsden sector {sector.name!r} must not define ratio settings.")
+        return
+
+    if not sector.tracer_flux_source.strip():
+        raise ValueError(f"Ramsden sector {sector.name!r} has an empty tracer_flux_source.")
+    if has_prior == has_fixed:
+        raise ValueError(
+            f"Tracer-emitting Ramsden sector {sector.name!r} requires exactly one of "
+            "`ratio_prior` and `fixed_ratio`."
+        )
+    if sector.fixed_ratio is not None and (
+        not math.isfinite(float(sector.fixed_ratio)) or float(sector.fixed_ratio) < 0
+    ):
+        raise ValueError(f"Ramsden sector {sector.name!r} fixed_ratio must be finite and non-negative.")
+    if sector.ratio_prior is not None:
+        _validate_ratio_prior(sector)
+    if sector.reference_ratio is not None and (
+        not math.isfinite(float(sector.reference_ratio)) or float(sector.reference_ratio) <= 0
+    ):
+        raise ValueError(f"Ramsden sector {sector.name!r} reference_ratio must be finite and positive.")
+
+
+def _validate_ratio_prior(sector: RamsdenSectorSpec) -> None:
+    """Require a sampled emission ratio to have non-negative support."""
+    assert sector.ratio_prior is not None
+    pdf = str(sector.ratio_prior.get("pdf", "")).lower()
+    positive_support = {
+        "chisquared",
+        "exponential",
+        "gamma",
+        "halfcauchy",
+        "halfnormal",
+        "halfstudentt",
+        "inversegamma",
+        "lognormal",
+        "pareto",
+        "weibull",
+    }
+    if pdf in positive_support:
+        return
+    if pdf in {"truncatednormal", "uniform"}:
+        lower = sector.ratio_prior.get("lower")
+        if lower is None:
+            lower_value = math.nan
+        else:
+            try:
+                lower_value = float(lower)
+            except (TypeError, ValueError):
+                lower_value = math.nan
+        if math.isfinite(lower_value) and lower_value >= 0:
+            return
+    raise ValueError(
+        f"Ramsden sector {sector.name!r} ratio_prior must use a distribution with non-negative support."
+    )
+
+
+def _validate_model_spec(model_spec: RamsdenModelSpec) -> None:
+    """Validate complete model metadata before mutating a PyMC model."""
+    _validate_channel_spec(model_spec.primary, label="primary")
+    _validate_channel_spec(model_spec.tracer, label="tracer")
+    primary_suffix = _channel_suffix(model_spec.primary)
+    tracer_suffix = _channel_suffix(model_spec.tracer)
+    if primary_suffix == tracer_suffix:
+        raise ValueError("Ramsden primary and tracer species must produce distinct model names.")
+    if not model_spec.sectors:
+        raise ValueError("Ramsden models require at least one primary-gas sector.")
+    for sector in model_spec.sectors:
+        _validate_sector_spec(sector)
+    if not any(sector.tracer_flux_source is not None for sector in model_spec.sectors):
+        raise ValueError("Ramsden models require at least one tracer-emitting sector.")
+
+    suffixes = [safe_pymc_name(sector.name) for sector in model_spec.sectors]
+    if any(not suffix for suffix in suffixes):
+        raise ValueError("Ramsden sector names must produce non-empty model variable names.")
+    if len(set(suffixes)) != len(suffixes):
+        raise ValueError("Ramsden sector names must produce unique model variable names.")
+
+    primary_sources = [sector.primary_flux_source for sector in model_spec.sectors]
+    if len(set(primary_sources)) != len(primary_sources):
+        raise ValueError("Ramsden sectors must select unique primary flux sources.")
+    tracer_sources = [
+        sector.tracer_flux_source for sector in model_spec.sectors if sector.tracer_flux_source is not None
+    ]
+    if len(set(tracer_sources)) != len(tracer_sources):
+        raise ValueError("Ramsden tracer-emitting sectors must select unique tracer flux sources.")
+
+
+def _validate_channel_data(
+    data: xr.Dataset,
+    spec: RamsdenChannelSpec,
+    *,
+    label: str,
+) -> None:
+    """Validate canonical variables needed by one gas channel."""
+    required = {"H", "mf", "mf_error", "min_error", "site_indicator"}
+    missing = sorted(required - set(data.data_vars))
+    if missing:
+        raise ValueError(f"Ramsden {label} inputs are missing required variable(s): {missing!r}.")
+    for name in required:
+        if "nmeasure" not in data[name].dims:
+            raise ValueError(f"Ramsden {label} input {name!r} must include the 'nmeasure' dimension.")
+    if data.sizes.get("nmeasure", 0) == 0:
+        raise ValueError(f"Ramsden {label} inputs require at least one observation.")
+    if spec.use_bc and "H_bc" not in data:
+        raise ValueError(f"Ramsden {label} inputs require 'H_bc' when use_bc=True.")
+    if "H_bc" in data and "nmeasure" not in data["H_bc"].dims:
+        raise ValueError(f"Ramsden {label} input 'H_bc' must include the 'nmeasure' dimension.")
+
+    expected_scale = _mole_fraction_unit_scale(spec.observation_units)
+    assert expected_scale is not None
+    for name in ("mf", "mf_error", "min_error", "H", "H_bc"):
+        if name not in data:
+            continue
+        units = data[name].attrs.get("units")
+        if units is None:
+            if name == "mf":
+                raise ValueError(
+                    f"Ramsden {label} input 'mf' requires a units attribute matching "
+                    f"{spec.observation_units!r}."
+                )
+            continue
+        actual_scale = _mole_fraction_unit_scale(units)
+        if actual_scale is None or not math.isclose(actual_scale, expected_scale):
+            raise ValueError(
+                f"Ramsden {label} input {name!r} units {units!r} do not match declared "
+                f"observation_units {spec.observation_units!r}."
+            )
+
+
+def _rename_observation_axis(data: xr.DataArray, suffix: str) -> xr.DataArray:
+    """Give one channel a unique observation dimension and auxiliary coords."""
+    output_dim = f"nmeasure_{suffix}"
+    result = data.rename({"nmeasure": output_dim})
+    if isinstance(result.indexes.get(output_dim), pd.MultiIndex):
+        result = result.reset_index(output_dim)
+
+    coord_renames = {
+        str(name): f"{suffix}_{name}"
+        for name, coord in result.coords.items()
+        if name != output_dim and output_dim in coord.dims
+    }
+    if coord_renames:
+        result = result.rename(coord_renames)
+    return result.assign_coords({output_dim: np.arange(result.sizes[output_dim])})
+
+
+def _state_dim(design: xr.DataArray, *, observation_dim: str, label: str) -> str:
+    """Return the sole state dimension for a selected sector design."""
+    dims = [str(dim) for dim in design.dims if dim != observation_dim]
+    if len(dims) != 1:
+        raise ValueError(
+            f"Ramsden {label} sector designs require exactly one state dimension; found {dims!r}."
+        )
+    return dims[0]
+
+
+def _state_index(design: xr.DataArray, state_dim: str) -> pd.Index:
+    """Return a comparable labelled index for one state dimension."""
+    index = design.indexes.get(state_dim)
+    if index is not None:
+        return index
+    return pd.Index(np.asarray(design.coords[state_dim].values), name=state_dim)
+
+
+def _basis_map_for_source(
+    basis_functions: BasisFunctions,
+    *,
+    source: str,
+    label: str,
+) -> xr.DataArray:
+    """Select the spatial basis map used by one sensitivity source."""
+    basis = basis_functions.flat_basis()
+    if isinstance(basis, dict):
+        try:
+            return basis[source]
+        except KeyError as exc:
+            raise ValueError(f"Ramsden {label} retained basis has no map for source {source!r}.") from exc
+    return basis
+
+
+def _validate_shared_basis(
+    prepared_inputs: RamsdenPreparedInputs,
+    sector: RamsdenSectorSpec,
+    *,
+    state_index: pd.Index,
+) -> None:
+    """Verify that a coupled sector uses one spatial basis in both channels."""
+    primary_basis = prepared_inputs.primary_basis_functions
+    tracer_basis = prepared_inputs.tracer_basis_functions
+    if (primary_basis is None) != (tracer_basis is None):
+        raise ValueError(
+            "Ramsden prepared inputs must provide both primary and tracer basis functions, or neither."
+        )
+
+    if primary_basis is None or tracer_basis is None:
+        if pd.api.types.is_numeric_dtype(state_index.dtype):
+            raise ValueError(
+                f"Ramsden sector {sector.name!r} has positional numeric state labels; provide both "
+                "retained basis functions so spatial coupling can be verified."
+            )
+        return
+
+    assert sector.tracer_flux_source is not None
+    primary_map = _basis_map_for_source(
+        primary_basis,
+        source=sector.primary_flux_source,
+        label="primary",
+    )
+    tracer_map = _basis_map_for_source(
+        tracer_basis,
+        source=sector.tracer_flux_source,
+        label="tracer",
+    )
+    if not primary_map.equals(tracer_map):
+        raise ValueError(
+            f"Ramsden sector {sector.name!r} primary and tracer spatial basis maps must match exactly."
+        )
+
+
+def _validate_ratio_provenance(
+    prepared_inputs: RamsdenPreparedInputs,
+    sector: RamsdenSectorSpec,
+) -> None:
+    """Check tracer-design ratio provenance against one sector declaration."""
+    assert sector.tracer_flux_source is not None
+    try:
+        actual = prepared_inputs.tracer_design_reference_ratios[sector.tracer_flux_source]
+    except KeyError as exc:
+        raise ValueError(
+            f"Ramsden tracer source {sector.tracer_flux_source!r} requires an explicit "
+            "tracer_design_reference_ratios entry."
+        ) from exc
+
+    expected = sector.reference_ratio
+    if actual is None and expected is None:
+        return
+    if actual is None or expected is None or not math.isclose(float(actual), float(expected)):
+        raise ValueError(
+            f"Ramsden sector {sector.name!r} tracer design reference ratio {actual!r} does not "
+            f"match model reference_ratio {expected!r}."
+        )
+
+
+def _select_sector_designs(
+    prepared_inputs: RamsdenPreparedInputs,
+    sector: RamsdenSectorSpec,
+) -> _SectorDesigns:
+    """Select and exactly align primary/tracer designs for one shared state."""
+    variable_suffix = safe_pymc_name(sector.name)
+    primary = _select_sector_design(
+        prepared_inputs.primary["H"],
+        sector=sector.name,
+        source=sector.primary_flux_source,
+        variable_suffix=variable_suffix,
+    )
+    primary_state_dim = _state_dim(primary, observation_dim="nmeasure", label="primary")
+
+    if sector.tracer_flux_source is None:
+        return _SectorDesigns(primary=primary, tracer=None, state_dim=primary_state_dim)
+
+    tracer = _select_sector_design(
+        prepared_inputs.tracer["H"],
+        sector=sector.name,
+        source=sector.tracer_flux_source,
+        variable_suffix=variable_suffix,
+    )
+    tracer_state_dim = _state_dim(tracer, observation_dim="nmeasure", label="tracer")
+    primary_index = _state_index(primary, primary_state_dim)
+    tracer_index = _state_index(tracer, tracer_state_dim)
+    if not primary_index.equals(tracer_index):
+        raise ValueError(
+            f"Ramsden sector {sector.name!r} primary and tracer state coordinates must match exactly."
+        )
+    if tracer_state_dim != primary_state_dim:
+        tracer = tracer.rename({tracer_state_dim: primary_state_dim})
+    _validate_shared_basis(prepared_inputs, sector, state_index=primary_index)
+    _validate_ratio_provenance(prepared_inputs, sector)
+
+    return _SectorDesigns(primary=primary, tracer=tracer, state_dim=primary_state_dim)
+
+
+def _fixed_parameter(
+    name: str,
+    value: float,
+    *,
+    state: TensorVariable,
+    state_dim: str,
+    resolution: RatioResolution,
+) -> TensorVariable:
+    """Expose a fixed scalar or state-aligned parameter as a deterministic."""
+    scalar = pt.as_tensor_variable(pm.floatX(value))
+    if resolution == "spatial":
+        return pm.Deterministic(name, pt.ones_like(state) * scalar, dims=state_dim)
+    return pm.Deterministic(name, scalar)
+
+
+def _ratio_tensors(
+    sector: RamsdenSectorSpec,
+    *,
+    state: TensorVariable,
+    state_dim: str,
+    variable_suffix: str,
+) -> tuple[TensorVariable, TensorVariable]:
+    """Create the forward ratio factor and direct molar-ratio diagnostic."""
+    compatibility_mode = sector.reference_ratio is not None
+    parameter_name = (
+        f"ratio_multiplier_{variable_suffix}" if compatibility_mode else f"emission_ratio_{variable_suffix}"
+    )
+    prior_dims = state_dim if sector.ratio_resolution == "spatial" else None
+    if sector.ratio_prior is not None:
+        kwargs = {"dims": prior_dims} if prior_dims is not None else {}
+        parameter = parse_prior(parameter_name, sector.ratio_prior, **kwargs)
+    else:
+        assert sector.fixed_ratio is not None
+        parameter = _fixed_parameter(
+            parameter_name,
+            float(sector.fixed_ratio),
+            state=state,
+            state_dim=state_dim,
+            resolution=sector.ratio_resolution,
+        )
+
+    if not compatibility_mode:
+        return parameter, parameter
+
+    assert sector.reference_ratio is not None
+    emission_ratio = pm.Deterministic(
+        f"emission_ratio_{variable_suffix}",
+        pm.floatX(sector.reference_ratio) * parameter,
+        dims=prior_dims,
+    )
+    return parameter, emission_ratio
+
+
+def _sum_terms(terms: list[TensorVariable], *, name: str, dim: str) -> TensorVariable:
+    """Register the ordered sum of non-empty observation-space terms."""
+    if not terms:
+        raise ValueError(f"Cannot construct {name!r} without at least one forward term.")
+    total = terms[0]
+    for term in terms[1:]:
+        total = total + term
+    return pm.Deterministic(name, total, dims=dim)
+
+
+def _add_boundary_component(
+    data: xr.Dataset,
+    spec: RamsdenChannelSpec,
+    *,
+    suffix: str,
+) -> TensorVariable | None:
+    """Add an independent optional boundary state for one channel."""
+    if not spec.use_bc:
+        return None
+
+    output_dim = f"nmeasure_{suffix}"
+    design = _rename_observation_axis(data["H_bc"], suffix)
+    state_renames = {str(dim): f"{dim}_{suffix}_bc" for dim in design.dims if str(dim) != output_dim}
+    if state_renames:
+        design = design.rename(state_renames)
+    assert spec.bc_prior is not None
+    component = add_linear_component(
+        design,
+        data_name=f"hbc_{suffix}",
+        prior_args=dict(spec.bc_prior),
+        var_name=f"bc_{suffix}",
+        output_name=f"mu_bc_{suffix}",
+        output_dim=output_dim,
+        compute_deterministic=True,
+    )
+    return component.output
+
+
+def _add_absolute_error_likelihood(
+    data: xr.Dataset,
+    spec: RamsdenChannelSpec,
+    *,
+    suffix: str,
+    mu: TensorVariable,
+    mu_bc: TensorVariable | None,
+) -> None:
+    """Add one namespaced Gaussian likelihood with absolute model error."""
+    output_dim = f"nmeasure_{suffix}"
+    observations = add_model_data(_rename_observation_axis(data["mf"], suffix), f"Y_{suffix}")
+    measurement_error = add_model_data(
+        _rename_observation_axis(data["mf_error"], suffix),
+        f"error_{suffix}",
+    )
+    min_error = add_model_data(
+        _rename_observation_axis(data["min_error"], suffix),
+        f"min_error_{suffix}",
+    )
+
+    alignment = SigmaAlignment.from_frequency(
+        data["site_indicator"],
+        frequency=spec.sigma_frequency,
+        per_site=spec.sigma_per_site,
+        anchor_time=spec.sigma_frequency_anchor,
+    )
+    site_index = add_model_data(
+        _rename_observation_axis(alignment.site_index, suffix),
+        f"sigma_site_index_{suffix}",
+    )
+    period_index = add_model_data(
+        _rename_observation_axis(alignment.period_index, suffix),
+        f"sigma_period_index_{suffix}",
+    )
+    site_dim = f"nsigma_site_{suffix}"
+    period_dim = f"nsigma_period_{suffix}"
+    add_coords(
+        {
+            site_dim: np.arange(alignment.nsite),
+            period_dim: np.arange(alignment.nperiod),
+        }
+    )
+    sigma = parse_prior(
+        f"sigma_{suffix}",
+        dict(spec.sigma_prior),
+        dims=(site_dim, period_dim),
+    )
+    sigma_aligned = sigma[site_index, period_index]
+    epsilon = pm.Deterministic(
+        f"epsilon_{suffix}",
+        pt.maximum(  # type: ignore[operator]
+            pt.sqrt(measurement_error**2 + sigma_aligned**2), min_error
+        ),
+        dims=output_dim,
+    )
+    total_mu = mu if mu_bc is None else mu + mu_bc
+    pm.Normal(
+        f"y_{suffix}",
+        mu=total_mu,
+        sigma=epsilon,
+        observed=observations,
+        dims=output_dim,
+    )
+
+
+def build_ramsden_model(
+    prepared_inputs: RamsdenPreparedInputs,
+    model_spec: RamsdenModelSpec,
+) -> pm.Model:
+    """Build the historical Ramsden methane/ethane model with modern PyMC.
+
+    Args:
+        prepared_inputs: Two canonical gas datasets. Each requires ``H``,
+            ``mf``, ``mf_error``, ``min_error``, and ``site_indicator`` on
+            ``nmeasure``; ``H_bc`` is required for enabled boundary states.
+            Observation coordinates may differ, but coupled sector state
+            coordinates must match exactly.
+        model_spec: Shared-state, ratio, likelihood, unit, and boundary
+            metadata. Direct ratios require ratio-free tracer designs;
+            reference-ratio mode requires tracer designs that already include
+            the declared reference ratio.
+
+    Returns:
+        Built PyMC model ready for :class:`RhimeSampler`.
+
+    Raises:
+        ValueError: If model metadata, required input variables, source labels,
+            or shared state coordinates are invalid.
+
+    Notes:
+        This function builds a PyMC graph only. It performs no data retrieval,
+        sampling, unit conversion, or postprocessing. Observation, error,
+        sigma-prior, and forward-model values must already use each channel's
+        declared ``observation_units``.
+    """
+    _validate_model_spec(model_spec)
+    _validate_channel_data(prepared_inputs.primary, model_spec.primary, label="primary")
+    _validate_channel_data(prepared_inputs.tracer, model_spec.tracer, label="tracer")
+    sector_designs = [
+        (sector, _select_sector_designs(prepared_inputs, sector)) for sector in model_spec.sectors
+    ]
+
+    primary_suffix = _channel_suffix(model_spec.primary)
+    tracer_suffix = _channel_suffix(model_spec.tracer)
+    primary_dim = f"nmeasure_{primary_suffix}"
+    tracer_dim = f"nmeasure_{tracer_suffix}"
+
+    with pm.Model() as model:
+        attach_coord_registry(model, CoordRegistry())
+        primary_terms: list[TensorVariable] = []
+        tracer_terms: list[TensorVariable] = []
+
+        for sector, designs in sector_designs:
+            variable_suffix = safe_pymc_name(sector.name)
+            primary_design = _rename_observation_axis(designs.primary, primary_suffix)
+            primary_h = add_model_data(primary_design.transpose(primary_dim, ...), f"hx_{variable_suffix}")
+            state = parse_prior(
+                f"x_{variable_suffix}",
+                sector.x_prior,
+                dims=designs.state_dim,
+            )
+            primary_terms.append(
+                pm.Deterministic(
+                    f"mu_{primary_suffix}_{variable_suffix}",
+                    pt.dot(primary_h, state),
+                    dims=primary_dim,
+                )
+            )
+
+            if designs.tracer is None:
+                continue
+            tracer_design = _rename_observation_axis(designs.tracer, tracer_suffix)
+            tracer_h = add_model_data(
+                tracer_design.transpose(tracer_dim, ...),
+                f"hx_{tracer_suffix}_{variable_suffix}",
+            )
+            ratio_factor, _ = _ratio_tensors(
+                sector,
+                state=state,
+                state_dim=designs.state_dim,
+                variable_suffix=variable_suffix,
+            )
+            tracer_terms.append(
+                pm.Deterministic(
+                    f"mu_{tracer_suffix}_{variable_suffix}",
+                    pt.dot(tracer_h, state * ratio_factor),
+                    dims=tracer_dim,
+                )
+            )
+
+        mu_primary = _sum_terms(primary_terms, name=f"mu_{primary_suffix}", dim=primary_dim)
+        mu_tracer = _sum_terms(tracer_terms, name=f"mu_{tracer_suffix}", dim=tracer_dim)
+        primary_bc = _add_boundary_component(
+            prepared_inputs.primary,
+            model_spec.primary,
+            suffix=primary_suffix,
+        )
+        tracer_bc = _add_boundary_component(
+            prepared_inputs.tracer,
+            model_spec.tracer,
+            suffix=tracer_suffix,
+        )
+        _add_absolute_error_likelihood(
+            prepared_inputs.primary,
+            model_spec.primary,
+            suffix=primary_suffix,
+            mu=mu_primary,
+            mu_bc=primary_bc,
+        )
+        _add_absolute_error_likelihood(
+            prepared_inputs.tracer,
+            model_spec.tracer,
+            suffix=tracer_suffix,
+            mu=mu_tracer,
+            mu_bc=tracer_bc,
+        )
+
+    return model
+
+
+def run_ramsden_from_prepared_inputs(
+    *,
+    prepared_inputs: RamsdenPreparedInputs,
+    model_spec: RamsdenModelSpec,
+    sampler: RhimeSampler | None = None,
+) -> RamsdenResult:
+    """Build and sample a historical two-gas model from canonical inputs.
+
+    Args:
+        prepared_inputs: Canonical primary and tracer datasets.
+        model_spec: Historical model specification.
+        sampler: Modern RHIME sampling configuration controlling seeds,
+            chains, draws, and predictive output. When omitted, the standard
+            sampler is used with both namespaced gas observations included in
+            posterior predictive sampling.
+
+    Returns:
+        Joint result containing the built model and labelled inference data.
+
+    Raises:
+        ValueError: If model metadata or prepared inputs are invalid.
+
+    Notes:
+        This function samples the model and may run multiple chains. It does
+        not retrieve data, convert units, or write postprocessed products.
+        Sampling exceptions raised by :class:`RhimeSampler` are propagated.
+    """
+    model = build_ramsden_model(prepared_inputs, model_spec)
+    primary_suffix = _channel_suffix(model_spec.primary)
+    tracer_suffix = _channel_suffix(model_spec.tracer)
+    predictive_names = (f"y_{primary_suffix}", f"y_{tracer_suffix}")
+    if sampler is None:
+        sampler = RhimeSampler(sample_posterior_predictive=predictive_names)
+    elif sampler.sample_posterior_predictive == ("y",):
+        sampler = RhimeSampler(
+            draws=sampler.draws,
+            burn=sampler.burn,
+            tune=sampler.tune,
+            chains=sampler.chains,
+            nuts_sampler=sampler.nuts_sampler,
+            progressbar=sampler.progressbar,
+            sample_kwargs=sampler.sample_kwargs,
+            sample_prior_predictive=sampler.sample_prior_predictive,
+            sample_posterior_predictive=predictive_names,
+            posterior_predictive_kwargs=sampler.posterior_predictive_kwargs,
+        )
+    elif isinstance(sampler.sample_posterior_predictive, tuple):
+        missing = set(sampler.sample_posterior_predictive) - set(model.named_vars)
+        if missing:
+            raise ValueError(
+                f"Ramsden sampler posterior-predictive variables are absent from the model: "
+                f"{sorted(missing)!r}."
+            )
+    idata = sampler.sample(model)
+    return RamsdenResult(
+        prepared_inputs=prepared_inputs,
+        model_spec=model_spec,
+        model=model,
+        idata=idata,
+        sampler=sampler,
+    )

--- a/openghg_inversions/experimental/ramsden2022/model.py
+++ b/openghg_inversions/experimental/ramsden2022/model.py
@@ -739,7 +739,8 @@ def build_ramsden_model(
             the declared reference ratio.
 
     Returns:
-        Built PyMC model ready for :class:`RhimeSampler`.
+        Built PyMC model ready for
+        :class:`~openghg_inversions.rhime.sampling.RhimeSampler`.
 
     Raises:
         ValueError: If model metadata, required input variables, source labels,
@@ -861,7 +862,9 @@ def run_ramsden_from_prepared_inputs(
     Notes:
         This function samples the model and may run multiple chains. It does
         not retrieve data, convert units, or write postprocessed products.
-        Sampling exceptions raised by :class:`RhimeSampler` are propagated.
+        Sampling exceptions raised by
+        :class:`~openghg_inversions.rhime.sampling.RhimeSampler` are
+        propagated.
     """
     model = build_ramsden_model(prepared_inputs, model_spec)
     primary_suffix = _channel_suffix(model_spec.primary)

--- a/tests/experimental/test_ramsden2022.py
+++ b/tests/experimental/test_ramsden2022.py
@@ -1,0 +1,397 @@
+"""Focused tests for the experimental Ramsden et al. two-gas model."""
+
+from __future__ import annotations
+
+import arviz as az
+import numpy as np
+import pymc as pm
+import pytest
+import xarray as xr
+
+from openghg_inversions.basis.basis_functions import BasisFunctions
+from openghg_inversions.experimental.ramsden2022 import (
+    RamsdenChannelSpec,
+    RamsdenModelSpec,
+    RamsdenPreparedInputs,
+    RamsdenSectorSpec,
+    build_ramsden_model,
+    run_ramsden_from_prepared_inputs,
+)
+from openghg_inversions.rhime import RhimeSampler
+
+
+X_PRIOR = {"pdf": "normal", "mu": [2.0, 3.0], "sigma": 0.5}
+SIGMA_PRIOR = {"pdf": "halfnormal", "sigma": 0.2}
+
+
+def _channel_inputs(
+    sensitivities: dict[str, list[list[float]]],
+    *,
+    observation_count: int,
+    state: tuple[str, ...] = ("west", "east"),
+    with_bc: bool = False,
+    units: str = "ppm",
+) -> xr.Dataset:
+    """Create a tiny canonical channel with labelled sources and observations."""
+    sources = tuple(sensitivities)
+    h = np.stack([sensitivities[source] for source in sources], axis=-1)
+    time = np.datetime64("2020-01-01") + np.arange(observation_count).astype("timedelta64[D]")
+    coords = {
+        "region": np.asarray(state),
+        "nmeasure": np.arange(observation_count),
+        "source": np.asarray(sources),
+        "time": ("nmeasure", time),
+    }
+    data_vars: dict[str, tuple[tuple[str, ...], np.ndarray]] = {
+        "H": (("nmeasure", "region", "source"), h),
+        "mf": (("nmeasure",), np.zeros(observation_count)),
+        "mf_error": (("nmeasure",), np.full(observation_count, 0.1)),
+        "min_error": (("nmeasure",), np.full(observation_count, 0.01)),
+        "site_indicator": (("nmeasure",), np.arange(observation_count) % 2),
+    }
+    if with_bc:
+        data_vars["H_bc"] = (
+            ("nmeasure", "bc_region"),
+            np.ones((observation_count, 1)),
+        )
+    result = xr.Dataset(data_vars, coords=coords)
+    for name in ("mf", "mf_error", "min_error", "H", "H_bc"):
+        if name in result:
+            result[name].attrs["units"] = units
+    return result
+
+
+def _prepared_inputs(
+    *,
+    tracer_state: tuple[str, ...] = ("west", "east"),
+    primary_bc: bool = False,
+    tracer_bc: bool = False,
+) -> RamsdenPreparedInputs:
+    """Create unequal-axis methane and ethane inputs for two sectors."""
+    primary = _channel_inputs(
+        {
+            "ff_ch4": [[1.0, 0.0], [0.0, 2.0], [1.0, 1.0]],
+            "bio_ch4": [[0.5, 0.0], [0.0, 1.0], [0.5, 0.5]],
+        },
+        observation_count=3,
+        with_bc=primary_bc,
+        units="ppm",
+    )
+    tracer = _channel_inputs(
+        {"ff_c2h6": [[4.0, 0.0], [0.0, 5.0]]},
+        observation_count=2,
+        state=tracer_state,
+        with_bc=tracer_bc,
+        units="ppb",
+    )
+    return RamsdenPreparedInputs(
+        primary=primary,
+        tracer=tracer,
+        tracer_design_reference_ratios={"ff_c2h6": None},
+    )
+
+
+def _model_spec(
+    *,
+    fixed_ratio: float | None = 0.25,
+    ratio_prior: dict[str, object] | None = None,
+    ratio_resolution: str = "spatial",
+    reference_ratio: float | None = None,
+    primary_bc: bool = False,
+    tracer_bc: bool = False,
+) -> RamsdenModelSpec:
+    """Create the two-sector paper-shaped model specification."""
+    return RamsdenModelSpec(
+        primary=RamsdenChannelSpec(
+            "ch4",
+            "ppm",
+            sigma_prior=SIGMA_PRIOR,
+            use_bc=primary_bc,
+            bc_prior={"pdf": "normal", "mu": 1.0, "sigma": 0.1},
+        ),
+        tracer=RamsdenChannelSpec(
+            "c2h6",
+            "ppb",
+            sigma_prior=SIGMA_PRIOR,
+            use_bc=tracer_bc,
+            bc_prior={"pdf": "normal", "mu": 1.0, "sigma": 0.1},
+        ),
+        sectors=(
+            RamsdenSectorSpec(
+                "fossil",
+                "ff_ch4",
+                X_PRIOR,
+                tracer_flux_source="ff_c2h6",
+                fixed_ratio=fixed_ratio,
+                ratio_prior=ratio_prior,
+                ratio_resolution=ratio_resolution,  # type: ignore[arg-type]
+                reference_ratio=reference_ratio,
+            ),
+            RamsdenSectorSpec("biogenic", "bio_ch4", X_PRIOR),
+        ),
+    )
+
+
+def _initial_value(model: pm.Model, variable: str) -> np.ndarray:
+    """Evaluate one model variable at the PyMC initial point."""
+    function = model.compile_fn(
+        model.replace_rvs_by_values([model[variable]])[0],
+        inputs=model.value_vars,
+        on_unused_input="ignore",
+    )
+    return np.asarray(function(model.initial_point()))
+
+
+def test_two_sector_equations_share_x_and_only_fossil_emits_tracer() -> None:
+    """Both gases share fossil x while the biogenic state affects methane only."""
+    prepared = _prepared_inputs()
+    model = build_ramsden_model(prepared, _model_spec())
+
+    np.testing.assert_allclose(_initial_value(model, "x_fossil"), [2.0, 3.0])
+    np.testing.assert_allclose(_initial_value(model, "mu_ch4_fossil"), [2.0, 6.0, 5.0])
+    np.testing.assert_allclose(_initial_value(model, "mu_ch4_biogenic"), [1.0, 3.0, 2.5])
+    np.testing.assert_allclose(_initial_value(model, "mu_ch4"), [3.0, 9.0, 7.5])
+    np.testing.assert_allclose(_initial_value(model, "mu_c2h6"), [2.0, 3.75])
+    assert "mu_c2h6_biogenic" not in model.named_vars
+    assert "emission_ratio_biogenic" not in model.named_vars
+
+
+def test_direct_and_reference_ratio_multiplier_contracts_are_equivalent() -> None:
+    """A pre-scaled reference inventory and multiplier match a direct ratio."""
+    direct = build_ramsden_model(_prepared_inputs(), _model_spec(fixed_ratio=0.2))
+    compatible_inputs = _prepared_inputs()
+    compatible_inputs = RamsdenPreparedInputs(
+        primary=compatible_inputs.primary,
+        tracer=compatible_inputs.tracer.assign(H=compatible_inputs.tracer.H * 0.1),
+        tracer_design_reference_ratios={"ff_c2h6": 0.1},
+    )
+    compatible = build_ramsden_model(
+        compatible_inputs,
+        _model_spec(fixed_ratio=2.0, reference_ratio=0.1),
+    )
+
+    np.testing.assert_allclose(
+        _initial_value(direct, "mu_c2h6"),
+        _initial_value(compatible, "mu_c2h6"),
+    )
+    np.testing.assert_allclose(_initial_value(compatible, "emission_ratio_fossil"), 0.2)
+    np.testing.assert_allclose(_initial_value(compatible, "ratio_multiplier_fossil"), 2.0)
+
+
+@pytest.mark.parametrize(
+    ("resolution", "expected_dims", "expected_shape"),
+    [
+        ("scalar", (), ()),
+        ("spatial", ("region",), (2,)),
+    ],
+)
+def test_ratio_resolution_controls_labelled_parameter_shape(
+    resolution: str,
+    expected_dims: tuple[str, ...],
+    expected_shape: tuple[int, ...],
+) -> None:
+    """Scalar ratios broadcast while spatial ratios retain the state dimension."""
+    model = build_ramsden_model(
+        _prepared_inputs(),
+        _model_spec(fixed_ratio=0.25, ratio_resolution=resolution),
+    )
+
+    assert model.named_vars_to_dims.get("emission_ratio_fossil", ()) == expected_dims
+    assert _initial_value(model, "emission_ratio_fossil").shape == expected_shape
+
+
+def test_unequal_observation_axes_have_namespaced_error_models() -> None:
+    """Independent observation grids receive distinct likelihood and sigma names."""
+    model = build_ramsden_model(_prepared_inputs(), _model_spec())
+
+    assert model.named_vars_to_dims["y_ch4"] == ("nmeasure_ch4",)
+    assert model.named_vars_to_dims["y_c2h6"] == ("nmeasure_c2h6",)
+    assert model.named_vars_to_dims["sigma_ch4"] == ("nsigma_site_ch4", "nsigma_period_ch4")
+    assert model.named_vars_to_dims["sigma_c2h6"] == ("nsigma_site_c2h6", "nsigma_period_c2h6")
+    assert _initial_value(model, "epsilon_ch4").shape == (3,)
+    assert _initial_value(model, "epsilon_c2h6").shape == (2,)
+    for base in ("Y", "error", "min_error", "sigma_site_index", "sigma_period_index"):
+        assert f"{base}_ch4" in model.named_vars
+        assert f"{base}_c2h6" in model.named_vars
+
+
+def test_absolute_error_equation_and_minimum_floor() -> None:
+    """Epsilon follows the paper's absolute error equation plus RHIME's floor."""
+    prepared = _prepared_inputs()
+    model = build_ramsden_model(prepared, _model_spec())
+    sigma = _initial_value(model, "sigma_ch4")
+    expected = np.sqrt(0.1**2 + sigma[[0, 1, 0], 0] ** 2)
+    np.testing.assert_allclose(_initial_value(model, "epsilon_ch4"), expected)
+
+    floored_primary = prepared.primary.copy()
+    floored_primary["min_error"] = xr.full_like(prepared.primary.mf, 0.5).assign_attrs(units="ppm")
+    floored = RamsdenPreparedInputs(
+        primary=floored_primary,
+        tracer=prepared.tracer,
+        tracer_design_reference_ratios=prepared.tracer_design_reference_ratios,
+    )
+    floored_model = build_ramsden_model(floored, _model_spec())
+    np.testing.assert_allclose(_initial_value(floored_model, "epsilon_ch4"), 0.5)
+
+
+def test_state_coordinate_mismatch_is_rejected() -> None:
+    """Shared states must have identical primary and tracer coordinate labels."""
+    with pytest.raises(ValueError, match="state coordinates must match exactly"):
+        build_ramsden_model(
+            _prepared_inputs(tracer_state=("east", "west")),
+            _model_spec(),
+        )
+
+
+def test_equal_positional_labels_with_different_basis_maps_are_rejected() -> None:
+    """Matching region numbers cannot hide different channel basis geometry."""
+    prepared = _prepared_inputs(tracer_state=("west", "east"))
+    flux = xr.DataArray(
+        np.ones((2, 1)),
+        dims=("lat", "lon"),
+        coords={"lat": [50.0, 51.0], "lon": [0.0]},
+        attrs={"units": "mol/m2/s"},
+    )
+    primary_basis = BasisFunctions.from_flat_basis(
+        xr.DataArray([[0], [1]], dims=("lat", "lon"), coords=flux.coords),
+        flux,
+    )
+    tracer_basis = BasisFunctions.from_flat_basis(
+        xr.DataArray([[1], [0]], dims=("lat", "lon"), coords=flux.coords),
+        flux,
+    )
+    prepared = RamsdenPreparedInputs(
+        primary=prepared.primary.assign_coords(region=[0, 1]),
+        tracer=prepared.tracer.assign_coords(region=[0, 1]),
+        tracer_design_reference_ratios=prepared.tracer_design_reference_ratios,
+        primary_basis_functions=primary_basis,
+        tracer_basis_functions=tracer_basis,
+    )
+
+    with pytest.raises(ValueError, match="spatial basis maps must match exactly"):
+        build_ramsden_model(prepared, _model_spec())
+
+
+def test_units_and_tracer_ratio_provenance_are_validated() -> None:
+    """Unit-scale and pre-scaled tracer declarations reject silent factor errors."""
+    prepared = _prepared_inputs()
+    numeric_units = RamsdenPreparedInputs(
+        primary=prepared.primary,
+        tracer=prepared.tracer.assign(mf=prepared.tracer.mf.assign_attrs(units="1e-9")),
+        tracer_design_reference_ratios=prepared.tracer_design_reference_ratios,
+    )
+    build_ramsden_model(numeric_units, _model_spec())
+
+    wrong_units = RamsdenPreparedInputs(
+        primary=prepared.primary,
+        tracer=prepared.tracer.assign(mf=prepared.tracer.mf.assign_attrs(units="ppt")),
+        tracer_design_reference_ratios=prepared.tracer_design_reference_ratios,
+    )
+    with pytest.raises(ValueError, match="do not match declared observation_units"):
+        build_ramsden_model(wrong_units, _model_spec())
+
+    wrong_ratio = RamsdenPreparedInputs(
+        primary=prepared.primary,
+        tracer=prepared.tracer,
+        tracer_design_reference_ratios={"ff_c2h6": 0.1},
+    )
+    with pytest.raises(ValueError, match="does not match model reference_ratio"):
+        build_ramsden_model(wrong_ratio, _model_spec())
+
+
+def test_duplicate_sources_and_negative_ratio_support_are_rejected() -> None:
+    """Non-identifiable source reuse and physically negative ratios fail early."""
+    base = _model_spec()
+    duplicate_sector = RamsdenSectorSpec("duplicate", "ff_ch4", X_PRIOR)
+    with pytest.raises(ValueError, match="unique primary flux sources"):
+        build_ramsden_model(
+            _prepared_inputs(),
+            RamsdenModelSpec(base.primary, base.tracer, (*base.sectors, duplicate_sector)),
+        )
+
+    with pytest.raises(ValueError, match="non-negative support"):
+        build_ramsden_model(
+            _prepared_inputs(),
+            _model_spec(
+                fixed_ratio=None,
+                ratio_prior={"pdf": "normal", "mu": 0.2, "sigma": 0.1},
+            ),
+        )
+
+
+@pytest.mark.parametrize(
+    ("primary_bc", "tracer_bc", "expected"),
+    [
+        (False, False, set()),
+        (True, False, {"bc_ch4", "mu_bc_ch4"}),
+        (False, True, {"bc_c2h6", "mu_bc_c2h6"}),
+        (True, True, {"bc_ch4", "mu_bc_ch4", "bc_c2h6", "mu_bc_c2h6"}),
+    ],
+)
+def test_boundary_components_are_optional_per_channel(
+    primary_bc: bool,
+    tracer_bc: bool,
+    expected: set[str],
+) -> None:
+    """Each gas independently opts into its own labelled boundary component."""
+    model = build_ramsden_model(
+        _prepared_inputs(primary_bc=primary_bc, tracer_bc=tracer_bc),
+        _model_spec(primary_bc=primary_bc, tracer_bc=tracer_bc),
+    )
+
+    present = {name for name in model.named_vars if name.startswith(("bc_", "mu_bc_"))}
+    assert present == expected
+
+
+def test_tiny_model_samples_through_rhime_sampler() -> None:
+    """The isolated historical model runs through the modern RHIME sampler."""
+    sampler = RhimeSampler(
+        draws=2,
+        tune=2,
+        chains=1,
+        progressbar=False,
+        sample_kwargs={"random_seed": 7, "compute_convergence_checks": False, "cores": 1},
+        sample_prior_predictive=False,
+        sample_posterior_predictive=False,
+    )
+
+    result = run_ramsden_from_prepared_inputs(
+        prepared_inputs=_prepared_inputs(),
+        model_spec=_model_spec(
+            fixed_ratio=None,
+            ratio_prior={"pdf": "uniform", "lower": 0.1, "upper": 0.4},
+        ),
+        sampler=sampler,
+    )
+
+    assert result.sampler is sampler
+    posterior = result.idata["posterior"]
+    log_likelihood = result.idata["log_likelihood"]
+    assert posterior.sizes["chain"] == 1
+    assert posterior.sizes["draw"] == 2
+    assert posterior.sizes["region"] == 2
+    assert {"x_fossil", "x_biogenic", "emission_ratio_fossil"} <= set(posterior)
+    assert {"y_ch4", "y_c2h6"} <= set(log_likelihood)
+
+
+def test_default_custom_sampler_uses_namespaced_predictive_variables(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A supplied sampler's standard y default is adapted before sampling."""
+    sampler = RhimeSampler(draws=2, tune=2, chains=1)
+    captured: dict[str, object] = {}
+
+    def fake_sample(configured_sampler: RhimeSampler, model: pm.Model) -> az.InferenceData:
+        captured["predictive"] = configured_sampler.sample_posterior_predictive
+        captured["model"] = model
+        return az.InferenceData()
+
+    monkeypatch.setattr(RhimeSampler, "sample", fake_sample)
+    result = run_ramsden_from_prepared_inputs(
+        prepared_inputs=_prepared_inputs(),
+        model_spec=_model_spec(),
+        sampler=sampler,
+    )
+
+    assert captured["predictive"] == ("y_ch4", "y_c2h6")
+    assert result.sampler is not sampler


### PR DESCRIPTION
## Summary

- add an isolated `openghg_inversions.experimental.ramsden2022` implementation of the Ramsden et al. (2022) CH4/C2H6 shared-state inversion
- reuse modern RHIME prepared inputs, `BasisFunctions`, coordinate handling, priors, sigma alignment, boundary components, and `RhimeSampler`
- support fixed or sampled scalar/spatial emission ratios and the historical branch's reference-ratio multiplier convention
- validate unit scales, ratio provenance, shared spatial basis geometry, source uniqueness, and non-negative ratio support
- add an **Experimental code** documentation section with the model contract, API reference, and a full retained-data validation report with a Matplotlib comparison figure
- retain the historical comparison/design note for `origin/adding_multi_gas_model`

## Why

`origin/adding_multi_gas_model` contains the scientific model needed for historical comparison, but it is more than 1,500 commits behind `devel`, depends on obsolete ACRG/OpenGHG interfaces, carries a custom sampler and output stack, and has no tests. Porting the model-specific shared-state equations behind current RHIME seams gives us a runnable comparison without restoring the legacy execution path or pre-empting the generic linked-tracer API planned in milestones 10 and 11.

The implementation follows Ramsden et al. (2022), https://doi.org/10.5194/acp-22-3911-2022. It explicitly distinguishes the paper's direct molar emission ratio from the historical branch's multiplier of a tracer inventory that already contains a reference ratio.

## Validation

- `tox -e py310-openghgCur -- tests/experimental/test_ramsden2022.py -q`: 16 passed
- full `py310-openghgCur` tox environment: passed during the model validation
- focused Ruff check and format check: passed
- scoped Pyright: 0 errors
- clean Sphinx HTML build including the new experimental pages and SVG: passed
- `git diff --check`: passed

The retained January 2019 real-data comparison is documented in [`docs/experimental/ramsden2022_validation.rst`](https://github.com/openghg/openghg_inversions/blob/codex/ramsden-2022-multigas/docs/experimental/ramsden2022_validation.rst). The key result is that annualized UK fossil-fuel methane changes by only **-0.96%** relative to the retained original run; all 49 regional 95% intervals overlap, and the regional fossil posterior-mean correlation is **0.980**.

The repository-wide default tox lint environment still reports 213 pre-existing Ruff findings outside this PR's files. On the current login node, its test environment also stops at the repository's compiler preflight because `g++` is unavailable. The strict documentation target reaches and renders the new pages but remains blocked by existing repository-wide Sphinx warnings; a non-strict clean build succeeds without warnings from these pages.

## Scope and follow-up

This draft intentionally starts at the prepared-input boundary. It does not port the historical retrieval/cache layer, custom Metropolis-Hastings sampler, isotope extensions, or bespoke NetCDF/country postprocessing. The retained January 2019 CH4/C2H6 case has now been run and compared with both the historical output and, where like-for-like comparison is possible, the paper.

The report does not claim full reproduction of the 2015–2019 paper result: that would require all 60 monthly inversions, the exact original measurement-error arrays, a matched methane-only counterfactual, and the paper's annual aggregation. Generic multi-channel preparation and tracer-aware outputs remain follow-up work for milestone 11.