### PR TITLE
Add influence-aware PCA eccentricity guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ## Code changes
 
+- Extended `MaxChildPCAEccentricity` with an optional
+  `min_child_target_weight_share` materiality threshold. The default zero keeps
+  the strict all-child eccentricity veto. Positive values allow only children
+  below that share of the class/source-local equal-target weight,
+  `weights.sum() / target_regions`, to bypass the veto; material children remain
+  guarded. This affects split acceptance only and does not reconnect, freeze,
+  prune, or marginalize the accepted low-weight child.
+  [PR #546](https://github.com/openghg/openghg_inversions/pull/546)
 - Added the opt-in `ConnectedBinaryPartitionStep` for repairing provisional
   binary cuts whose sides contain disconnected components. Repair candidates
   preserve the parent exactly, return two connected children, and are selected

--- a/docs/usage/rhime.rst
+++ b/docs/usage/rhime.rst
@@ -257,6 +257,15 @@ different things for those policies, and generated region counts become upper
 targets when split stopping rejects remaining candidates. These child-share
 policies are not currently routed through RHIME config options.
 
+``MaxChildPCAEccentricity`` strictly checks every proposed child by default.
+Its optional ``min_child_target_weight_share`` parameter can exempt only
+children below a configured share of the same class/source-local equal-target
+weight. This lets a low-weight, topology-forced fragment avoid vetoing
+well-shaped material children produced by ``ConnectedComponentPartitionStep``.
+The exception changes split acceptance only: it does not reconnect, freeze,
+prune, or marginalize the resulting small region. A direct three-argument
+policy call has no target-region context and therefore remains strict.
+
 Output Formats
 --------------
 

--- a/openghg_inversions/basis/algorithms/_constrained.py
+++ b/openghg_inversions/basis/algorithms/_constrained.py
@@ -467,18 +467,31 @@ class MaxChildPCAEccentricity:
     eccentricity ``1`` because they have no resolvable long axis. Multi-cell
     rank-one children have infinite eccentricity and are rejected by any finite
     threshold.
+
+    By default, every child is subject to the eccentricity limit. Setting
+    ``min_child_target_weight_share`` exempts children whose weight is below
+    that share of one class/source-local equal-weight target region,
+    ``weights.sum() / target_regions``. This target-aware exception is used
+    only through :meth:`accept_split`; the conservative three-argument call
+    remains strict.
+
+    The exception affects split acceptance only. It does not reconnect, freeze,
+    prune, or marginalize an exempt child after the split is accepted.
     """
 
     max_child_pca_eccentricity: float
     geometry: SplitGeometry | None = None
     tolerance: float = _INERTIAL_TOLERANCE
+    min_child_target_weight_share: float = 0.0
 
     def __post_init__(self) -> None:
-        """Validate the eccentricity threshold and tolerance."""
+        """Validate the eccentricity, tolerance, and materiality thresholds."""
         if self.max_child_pca_eccentricity < 1.0 or not np.isfinite(self.max_child_pca_eccentricity):
             raise ValueError("max_child_pca_eccentricity must be at least 1 and finite.")
         if self.tolerance < 0.0 or not np.isfinite(self.tolerance):
             raise ValueError("tolerance must be non-negative and finite.")
+        if not 0.0 <= self.min_child_target_weight_share <= 1.0:
+            raise ValueError("min_child_target_weight_share must be between 0 and 1.")
 
     def __call__(
         self,
@@ -493,6 +506,52 @@ class MaxChildPCAEccentricity:
             <= self.max_child_pca_eccentricity
             for child in children
         )
+
+    def accept_split(
+        self,
+        parent: GridPartition,
+        children: list[GridPartition],
+        weights: np.ndarray,
+        target_regions: int,
+    ) -> bool:
+        """Return true when every materially weighted child meets the limit.
+
+        ``weights`` is the class/source-local field passed to greedy
+        partitioning, so ``weights.sum() / target_regions`` is the equal-weight
+        target region weight. Children strictly below
+        ``min_child_target_weight_share`` times that reference weight are
+        exempt from the eccentricity veto.
+
+        If the total weight is zero, cell counts provide the same direct-call
+        fallback used by :class:`MinChildTargetWeightShare`; the default greedy
+        strategy already converts all-zero classes to an area surrogate before
+        policies are evaluated. If every child is below the materiality
+        threshold, the strict guard is retained rather than accepting
+        vacuously.
+        """
+        if target_regions < 1:
+            raise ValueError("target_regions must be at least 1.")
+        if self.min_child_target_weight_share == 0.0:
+            return self(parent, children, weights)
+
+        total_weight = float(weights.sum())
+        if total_weight <= 0.0:
+            total_weight = float(weights.size)
+            child_weights = [float(len(child)) for child in children]
+        else:
+            child_weights = [_node_weight(child, weights) for child in children]
+
+        if total_weight <= 0.0:
+            return False
+        minimum_material_weight = self.min_child_target_weight_share * total_weight / target_regions
+        material_children = [
+            child
+            for child, child_weight in zip(children, child_weights, strict=True)
+            if child_weight >= minimum_material_weight
+        ]
+        if not material_children:
+            material_children = children
+        return self(parent, material_children, weights)
 
 
 @dataclass(frozen=True, init=False)

--- a/tests/test_constrained_basis_algorithm.py
+++ b/tests/test_constrained_basis_algorithm.py
@@ -440,6 +440,54 @@ def test_connected_binary_repair_avoids_eccentricity_rejection_and_target_oversh
     assert all(ndimage.label(repaired_labels == label)[1] == 1 for label in (1, 2))
 
 
+def test_influence_aware_eccentricity_accepts_connected_component_fragment():
+    """A low-weight eccentric component no longer vetoes material children."""
+    weights, class_mask, nodes = _coastline_like_binary_case()
+    split_step = ConnectedComponentPartitionStep(
+        AxisParallelSplitStep(balanced=True, clean_splits=True),
+        connectivity=1,
+    )
+    children = split_step(nodes, weights)
+    strict_guard = MaxChildPCAEccentricity(max_child_pca_eccentricity=10.0)
+    influence_aware_guard = MaxChildPCAEccentricity(
+        max_child_pca_eccentricity=10.0,
+        min_child_target_weight_share=0.1,
+    )
+
+    labels = GreedyAxisParallelSplitStrategy(
+        split_step=split_step,
+        split_acceptance=influence_aware_guard,
+    )(weights, class_mask, target_regions=3)
+
+    assert not strict_guard.accept_split(nodes, children, weights, target_regions=3)
+    assert influence_aware_guard.accept_split(nodes, children, weights, target_regions=3)
+    assert set(np.unique(labels)) == {0, 1, 2, 3}
+    assert all(ndimage.label(labels == label)[1] == 1 for label in (1, 2, 3))
+
+
+def test_influence_aware_eccentricity_preserves_connected_binary_result():
+    """Selecting connected-binary repair retains its existing guarded result."""
+    weights, class_mask, _nodes = _coastline_like_binary_case()
+    split_step = ConnectedBinaryPartitionStep(
+        AxisParallelSplitStep(balanced=True, clean_splits=True),
+        connectivity=1,
+    )
+    strict_labels = GreedyAxisParallelSplitStrategy(
+        split_step=split_step,
+        split_acceptance=MaxChildPCAEccentricity(max_child_pca_eccentricity=10.0),
+    )(weights, class_mask, target_regions=2)
+    influence_aware_labels = GreedyAxisParallelSplitStrategy(
+        split_step=split_step,
+        split_acceptance=MaxChildPCAEccentricity(
+            max_child_pca_eccentricity=10.0,
+            min_child_target_weight_share=0.1,
+        ),
+    )(weights, class_mask, target_regions=2)
+
+    assert np.array_equal(influence_aware_labels, strict_labels)
+    assert set(np.unique(influence_aware_labels)) == {0, 1, 2}
+
+
 def test_connected_strategy_raises_target_to_disconnected_class_minimum():
     """Disconnected class pieces receive distinct labels below the minimum target."""
     weights = np.asarray(
@@ -1308,6 +1356,91 @@ def test_max_child_pca_eccentricity_accepts_compact_and_single_cell_children():
     assert MaxChildPCAEccentricity(max_child_pca_eccentricity=2.0)(parent, children, weights)
 
 
+def test_max_child_pca_eccentricity_default_and_direct_calls_remain_strict():
+    """The default and target-free calls retain the strict all-child guard."""
+    weights = np.zeros((3, 5))
+    weights[0, :3] = 0.01
+    weights[1:, 3:] = 1.0
+    elongated = [(0, 0), (0, 1), (0, 2)]
+    compact = [(1, 3), (1, 4), (2, 3), (2, 4)]
+    parent = elongated + compact
+    children = [elongated, compact]
+    strict = MaxChildPCAEccentricity(max_child_pca_eccentricity=2.0)
+    target_aware = MaxChildPCAEccentricity(
+        max_child_pca_eccentricity=2.0,
+        min_child_target_weight_share=0.1,
+    )
+
+    assert not strict(parent, children, weights)
+    assert not strict.accept_split(parent, children, weights, target_regions=2)
+    assert not target_aware(parent, children, weights)
+
+
+def test_max_child_pca_eccentricity_exempts_immaterial_elongated_child():
+    """An eccentric child below the equal-target weight threshold is exempt."""
+    weights = np.zeros((3, 5))
+    weights[0, :3] = 0.01
+    weights[1:, 3:] = 1.0
+    elongated = [(0, 0), (0, 1), (0, 2)]
+    compact = [(1, 3), (1, 4), (2, 3), (2, 4)]
+    parent = elongated + compact
+    policy = MaxChildPCAEccentricity(
+        max_child_pca_eccentricity=2.0,
+        min_child_target_weight_share=0.1,
+    )
+
+    assert policy.accept_split(parent, [elongated, compact], weights, target_regions=2)
+
+
+def test_max_child_pca_eccentricity_rejects_material_elongated_child():
+    """An eccentric child at or above the materiality threshold still vetoes."""
+    weights = np.zeros((3, 5))
+    weights[0, :3] = 0.25
+    weights[1:, 3:] = 1.0
+    elongated = [(0, 0), (0, 1), (0, 2)]
+    compact = [(1, 3), (1, 4), (2, 3), (2, 4)]
+    parent = elongated + compact
+    policy = MaxChildPCAEccentricity(
+        max_child_pca_eccentricity=2.0,
+        min_child_target_weight_share=0.1,
+    )
+
+    assert not policy.accept_split(parent, [elongated, compact], weights, target_regions=2)
+
+
+def test_max_child_pca_eccentricity_zero_weight_falls_back_to_cell_target():
+    """Zero total weight uses cell counts to decide child materiality."""
+    weights = np.zeros((2, 4))
+    elongated = [(0, 0), (0, 1)]
+    compact = [(0, 2), (0, 3), (1, 2), (1, 3)]
+    parent = elongated + compact
+    children = [elongated, compact]
+
+    assert MaxChildPCAEccentricity(
+        max_child_pca_eccentricity=2.0,
+        min_child_target_weight_share=0.75,
+    ).accept_split(parent, children, weights, target_regions=2)
+    assert not MaxChildPCAEccentricity(
+        max_child_pca_eccentricity=2.0,
+        min_child_target_weight_share=0.5,
+    ).accept_split(parent, children, weights, target_regions=2)
+
+
+def test_max_child_pca_eccentricity_avoids_vacuous_immaterial_acceptance():
+    """If no child is material, the policy falls back to the strict guard."""
+    weights = np.zeros((2, 8))
+    weights[0, :4] = 0.01
+    weights[1, 7] = 100.0
+    children = [[(0, 0), (0, 1)], [(0, 2), (0, 3)]]
+    parent = children[0] + children[1]
+    policy = MaxChildPCAEccentricity(
+        max_child_pca_eccentricity=2.0,
+        min_child_target_weight_share=1.0,
+    )
+
+    assert not policy.accept_split(parent, children, weights, target_regions=2)
+
+
 def test_greedy_strategy_pca_eccentricity_stopping_freezes_rejected_partition():
     """Shape stopping can reject an otherwise valid split."""
     weights = np.ones((1, 4))
@@ -1370,6 +1503,25 @@ def test_max_child_pca_eccentricity_composes_with_target_weight_policy():
     assert set(np.unique(labels)) == {1}
 
 
+def test_influence_aware_eccentricity_composes_with_balance_policy():
+    """An eccentricity exemption does not bypass another acceptance policy."""
+    weights = np.zeros((3, 5))
+    weights[0, :3] = 0.01
+    weights[1:, 3:] = 1.0
+    elongated = [(0, 0), (0, 1), (0, 2)]
+    compact = [(1, 3), (1, 4), (2, 3), (2, 4)]
+    parent = elongated + compact
+    policy = AllSplitAcceptancePolicies(
+        MaxChildPCAEccentricity(
+            max_child_pca_eccentricity=2.0,
+            min_child_target_weight_share=0.1,
+        ),
+        MinChildWeightShare(min_child_weight_share=0.1),
+    )
+
+    assert not policy(parent, [elongated, compact], weights, target_regions=2)
+
+
 @pytest.mark.parametrize("threshold", [0.0, 0.999, -1.0, np.inf, np.nan])
 def test_max_child_pca_eccentricity_validates_threshold(threshold: float):
     """PCA eccentricity thresholds must be positive and finite."""
@@ -1382,6 +1534,16 @@ def test_max_child_pca_eccentricity_validates_tolerance(tolerance: float):
     """PCA eccentricity tolerance must be non-negative and finite."""
     with pytest.raises(ValueError, match="tolerance must be non-negative and finite"):
         MaxChildPCAEccentricity(max_child_pca_eccentricity=10.0, tolerance=tolerance)
+
+
+@pytest.mark.parametrize("threshold", [-0.1, 1.1, np.inf, np.nan])
+def test_max_child_pca_eccentricity_validates_materiality_threshold(threshold: float):
+    """PCA materiality thresholds must be finite shares from zero to one."""
+    with pytest.raises(ValueError, match="min_child_target_weight_share must be between 0 and 1"):
+        MaxChildPCAEccentricity(
+            max_child_pca_eccentricity=10.0,
+            min_child_target_weight_share=threshold,
+        )
 
 
 def test_split_contrast_score_is_zero_for_equal_mass_weighted_mean_contribution():


### PR DESCRIPTION
* **Summary of changes**

Extends `MaxChildPCAEccentricity` with an optional `min_child_target_weight_share: float = 0.0` policy. The default remains the strict all-child eccentricity veto. When a positive threshold is used through the target-aware `accept_split` protocol, only children below

`min_child_target_weight_share * (weights.sum() / target_regions)`

are exempt from the eccentricity check. Material children remain guarded. All-zero inputs use the existing cell-count fallback semantics, and a proposal with no material children falls back to the strict guard instead of being accepted vacuously. The conservative three-argument direct call remains strict.

This keeps the existing positional `geometry` and `tolerance` API compatible by adding the new field last. It also preserves composition through `AllSplitAcceptancePolicies`. The exemption affects split acceptance only; it does not reconnect, freeze, prune, or marginalize the resulting small region.

The motivating predecessor is PR #546. Its connected-binary repair remains available and unchanged, while this policy lets callers retain historical multi-child `ConnectedComponentPartitionStep` decomposition without allowing a tiny topology-forced eccentric component to veto scientifically important material children.

Documentation and the changelog are updated. No verification-games consumer code is included in this PR.

* **Validation**

- `tox -e py310-openghgCur -- tests/test_constrained_basis_algorithm.py`: 103 passed.
- Required parallel workflow test environment: 658 passed, 9 skipped, 6 xfailed.
- Focused Ruff checks pass for the changed implementation and tests. The repository-wide `lint` tox sibling still reports 211 pre-existing violations on current `devel`; those unrelated files were preserved.
- Blue Pebble DFIN July basis-only regression, using the upstream class via a temporary consumer monkeypatch (SLURM job 18219419; no analytic or RHIME inversion):
  - GPP: 120 regions.
  - TER: 120 regions.
  - FF: 117 regions.
  - FF `int16` label bytes are identical to historical `full_fit_basis` (SHA-256 `32141cbc19d5b1ca628298c03921080c91d99b0114468111795251fbda939a95`; zero changed cells).
  - FF differs from `full_fit_basis_connected_binary_pr546` at 11,746 cells.
  - Every label in GPP, TER, FF, and ocean is a single four-neighbour component; no component consolidation was enabled.
  - Recorded policy provenance resolves to `openghg_inversions.basis.algorithms._constrained.MaxChildPCAEccentricity` with threshold `0.1`.

* **Please check if the PR fulfills these requirements**

- [ ] Closes an issue (not applicable; motivated by PR #546)
- [x] Tests added and passing
- [x] Documentation and tutorials updated/added
- [x] Added an entry to the `CHANGELOG.md` file
- [x] No new requirements needed