### PR TITLE
Generalize gathered multisector auxiliary coordinate namespacing

### DIFF
--- a/openghg_inversions/models/_rhime_flux.py
+++ b/openghg_inversions/models/_rhime_flux.py
@@ -241,7 +241,20 @@ def _select_sector_design(
         ragged_dim=ragged_levels[0],
         stack_dim=state_dim,
     )
-    return selected.rename({state_dim: f"{state_dim}_{variable_suffix}"})
+    selected_state_dim = f"{state_dim}_{variable_suffix}"
+    selected = selected.rename({state_dim: selected_state_dim})
+
+    # A gathered design can retain state-aligned provenance coordinates after
+    # source selection. Each source is registered on its own model dimension,
+    # so give those auxiliary coordinates the same sector-specific namespace.
+    # Otherwise unequal source blocks attempt to register one coordinate name
+    # with incompatible dimensions and shapes in the model CoordRegistry.
+    auxiliary_renames = {
+        str(name): f"{name}_{variable_suffix}"
+        for name, coord in selected.coords.items()
+        if name != selected_state_dim and selected_state_dim in coord.dims
+    }
+    return selected.rename(auxiliary_renames)
 
 
 def _normalize_standard_flux_plan(inv_inputs: xr.Dataset, x_prior: Mapping[str, Any]) -> _FluxPlan:

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -2830,7 +2830,7 @@ def test_rhime_prepared_inputs_contract_exposes_only_modern_fields() -> None:
 def test_prepared_multisector_runner_accepts_gathered_source_specific_basis_layout(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Prepared-input validation accepts exact ragged source/state coordinates."""
+    """Prepared runner accepts unequal gathered blocks with sector provenance."""
     basis_ff = xr.DataArray(
         [[0, 0], [1, 1]],
         dims=("lat", "lon"),
@@ -2881,10 +2881,14 @@ def test_prepared_multisector_runner_accepts_gathered_source_specific_basis_layo
     )
     inv_inputs = _minimal_output_inv_inputs().drop_dims("region")
     inv_inputs["min_error"] = xr.zeros_like(inv_inputs["mf"])
-    inv_inputs["H"] = (
+    sensitivity = (
         basis_functions.sensitivity(fp_x_flux)
         .rename(time="nmeasure")
         .assign_coords(nmeasure=inv_inputs.coords["nmeasure"])
+    )
+    state_dim = next(dim for dim in sensitivity.dims if dim != "nmeasure")
+    inv_inputs["H"] = sensitivity.assign_coords(
+        sector=(state_dim, sensitivity.coords["source"].values),
     )
 
     prepared = RhimePreparedInputs(
@@ -2918,6 +2922,10 @@ def test_prepared_multisector_runner_accepts_gathered_source_specific_basis_layo
 
     assert result.model.named_vars_to_dims["x_ff"] == ("region_ff",)
     assert result.model.named_vars_to_dims["x_ocean"] == ("region_ocean",)
+    registry = models.get_coord_registry(result.model)
+    assert registry is not None
+    assert registry.auxiliary_coords["sector_ff"].values.tolist() == ["ff-inventory"] * 2
+    assert registry.auxiliary_coords["sector_ocean"].values.tolist() == ["ocean-inventory"] * 3
 
 
 def test_multisector_runner_rejects_shared_basis_h_layout_mismatch() -> None:


### PR DESCRIPTION
## Summary

- merged current `devel` so coordinate namespacing remains after semantic state-policy resolution
- generalized model lowering to namespace every non-scalar auxiliary coordinate spanning a sector-local state dimension, including mixed `(state, nmeasure)` coordinates
- kept observation-only auxiliary coordinates shared
- added the exact #554 regression through `RhimePreparedInputs.save/load` and `run_rhime_from_prepared_inputs`

The regression verifies that the durable `(source, region_in_source)` state identity and the legacy source-valued `sector(state)` auxiliary survive round-trip unchanged, execution does not mutate the loaded inputs, and model-local coordinates are namespaced for unequal source blocks.

`source` remains the OpenGHG retrieval/provenance identity; semantic model-sector names remain separate in `SectorSpec.name`.

## Validation

- `tox -p --parallel-no-spinner` — passed
- focused gathered-state and coordinate-registry tox group — 4 passed
- `uv run ruff check openghg_inversions/models/_rhime_flux.py tests/test_rhime.py` — passed
- `uv run ruff format --check openghg_inversions/models/_rhime_flux.py tests/test_rhime.py` — passed
- configured mypy environment attempted; it reports existing missing-stub and unrelated project errors, with no new error attributable to this patch

Regression coverage for #554.