### PR TITLE
Speed up pytest sampling tests

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -75,7 +75,7 @@ jobs:
       - name: Prime ArviZ cache
         run: python -c "import arviz"
       - name: Run tests
-        run: pytest tests/ -n 2 --dist=loadscope
+        run: pytest tests/ -n 2 --dist=worksteal
 
   lint:
     name: Run lint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ This adds Python 3.10 test environments for the previous OpenGHG minor
 release and OpenGHG `devel`. The previous-release environment defaults to
 `openghg==0.18.0`; set `OPENGHG_PREV_SPEC` to test another deterministic
 package spec. The tox test environments use `pytest-xdist` with
-`--dist=loadscope`, matching the main CI pytest invocation. The `type` tox
+`--dist=worksteal`, matching the main CI pytest invocation. The `type` tox
 environment is available for focused type-checking, but it is not part of
 either tox set.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ dev = { features = ["dev", "jupyter"], solve-group = "default" }
 
 [tool.pixi.feature.dev.tasks]
 test = "pytest"
-test-xdist = "pytest -n 2 --dist=loadscope tests"
+test-xdist = "pytest -n 2 --dist=worksteal tests"
 country-file-smoke = "pytest -s tests/postprocessing/test_country_file_smoke.py"
 lint = "ruff check ."
 typecheck = "pyright"

--- a/tests/experimental/test_ramsden2022.py
+++ b/tests/experimental/test_ramsden2022.py
@@ -343,6 +343,7 @@ def test_boundary_components_are_optional_per_channel(
     assert present == expected
 
 
+@pytest.mark.slow
 def test_tiny_model_samples_through_rhime_sampler() -> None:
     """The isolated historical model runs through the modern RHIME sampler."""
     sampler = RhimeSampler(

--- a/tests/models/test_components.py
+++ b/tests/models/test_components.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 import pymc as pm
 import xarray as xr
+from pytensor.compile.mode import Mode
 
 from openghg_inversions.models.components import (
     LinearComponentResult,
@@ -291,7 +292,7 @@ def test_likelihood_pollution_events_from_obs_can_run_without_boundary_condition
             power=2.0,
         )
 
-    epsilon = model.named_vars["epsilon"].eval()
+    epsilon = model.named_vars["epsilon"].eval(mode=Mode(linker="py", optimizer="fast_run"))
     assert np.all(np.diff(epsilon) > 0)
     assert "y" in model.named_vars
 

--- a/tests/test_full_inversion.py
+++ b/tests/test_full_inversion.py
@@ -1,7 +1,154 @@
+import arviz as az
 import numpy as np
 import pytest
+import xarray as xr
 
+import openghg_inversions.hbmcmc.hbmcmc as hbmcmc_module
 from openghg_inversions.hbmcmc.hbmcmc import fixedbasisMCMC
+
+
+def _deterministic_inferpymc_results(
+    inv_inputs: xr.Dataset,
+    *,
+    use_bc: bool,
+    reparameterise_log_normal: bool,
+) -> dict[str, object]:
+    """Build realistic fixedbasis sampler results without posterior sampling.
+
+    Args:
+        inv_inputs: Fully prepared fixedbasis model inputs.
+        use_bc: Whether boundary-condition variables should be included.
+        reparameterise_log_normal: Whether to include the sampler's latent
+            lognormal variable alongside the public scaling factor.
+
+    Returns:
+        A fresh legacy ``inferpymc`` result mapping with deterministic prior,
+        posterior, and predictive traces derived from ``inv_inputs``.
+    """
+    draw_count = 8
+    nregion = inv_inputs.sizes["region"]
+    draw_offsets = np.linspace(-0.1, 0.1, draw_count)
+    x_posterior = 1.0 + draw_offsets[:, None] + 0.01 * np.arange(nregion)[None, :]
+    x_prior = 1.0 + 2 * draw_offsets[:, None] + 0.01 * np.arange(nregion)[None, :]
+    h_matrix = inv_inputs["H"].transpose("region", "nmeasure").values
+    mu_posterior = x_posterior @ h_matrix
+    mu_prior = x_prior @ h_matrix
+
+    site_index = np.asarray(inv_inputs["site_indicator"].values, dtype=int)
+    sigma_index = np.asarray(inv_inputs["sigma_freq_index"].values, dtype=int)
+    nsite = int(site_index.max(initial=0)) + 1
+    nsigma_time = int(sigma_index.max(initial=0)) + 1
+    sigma_posterior = np.broadcast_to(
+        1.0 + draw_offsets[:, None, None],
+        (draw_count, nsite, nsigma_time),
+    ).copy()
+    sigma_prior = np.broadcast_to(
+        1.2 + draw_offsets[:, None, None],
+        (draw_count, nsite, nsigma_time),
+    ).copy()
+    observation_error = np.asarray(inv_inputs["mf_error"].values)
+    epsilon_posterior = np.sqrt(
+        observation_error[None, :] ** 2 + sigma_posterior[:, site_index, sigma_index] ** 2
+    )
+    epsilon_prior = np.sqrt(observation_error[None, :] ** 2 + sigma_prior[:, site_index, sigma_index] ** 2)
+
+    posterior = {
+        "x": x_posterior[None, ...],
+        "sigma": sigma_posterior[None, ...],
+        "mu": mu_posterior[None, ...],
+        "epsilon": epsilon_posterior[None, ...],
+    }
+    prior = {
+        "x": x_prior[None, ...],
+        "sigma": sigma_prior[None, ...],
+        "mu": mu_prior[None, ...],
+        "epsilon": epsilon_prior[None, ...],
+    }
+    dims = {
+        "x": ["nx"],
+        "sigma": ["nsigma_site", "nsigma_time"],
+        "mu": ["nmeasure"],
+        "epsilon": ["nmeasure"],
+        "y": ["nmeasure"],
+    }
+    if reparameterise_log_normal:
+        posterior["x_latent"] = np.log(x_posterior)[None, ...]
+        prior["x_latent"] = np.log(x_prior)[None, ...]
+        dims["x_latent"] = ["nx"]
+    coords = {
+        "nx": inv_inputs["region"].values,
+        "nsigma_site": np.arange(nsite),
+        "nsigma_time": np.arange(nsigma_time),
+        "nmeasure": np.arange(inv_inputs.sizes["nmeasure"]),
+    }
+
+    if use_bc:
+        h_bc = inv_inputs["H_bc"].transpose("bc_region", "nmeasure").values
+        nbc = h_bc.shape[0]
+        bc_posterior = 1.0 + 0.5 * draw_offsets[:, None] + 0.01 * np.arange(nbc)[None, :]
+        bc_prior = 1.0 + draw_offsets[:, None] + 0.01 * np.arange(nbc)[None, :]
+        mu_bc_posterior = bc_posterior @ h_bc
+        mu_bc_prior = bc_prior @ h_bc
+        posterior.update({"bc": bc_posterior[None, ...], "mu_bc": mu_bc_posterior[None, ...]})
+        prior.update({"bc": bc_prior[None, ...], "mu_bc": mu_bc_prior[None, ...]})
+        dims.update({"bc": ["nbc"], "mu_bc": ["nmeasure"]})
+        coords["nbc"] = np.arange(nbc)
+    else:
+        mu_bc_posterior = np.zeros_like(mu_posterior)
+        mu_bc_prior = np.zeros_like(mu_prior)
+
+    y_posterior = mu_posterior + mu_bc_posterior
+    y_prior = mu_prior + mu_bc_prior
+    trace = az.from_dict(
+        posterior=posterior,
+        prior=prior,
+        posterior_predictive={"y": y_posterior[None, ...]},
+        prior_predictive={"y": y_prior[None, ...]},
+        coords=coords,
+        dims=dims,
+    )
+    trace_groups: dict[str, xr.Dataset] = {}
+    nmeasure_index = inv_inputs.indexes["nmeasure"]
+    for group in trace.groups():
+        dataset = trace[group]
+        if "nmeasure" in dataset.dims:
+            level_names = list(nmeasure_index.names)
+            dataset = dataset.assign_coords(
+                {name: ("nmeasure", nmeasure_index.get_level_values(name)) for name in level_names}
+            ).set_index(nmeasure=level_names)
+        if "nbc" in dataset.dims:
+            bc_index = inv_inputs.indexes["bc_region"]
+            level_names = list(bc_index.names)
+            dataset = dataset.assign_coords(
+                {name: ("nbc", bc_index.get_level_values(name)) for name in level_names}
+            ).set_index(nbc=level_names)
+        trace_groups[group] = dataset
+    trace = az.InferenceData(**trace_groups)
+    return {
+        "trace": trace,
+        "model": object(),
+        "xouts": x_posterior,
+    }
+
+
+@pytest.fixture
+def deterministic_sampler(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, object]]:
+    """Replace only ``inferpymc`` and expose the fully prepared call arguments."""
+    calls: list[dict[str, object]] = []
+
+    def fake_inferpymc(**kwargs: object) -> dict[str, object]:
+        """Return deterministic results for the prepared fixedbasis inputs."""
+        calls.append(dict(kwargs))
+        inv_inputs = kwargs["inv_inputs"]
+        assert isinstance(inv_inputs, xr.Dataset)
+        return _deterministic_inferpymc_results(
+            inv_inputs,
+            use_bc=bool(kwargs["use_bc"]),
+            reparameterise_log_normal=bool(kwargs.get("reparameterise_log_normal", False)),
+        )
+
+    monkeypatch.setattr(hbmcmc_module.mcmc, "inferpymc", fake_inferpymc)
+    return calls
 
 
 @pytest.fixture
@@ -103,7 +250,7 @@ def test_full_inversion(mcmc_args):
     assert np.mean(np.abs(out.Yobs.values - out.Yapriori.values)) < 0.5 * np.mean(out.Yobs.values)
 
 
-def test_full_inversion_paris_outputs(mcmc_args):
+def test_full_inversion_paris_outputs(mcmc_args, deterministic_sampler):
     """Test full inversion including loading data with PARIS output format."""
     mcmc_args["reload_merged_data"] = False
     mcmc_args["output_format"] = "paris"
@@ -112,13 +259,13 @@ def test_full_inversion_paris_outputs(mcmc_args):
     assert "Yapost" in out
 
 
-def test_full_inversion_flux_dim_shuffled(mcmc_args):
+def test_full_inversion_flux_dim_shuffled(mcmc_args, deterministic_sampler):
     mcmc_args["emissions_name"] = ["total-ukghg-edgar7-shuffled"]
     mcmc_args["reload_merged_data"] = False
     fixedbasisMCMC(**mcmc_args)
 
 
-def test_full_inversion_lognormal_infer(mcmc_args):
+def test_full_inversion_lognormal_infer(mcmc_args, deterministic_sampler):
     mcmc_args["xprior"] = {"pdf": "lognormal", "stdev": 2.0}
     out = fixedbasisMCMC(**mcmc_args)
 
@@ -126,9 +273,14 @@ def test_full_inversion_lognormal_infer(mcmc_args):
 
     # look for a few decimal places of expected sigma in output attributes
     assert expected_sigma[:4] in out.attrs["Emissions Prior"]
+    assert deterministic_sampler[0]["xprior"] == {
+        "pdf": "lognormal",
+        "mu": 0.5 * np.log(0.2),
+        "sigma": np.sqrt(np.log(5)),
+    }
 
 
-def test_inversion_if_merged_data_does_not_exist(mcmc_args):
+def test_inversion_if_merged_data_does_not_exist(mcmc_args, deterministic_sampler):
     """Test that inversion runs if reload_merged_data is True, but
     no merged data exists under the default merged data name.
     """

--- a/tests/test_full_inversion.py
+++ b/tests/test_full_inversion.py
@@ -168,6 +168,7 @@ def mcmc_args(
             "basis_algorithm": "quadtree",
             "basis_output_path": str(tmp_path),
             "nbasis": 4,
+            "xprior": {"pdf": "lognormal", "stdev": 1.0},
             "nit": 1,
             "burn": 0,
             "tune": 0,
@@ -240,7 +241,9 @@ def test_full_satellite_inversion(satellite_mcmc_args):
 
 
 def test_full_inversion(mcmc_args):
+    """Run one real fixed-basis integration with current priors and NumPyro."""
     mcmc_args["reload_merged_data"] = False
+    mcmc_args["nuts_sampler"] = "numpyro"
     out = fixedbasisMCMC(**mcmc_args)
 
     assert "Yerror_repeatability" in out

--- a/tests/test_inferpymc.py
+++ b/tests/test_inferpymc.py
@@ -60,6 +60,127 @@ def sample_args() -> dict:
     return {"draws": 1, "tune": 0, "chains": 1, "random_seed": 123, "compute_convergence_checks": False}
 
 
+def _mock_posterior_trace(model: pm.Model, *, draws: int, chains: int) -> az.InferenceData:
+    """Create realistic deterministic posterior groups for a built PyMC model."""
+    coords: dict[str, Any] = {
+        "chain": np.arange(chains),
+        "draw": np.arange(draws),
+    }
+    coords.update({dim: np.asarray(values) for dim, values in model.coords.items() if values is not None})
+
+    posterior_values = {
+        "x": 1.0,
+        "bc": 0.25,
+        "sigma": 0.2,
+        "mu": 2.0,
+        "mu_bc": 0.5,
+        "offset": 0.0,
+    }
+    posterior_vars: dict[str, tuple[tuple[str, ...], np.ndarray]] = {}
+    for name, value in posterior_values.items():
+        if name not in model.named_vars:
+            continue
+        dims = cast(tuple[str, ...], ("chain", "draw", *model.named_vars_to_dims.get(name, ())))
+        shape = tuple(len(coords[dim]) for dim in dims)
+        posterior_vars[name] = (dims, np.full(shape, value))
+
+    observation_dims = ("chain", "draw", "nmeasure")
+    observation_shape = tuple(len(coords[dim]) for dim in observation_dims)
+    return az.InferenceData(
+        posterior=xr.Dataset(posterior_vars, coords=coords),
+        sample_stats=xr.Dataset(
+            {"diverging": (("chain", "draw"), np.zeros((chains, draws), dtype=bool))},
+            coords={"chain": coords["chain"], "draw": coords["draw"]},
+        ),
+        log_likelihood=xr.Dataset(
+            {"y": (observation_dims, np.zeros(observation_shape))},
+            coords={dim: coords[dim] for dim in observation_dims},
+        ),
+    )
+
+
+@pytest.fixture
+def mocked_pymc_sampling(monkeypatch: pytest.MonkeyPatch) -> dict[str, list[dict[str, Any]]]:
+    """Replace PyMC sampling with deterministic InferenceData-producing fakes."""
+    calls: dict[str, list[dict[str, Any]]] = {
+        "sample": [],
+        "prior_predictive": [],
+        "posterior_predictive": [],
+    }
+
+    def fake_sample(**kwargs: Any) -> az.InferenceData:
+        """Return posterior groups sized from the active model and sampler arguments."""
+        calls["sample"].append(kwargs)
+        model = pm.modelcontext(None)
+        return _mock_posterior_trace(model, draws=kwargs["draws"], chains=kwargs["chains"])
+
+    def fake_prior_predictive(draws: int, model: pm.Model) -> az.InferenceData:
+        """Return deterministic prior and prior-predictive groups."""
+        calls["prior_predictive"].append({"draws": draws, "model": model})
+        coords = {
+            "chain": [0],
+            "draw": np.arange(draws),
+            "region": np.asarray(model.coords["region"]),
+            "nmeasure": np.asarray(model.coords["nmeasure"]),
+        }
+        return az.InferenceData(
+            prior=xr.Dataset(
+                {"x": (("chain", "draw", "region"), np.ones((1, draws, len(coords["region"]))))},
+                coords={dim: coords[dim] for dim in ("chain", "draw", "region")},
+            ),
+            prior_predictive=xr.Dataset(
+                {"y": (("chain", "draw", "nmeasure"), np.ones((1, draws, len(coords["nmeasure"]))))},
+                coords={dim: coords[dim] for dim in ("chain", "draw", "nmeasure")},
+            ),
+        )
+
+    def fake_posterior_predictive(
+        trace: az.InferenceData,
+        *,
+        model: pm.Model,
+        var_names: list[str] | None,
+    ) -> az.InferenceData:
+        """Return deterministic posterior predictions aligned to the posterior trace."""
+        calls["posterior_predictive"].append({"trace": trace, "model": model, "var_names": var_names})
+        trace_groups = cast(Any, trace)
+        chains = trace_groups.posterior.sizes["chain"]
+        draws = trace_groups.posterior.sizes["draw"]
+        nmeasure_coord = model.coords["nmeasure"]
+        assert nmeasure_coord is not None
+        nmeasure = len(nmeasure_coord)
+        return az.InferenceData(
+            posterior_predictive=xr.Dataset(
+                {
+                    "y": (
+                        ("chain", "draw", "nmeasure"),
+                        np.ones((chains, draws, nmeasure)),
+                    )
+                },
+                coords={
+                    "chain": trace_groups.posterior.chain,
+                    "draw": trace_groups.posterior.draw,
+                    "nmeasure": np.asarray(model.coords["nmeasure"]),
+                },
+            )
+        )
+
+    monkeypatch.setattr(inversion_pymc_module.pm, "sample", fake_sample)
+    monkeypatch.setattr(inversion_pymc_module.pm, "sample_prior_predictive", fake_prior_predictive)
+    monkeypatch.setattr(
+        inversion_pymc_module.pm,
+        "sample_posterior_predictive",
+        fake_posterior_predictive,
+    )
+    monkeypatch.setattr(inversion_pymc_module.pm, "NUTS", lambda variables: "mock-nuts-step")
+    monkeypatch.setattr(inversion_pymc_module.pm, "Slice", lambda variables: "mock-slice-step")
+    monkeypatch.setattr(
+        inversion_pymc_module.pm,
+        "rhat",
+        lambda trace: xr.Dataset({"x": xr.DataArray(1.0)}),
+    )
+    return calls
+
+
 def test_build_inferpymc_model_returns_model(inv_inputs: xr.Dataset, model_args: dict) -> None:
     """Building the modern inferpymc model returns a PyMC model with canonical coords."""
     model = build_inferpymc_model(inv_inputs, **model_args)
@@ -100,7 +221,10 @@ def test_build_inferpymc_model_requires_legacy_sigma_index(
 
 
 def test_sample_returns_burned_modern_result(
-    inv_inputs: xr.Dataset, model_args: dict, sample_args: dict
+    inv_inputs: xr.Dataset,
+    model_args: dict,
+    sample_args: dict,
+    mocked_pymc_sampling: dict[str, list[dict[str, Any]]],
 ) -> None:
     """Modern sampling returns burn-sliced inference data with canonical dims."""
     model = build_inferpymc_model(inv_inputs, **model_args)
@@ -113,10 +237,14 @@ def test_sample_returns_burned_modern_result(
     assert modern_result.posterior.sizes["draw"] == 1
     assert "region" in modern_result.posterior["x"].dims
     assert "bc_region" in modern_result.posterior["bc"].dims
+    assert mocked_pymc_sampling["sample"][0]["draws"] == 2
 
 
 def test_sample_does_not_add_predictive_groups_by_default(
-    inv_inputs: xr.Dataset, model_args: dict, sample_args: dict
+    inv_inputs: xr.Dataset,
+    model_args: dict,
+    sample_args: dict,
+    mocked_pymc_sampling: dict[str, list[dict[str, Any]]],
 ) -> None:
     """Modern sampling leaves predictive groups out unless requested."""
     model = build_inferpymc_model(inv_inputs, **model_args)
@@ -125,10 +253,15 @@ def test_sample_does_not_add_predictive_groups_by_default(
     assert "prior" not in modern_result
     assert "prior_predictive" not in modern_result
     assert "posterior_predictive" not in modern_result
+    assert not mocked_pymc_sampling["prior_predictive"]
+    assert not mocked_pymc_sampling["posterior_predictive"]
 
 
 def test_sample_accepts_plain_model_and_predictive_options(
-    inv_inputs: xr.Dataset, model_args: dict, sample_args: dict
+    inv_inputs: xr.Dataset,
+    model_args: dict,
+    sample_args: dict,
+    mocked_pymc_sampling: dict[str, list[dict[str, Any]]],
 ) -> None:
     """Modern sampling adds predictive groups only when explicitly requested."""
     model = build_inferpymc_model(inv_inputs, **model_args)
@@ -140,6 +273,8 @@ def test_sample_accepts_plain_model_and_predictive_options(
     assert "prior" in modern_result
     assert "prior_predictive" in modern_result
     assert "posterior_predictive" in modern_result
+    assert mocked_pymc_sampling["prior_predictive"][0]["draws"] == 1
+    assert mocked_pymc_sampling["posterior_predictive"][0]["var_names"] == ["y"]
 
 
 def test_sample_resets_burned_draws_before_extending_predictive_groups(
@@ -229,7 +364,10 @@ def test_sample_resets_burned_draws_before_extending_predictive_groups(
 
 
 def test_sample_always_returns_inferencedata(
-    inv_inputs: xr.Dataset, model_args: dict, sample_args: dict
+    inv_inputs: xr.Dataset,
+    model_args: dict,
+    sample_args: dict,
+    mocked_pymc_sampling: dict[str, list[dict[str, Any]]],
 ) -> None:
     """Modern sampling always returns InferenceData regardless of caller kwargs."""
     model = build_inferpymc_model(inv_inputs, **model_args)
@@ -239,17 +377,28 @@ def test_sample_always_returns_inferencedata(
     modern_result = sample(model, **args)
 
     assert isinstance(modern_result, az.InferenceData)
+    assert mocked_pymc_sampling["sample"][0]["return_inferencedata"] is True
 
 
-def test_sample_preserves_log_likelihood(inv_inputs: xr.Dataset, model_args: dict, sample_args: dict) -> None:
+def test_sample_preserves_log_likelihood(
+    inv_inputs: xr.Dataset,
+    model_args: dict,
+    sample_args: dict,
+    mocked_pymc_sampling: dict[str, list[dict[str, Any]]],
+) -> None:
     """Modern sampling keeps log likelihood data in the trace."""
     model = build_inferpymc_model(inv_inputs, **model_args)
     modern_result = sample(model, **sample_args)
 
     assert "log_likelihood" in modern_result
+    assert mocked_pymc_sampling["sample"][0]["idata_kwargs"]["log_likelihood"] is True
 
 
-def test_inferpymc_preserves_legacy_compatibility_outputs(inv_inputs: xr.Dataset, model_args: dict) -> None:
+def test_inferpymc_preserves_legacy_compatibility_outputs(
+    inv_inputs: xr.Dataset,
+    model_args: dict,
+    mocked_pymc_sampling: dict[str, list[dict[str, Any]]],
+) -> None:
     """The public inferpymc wrapper still returns the legacy-shaped outputs."""
     result = inferpymc(
         inv_inputs=inv_inputs,
@@ -299,11 +448,15 @@ def test_inferpymc_preserves_legacy_compatibility_outputs(inv_inputs: xr.Dataset
 
     assert "step1" in result
     assert "step2" in result
+    assert result["step1"] == "mock-nuts-step"
+    assert result["step2"] == "mock-slice-step"
+    assert mocked_pymc_sampling["sample"][0]["progressbar"] is False
 
 
 def test_inferpymc_pymc_sampler_runs_without_boundary_conditions(
     inv_inputs: xr.Dataset,
     model_args: dict,
+    mocked_pymc_sampling: dict[str, list[dict[str, Any]]],
 ) -> None:
     """The single-sector legacy sampler never constructs an empty BC step."""
     args = dict(model_args)
@@ -324,6 +477,9 @@ def test_inferpymc_pymc_sampler_runs_without_boundary_conditions(
     assert result["model"]["x"] in result["model"].free_RVs
     assert "step1" in result
     assert "step2" in result
+    assert "bcouts" not in result
+    assert "YBCtrace" not in result
+    assert mocked_pymc_sampling["sample"][0]["step"] == ["mock-nuts-step", "mock-slice-step"]
 
 
 def test_inferpymc_forwards_numpyro_sampler_without_pymc_step(

--- a/tests/test_inferpymc_month_gap.py
+++ b/tests/test_inferpymc_month_gap.py
@@ -1,10 +1,16 @@
 """Synthetic regression scaffolding for monthly sigma/bc with missing month."""
 
+from typing import Any, cast
+
+import arviz as az
 import numpy as np
 import pandas as pd
+import pymc as pm
+import pytest
 import xarray as xr
 
 from openghg_inversions import utils
+import openghg_inversions.hbmcmc.inversion_pymc as inversion_pymc_module
 from openghg_inversions.inversion_inputs import make_inv_inputs
 from openghg_inversions.hbmcmc.inversion_pymc import (
     _weighted_apriori_flux_for_months,
@@ -52,6 +58,50 @@ def _synthetic_fp_data_one_site_with_missing_month() -> dict[str, xr.Dataset]:
     return {"AAA": ds}
 
 
+def _mock_month_gap_trace(model: pm.Model) -> az.InferenceData:
+    """Create deterministic posterior and predictive groups for month-gap routing."""
+    coords = {
+        "chain": [0],
+        "draw": [0],
+        **{dim: np.asarray(values) for dim, values in model.coords.items() if values is not None},
+    }
+    posterior_values = {
+        "x": 1.0,
+        "bc": 0.25,
+        "sigma": 0.2,
+        "mu": 2.0,
+        "mu_bc": 0.5,
+    }
+    posterior_vars: dict[str, tuple[tuple[str, ...], np.ndarray]] = {}
+    for name, value in posterior_values.items():
+        dims = cast(tuple[str, ...], ("chain", "draw", *model.named_vars_to_dims[name]))
+        shape = tuple(len(coords[dim]) for dim in dims)
+        posterior_vars[name] = (dims, np.full(shape, value))
+
+    prediction_dims = ("chain", "draw", "nmeasure")
+    prediction_shape = tuple(len(coords[dim]) for dim in prediction_dims)
+    return az.InferenceData(
+        posterior=xr.Dataset(posterior_vars, coords=coords),
+        prior=xr.Dataset(
+            {
+                "x": (
+                    ("chain", "draw", "region"),
+                    np.ones((1, 1, len(coords["region"]))),
+                )
+            },
+            coords={dim: coords[dim] for dim in ("chain", "draw", "region")},
+        ),
+        prior_predictive=xr.Dataset(
+            {"y": (prediction_dims, np.ones(prediction_shape))},
+            coords={dim: coords[dim] for dim in prediction_dims},
+        ),
+        posterior_predictive=xr.Dataset(
+            {"y": (prediction_dims, np.full(prediction_shape, 2.5))},
+            coords={dim: coords[dim] for dim in prediction_dims},
+        ),
+    )
+
+
 def test_sigma_alignment_month_gap_monthly_indices_are_contiguous():
     """Frequency-derived sigma indices stay contiguous when a month is missing."""
     fp_data = _synthetic_fp_data_one_site_with_missing_month()
@@ -74,8 +124,10 @@ def test_sigma_alignment_month_gap_monthly_indices_are_contiguous():
     np.testing.assert_array_equal(uniq, np.array([0, 1]))
 
 
-def test_inferpymc_smoke_runs_for_month_gap():
-    """The legacy inferpymc wrapper still runs on gappy monthly inputs."""
+def test_inferpymc_routes_month_gap_through_legacy_outputs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The legacy wrapper routes compact monthly inputs without running MCMC."""
     fp_data = _synthetic_fp_data_one_site_with_missing_month()
 
     inv_inputs = make_inv_inputs(
@@ -91,8 +143,23 @@ def test_inferpymc_smoke_runs_for_month_gap():
         frequency="monthly",
         anchor_time="2019-01-01",
     )
-    inv_inputs = inv_inputs.assign(
-        sigma_freq_index=alignment.period_index.rename("sigma_freq_index")
+    inv_inputs = inv_inputs.assign(sigma_freq_index=alignment.period_index.rename("sigma_freq_index"))
+
+    captured: dict[str, Any] = {}
+
+    def fake_sample(model: pm.Model, **kwargs: Any) -> az.InferenceData:
+        """Capture legacy routing and return deterministic posterior products."""
+        captured["model"] = model
+        captured["sample_kwargs"] = kwargs
+        return _mock_month_gap_trace(model)
+
+    monkeypatch.setattr(inversion_pymc_module, "sample", fake_sample)
+    monkeypatch.setattr(inversion_pymc_module.pm, "NUTS", lambda variables: "mock-nuts-step")
+    monkeypatch.setattr(inversion_pymc_module.pm, "Slice", lambda variables: "mock-slice-step")
+    monkeypatch.setattr(
+        inversion_pymc_module.pm,
+        "rhat",
+        lambda trace: xr.Dataset({"x": xr.DataArray(1.0)}),
     )
 
     result = inferpymc(
@@ -111,8 +178,23 @@ def test_inferpymc_smoke_runs_for_month_gap():
         sampler_kwargs={"compute_convergence_checks": False},
     )
 
-    assert "sigouts" in result
-    assert "trace" in result
+    sample_kwargs = captured["sample_kwargs"]
+    assert sample_kwargs["draws"] == 1
+    assert sample_kwargs["burn"] == 0
+    assert sample_kwargs["tune"] == 0
+    assert sample_kwargs["chains"] == 1
+    assert sample_kwargs["sample_prior_predictive"] is True
+    assert sample_kwargs["sample_posterior_predictive"] == ["y"]
+    assert sample_kwargs["nuts_sampler"] == "pymc"
+    assert sample_kwargs["step"] == ["mock-nuts-step", "mock-slice-step"]
+
+    assert result["sigouts"].sizes["nsigma_time"] == 2
+    assert result["sigouts"].sizes["nsigma_site"] == 1
+    assert result["xouts"].sizes["nx"] == inv_inputs.sizes["region"]
+    assert result["bcouts"].sizes["nbc"] == inv_inputs.sizes["bc_region"]
+    assert result["Ytrace"].shape == (inv_inputs.sizes["nmeasure"], 1)
+    assert result["YBCtrace"].shape == result["Ytrace"].shape
+    assert {"prior", "prior_predictive", "posterior_predictive"}.issubset(result["trace"].groups())
 
 
 def test_weighted_apriori_flux_handles_missing_month():

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -110,6 +110,151 @@ def _minimal_fixedbasis_prepared_data(**overrides):
     return hbmcmc_module.FixedBasisPreparedData(**defaults)
 
 
+def _deterministic_inferpymc_results(
+    inv_inputs: xr.Dataset,
+    *,
+    use_bc: bool,
+    reparameterise_log_normal: bool,
+) -> dict[str, object]:
+    """Build fresh realistic traces from prepared inputs without sampling.
+
+    Args:
+        inv_inputs: Fully prepared fixedbasis model inputs.
+        use_bc: Whether boundary-condition variables should be included.
+        reparameterise_log_normal: Whether to include the sampler's latent
+            lognormal variable alongside the public scaling factor.
+
+    Returns:
+        A legacy ``inferpymc`` result mapping containing deterministic prior,
+        posterior, and predictive traces suitable for real postprocessing and
+        serialization.
+    """
+    draw_count = 8
+    nregion = inv_inputs.sizes["region"]
+    draw_offsets = np.linspace(-0.1, 0.1, draw_count)
+    x_posterior = 1.0 + draw_offsets[:, None] + 0.01 * np.arange(nregion)[None, :]
+    x_prior = 1.0 + 2 * draw_offsets[:, None] + 0.01 * np.arange(nregion)[None, :]
+    h_matrix = inv_inputs["H"].transpose("region", "nmeasure").values
+    mu_posterior = x_posterior @ h_matrix
+    mu_prior = x_prior @ h_matrix
+
+    site_index = np.asarray(inv_inputs["site_indicator"].values, dtype=int)
+    sigma_index = np.asarray(inv_inputs["sigma_freq_index"].values, dtype=int)
+    nsite = int(site_index.max(initial=0)) + 1
+    nsigma_time = int(sigma_index.max(initial=0)) + 1
+    sigma_posterior = np.broadcast_to(
+        1.0 + draw_offsets[:, None, None],
+        (draw_count, nsite, nsigma_time),
+    ).copy()
+    sigma_prior = np.broadcast_to(
+        1.2 + draw_offsets[:, None, None],
+        (draw_count, nsite, nsigma_time),
+    ).copy()
+    observation_error = np.asarray(inv_inputs["mf_error"].values)
+    epsilon_posterior = np.sqrt(
+        observation_error[None, :] ** 2 + sigma_posterior[:, site_index, sigma_index] ** 2
+    )
+    epsilon_prior = np.sqrt(observation_error[None, :] ** 2 + sigma_prior[:, site_index, sigma_index] ** 2)
+
+    posterior = {
+        "x": x_posterior[None, ...],
+        "sigma": sigma_posterior[None, ...],
+        "mu": mu_posterior[None, ...],
+        "epsilon": epsilon_posterior[None, ...],
+    }
+    prior = {
+        "x": x_prior[None, ...],
+        "sigma": sigma_prior[None, ...],
+        "mu": mu_prior[None, ...],
+        "epsilon": epsilon_prior[None, ...],
+    }
+    dims = {
+        "x": ["nx"],
+        "sigma": ["nsigma_site", "nsigma_time"],
+        "mu": ["nmeasure"],
+        "epsilon": ["nmeasure"],
+        "y": ["nmeasure"],
+    }
+    if reparameterise_log_normal:
+        posterior["x_latent"] = np.log(x_posterior)[None, ...]
+        prior["x_latent"] = np.log(x_prior)[None, ...]
+        dims["x_latent"] = ["nx"]
+    coords = {
+        "nx": inv_inputs["region"].values,
+        "nsigma_site": np.arange(nsite),
+        "nsigma_time": np.arange(nsigma_time),
+        "nmeasure": np.arange(inv_inputs.sizes["nmeasure"]),
+    }
+
+    if use_bc:
+        h_bc = inv_inputs["H_bc"].transpose("bc_region", "nmeasure").values
+        nbc = h_bc.shape[0]
+        bc_posterior = 1.0 + 0.5 * draw_offsets[:, None] + 0.01 * np.arange(nbc)[None, :]
+        bc_prior = 1.0 + draw_offsets[:, None] + 0.01 * np.arange(nbc)[None, :]
+        mu_bc_posterior = bc_posterior @ h_bc
+        mu_bc_prior = bc_prior @ h_bc
+        posterior.update({"bc": bc_posterior[None, ...], "mu_bc": mu_bc_posterior[None, ...]})
+        prior.update({"bc": bc_prior[None, ...], "mu_bc": mu_bc_prior[None, ...]})
+        dims.update({"bc": ["nbc"], "mu_bc": ["nmeasure"]})
+        coords["nbc"] = np.arange(nbc)
+    else:
+        mu_bc_posterior = np.zeros_like(mu_posterior)
+        mu_bc_prior = np.zeros_like(mu_prior)
+
+    y_posterior = mu_posterior + mu_bc_posterior
+    y_prior = mu_prior + mu_bc_prior
+    trace = az.from_dict(
+        posterior=posterior,
+        prior=prior,
+        posterior_predictive={"y": y_posterior[None, ...]},
+        prior_predictive={"y": y_prior[None, ...]},
+        coords=coords,
+        dims=dims,
+    )
+    trace_groups: dict[str, xr.Dataset] = {}
+    nmeasure_index = inv_inputs.indexes["nmeasure"]
+    for group in trace.groups():
+        dataset = trace[group]
+        if "nmeasure" in dataset.dims:
+            level_names = list(nmeasure_index.names)
+            dataset = dataset.assign_coords(
+                {name: ("nmeasure", nmeasure_index.get_level_values(name)) for name in level_names}
+            ).set_index(nmeasure=level_names)
+        if "nbc" in dataset.dims:
+            bc_index = inv_inputs.indexes["bc_region"]
+            level_names = list(bc_index.names)
+            dataset = dataset.assign_coords(
+                {name: ("nbc", bc_index.get_level_values(name)) for name in level_names}
+            ).set_index(nbc=level_names)
+        trace_groups[group] = dataset
+    trace = az.InferenceData(**trace_groups)
+    return {
+        "trace": trace,
+        "model": object(),
+        "xouts": x_posterior,
+    }
+
+
+@pytest.fixture
+def deterministic_sampler(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, object]]:
+    """Replace only ``inferpymc`` and expose the fully prepared call arguments."""
+    calls: list[dict[str, object]] = []
+
+    def fake_inferpymc(**kwargs: object) -> dict[str, object]:
+        """Return independent deterministic results for each fixedbasis call."""
+        calls.append(dict(kwargs))
+        inv_inputs = kwargs["inv_inputs"]
+        assert isinstance(inv_inputs, xr.Dataset)
+        return _deterministic_inferpymc_results(
+            inv_inputs,
+            use_bc=bool(kwargs["use_bc"]),
+            reparameterise_log_normal=bool(kwargs.get("reparameterise_log_normal", False)),
+        )
+
+    monkeypatch.setattr(hbmcmc_module.mcmc, "inferpymc", fake_inferpymc)
+    return calls
+
+
 @pytest.fixture
 def mcmc_args(
     tmp_path,
@@ -151,7 +296,7 @@ def slow_mcmc_args(mcmc_args):
 
 
 @pytest.fixture
-def inv_out(mcmc_args):
+def inv_out(mcmc_args, deterministic_sampler):
     """Return a modern fixedbasis inversion output for postprocessing tests."""
     mcmc_args["output_format"] = "inv_out"
     result = fixedbasisMCMC(**mcmc_args)
@@ -950,7 +1095,7 @@ def test_paris_template_registry_requires_explicit_latest():
     assert latest.flux.exists()
 
 
-def test_save_inversion_output(mcmc_args, tmpdir):
+def test_save_inversion_output(mcmc_args, tmpdir, deterministic_sampler):
     """Check that we can save and reload inversion outputs"""
     mcmc_args["save_inversion_output"] = str(tmpdir / "inv_out.nc")
     mcmc_args["output_format"] = "inv_out"
@@ -965,15 +1110,21 @@ def test_save_inversion_output(mcmc_args, tmpdir):
     xr.testing.assert_identical(inv_out_reloaded.inv_inputs, inv_out.inv_inputs)
 
 
-def test_country_outputs_lognormal_reparam_conflict(mcmc_args, europe_country_file):
+def test_country_outputs_lognormal_reparam_conflict(
+    mcmc_args,
+    europe_country_file,
+    deterministic_sampler,
+):
     """Check country outputs ignore reparameterized latent-only traces."""
     mcmc_args["output_format"] = "inv_out"
     mcmc_args["reparameterise_log_normal"] = True
     mcmc_args["xprior"] = {"pdf": "lognormal", "mu": 1.0, "sigma": 1.0}
 
-    with pytest.warns(FutureWarning, match="reparameterise_log_normal"):
-        inv_out = fixedbasisMCMC(**mcmc_args)
+    inv_out = fixedbasisMCMC(**mcmc_args)
     assert isinstance(inv_out, InversionOutput)
+    assert deterministic_sampler[0]["reparameterise_log_normal"] is True
+    assert deterministic_sampler[0]["xprior"] == mcmc_args["xprior"]
+    assert "x_latent" in inv_out.trace.posterior
     trace_ds = inv_out.trace_dataset(var_roles="flux_scale")
     assert "x_prior" in trace_ds
     assert "x_posterior" in trace_ds
@@ -985,7 +1136,7 @@ def test_country_outputs_lognormal_reparam_conflict(mcmc_args, europe_country_fi
     assert "country_posterior_mean" in country_outs
 
 
-def test_hbmcmc_postprocessing_saves_legacy_output(mcmc_args, tmpdir):
+def test_hbmcmc_postprocessing_saves_legacy_output(mcmc_args, tmpdir, deterministic_sampler):
     """Legacy postprocessing output can still be saved and reloaded."""
     mcmc_args["output_format"] = "hbmcmc_postprocessing"
     mcmc_args["outputpath"] = str(tmpdir)
@@ -1099,7 +1250,10 @@ def test_fixedbasis_mcmc_rejects_retained_column_from_mixed_request(
         fixedbasisMCMC(**mcmc_args)
 
 
-def test_paris_postprocessing_compatibility_matches_paris_output_format(mcmc_args):
+def test_paris_postprocessing_compatibility_matches_paris_output_format(
+    mcmc_args,
+    deterministic_sampler,
+):
     """Compatibility PARIS output matches the explicit canonical format."""
     explicit_args = mcmc_args.copy()
     explicit_args["output_format"] = "paris"
@@ -1120,7 +1274,11 @@ def test_paris_postprocessing_compatibility_matches_paris_output_format(mcmc_arg
     assert explicit["Yapost"].dims == compat["Yapost"].dims
 
 
-def test_hbmcmc_postprocessing_preserves_expected_vars_attrs_and_coords(mcmc_args, tmpdir):
+def test_hbmcmc_postprocessing_preserves_expected_vars_attrs_and_coords(
+    mcmc_args,
+    tmpdir,
+    deterministic_sampler,
+):
     """Legacy-style postprocessing keeps its core vars, attrs, and coords."""
     mcmc_args["output_format"] = "hbmcmc_postprocessing"
     mcmc_args["outputpath"] = str(tmpdir)
@@ -1152,7 +1310,11 @@ def test_hbmcmc_postprocessing_preserves_expected_vars_attrs_and_coords(mcmc_arg
     assert "countrynames" in outputs.coords
 
 
-def test_inv_out_and_trace_outputs_preserve_downstream_dims_and_custom_paths(mcmc_args, tmpdir):
+def test_inv_out_and_trace_outputs_preserve_downstream_dims_and_custom_paths(
+    mcmc_args,
+    tmpdir,
+    deterministic_sampler,
+):
     """Saved trace and inversion output files preserve downstream-facing dims."""
     trace_path = Path(tmpdir) / "custom_trace.nc"
     inv_out_path = Path(tmpdir) / "custom_inv_out.nc"

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -12,6 +12,7 @@ import pandas as pd
 import pymc as pm
 import pytest
 import xarray as xr
+from pytensor.compile.mode import Mode
 
 import openghg_inversions.hbmcmc.inversion_pymc as legacy_mcmc
 import openghg_inversions.inversion_data.preparation as prep_module
@@ -673,6 +674,7 @@ def test_compile_loop_sum_reuses_state_and_sums_named_terms() -> None:
             draws=3,
             var_names=["x_shared", "mu_a", "mu_b", "mu"],
             random_seed=402,
+            compile_kwargs={"mode": Mode(linker="py", optimizer="fast_run")},
         )
 
     assert [rv.name for rv in model.free_RVs].count("x_shared") == 1

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -436,6 +436,32 @@ def _minimal_output_idata() -> az.InferenceData:
     )
 
 
+def _posterior_only_idata(model: pm.Model, variable_names: tuple[str, ...]) -> az.InferenceData:
+    """Build deterministic posterior variables using a PyMC model's coordinates.
+
+    Args:
+        model: Built model defining the requested variables and their dimensions.
+        variable_names: Posterior variable names to include.
+
+    Returns:
+        One-chain, one-draw inference data containing only the requested
+        posterior variables.
+    """
+    coords = {"chain": np.arange(1), "draw": np.arange(1)}
+    posterior_vars: dict[str, tuple[tuple[str, ...], np.ndarray]] = {}
+    for variable_name in variable_names:
+        model_dims = model.named_vars_to_dims[variable_name]
+        for dim in model_dims:
+            coord = model.coords[dim]
+            assert coord is not None
+            coords[dim] = np.asarray(coord)
+        dims = ("chain", "draw", *model_dims)
+        shape = tuple(len(coords[dim]) for dim in dims)
+        posterior_vars[variable_name] = (dims, np.ones(shape))
+
+    return az.InferenceData(posterior=xr.Dataset(posterior_vars, coords=coords))
+
+
 def _postprocessing_output_idata(nregion: int = 1) -> az.InferenceData:
     """Build a small complete trace for modern postprocessing smoke tests."""
     region = np.arange(nregion)
@@ -6174,7 +6200,13 @@ def test_run_rhime_multisector_rejects_single_flux_source(tac_ch4_data_args, tmp
         run_rhime_multisector(**args)
 
 
-def test_run_rhime_api_smoke(tac_ch4_data_args, tmp_path: Path, default_bc_basis_directory) -> None:
+def test_run_rhime_api_smoke(
+    monkeypatch: pytest.MonkeyPatch,
+    tac_ch4_data_args: dict[str, Any],
+    tmp_path: Path,
+    default_bc_basis_directory: Path,
+) -> None:
+    """Run the single-sector API with real preparation, outputs, and mocked sampling."""
     args = tac_ch4_data_args.copy()
     args.update(
         {
@@ -6196,6 +6228,13 @@ def test_run_rhime_api_smoke(tac_ch4_data_args, tmp_path: Path, default_bc_basis
             "sample_kwargs": {"random_seed": 123, "compute_convergence_checks": False},
         }
     )
+
+    def fake_sample(self: RhimeSampler, model: pm.Model) -> az.InferenceData:
+        """Return deterministic scale and modeled-concentration posteriors."""
+        assert self.draws == 1
+        return _posterior_only_idata(model, ("x", "mu"))
+
+    monkeypatch.setattr(RhimeSampler, "sample", fake_sample)
 
     result = run_rhime(**args)
 
@@ -6233,8 +6272,12 @@ def test_run_rhime_api_smoke(tac_ch4_data_args, tmp_path: Path, default_bc_basis
 
 
 def test_run_rhime_multisector_api_smoke(
-    tac_ch4_data_args, tmp_path: Path, default_bc_basis_directory
+    monkeypatch: pytest.MonkeyPatch,
+    tac_ch4_data_args: dict[str, Any],
+    tmp_path: Path,
+    default_bc_basis_directory: Path,
 ) -> None:
+    """Run the multisector API with real diagnostics and mocked sampling."""
     args = tac_ch4_data_args.copy()
     args.update(
         {
@@ -6265,6 +6308,13 @@ def test_run_rhime_multisector_api_smoke(
         }
     )
     args.pop("emissions_name")
+
+    def fake_sample(self: RhimeSampler, model: pm.Model) -> az.InferenceData:
+        """Return deterministic posterior scale factors for both sectors."""
+        assert self.draws == 1
+        return _posterior_only_idata(model, ("x_ff", "x_ocean"))
+
+    monkeypatch.setattr(RhimeSampler, "sample", fake_sample)
 
     result = run_rhime_multisector(**args)
 

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ deps =
     openghgDev: git+https://github.com/openghg/openghg.git@devel
     openghgPrev: {env:OPENGHG_PREV_SPEC:openghg==0.18.0}
 commands =
-    bash {tox_root}/scripts/run_pytest_with_pytensor_compiler.sh pytest -n {env:PYTEST_XDIST_WORKERS:2} --dist=loadscope {posargs:tests}
+    bash {tox_root}/scripts/run_pytest_with_pytensor_compiler.sh pytest -n {env:PYTEST_XDIST_WORKERS:2} --dist=worksteal {posargs:tests}
 
 [testenv:lint]
 description = "Run linters."


### PR DESCRIPTION
* **Summary of changes**

  - Replace redundant PyMC sampling in API, compatibility, postprocessing, and serialization tests with deterministic model-shaped traces.
  - Keep real model preparation, output generation, diagnostics, and file round trips under test.
  - Retain one legacy fixed-basis NumPyro sampling integration as the default suite's end-to-end sampler coverage.
  - Exercise that integration with the current lognormal emissions prior (`stdev=1`) rather than the legacy truncated-normal `x` default.
  - Mark the real sampler test for the experimental Ramsden model as `slow`; its model construction and equations remain covered by default.
  - Use an explicit per-call pure-Python PyTensor linker for two tiny numerical/graph tests that do not need C compilation.
  - Use pytest-xdist's `worksteal` scheduler consistently in CI, tox, and the Pixi task.
  - Reduce fresh-cache two-worker local pytest from 251.88 s before this PR to a 106.84 s mean (about 58%).

Backend and scheduler experiments:

- For the two compile-only targets, default C took 18.39 s, Numba took 5.26 s, and the pure-Python linker took 4.12 s.
- The retained NumPyro integration supports the truncated-normal BC prior; a global `PYTENSOR_FLAGS=mode=JAX` does not support that distribution during prior-predictive sampling.
- A raw explicit Numba linker was not retained because it did not apply the random-variable rewrites required by the components graph.
- Backend choices are scoped to individual tests; production and process-wide defaults are unchanged.
- Two independent fresh-cache `worksteal` runs took 106.94 s and 106.74 s, versus 116.88 s with `loadscope` (8.6% additional improvement), with identical test results.

* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx (no linked issue)
- [x] Tests added and passing
- [ ] Documentation and tutorials updated/added (not required: test/config-only change)
- [ ] Added an entry to the `CHANGELOG.md` file (not required: test/config-only change)
- [ ] Added any new requirements to `requirements.txt` (no new requirements)

Validation:

- `tox -r -p --parallel-no-spinner`
- Fresh-cache full default suite with `worksteal`: 942 passed, 8 skipped, 6 xfailed in 106.94 s and 106.74 s
- Focused backend/marker tests: 17 passed, 1 slow test deselected
- TOML parsing and resolved tox command
- Ruff check and format check