### PR TITLE
Add correlated LogNormal state foundation

### DIFF
--- a/docs/reference/openghg_inversions.correlated_state.rst
+++ b/docs/reference/openghg_inversions.correlated_state.rst
@@ -1,0 +1,7 @@
+openghg\_inversions.correlated\_state
+====================================
+
+.. automodule:: openghg_inversions.correlated_state
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/reference/openghg_inversions.correlated_state.rst
+++ b/docs/reference/openghg_inversions.correlated_state.rst
@@ -1,5 +1,5 @@
 openghg\_inversions.correlated\_state
-====================================
+========================================
 
 .. automodule:: openghg_inversions.correlated_state
    :members:

--- a/docs/reference/openghg_inversions.rst
+++ b/docs/reference/openghg_inversions.rst
@@ -23,6 +23,7 @@ openghg\_inversions
    :maxdepth: 4
 
    openghg_inversions.array_ops
+   openghg_inversions.correlated_state
    openghg_inversions.convert
    openghg_inversions.filters
    openghg_inversions.model_error

--- a/docs/usage/rhime.rst
+++ b/docs/usage/rhime.rst
@@ -720,7 +720,7 @@ public state ``<name>``.
        dims="state",
        coords={"state": ["region-a", "region-b"]},
    )
-   prior = CorrelatedLognormalPrior.from_moments(
+   prior = CorrelatedLognormalPrior(
        mean,
        np.array([[0.16, 0.03], [0.03, 0.09]]),
    )

--- a/docs/usage/rhime.rst
+++ b/docs/usage/rhime.rst
@@ -697,6 +697,7 @@ public state ``<name>``.
 
 .. code-block:: python
 
+   import numpy as np
    import pymc as pm
    import xarray as xr
 
@@ -712,11 +713,11 @@ public state ``<name>``.
    )
    prior = CorrelatedLognormalPrior.from_moments(
        mean,
-       [[0.16, 0.03], [0.03, 0.09]],
+       np.array([[0.16, 0.03], [0.03, 0.09]]),
    )
 
    with pm.Model():
-       state = add_correlated_lognormal_state(prior, var_name="x")
+       state_result = add_correlated_lognormal_state(prior, var_name="x")
 
 This component is intentionally separate from ``StateActivity``. An inactive
 ``StateActivity`` entry is conditioned on a fixed value and restored into the

--- a/docs/usage/rhime.rst
+++ b/docs/usage/rhime.rst
@@ -676,6 +676,72 @@ baseline component.
 The legacy single-sector ``inferpymc`` / ``fixedbasisMCMC`` compatibility path
 continues to sample its full flux state and does not gain multisector behavior.
 
+Correlated Positive States And Marginalization
+----------------------------------------------
+
+``CorrelatedLognormalPrior`` is the low-level contract for one labelled joint
+positive state. It accepts an arithmetic mean vector ``m`` and covariance
+``C`` and constructs the latent Gaussian moments
+
+.. math::
+
+   \Sigma_{ij} = \log\left(1 + \frac{C_{ij}}{m_i m_j}\right),
+   \qquad
+   \mu_i = \log(m_i) - \frac{1}{2}\Sigma_{ii}.
+
+For a mean-one scale state this reduces to ``Sigma = log1p(C)``. The contract
+validates labelled state order, arithmetic covariance, and positive
+definiteness of the derived latent covariance. ``add_correlated_lognormal_state``
+then creates a whitened standard-normal ``<name>_latent`` and the positive
+public state ``<name>``.
+
+.. code-block:: python
+
+   import pymc as pm
+   import xarray as xr
+
+   from openghg_inversions.models import (
+       CorrelatedLognormalPrior,
+       add_correlated_lognormal_state,
+   )
+
+   mean = xr.DataArray(
+       [1.0, 1.0],
+       dims="state",
+       coords={"state": ["region-a", "region-b"]},
+   )
+   prior = CorrelatedLognormalPrior.from_moments(
+       mean,
+       [[0.16, 0.03], [0.03, 0.09]],
+   )
+
+   with pm.Model():
+       state = add_correlated_lognormal_state(prior, var_name="x")
+
+This component is intentionally separate from ``StateActivity``. An inactive
+``StateActivity`` entry is conditioned on a fixed value and restored into the
+full public state. By contrast, ``prior.select_marginal(retained)`` selects the
+principal marginal distribution and returns only retained states; it has no
+fixed-value reconstruction.
+
+Selecting a prior marginal does **not** reduce ``H`` or construct an unresolved
+aggregation covariance. A coherent reduced model must provide a matching
+retained design and aggregation covariance from the same preparation ledger.
+Do not apply ``select_marginal`` independently to an ordinary full-state RHIME
+design. `Issue #566 <https://github.com/openghg/openghg_inversions/issues/566>`_
+tracks that coherent preparation contract.
+
+The covariance matrix uses a distinct second dimension, named
+``<state_dim>_covariance`` by default. If an xarray covariance supplies column
+labels, they must exactly equal the primary state labels in the same order.
+An unlabelled NumPy covariance is interpreted in the arithmetic mean's state
+order. Reordered inputs are rejected rather than interpreted positionally.
+
+The initial public component is intended for custom model builders. Built-in
+``RhimeModelSpec`` integration for a gathered joint state and compatibility
+per-sector aliases is follow-up work; current ``SectorSpec`` priors remain
+independent.
+
 Basis-Aware Prior Standard Deviations
 -------------------------------------
 

--- a/docs/usage/rhime.rst
+++ b/docs/usage/rhime.rst
@@ -616,18 +616,25 @@ Active And Fixed States
 The modern model builders sample only active flux-scaling states. Inactive
 columns are removed from the sampled vector and restored into the full ordered
 ``x`` (or ``x_<sector>``) model variable before the forward calculation and
-postprocessing. By default, a sensitivity column is inactive only when every
-value in that column is exactly zero. No tolerance is applied, so a near-zero
-nonzero column remains active. Inactive multiplicative scaling states default
-to one.
+postprocessing; the corresponding columns of ``H`` are not physically removed.
+By default, a sensitivity column is inactive only when every value in that
+column is exactly zero. No tolerance is applied, so a near-zero nonzero column
+remains active. Inactive multiplicative scaling states default to one. For an
+exactly-zero column the fixed value cannot affect the forward calculation.
 
 ``StateActivity`` can also freeze labelled states, ``basis_group`` values, or a
 complete sector. Labelled masks and fixed values are aligned to the state
 coordinate rather than interpreted as numeric state ranges. Prior distribution
 parameters may likewise be scalars, full one-dimensional arrays, or labelled
-``DataArray`` objects. Given canonical ``inv_inputs``, the following example
-assumes that ``inv_inputs["H"]`` carries a state-aligned ``basis_group``
-coordinate containing the value ``"outer"``:
+``DataArray`` objects. Fixing a nonzero state treats that parameter as known
+exactly; it does not integrate over its prior uncertainty. This represents an
+experiment such as asking what could be recovered if one emissions sector were
+known without uncertainty. The fixed state's uncertainty is deliberately
+removed rather than transferred into aggregation error.
+
+Given canonical ``inv_inputs``, the following example assumes that
+``inv_inputs["H"]`` carries a state-aligned ``basis_group`` coordinate
+containing the value ``"outer"``:
 
 .. code-block:: python
 
@@ -676,8 +683,8 @@ baseline component.
 The legacy single-sector ``inferpymc`` / ``fixedbasisMCMC`` compatibility path
 continues to sample its full flux state and does not gain multisector behavior.
 
-Correlated Positive States And Marginalization
-----------------------------------------------
+Correlated Positive Reduced States
+----------------------------------
 
 ``CorrelatedLognormalPrior`` is the low-level contract for one labelled joint
 positive state. It accepts an arithmetic mean vector ``m`` and covariance
@@ -689,7 +696,9 @@ positive state. It accepts an arithmetic mean vector ``m`` and covariance
    \qquad
    \mu_i = \log(m_i) - \frac{1}{2}\Sigma_{ii}.
 
-For a mean-one scale state this reduces to ``Sigma = log1p(C)``. The contract
+For a mean-one scale state this reduces elementwise to
+:math:`\Sigma_{ij} = \log(1 + C_{ij})`; this is not a matrix logarithm. The
+implementation uses ``np.log1p`` for numerical stability. The contract
 validates labelled state order, arithmetic covariance, and positive
 definiteness of the derived latent covariance. ``add_correlated_lognormal_state``
 then creates a whitened standard-normal ``<name>_latent`` and the positive
@@ -719,18 +728,27 @@ public state ``<name>``.
    with pm.Model():
        state_result = add_correlated_lognormal_state(prior, var_name="x")
 
-This component is intentionally separate from ``StateActivity``. An inactive
-``StateActivity`` entry is conditioned on a fixed value and restored into the
-full public state. By contrast, ``prior.select_marginal(retained)`` selects the
-principal marginal distribution and returns only retained states; it has no
-fixed-value reconstruction.
+``C`` must be the dense covariance of an already-reduced sampled state, such as
+a basis-state covariance ``C_alpha``. It is not the covariance of a native grid.
+For ``p`` sampled states this contract retains several dense ``p`` by ``p``
+matrices, uses additional dense temporaries, and performs a Cholesky
+factorization: persistent matrix storage scales as :math:`O(p^2)` and the
+factorization as :math:`O(p^3)`. Current inversions typically have fewer than
+500 sampled states. Construction emits an operational warning above 1,000
+states; this threshold is not a mathematical limit. Native grids with more
+than 100,000 cells require a structured covariance representation, such as a
+Kronecker product, whose projected products can be evaluated without realizing
+the full native covariance.
 
-Selecting a prior marginal does **not** reduce ``H`` or construct an unresolved
-aggregation covariance. A coherent reduced model must provide a matching
-retained design and aggregation covariance from the same preparation ledger.
-Do not apply ``select_marginal`` independently to an ordinary full-state RHIME
-design. `Issue #566 <https://github.com/openghg/openghg_inversions/issues/566>`_
-tracks that coherent preparation contract.
+This component does **not** perform the native-to-reduced uncertainty
+transformation or remove state coordinates. That work must transform the prior
+uncertainty, forward operator, and aggregation error together. The coherent
+covariance, transformed-forward-model, and aggregation-error identities are
+exact only for a jointly Gaussian state. Reusing the resulting first two
+moments while representing the retained state as LogNormal and the unresolved
+contribution as Gaussian is a moment-matched closure, not exact marginalization
+of a LogNormal state. `Issue #566 <https://github.com/openghg/openghg_inversions/issues/566>`_
+tracks the coherent preparation contract.
 
 The covariance matrix uses a distinct second dimension, named
 ``<state_dim>_covariance`` by default. If an xarray covariance supplies column

--- a/openghg_inversions/correlated_state.py
+++ b/openghg_inversions/correlated_state.py
@@ -23,6 +23,18 @@ import pandas as pd
 import xarray as xr
 
 
+_SERIALIZED_VARIABLE_NAMES = frozenset(
+    {
+        "arithmetic_mean",
+        "arithmetic_covariance",
+        "latent_mean",
+        "latent_covariance",
+        "latent_cholesky",
+        "retained_state",
+    }
+)
+
+
 def _materialize_numeric(array: xr.DataArray, *, name: str) -> np.ndarray:
     """Return an owned array of finite real float64 values."""
     values = np.asarray(array.compute().values)
@@ -261,6 +273,14 @@ class CorrelatedLognormalPrior:
         covariance_dim = covariance_dim or f"{state_dim}_covariance"
         if covariance_dim == state_dim:
             raise ValueError("Covariance matrix axes must use distinct dimension names.")
+        reserved_coord_names = _SERIALIZED_VARIABLE_NAMES | {f"{covariance_dim}_label"}
+        auxiliary_names = {name for name in mean.coords if isinstance(name, str) and name != state_dim}
+        reserved_auxiliary_names = auxiliary_names & reserved_coord_names
+        if reserved_auxiliary_names:
+            raise ValueError(
+                "State auxiliary coordinate names must not use reserved correlated-state "
+                f"dataset names; got {sorted(reserved_auxiliary_names)!r}."
+            )
         if covariance_dim in mean.coords:
             raise ValueError(
                 "Covariance matrix column dimension must not collide with a state or auxiliary "
@@ -549,7 +569,7 @@ class MarginalCorrelatedLognormalPrior:
         dataset = self.full_prior.to_dataset()
         dataset["retained_state"] = (
             self.full_prior.state_dim,
-            np.asarray(self._retained.values, dtype=bool),
+            np.array(self._retained.values, dtype=bool, copy=True),
         )
         dataset.attrs = dict(dataset.attrs)
         dataset.attrs["inactive_state_semantics"] = "coherent_prior_marginalization"

--- a/openghg_inversions/correlated_state.py
+++ b/openghg_inversions/correlated_state.py
@@ -1,21 +1,37 @@
 """Labelled arithmetic-moment contracts for correlated positive states.
 
-This module is backend-neutral.  It validates the scientific state coordinate
-and converts requested arithmetic LogNormal moments into the latent Gaussian
-moments needed by a model backend.  PyMC graph construction lives in
+This backend-neutral module validates an already-reduced state coordinate and
+an explicitly dense arithmetic covariance, then derives the latent Gaussian
+moments required to represent those moments with a multivariate LogNormal
+distribution. PyMC graph construction lives in
 ``openghg_inversions.models.components``.
 
-Correlated marginalization is deliberately separate from
-``models.StateActivity``.  ``StateActivity`` conditions inactive states on
-configured fixed values; selecting a principal marginal from a joint prior is
-a different statistical operation and must not silently restore omitted states
-as constants.
+The covariance accepted here is for the reduced inversion state, not a native
+grid. The implementation materializes dense covariance, latent-covariance, and
+Cholesky arrays, with quadratic memory use and cubic factorization cost. Native
+covariances with tens or hundreds of thousands of grid cells must therefore
+remain structured and be projected into the reduced state before constructing
+this contract.
+
+This module does not perform that native-to-reduced transformation or remove
+state components. The coherent covariance, transformed-forward-model, and
+aggregation-error identities are exact only for a jointly Gaussian state.
+Reusing the resulting first two moments while representing the retained state
+as LogNormal and the unresolved contribution as Gaussian is a moment-matched
+closure, not exact marginalization of a LogNormal state. Fixing a state at a
+known value is instead handled by ``models.StateActivity``.
+
+The main entry point is ``CorrelatedLognormalPrior``. Its constructor and
+``from_moments`` eagerly compute xarray inputs and own independent copies;
+``to_dataset`` and ``from_dataset`` provide persistence boundaries. Construction
+warns before dense covariance materialization when the reduced state exceeds
+1,000 components.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 import json
+import warnings
 from typing import Any
 
 import numpy as np
@@ -30,13 +46,29 @@ _SERIALIZED_VARIABLE_NAMES = frozenset(
         "latent_mean",
         "latent_covariance",
         "latent_cholesky",
-        "retained_state",
     }
 )
 
+_DENSE_STATE_WARNING_THRESHOLD = 1000
+
 
 def _materialize_numeric(array: xr.DataArray, *, name: str) -> np.ndarray:
-    """Return an owned array of finite real float64 values."""
+    """Materialize an xarray object as owned finite real float64 values.
+
+    Args:
+        array: Labelled array to compute and copy into memory.
+        name: Human-readable input name used in validation errors.
+
+    Returns:
+        An owned NumPy array with ``float64`` dtype.
+
+    Raises:
+        ValueError: If the values are non-numeric, complex, or non-finite.
+
+    Notes:
+        Calling ``compute`` can trigger lazy computation or input/output before
+        the returned values are copied into memory.
+    """
     values = np.asarray(array.compute().values)
     if not np.issubdtype(values.dtype, np.number) or np.issubdtype(values.dtype, np.complexfloating):
         raise ValueError(f"{name} must contain real numeric values.")
@@ -52,7 +84,22 @@ def _copy_state_auxiliary_coords(
     *,
     state_dim: str,
 ) -> xr.DataArray:
-    """Copy ordinary state-aligned metadata not recreated by the state index."""
+    """Copy state-aligned auxiliary coordinates into a canonical array.
+
+    Args:
+        target: Canonical array that already owns its primary coordinates.
+        source: Array from which auxiliary state metadata is copied.
+        state_dim: Name of the sole permitted dimension for copied coordinates.
+
+    Returns:
+        A deep copy of ``target`` with compatible auxiliary coordinates copied
+        from ``source``.
+
+    Notes:
+        Scalar and ``state_dim``-only coordinates are compatible. Coordinates
+        already present on ``target`` or involving any other dimension are
+        skipped.
+    """
     result = target
     for name, coord in source.coords.items():
         if name in result.coords:
@@ -63,7 +110,20 @@ def _copy_state_auxiliary_coords(
 
 
 def _require_state_index(array: xr.DataArray, state_dim: str, *, name: str) -> pd.Index:
-    """Return the unique labelled index owned by ``state_dim``."""
+    """Validate and return the labelled index owned by a state dimension.
+
+    Args:
+        array: Array whose state index is required.
+        state_dim: Name of the state dimension and coordinate.
+        name: Human-readable input name used in validation errors.
+
+    Returns:
+        The unique pandas index attached to ``state_dim``.
+
+    Raises:
+        ValueError: If the coordinate is absent or non-unique, or if a
+            MultiIndex has missing or duplicate level names.
+    """
     if state_dim not in array.coords or state_dim not in array.indexes:
         raise ValueError(f"{name} must have a labelled {state_dim!r} coordinate.")
     index = array.indexes[state_dim]
@@ -96,7 +156,22 @@ def _covariance_array(
     state_dim: str,
     covariance_dim: str,
 ) -> xr.DataArray:
-    """Normalize covariance to one labelled and one same-order matrix axis."""
+    """Normalize covariance to labelled rows and a same-order column axis.
+
+    Args:
+        covariance: Dense covariance values, optionally with xarray labels.
+        mean: Validated one-dimensional arithmetic mean.
+        state_dim: Name of the labelled covariance row dimension.
+        covariance_dim: Distinct name for the covariance column dimension.
+
+    Returns:
+        An owned ``float64`` covariance with canonical dimensions and a
+        serialized column-label identity coordinate.
+
+    Raises:
+        ValueError: If the shape, dimensions, labels, values, or serialized
+            column identity do not match the arithmetic mean.
+    """
     state_coord = mean.coords[state_dim]
     mean_index = _require_state_index(mean, state_dim, name="Arithmetic mean")
     state_size = mean.sizes[state_dim]
@@ -176,15 +251,57 @@ def _matrix_tolerance(values: np.ndarray) -> float:
     return 1e-10 * max(float(np.max(np.abs(values))), 1.0)
 
 
-@dataclass(frozen=True, init=False)
+def _warn_large_dense_state(state_size: int) -> None:
+    """Warn when a dense reduced state exceeds the operational size threshold.
+
+    Args:
+        state_size: Number of components in the reduced inversion state.
+
+    Warns:
+        UserWarning: If ``state_size`` exceeds the operational threshold of
+            1000 components. The threshold is not a mathematical limit.
+    """
+    if state_size > _DENSE_STATE_WARNING_THRESHOLD:
+        warnings.warn(
+            "CorrelatedLognormalPrior expects an already-reduced dense covariance; "
+            f"state size {state_size} exceeds the operational threshold of "
+            f"{_DENSE_STATE_WARNING_THRESHOLD} (not a mathematical limit). This "
+            "representation is unsuitable for a native-grid covariance.",
+            UserWarning,
+            stacklevel=3,
+        )
+
+
 class CorrelatedLognormalPrior:
     """Validated labelled moments for one correlated positive state vector.
 
-    ``arithmetic_covariance`` uses a distinct second matrix dimension whose
-    entries are declared to follow the primary state coordinate in the same
-    order.  Only the primary axis owns the rich scientific coordinate.  This
-    avoids duplicating MultiIndex level coordinates while retaining an explicit
-    labelled row contract.
+    The arithmetic covariance is an already-reduced dense matrix. It uses a
+    distinct second dimension whose entries follow the primary state coordinate
+    in the same order. Only the primary axis owns the rich scientific
+    coordinate, avoiding duplicate MultiIndex level coordinates while retaining
+    an explicit labelled-row contract.
+
+    Attributes:
+        mean: Arithmetic mean with dimension ``(state_dim,)``. Access returns
+            an independent deep copy.
+        arithmetic_covariance: Dense arithmetic covariance with dimensions
+            ``(state_dim, covariance_dim)``. Access returns an independent deep
+            copy.
+        latent_mean: Derived Gaussian mean with dimension ``(state_dim,)``.
+            Access returns an independent deep copy.
+        latent_covariance: Derived Gaussian covariance with dimensions
+            ``(state_dim, covariance_dim)``. Access returns an independent deep
+            copy.
+        latent_cholesky: Lower Cholesky factor with dimensions
+            ``(state_dim, covariance_dim)``. Access returns an independent deep
+            copy.
+        state_dim: Name of the scientific state dimension.
+        covariance_dim: Name of the same-order covariance column dimension.
+
+    Notes:
+        Construction owns all supplied values. Array properties return deep
+        copies so callers cannot mutate the cached validated moments through
+        the public API.
     """
 
     _mean: xr.DataArray
@@ -195,75 +312,94 @@ class CorrelatedLognormalPrior:
     state_dim: str
     covariance_dim: str
 
-    def __init__(self, *_args: object, **_kwargs: object) -> None:
-        """Require construction through ``from_moments`` validation."""
-        raise TypeError("Use CorrelatedLognormalPrior.from_moments(...) to construct a prior.")
-
-    @classmethod
-    def _from_validated(
-        cls,
-        *,
-        mean: xr.DataArray,
-        arithmetic_covariance: xr.DataArray,
-        latent_mean: xr.DataArray,
-        latent_covariance: xr.DataArray,
-        latent_cholesky: xr.DataArray,
-        state_dim: str,
-        covariance_dim: str,
-    ) -> CorrelatedLognormalPrior:
-        """Construct an instance after the public validation boundary."""
-        instance = object.__new__(cls)
-        object.__setattr__(instance, "_mean", mean.copy(deep=True))
-        object.__setattr__(instance, "_arithmetic_covariance", arithmetic_covariance.copy(deep=True))
-        object.__setattr__(instance, "_latent_mean", latent_mean.copy(deep=True))
-        object.__setattr__(instance, "_latent_covariance", latent_covariance.copy(deep=True))
-        object.__setattr__(instance, "_latent_cholesky", latent_cholesky.copy(deep=True))
-        object.__setattr__(instance, "state_dim", state_dim)
-        object.__setattr__(instance, "covariance_dim", covariance_dim)
-        return instance
-
     @property
     def mean(self) -> xr.DataArray:
-        """Return an independent copy of the validated arithmetic mean."""
+        """Return the validated arithmetic mean.
+
+        Returns:
+            An independent deep copy of the labelled arithmetic mean.
+        """
         return self._mean.copy(deep=True)
 
     @property
     def arithmetic_covariance(self) -> xr.DataArray:
-        """Return an independent copy of the validated arithmetic covariance."""
+        """Return the validated arithmetic covariance.
+
+        Returns:
+            An independent deep copy of the dense labelled covariance.
+        """
         return self._arithmetic_covariance.copy(deep=True)
 
     @property
     def latent_mean(self) -> xr.DataArray:
-        """Return an independent copy of the derived latent mean."""
+        """Return the derived latent Gaussian mean.
+
+        Returns:
+            An independent deep copy of the labelled latent mean.
+        """
         return self._latent_mean.copy(deep=True)
 
     @property
     def latent_covariance(self) -> xr.DataArray:
-        """Return an independent copy of the derived latent covariance."""
+        """Return the derived latent Gaussian covariance.
+
+        Returns:
+            An independent deep copy of the dense latent covariance.
+        """
         return self._latent_covariance.copy(deep=True)
 
     @property
     def latent_cholesky(self) -> xr.DataArray:
-        """Return an independent copy of the derived latent Cholesky factor."""
+        """Return the Cholesky factor of the latent covariance.
+
+        Returns:
+            An independent deep copy of the dense lower-triangular factor.
+        """
         return self._latent_cholesky.copy(deep=True)
 
-    @classmethod
-    def from_moments(
-        cls,
+    def __init__(
+        self,
         mean: xr.DataArray,
         arithmetic_covariance: xr.DataArray | np.ndarray,
         *,
         covariance_dim: str | None = None,
-    ) -> CorrelatedLognormalPrior:
-        """Validate arithmetic moments and derive latent Gaussian moments.
+    ) -> None:
+        """Validate arithmetic moments and derive cached latent moments.
 
-        For arithmetic mean ``m`` and covariance ``C``, the latent moments are
+        Args:
+            mean: Positive one-dimensional arithmetic mean with a unique
+                labelled state coordinate.
+            arithmetic_covariance: Already-reduced dense arithmetic covariance.
+                Its shape must be ``(p, p)`` for a length-``p`` mean. Xarray
+                input must use the state dimension for rows and
+                ``covariance_dim`` for columns, with matching label order;
+                NumPy input is interpreted positionally in mean-label order.
+            covariance_dim: Optional name for the covariance column dimension.
+                Defaults to ``"{state_dim}_covariance"``.
 
-        ``Sigma[i,j] = log(1 + C[i,j] / (m[i] * m[j]))`` and
-        ``mu[i] = log(m[i]) - 0.5 * Sigma[i,i]``.
+        Raises:
+            TypeError: If ``mean`` is not an xarray ``DataArray``.
+            ValueError: If dimensions, labels, values, or arithmetic moments
+                do not define a finite positive-definite latent covariance.
 
-        The familiar mean-one contract is the special case
-        ``Sigma = log1p(C)``.
+        Warns:
+            UserWarning: If the reduced state contains more than 1000
+                components. This is an operational threshold, not a
+                mathematical limit.
+
+        Notes:
+            Inputs are eagerly computed, canonicalized, and copied. Mean and
+            covariance units must be consistent (covariance has squared mean
+            units); unit metadata is retained where possible but is neither
+            converted nor validated.
+
+            For arithmetic mean ``m`` and covariance ``C``, each latent
+            covariance entry is
+            ``Sigma[i,j] = log(1 + C[i,j] / (m[i] * m[j]))`` and
+            ``mu[i] = log(m[i]) - 0.5 * Sigma[i,i]``. For a mean-one state this
+            becomes ``Sigma[i,j] = log(1 + C[i,j])`` element by element; the
+            implementation uses ``numpy.log1p`` for that scalar operation and
+            does not take a matrix logarithm.
         """
         if not isinstance(mean, xr.DataArray):
             raise TypeError("Arithmetic mean must be an xarray DataArray.")
@@ -295,6 +431,7 @@ class CorrelatedLognormalPrior:
         mean_values = _materialize_numeric(mean, name="Arithmetic mean")
         if (mean_values <= 0).any():
             raise ValueError("Arithmetic mean must contain only positive values.")
+        _warn_large_dense_state(mean.sizes[state_dim])
 
         covariance = _covariance_array(
             arithmetic_covariance,
@@ -368,79 +505,70 @@ class CorrelatedLognormalPrior:
             canonical_mean,
             state_dim=state_dim,
         )
-        return cls._from_validated(
-            mean=canonical_mean,
-            arithmetic_covariance=covariance,
-            latent_mean=canonical_latent_mean,
-            latent_covariance=xr.DataArray(
-                latent_covariance_values,
-                dims=(state_dim, covariance_dim),
-                coords=matrix_coords,
-                name="latent_covariance",
-            ),
-            latent_cholesky=xr.DataArray(
-                latent_cholesky_values,
-                dims=(state_dim, covariance_dim),
-                coords=matrix_coords,
-                name="latent_cholesky",
-            ),
-            state_dim=state_dim,
+        self._mean = canonical_mean.copy(deep=True)
+        self._arithmetic_covariance = covariance.copy(deep=True)
+        self._latent_mean = canonical_latent_mean.copy(deep=True)
+        self._latent_covariance = xr.DataArray(
+            latent_covariance_values,
+            dims=(state_dim, covariance_dim),
+            coords=matrix_coords,
+            name="latent_covariance",
+        ).copy(deep=True)
+        self._latent_cholesky = xr.DataArray(
+            latent_cholesky_values,
+            dims=(state_dim, covariance_dim),
+            coords=matrix_coords,
+            name="latent_cholesky",
+        ).copy(deep=True)
+        self.state_dim = state_dim
+        self.covariance_dim = covariance_dim
+
+    @classmethod
+    def from_moments(
+        cls,
+        mean: xr.DataArray,
+        arithmetic_covariance: xr.DataArray | np.ndarray,
+        *,
+        covariance_dim: str | None = None,
+    ) -> CorrelatedLognormalPrior:
+        """Construct a prior from labelled arithmetic moments.
+
+        Args:
+            mean: Positive one-dimensional arithmetic mean with a unique
+                labelled state coordinate.
+            arithmetic_covariance: Already-reduced dense ``(p, p)`` arithmetic
+                covariance. Xarray labels must match ``mean`` exactly; NumPy
+                values are interpreted in mean-label order.
+            covariance_dim: Optional name for the covariance column dimension;
+                see the constructor for the complete coordinate contract.
+
+        Returns:
+            A validated contract containing owned arithmetic moments and the
+            derived latent Gaussian moments.
+
+        Raises:
+            TypeError: If ``mean`` is not an xarray ``DataArray``.
+            ValueError: If dimensions, labels, values, or arithmetic moments
+                fail validation.
+
+        Warns:
+            UserWarning: If the reduced state contains more than 1000
+                components. This is an operational threshold, not a
+                mathematical limit.
+        """
+        return cls(
+            mean,
+            arithmetic_covariance,
             covariance_dim=covariance_dim,
         )
 
-    def select_marginal(self, retained: xr.DataArray) -> MarginalCorrelatedLognormalPrior:
-        """Select a labelled principal marginal without fixing omitted states.
-
-        This operation only marginalizes the prior. It does not reduce a
-        forward operator or construct the unresolved aggregation covariance.
-        Callers using coherent reduction must supply the matching retained
-        design and unresolved covariance from the same preparation ledger.
-        """
-        if retained.dims != (self.state_dim,):
-            raise ValueError(
-                f"Retained-state mask must have only the {self.state_dim!r} dimension; got {retained.dims!r}."
-            )
-        retained_index = _require_state_index(retained, self.state_dim, name="Retained-state mask")
-        state_index = self._mean.indexes[self.state_dim]
-        if not retained_index.equals(state_index):
-            raise ValueError(
-                "Retained-state mask labels must exactly match the prior state labels in the same order."
-            )
-        retained_values = np.asarray(retained.compute().values)
-        if retained_values.dtype != np.dtype(bool):
-            raise ValueError("Retained-state mask must contain only boolean values.")
-        positions = np.flatnonzero(retained_values)
-        if positions.size == 0:
-            raise ValueError("A correlated LogNormal marginal must retain at least one state.")
-
-        marginal_mean = self._mean.isel({self.state_dim: positions})
-        marginal_covariance = self._arithmetic_covariance.isel(
-            {self.state_dim: positions, self.covariance_dim: positions}
-        )
-        prior = CorrelatedLognormalPrior.from_moments(
-            marginal_mean,
-            marginal_covariance,
-            covariance_dim=self.covariance_dim,
-        )
-        canonical_mask = xr.DataArray(
-            retained_values,
-            dims=(self.state_dim,),
-            coords={self.state_dim: self._mean.coords[self.state_dim]},
-            name="retained_state",
-        )
-        canonical_mask = _copy_state_auxiliary_coords(
-            canonical_mask,
-            self._mean,
-            state_dim=self.state_dim,
-        )
-        return MarginalCorrelatedLognormalPrior._from_validated(
-            full_prior=self,
-            retained=canonical_mask,
-            prior=prior,
-        )
-
     def to_dataset(self) -> xr.Dataset:
-        """Return a serializable labelled dataset containing both moment spaces."""
+        """Serialize the validated arithmetic and latent moments.
+
+        Returns:
+            A new labelled dataset containing deep copies of both moment
+            parameterizations and the correlated-state schema metadata.
+        """
         return xr.Dataset(
             {
                 self._mean.name: self._mean.copy(deep=True),
@@ -460,7 +588,28 @@ class CorrelatedLognormalPrior:
 
     @classmethod
     def from_dataset(cls, dataset: xr.Dataset) -> CorrelatedLognormalPrior:
-        """Reload and revalidate a dataset produced by ``to_dataset``."""
+        """Reload and revalidate a serialized correlated-state contract.
+
+        Args:
+            dataset: Dataset produced by :meth:`to_dataset`.
+
+        Returns:
+            A newly validated prior derived from the stored arithmetic moments.
+
+        Raises:
+            ValueError: If schema metadata, variables, dimensions, labels, or
+                cached latent moments are missing or inconsistent.
+
+        Warns:
+            UserWarning: If the stored reduced state contains more than 1000
+                components. This is an operational threshold, not a
+                mathematical limit.
+
+        Notes:
+            Stored latent values are checked against moments recomputed from
+            the eagerly materialized arithmetic inputs; they are never trusted
+            as an alternative construction path.
+        """
         expected_schema = "openghg_inversions.correlated_lognormal_prior/v1"
         if dataset.attrs.get("correlated_state_schema") != expected_schema:
             raise ValueError("Correlated-state dataset has an unsupported or missing schema declaration.")
@@ -521,66 +670,3 @@ class CorrelatedLognormalPrior:
             ):
                 raise ValueError(f"Stored {name!r} is inconsistent with the declared arithmetic moments.")
         return prior
-
-
-@dataclass(frozen=True, init=False)
-class MarginalCorrelatedLognormalPrior:
-    """Explicit result of marginalizing a labelled joint prior.
-
-    This object intentionally has no fixed-value or full-state reconstruction
-    field.  Omitted states are integrated out, not conditioned on constants.
-    """
-
-    full_prior: CorrelatedLognormalPrior
-    _retained: xr.DataArray
-    prior: CorrelatedLognormalPrior
-
-    def __init__(self, *_args: object, **_kwargs: object) -> None:
-        """Require construction through validated marginal selection."""
-        raise TypeError("Use CorrelatedLognormalPrior.select_marginal(...) to construct a marginal prior.")
-
-    @classmethod
-    def _from_validated(
-        cls,
-        *,
-        full_prior: CorrelatedLognormalPrior,
-        retained: xr.DataArray,
-        prior: CorrelatedLognormalPrior,
-    ) -> MarginalCorrelatedLognormalPrior:
-        """Construct the wrapper after recomputing its principal marginal."""
-        instance = object.__new__(cls)
-        object.__setattr__(instance, "full_prior", full_prior)
-        object.__setattr__(instance, "_retained", retained.copy(deep=True))
-        object.__setattr__(instance, "prior", prior)
-        return instance
-
-    @property
-    def retained(self) -> xr.DataArray:
-        """Return an independent copy of the validated retained-state mask."""
-        return self._retained.copy(deep=True)
-
-    @property
-    def omitted(self) -> xr.DataArray:
-        """Return the labelled omitted-state mask in full-state order."""
-        return (~self._retained).rename("marginalized_state").copy(deep=True)
-
-    def to_dataset(self) -> xr.Dataset:
-        """Serialize the full prior and retained-state marginalization ledger."""
-        dataset = self.full_prior.to_dataset()
-        dataset["retained_state"] = (
-            self.full_prior.state_dim,
-            np.array(self._retained.values, dtype=bool, copy=True),
-        )
-        dataset.attrs = dict(dataset.attrs)
-        dataset.attrs["inactive_state_semantics"] = "coherent_prior_marginalization"
-        return dataset
-
-    @classmethod
-    def from_dataset(cls, dataset: xr.Dataset) -> MarginalCorrelatedLognormalPrior:
-        """Reload and reapply an explicit coherent-marginalization ledger."""
-        if dataset.attrs.get("inactive_state_semantics") != "coherent_prior_marginalization":
-            raise ValueError("Marginal correlated-state dataset must declare coherent prior marginalization.")
-        if "retained_state" not in dataset:
-            raise ValueError("Marginal correlated-state dataset is missing 'retained_state'.")
-        full_prior = CorrelatedLognormalPrior.from_dataset(dataset)
-        return full_prior.select_marginal(dataset["retained_state"])

--- a/openghg_inversions/correlated_state.py
+++ b/openghg_inversions/correlated_state.py
@@ -24,14 +24,30 @@ import xarray as xr
 
 
 def _materialize_numeric(array: xr.DataArray, *, name: str) -> np.ndarray:
-    """Return finite float64 values from a labelled array."""
+    """Return an owned array of finite real float64 values."""
     values = np.asarray(array.compute().values)
-    if not np.issubdtype(values.dtype, np.number):
-        raise ValueError(f"{name} must contain numeric values.")
-    values = np.asarray(values, dtype=np.float64)
+    if not np.issubdtype(values.dtype, np.number) or np.issubdtype(values.dtype, np.complexfloating):
+        raise ValueError(f"{name} must contain real numeric values.")
+    values = np.array(values, dtype=np.float64, copy=True)
     if not np.isfinite(values).all():
         raise ValueError(f"{name} must contain only finite values.")
     return values
+
+
+def _copy_state_auxiliary_coords(
+    target: xr.DataArray,
+    source: xr.DataArray,
+    *,
+    state_dim: str,
+) -> xr.DataArray:
+    """Copy ordinary state-aligned metadata not recreated by the state index."""
+    result = target
+    for name, coord in source.coords.items():
+        if name in result.coords:
+            continue
+        if set(coord.dims).issubset({state_dim}):
+            result = result.assign_coords({name: coord.copy(deep=True)})
+    return result.copy(deep=True)
 
 
 def _require_state_index(array: xr.DataArray, state_dim: str, *, name: str) -> pd.Index:
@@ -124,13 +140,13 @@ def _covariance_array(
                 "Arithmetic covariance must be square and match the state length; "
                 f"got shape {values.shape!r} for {state_size} states."
             )
-        if not np.issubdtype(values.dtype, np.number):
-            raise ValueError("Arithmetic covariance must contain numeric values.")
-        values = np.asarray(values, dtype=np.float64)
+        if not np.issubdtype(values.dtype, np.number) or np.issubdtype(values.dtype, np.complexfloating):
+            raise ValueError("Arithmetic covariance must contain real numeric values.")
+        values = np.array(values, dtype=np.float64, copy=True)
         if not np.isfinite(values).all():
             raise ValueError("Arithmetic covariance must contain only finite values.")
 
-    return xr.DataArray(
+    result = xr.DataArray(
         values,
         dims=(state_dim, covariance_dim),
         coords={
@@ -140,6 +156,7 @@ def _covariance_array(
         name="arithmetic_covariance",
         attrs=covariance_attrs,
     )
+    return _copy_state_auxiliary_coords(result, mean, state_dim=state_dim)
 
 
 def _matrix_tolerance(values: np.ndarray) -> float:
@@ -158,11 +175,11 @@ class CorrelatedLognormalPrior:
     labelled row contract.
     """
 
-    mean: xr.DataArray
-    arithmetic_covariance: xr.DataArray
-    latent_mean: xr.DataArray
-    latent_covariance: xr.DataArray
-    latent_cholesky: xr.DataArray
+    _mean: xr.DataArray
+    _arithmetic_covariance: xr.DataArray
+    _latent_mean: xr.DataArray
+    _latent_covariance: xr.DataArray
+    _latent_cholesky: xr.DataArray
     state_dim: str
     covariance_dim: str
 
@@ -184,14 +201,39 @@ class CorrelatedLognormalPrior:
     ) -> CorrelatedLognormalPrior:
         """Construct an instance after the public validation boundary."""
         instance = object.__new__(cls)
-        object.__setattr__(instance, "mean", mean)
-        object.__setattr__(instance, "arithmetic_covariance", arithmetic_covariance)
-        object.__setattr__(instance, "latent_mean", latent_mean)
-        object.__setattr__(instance, "latent_covariance", latent_covariance)
-        object.__setattr__(instance, "latent_cholesky", latent_cholesky)
+        object.__setattr__(instance, "_mean", mean.copy(deep=True))
+        object.__setattr__(instance, "_arithmetic_covariance", arithmetic_covariance.copy(deep=True))
+        object.__setattr__(instance, "_latent_mean", latent_mean.copy(deep=True))
+        object.__setattr__(instance, "_latent_covariance", latent_covariance.copy(deep=True))
+        object.__setattr__(instance, "_latent_cholesky", latent_cholesky.copy(deep=True))
         object.__setattr__(instance, "state_dim", state_dim)
         object.__setattr__(instance, "covariance_dim", covariance_dim)
         return instance
+
+    @property
+    def mean(self) -> xr.DataArray:
+        """Return an independent copy of the validated arithmetic mean."""
+        return self._mean.copy(deep=True)
+
+    @property
+    def arithmetic_covariance(self) -> xr.DataArray:
+        """Return an independent copy of the validated arithmetic covariance."""
+        return self._arithmetic_covariance.copy(deep=True)
+
+    @property
+    def latent_mean(self) -> xr.DataArray:
+        """Return an independent copy of the derived latent mean."""
+        return self._latent_mean.copy(deep=True)
+
+    @property
+    def latent_covariance(self) -> xr.DataArray:
+        """Return an independent copy of the derived latent covariance."""
+        return self._latent_covariance.copy(deep=True)
+
+    @property
+    def latent_cholesky(self) -> xr.DataArray:
+        """Return an independent copy of the derived latent Cholesky factor."""
+        return self._latent_cholesky.copy(deep=True)
 
     @classmethod
     def from_moments(
@@ -214,9 +256,7 @@ class CorrelatedLognormalPrior:
         if not isinstance(mean, xr.DataArray):
             raise TypeError("Arithmetic mean must be an xarray DataArray.")
         if mean.ndim != 1:
-            raise ValueError(
-                f"Arithmetic mean must be one-dimensional; got dimensions {mean.dims!r}."
-            )
+            raise ValueError(f"Arithmetic mean must be one-dimensional; got dimensions {mean.dims!r}.")
         state_dim = str(mean.dims[0])
         covariance_dim = covariance_dim or f"{state_dim}_covariance"
         if covariance_dim == state_dim:
@@ -256,12 +296,16 @@ class CorrelatedLognormalPrior:
         if float(np.linalg.eigvalsh(covariance_values).min()) < -tolerance:
             raise ValueError("Arithmetic covariance must be positive semidefinite.")
 
-        relative_covariance = covariance_values / np.outer(mean_values, mean_values)
+        with np.errstate(divide="ignore", invalid="ignore", over="ignore"):
+            relative_covariance = covariance_values / np.outer(mean_values, mean_values)
+        if not np.isfinite(relative_covariance).all():
+            raise ValueError("Arithmetic moments must produce only finite relative covariance values.")
         if (1.0 + relative_covariance <= 0).any():
-            raise ValueError(
-                "Arithmetic moments do not define finite LogNormal latent covariance entries."
-            )
-        latent_covariance_values = np.log1p(relative_covariance)
+            raise ValueError("Arithmetic moments do not define finite LogNormal latent covariance entries.")
+        with np.errstate(divide="ignore", invalid="ignore", over="ignore"):
+            latent_covariance_values = np.log1p(relative_covariance)
+        if not np.isfinite(latent_covariance_values).all():
+            raise ValueError("Derived latent covariance must contain only finite values.")
         latent_tolerance = _matrix_tolerance(latent_covariance_values)
         if not np.allclose(
             latent_covariance_values,
@@ -275,29 +319,39 @@ class CorrelatedLognormalPrior:
         except np.linalg.LinAlgError as exc:
             minimum = float(np.linalg.eigvalsh(latent_covariance_values).min())
             raise ValueError(
-                "Derived latent covariance must be positive definite; "
-                f"minimum eigenvalue is {minimum:.6g}."
+                f"Derived latent covariance must be positive definite; minimum eigenvalue is {minimum:.6g}."
             ) from exc
 
         latent_mean_values = np.log(mean_values) - 0.5 * np.diag(latent_covariance_values)
+        if not np.isfinite(latent_mean_values).all():
+            raise ValueError("Derived latent mean must contain only finite values.")
         state_coord = mean.coords[state_dim]
-        canonical_mean = xr.DataArray(
-            mean_values,
-            dims=(state_dim,),
-            coords={state_dim: state_coord},
-            name="arithmetic_mean",
-            attrs=dict(mean.attrs),
+        canonical_mean = _copy_state_auxiliary_coords(
+            xr.DataArray(
+                mean_values,
+                dims=(state_dim,),
+                coords={state_dim: state_coord},
+                name="arithmetic_mean",
+                attrs=dict(mean.attrs),
+            ),
+            mean,
+            state_dim=state_dim,
         )
-        matrix_coords = {state_dim: state_coord}
-        return cls._from_validated(
-            mean=canonical_mean,
-            arithmetic_covariance=covariance,
-            latent_mean=xr.DataArray(
+        matrix_coords = {name: coord for name, coord in canonical_mean.coords.items()}
+        canonical_latent_mean = _copy_state_auxiliary_coords(
+            xr.DataArray(
                 latent_mean_values,
                 dims=(state_dim,),
                 coords={state_dim: state_coord},
                 name="latent_mean",
             ),
+            canonical_mean,
+            state_dim=state_dim,
+        )
+        return cls._from_validated(
+            mean=canonical_mean,
+            arithmetic_covariance=covariance,
+            latent_mean=canonical_latent_mean,
             latent_covariance=xr.DataArray(
                 latent_covariance_values,
                 dims=(state_dim, covariance_dim),
@@ -324,11 +378,10 @@ class CorrelatedLognormalPrior:
         """
         if retained.dims != (self.state_dim,):
             raise ValueError(
-                f"Retained-state mask must have only the {self.state_dim!r} dimension; "
-                f"got {retained.dims!r}."
+                f"Retained-state mask must have only the {self.state_dim!r} dimension; got {retained.dims!r}."
             )
         retained_index = _require_state_index(retained, self.state_dim, name="Retained-state mask")
-        state_index = self.mean.indexes[self.state_dim]
+        state_index = self._mean.indexes[self.state_dim]
         if not retained_index.equals(state_index):
             raise ValueError(
                 "Retained-state mask labels must exactly match the prior state labels in the same order."
@@ -340,8 +393,8 @@ class CorrelatedLognormalPrior:
         if positions.size == 0:
             raise ValueError("A correlated LogNormal marginal must retain at least one state.")
 
-        marginal_mean = self.mean.isel({self.state_dim: positions})
-        marginal_covariance = self.arithmetic_covariance.isel(
+        marginal_mean = self._mean.isel({self.state_dim: positions})
+        marginal_covariance = self._arithmetic_covariance.isel(
             {self.state_dim: positions, self.covariance_dim: positions}
         )
         prior = CorrelatedLognormalPrior.from_moments(
@@ -352,20 +405,29 @@ class CorrelatedLognormalPrior:
         canonical_mask = xr.DataArray(
             retained_values,
             dims=(self.state_dim,),
-            coords={self.state_dim: self.mean.coords[self.state_dim]},
+            coords={self.state_dim: self._mean.coords[self.state_dim]},
             name="retained_state",
         )
-        return MarginalCorrelatedLognormalPrior(full_prior=self, retained=canonical_mask, prior=prior)
+        canonical_mask = _copy_state_auxiliary_coords(
+            canonical_mask,
+            self._mean,
+            state_dim=self.state_dim,
+        )
+        return MarginalCorrelatedLognormalPrior._from_validated(
+            full_prior=self,
+            retained=canonical_mask,
+            prior=prior,
+        )
 
     def to_dataset(self) -> xr.Dataset:
         """Return a serializable labelled dataset containing both moment spaces."""
         return xr.Dataset(
             {
-                self.mean.name: self.mean,
-                self.arithmetic_covariance.name: self.arithmetic_covariance,
-                self.latent_mean.name: self.latent_mean,
-                self.latent_covariance.name: self.latent_covariance,
-                self.latent_cholesky.name: self.latent_cholesky,
+                self._mean.name: self._mean.copy(deep=True),
+                self._arithmetic_covariance.name: self._arithmetic_covariance.copy(deep=True),
+                self._latent_mean.name: self._latent_mean.copy(deep=True),
+                self._latent_covariance.name: self._latent_covariance.copy(deep=True),
+                self._latent_cholesky.name: self._latent_cholesky.copy(deep=True),
             },
             attrs={
                 "correlated_state_schema": "openghg_inversions.correlated_lognormal_prior/v1",
@@ -381,9 +443,7 @@ class CorrelatedLognormalPrior:
         """Reload and revalidate a dataset produced by ``to_dataset``."""
         expected_schema = "openghg_inversions.correlated_lognormal_prior/v1"
         if dataset.attrs.get("correlated_state_schema") != expected_schema:
-            raise ValueError(
-                "Correlated-state dataset has an unsupported or missing schema declaration."
-            )
+            raise ValueError("Correlated-state dataset has an unsupported or missing schema declaration.")
         state_dim = dataset.attrs.get("state_dim")
         covariance_dim = dataset.attrs.get("covariance_dim")
         if not isinstance(state_dim, str) or not isinstance(covariance_dim, str):
@@ -416,18 +476,14 @@ class CorrelatedLognormalPrior:
         )
         for name, dims in expected_dims.items():
             if dataset[name].dims != dims:
-                raise ValueError(
-                    f"Stored {name!r} dimensions must be {dims!r}; got {dataset[name].dims!r}."
-                )
+                raise ValueError(f"Stored {name!r} dimensions must be {dims!r}; got {dataset[name].dims!r}.")
             derived_index = _require_state_index(
                 dataset[name],
                 state_dim,
                 name=f"Stored {name}",
             )
             if not derived_index.equals(arithmetic_index):
-                raise ValueError(
-                    f"Stored {name!r} state labels must match the arithmetic mean labels."
-                )
+                raise ValueError(f"Stored {name!r} state labels must match the arithmetic mean labels.")
 
         prior = cls.from_moments(
             dataset["arithmetic_mean"],
@@ -443,13 +499,11 @@ class CorrelatedLognormalPrior:
                 rtol=1e-12,
                 atol=1e-12,
             ):
-                raise ValueError(
-                    f"Stored {name!r} is inconsistent with the declared arithmetic moments."
-                )
+                raise ValueError(f"Stored {name!r} is inconsistent with the declared arithmetic moments.")
         return prior
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, init=False)
 class MarginalCorrelatedLognormalPrior:
     """Explicit result of marginalizing a labelled joint prior.
 
@@ -458,20 +512,44 @@ class MarginalCorrelatedLognormalPrior:
     """
 
     full_prior: CorrelatedLognormalPrior
-    retained: xr.DataArray
+    _retained: xr.DataArray
     prior: CorrelatedLognormalPrior
+
+    def __init__(self, *_args: object, **_kwargs: object) -> None:
+        """Require construction through validated marginal selection."""
+        raise TypeError("Use CorrelatedLognormalPrior.select_marginal(...) to construct a marginal prior.")
+
+    @classmethod
+    def _from_validated(
+        cls,
+        *,
+        full_prior: CorrelatedLognormalPrior,
+        retained: xr.DataArray,
+        prior: CorrelatedLognormalPrior,
+    ) -> MarginalCorrelatedLognormalPrior:
+        """Construct the wrapper after recomputing its principal marginal."""
+        instance = object.__new__(cls)
+        object.__setattr__(instance, "full_prior", full_prior)
+        object.__setattr__(instance, "_retained", retained.copy(deep=True))
+        object.__setattr__(instance, "prior", prior)
+        return instance
+
+    @property
+    def retained(self) -> xr.DataArray:
+        """Return an independent copy of the validated retained-state mask."""
+        return self._retained.copy(deep=True)
 
     @property
     def omitted(self) -> xr.DataArray:
         """Return the labelled omitted-state mask in full-state order."""
-        return (~self.retained).rename("marginalized_state")
+        return (~self._retained).rename("marginalized_state").copy(deep=True)
 
     def to_dataset(self) -> xr.Dataset:
         """Serialize the full prior and retained-state marginalization ledger."""
         dataset = self.full_prior.to_dataset()
         dataset["retained_state"] = (
             self.full_prior.state_dim,
-            np.asarray(self.retained.values, dtype=bool),
+            np.asarray(self._retained.values, dtype=bool),
         )
         dataset.attrs = dict(dataset.attrs)
         dataset.attrs["inactive_state_semantics"] = "coherent_prior_marginalization"
@@ -481,9 +559,7 @@ class MarginalCorrelatedLognormalPrior:
     def from_dataset(cls, dataset: xr.Dataset) -> MarginalCorrelatedLognormalPrior:
         """Reload and reapply an explicit coherent-marginalization ledger."""
         if dataset.attrs.get("inactive_state_semantics") != "coherent_prior_marginalization":
-            raise ValueError(
-                "Marginal correlated-state dataset must declare coherent prior marginalization."
-            )
+            raise ValueError("Marginal correlated-state dataset must declare coherent prior marginalization.")
         if "retained_state" not in dataset:
             raise ValueError("Marginal correlated-state dataset is missing 'retained_state'.")
         full_prior = CorrelatedLognormalPrior.from_dataset(dataset)

--- a/openghg_inversions/correlated_state.py
+++ b/openghg_inversions/correlated_state.py
@@ -1,0 +1,490 @@
+"""Labelled arithmetic-moment contracts for correlated positive states.
+
+This module is backend-neutral.  It validates the scientific state coordinate
+and converts requested arithmetic LogNormal moments into the latent Gaussian
+moments needed by a model backend.  PyMC graph construction lives in
+``openghg_inversions.models.components``.
+
+Correlated marginalization is deliberately separate from
+``models.StateActivity``.  ``StateActivity`` conditions inactive states on
+configured fixed values; selecting a principal marginal from a joint prior is
+a different statistical operation and must not silently restore omitted states
+as constants.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+
+def _materialize_numeric(array: xr.DataArray, *, name: str) -> np.ndarray:
+    """Return finite float64 values from a labelled array."""
+    values = np.asarray(array.compute().values)
+    if not np.issubdtype(values.dtype, np.number):
+        raise ValueError(f"{name} must contain numeric values.")
+    values = np.asarray(values, dtype=np.float64)
+    if not np.isfinite(values).all():
+        raise ValueError(f"{name} must contain only finite values.")
+    return values
+
+
+def _require_state_index(array: xr.DataArray, state_dim: str, *, name: str) -> pd.Index:
+    """Return the unique labelled index owned by ``state_dim``."""
+    if state_dim not in array.coords or state_dim not in array.indexes:
+        raise ValueError(f"{name} must have a labelled {state_dim!r} coordinate.")
+    index = array.indexes[state_dim]
+    if not index.is_unique:
+        raise ValueError(f"{name} {state_dim!r} coordinate must contain unique values.")
+    if isinstance(index, pd.MultiIndex):
+        names = tuple(index.names)
+        if any(not isinstance(level, str) or not level for level in names):
+            raise ValueError(f"{name} {state_dim!r} MultiIndex levels must have non-empty names.")
+        if len(set(names)) != len(names):
+            raise ValueError(f"{name} {state_dim!r} MultiIndex level names must be unique.")
+    return index
+
+
+def _coord_values(coord: xr.DataArray) -> list[Any]:
+    """Return coordinate labels without promoting tuple objects to a MultiIndex."""
+    index = coord.to_index()
+    return list(index.tolist())
+
+
+def _label_token(value: Any) -> str:
+    """Return a stable, serializable identity token for one state label."""
+    return json.dumps(value, default=str, ensure_ascii=False, separators=(",", ":"))
+
+
+def _covariance_array(
+    covariance: xr.DataArray | np.ndarray,
+    *,
+    mean: xr.DataArray,
+    state_dim: str,
+    covariance_dim: str,
+) -> xr.DataArray:
+    """Normalize covariance to one labelled and one same-order matrix axis."""
+    state_coord = mean.coords[state_dim]
+    mean_index = _require_state_index(mean, state_dim, name="Arithmetic mean")
+    state_size = mean.sizes[state_dim]
+    expected_label_tokens = [_label_token(label) for label in mean_index.tolist()]
+    label_coord = f"{covariance_dim}_label"
+    if isinstance(covariance, xr.DataArray):
+        covariance_attrs = dict(covariance.attrs)
+        if covariance.dims != (state_dim, covariance_dim):
+            raise ValueError(
+                "Arithmetic covariance must have dimensions "
+                f"({state_dim!r}, {covariance_dim!r}); got {covariance.dims!r}."
+            )
+        if covariance.shape != (state_size, state_size):
+            raise ValueError(
+                "Arithmetic covariance must be square and match the state length; "
+                f"got shape {covariance.shape!r} for {state_size} states."
+            )
+        covariance_index = _require_state_index(
+            covariance,
+            state_dim,
+            name="Arithmetic covariance",
+        )
+        if not covariance_index.equals(mean_index):
+            raise ValueError(
+                "Arithmetic covariance row labels must exactly match the arithmetic mean labels "
+                "in the same order."
+            )
+        if covariance_dim in covariance.coords:
+            column_labels = _coord_values(covariance.coords[covariance_dim])
+            if column_labels != list(mean_index.tolist()):
+                raise ValueError(
+                    "Arithmetic covariance column labels must exactly match the arithmetic mean "
+                    "labels in the same order."
+                )
+        if label_coord in covariance.coords:
+            stored_label_coord = covariance.coords[label_coord]
+            if stored_label_coord.dims != (covariance_dim,):
+                raise ValueError(
+                    f"Arithmetic covariance label coordinate {label_coord!r} must have only "
+                    f"the {covariance_dim!r} dimension."
+                )
+            if list(np.asarray(stored_label_coord.values, dtype=str)) != expected_label_tokens:
+                raise ValueError(
+                    "Arithmetic covariance serialized column identity must exactly match the "
+                    "arithmetic mean labels in the same order."
+                )
+        values = _materialize_numeric(covariance, name="Arithmetic covariance")
+    else:
+        covariance_attrs = {}
+        values = np.asarray(covariance)
+        if values.shape != (state_size, state_size):
+            raise ValueError(
+                "Arithmetic covariance must be square and match the state length; "
+                f"got shape {values.shape!r} for {state_size} states."
+            )
+        if not np.issubdtype(values.dtype, np.number):
+            raise ValueError("Arithmetic covariance must contain numeric values.")
+        values = np.asarray(values, dtype=np.float64)
+        if not np.isfinite(values).all():
+            raise ValueError("Arithmetic covariance must contain only finite values.")
+
+    return xr.DataArray(
+        values,
+        dims=(state_dim, covariance_dim),
+        coords={
+            state_dim: state_coord,
+            label_coord: (covariance_dim, np.asarray(expected_label_tokens, dtype=str)),
+        },
+        name="arithmetic_covariance",
+        attrs=covariance_attrs,
+    )
+
+
+def _matrix_tolerance(values: np.ndarray) -> float:
+    """Return a scale-aware numerical validation tolerance."""
+    return 1e-10 * max(float(np.max(np.abs(values))), 1.0)
+
+
+@dataclass(frozen=True, init=False)
+class CorrelatedLognormalPrior:
+    """Validated labelled moments for one correlated positive state vector.
+
+    ``arithmetic_covariance`` uses a distinct second matrix dimension whose
+    entries are declared to follow the primary state coordinate in the same
+    order.  Only the primary axis owns the rich scientific coordinate.  This
+    avoids duplicating MultiIndex level coordinates while retaining an explicit
+    labelled row contract.
+    """
+
+    mean: xr.DataArray
+    arithmetic_covariance: xr.DataArray
+    latent_mean: xr.DataArray
+    latent_covariance: xr.DataArray
+    latent_cholesky: xr.DataArray
+    state_dim: str
+    covariance_dim: str
+
+    def __init__(self, *_args: object, **_kwargs: object) -> None:
+        """Require construction through ``from_moments`` validation."""
+        raise TypeError("Use CorrelatedLognormalPrior.from_moments(...) to construct a prior.")
+
+    @classmethod
+    def _from_validated(
+        cls,
+        *,
+        mean: xr.DataArray,
+        arithmetic_covariance: xr.DataArray,
+        latent_mean: xr.DataArray,
+        latent_covariance: xr.DataArray,
+        latent_cholesky: xr.DataArray,
+        state_dim: str,
+        covariance_dim: str,
+    ) -> CorrelatedLognormalPrior:
+        """Construct an instance after the public validation boundary."""
+        instance = object.__new__(cls)
+        object.__setattr__(instance, "mean", mean)
+        object.__setattr__(instance, "arithmetic_covariance", arithmetic_covariance)
+        object.__setattr__(instance, "latent_mean", latent_mean)
+        object.__setattr__(instance, "latent_covariance", latent_covariance)
+        object.__setattr__(instance, "latent_cholesky", latent_cholesky)
+        object.__setattr__(instance, "state_dim", state_dim)
+        object.__setattr__(instance, "covariance_dim", covariance_dim)
+        return instance
+
+    @classmethod
+    def from_moments(
+        cls,
+        mean: xr.DataArray,
+        arithmetic_covariance: xr.DataArray | np.ndarray,
+        *,
+        covariance_dim: str | None = None,
+    ) -> CorrelatedLognormalPrior:
+        """Validate arithmetic moments and derive latent Gaussian moments.
+
+        For arithmetic mean ``m`` and covariance ``C``, the latent moments are
+
+        ``Sigma[i,j] = log(1 + C[i,j] / (m[i] * m[j]))`` and
+        ``mu[i] = log(m[i]) - 0.5 * Sigma[i,i]``.
+
+        The familiar mean-one contract is the special case
+        ``Sigma = log1p(C)``.
+        """
+        if not isinstance(mean, xr.DataArray):
+            raise TypeError("Arithmetic mean must be an xarray DataArray.")
+        if mean.ndim != 1:
+            raise ValueError(
+                f"Arithmetic mean must be one-dimensional; got dimensions {mean.dims!r}."
+            )
+        state_dim = str(mean.dims[0])
+        covariance_dim = covariance_dim or f"{state_dim}_covariance"
+        if covariance_dim == state_dim:
+            raise ValueError("Covariance matrix axes must use distinct dimension names.")
+        if covariance_dim in mean.coords:
+            raise ValueError(
+                "Covariance matrix column dimension must not collide with a state or auxiliary "
+                f"coordinate name; got {covariance_dim!r}."
+            )
+        if f"{covariance_dim}_label" in mean.coords:
+            raise ValueError(
+                "Covariance matrix label coordinate must not collide with a state auxiliary "
+                f"coordinate name; got {covariance_dim + '_label'!r}."
+            )
+        _require_state_index(mean, state_dim, name="Arithmetic mean")
+        mean_values = _materialize_numeric(mean, name="Arithmetic mean")
+        if (mean_values <= 0).any():
+            raise ValueError("Arithmetic mean must contain only positive values.")
+
+        covariance = _covariance_array(
+            arithmetic_covariance,
+            mean=mean,
+            state_dim=state_dim,
+            covariance_dim=covariance_dim,
+        )
+        covariance_values = np.asarray(covariance.values, dtype=np.float64)
+        tolerance = _matrix_tolerance(covariance_values)
+        if not np.allclose(
+            covariance_values,
+            covariance_values.T,
+            rtol=1e-10,
+            atol=tolerance,
+        ):
+            raise ValueError("Arithmetic covariance must be symmetric.")
+        covariance_values = 0.5 * (covariance_values + covariance_values.T)
+        covariance = covariance.copy(data=covariance_values)
+        if float(np.linalg.eigvalsh(covariance_values).min()) < -tolerance:
+            raise ValueError("Arithmetic covariance must be positive semidefinite.")
+
+        relative_covariance = covariance_values / np.outer(mean_values, mean_values)
+        if (1.0 + relative_covariance <= 0).any():
+            raise ValueError(
+                "Arithmetic moments do not define finite LogNormal latent covariance entries."
+            )
+        latent_covariance_values = np.log1p(relative_covariance)
+        latent_tolerance = _matrix_tolerance(latent_covariance_values)
+        if not np.allclose(
+            latent_covariance_values,
+            latent_covariance_values.T,
+            rtol=1e-10,
+            atol=latent_tolerance,
+        ):
+            raise ValueError("Derived latent covariance must be symmetric.")
+        try:
+            latent_cholesky_values = np.linalg.cholesky(latent_covariance_values)
+        except np.linalg.LinAlgError as exc:
+            minimum = float(np.linalg.eigvalsh(latent_covariance_values).min())
+            raise ValueError(
+                "Derived latent covariance must be positive definite; "
+                f"minimum eigenvalue is {minimum:.6g}."
+            ) from exc
+
+        latent_mean_values = np.log(mean_values) - 0.5 * np.diag(latent_covariance_values)
+        state_coord = mean.coords[state_dim]
+        canonical_mean = xr.DataArray(
+            mean_values,
+            dims=(state_dim,),
+            coords={state_dim: state_coord},
+            name="arithmetic_mean",
+            attrs=dict(mean.attrs),
+        )
+        matrix_coords = {state_dim: state_coord}
+        return cls._from_validated(
+            mean=canonical_mean,
+            arithmetic_covariance=covariance,
+            latent_mean=xr.DataArray(
+                latent_mean_values,
+                dims=(state_dim,),
+                coords={state_dim: state_coord},
+                name="latent_mean",
+            ),
+            latent_covariance=xr.DataArray(
+                latent_covariance_values,
+                dims=(state_dim, covariance_dim),
+                coords=matrix_coords,
+                name="latent_covariance",
+            ),
+            latent_cholesky=xr.DataArray(
+                latent_cholesky_values,
+                dims=(state_dim, covariance_dim),
+                coords=matrix_coords,
+                name="latent_cholesky",
+            ),
+            state_dim=state_dim,
+            covariance_dim=covariance_dim,
+        )
+
+    def select_marginal(self, retained: xr.DataArray) -> MarginalCorrelatedLognormalPrior:
+        """Select a labelled principal marginal without fixing omitted states.
+
+        This operation only marginalizes the prior. It does not reduce a
+        forward operator or construct the unresolved aggregation covariance.
+        Callers using coherent reduction must supply the matching retained
+        design and unresolved covariance from the same preparation ledger.
+        """
+        if retained.dims != (self.state_dim,):
+            raise ValueError(
+                f"Retained-state mask must have only the {self.state_dim!r} dimension; "
+                f"got {retained.dims!r}."
+            )
+        retained_index = _require_state_index(retained, self.state_dim, name="Retained-state mask")
+        state_index = self.mean.indexes[self.state_dim]
+        if not retained_index.equals(state_index):
+            raise ValueError(
+                "Retained-state mask labels must exactly match the prior state labels in the same order."
+            )
+        retained_values = np.asarray(retained.compute().values)
+        if retained_values.dtype != np.dtype(bool):
+            raise ValueError("Retained-state mask must contain only boolean values.")
+        positions = np.flatnonzero(retained_values)
+        if positions.size == 0:
+            raise ValueError("A correlated LogNormal marginal must retain at least one state.")
+
+        marginal_mean = self.mean.isel({self.state_dim: positions})
+        marginal_covariance = self.arithmetic_covariance.isel(
+            {self.state_dim: positions, self.covariance_dim: positions}
+        )
+        prior = CorrelatedLognormalPrior.from_moments(
+            marginal_mean,
+            marginal_covariance,
+            covariance_dim=self.covariance_dim,
+        )
+        canonical_mask = xr.DataArray(
+            retained_values,
+            dims=(self.state_dim,),
+            coords={self.state_dim: self.mean.coords[self.state_dim]},
+            name="retained_state",
+        )
+        return MarginalCorrelatedLognormalPrior(full_prior=self, retained=canonical_mask, prior=prior)
+
+    def to_dataset(self) -> xr.Dataset:
+        """Return a serializable labelled dataset containing both moment spaces."""
+        return xr.Dataset(
+            {
+                self.mean.name: self.mean,
+                self.arithmetic_covariance.name: self.arithmetic_covariance,
+                self.latent_mean.name: self.latent_mean,
+                self.latent_covariance.name: self.latent_covariance,
+                self.latent_cholesky.name: self.latent_cholesky,
+            },
+            attrs={
+                "correlated_state_schema": "openghg_inversions.correlated_lognormal_prior/v1",
+                "state_dim": self.state_dim,
+                "covariance_dim": self.covariance_dim,
+                "moment_parameterization": "arithmetic_mean_and_covariance",
+                "latent_parameterization": "whitened_gaussian",
+            },
+        )
+
+    @classmethod
+    def from_dataset(cls, dataset: xr.Dataset) -> CorrelatedLognormalPrior:
+        """Reload and revalidate a dataset produced by ``to_dataset``."""
+        expected_schema = "openghg_inversions.correlated_lognormal_prior/v1"
+        if dataset.attrs.get("correlated_state_schema") != expected_schema:
+            raise ValueError(
+                "Correlated-state dataset has an unsupported or missing schema declaration."
+            )
+        state_dim = dataset.attrs.get("state_dim")
+        covariance_dim = dataset.attrs.get("covariance_dim")
+        if not isinstance(state_dim, str) or not isinstance(covariance_dim, str):
+            raise ValueError("Correlated-state dataset dimension metadata must contain strings.")
+        missing = [
+            name
+            for name in (
+                "arithmetic_mean",
+                "arithmetic_covariance",
+                "latent_mean",
+                "latent_covariance",
+                "latent_cholesky",
+            )
+            if name not in dataset
+        ]
+        if missing:
+            raise ValueError(f"Correlated-state dataset is missing variable(s): {missing!r}.")
+        if dataset["arithmetic_mean"].dims != (state_dim,):
+            raise ValueError("Stored arithmetic mean dimensions do not match the schema metadata.")
+
+        expected_dims = {
+            "latent_mean": (state_dim,),
+            "latent_covariance": (state_dim, covariance_dim),
+            "latent_cholesky": (state_dim, covariance_dim),
+        }
+        arithmetic_index = _require_state_index(
+            dataset["arithmetic_mean"],
+            state_dim,
+            name="Stored arithmetic mean",
+        )
+        for name, dims in expected_dims.items():
+            if dataset[name].dims != dims:
+                raise ValueError(
+                    f"Stored {name!r} dimensions must be {dims!r}; got {dataset[name].dims!r}."
+                )
+            derived_index = _require_state_index(
+                dataset[name],
+                state_dim,
+                name=f"Stored {name}",
+            )
+            if not derived_index.equals(arithmetic_index):
+                raise ValueError(
+                    f"Stored {name!r} state labels must match the arithmetic mean labels."
+                )
+
+        prior = cls.from_moments(
+            dataset["arithmetic_mean"],
+            dataset["arithmetic_covariance"],
+            covariance_dim=covariance_dim,
+        )
+        for name in ("latent_mean", "latent_covariance", "latent_cholesky"):
+            stored = np.asarray(dataset[name].values)
+            recomputed = np.asarray(getattr(prior, name).values)
+            if stored.shape != recomputed.shape or not np.allclose(
+                stored,
+                recomputed,
+                rtol=1e-12,
+                atol=1e-12,
+            ):
+                raise ValueError(
+                    f"Stored {name!r} is inconsistent with the declared arithmetic moments."
+                )
+        return prior
+
+
+@dataclass(frozen=True)
+class MarginalCorrelatedLognormalPrior:
+    """Explicit result of marginalizing a labelled joint prior.
+
+    This object intentionally has no fixed-value or full-state reconstruction
+    field.  Omitted states are integrated out, not conditioned on constants.
+    """
+
+    full_prior: CorrelatedLognormalPrior
+    retained: xr.DataArray
+    prior: CorrelatedLognormalPrior
+
+    @property
+    def omitted(self) -> xr.DataArray:
+        """Return the labelled omitted-state mask in full-state order."""
+        return (~self.retained).rename("marginalized_state")
+
+    def to_dataset(self) -> xr.Dataset:
+        """Serialize the full prior and retained-state marginalization ledger."""
+        dataset = self.full_prior.to_dataset()
+        dataset["retained_state"] = (
+            self.full_prior.state_dim,
+            np.asarray(self.retained.values, dtype=bool),
+        )
+        dataset.attrs = dict(dataset.attrs)
+        dataset.attrs["inactive_state_semantics"] = "coherent_prior_marginalization"
+        return dataset
+
+    @classmethod
+    def from_dataset(cls, dataset: xr.Dataset) -> MarginalCorrelatedLognormalPrior:
+        """Reload and reapply an explicit coherent-marginalization ledger."""
+        if dataset.attrs.get("inactive_state_semantics") != "coherent_prior_marginalization":
+            raise ValueError(
+                "Marginal correlated-state dataset must declare coherent prior marginalization."
+            )
+        if "retained_state" not in dataset:
+            raise ValueError("Marginal correlated-state dataset is missing 'retained_state'.")
+        full_prior = CorrelatedLognormalPrior.from_dataset(dataset)
+        return full_prior.select_marginal(dataset["retained_state"])

--- a/openghg_inversions/correlated_state.py
+++ b/openghg_inversions/correlated_state.py
@@ -21,11 +21,11 @@ as LogNormal and the unresolved contribution as Gaussian is a moment-matched
 closure, not exact marginalization of a LogNormal state. Fixing a state at a
 known value is instead handled by ``models.StateActivity``.
 
-The main entry point is ``CorrelatedLognormalPrior``. Its constructor and
-``from_moments`` eagerly compute xarray inputs and own independent copies;
-``to_dataset`` and ``from_dataset`` provide persistence boundaries. Construction
-warns before dense covariance materialization when the reduced state exceeds
-1,000 components.
+The main entry point is ``CorrelatedLognormalPrior``. Its constructor eagerly
+computes xarray inputs and owns independent copies; ``to_dataset`` and
+``from_dataset`` provide persistence boundaries. Construction warns before
+dense covariance materialization when the reduced state exceeds 1,000
+components.
 """
 
 from __future__ import annotations
@@ -523,45 +523,6 @@ class CorrelatedLognormalPrior:
         self.state_dim = state_dim
         self.covariance_dim = covariance_dim
 
-    @classmethod
-    def from_moments(
-        cls,
-        mean: xr.DataArray,
-        arithmetic_covariance: xr.DataArray | np.ndarray,
-        *,
-        covariance_dim: str | None = None,
-    ) -> CorrelatedLognormalPrior:
-        """Construct a prior from labelled arithmetic moments.
-
-        Args:
-            mean: Positive one-dimensional arithmetic mean with a unique
-                labelled state coordinate.
-            arithmetic_covariance: Already-reduced dense ``(p, p)`` arithmetic
-                covariance. Xarray labels must match ``mean`` exactly; NumPy
-                values are interpreted in mean-label order.
-            covariance_dim: Optional name for the covariance column dimension;
-                see the constructor for the complete coordinate contract.
-
-        Returns:
-            A validated contract containing owned arithmetic moments and the
-            derived latent Gaussian moments.
-
-        Raises:
-            TypeError: If ``mean`` is not an xarray ``DataArray``.
-            ValueError: If dimensions, labels, values, or arithmetic moments
-                fail validation.
-
-        Warns:
-            UserWarning: If the reduced state contains more than 1000
-                components. This is an operational threshold, not a
-                mathematical limit.
-        """
-        return cls(
-            mean,
-            arithmetic_covariance,
-            covariance_dim=covariance_dim,
-        )
-
     def to_dataset(self) -> xr.Dataset:
         """Serialize the validated arithmetic and latent moments.
 
@@ -654,7 +615,7 @@ class CorrelatedLognormalPrior:
             if not derived_index.equals(arithmetic_index):
                 raise ValueError(f"Stored {name!r} state labels must match the arithmetic mean labels.")
 
-        prior = cls.from_moments(
+        prior = cls(
             dataset["arithmetic_mean"],
             dataset["arithmetic_covariance"],
             covariance_dim=covariance_dim,

--- a/openghg_inversions/models/__init__.py
+++ b/openghg_inversions/models/__init__.py
@@ -34,10 +34,7 @@ from openghg_inversions.models.coords import (
     restore_inferencedata_coords,
 )
 from openghg_inversions.models.priors import parse_prior
-from openghg_inversions.correlated_state import (
-    CorrelatedLognormalPrior,
-    MarginalCorrelatedLognormalPrior,
-)
+from openghg_inversions.correlated_state import CorrelatedLognormalPrior
 from openghg_inversions.models.state_activity import (
     ResolvedStateActivity,
     StateActivity,
@@ -96,7 +93,6 @@ __all__ = [
     "restore_inferencedata_coords",
     "parse_prior",
     "LinearComponentResult",
-    "MarginalCorrelatedLognormalPrior",
     "StateLinearComponentResult",
     "add_model_data",
     "add_correlated_lognormal_state",

--- a/openghg_inversions/models/__init__.py
+++ b/openghg_inversions/models/__init__.py
@@ -15,12 +15,14 @@ from openghg_inversions._pymc_config import configure_pytensor
 configure_pytensor()
 
 from openghg_inversions.models.components import (
+    CorrelatedStateResult,
     LinearComponentResult,
     StateLinearComponentResult,
     add_inferpymc_likelihood_component,
     add_linear_component,
     add_model_data,
     add_offset_component,
+    add_correlated_lognormal_state,
     add_sigma_component,
     add_state_linear_component,
 )
@@ -32,6 +34,10 @@ from openghg_inversions.models.coords import (
     restore_inferencedata_coords,
 )
 from openghg_inversions.models.priors import parse_prior
+from openghg_inversions.correlated_state import (
+    CorrelatedLognormalPrior,
+    MarginalCorrelatedLognormalPrior,
+)
 from openghg_inversions.models.state_activity import (
     ResolvedStateActivity,
     StateActivity,
@@ -68,6 +74,8 @@ from openghg_inversions.observation_error import AggregationErrorMode
 
 __all__ = [
     "CoordRegistry",
+    "CorrelatedLognormalPrior",
+    "CorrelatedStateResult",
     "DEFAULT_BC_PRIOR",
     "DEFAULT_OFFSET_PRIOR",
     "DEFAULT_SIGMA_PRIOR",
@@ -88,8 +96,10 @@ __all__ = [
     "restore_inferencedata_coords",
     "parse_prior",
     "LinearComponentResult",
+    "MarginalCorrelatedLognormalPrior",
     "StateLinearComponentResult",
     "add_model_data",
+    "add_correlated_lognormal_state",
     "add_linear_component",
     "add_state_linear_component",
     "add_sigma_component",

--- a/openghg_inversions/models/components.py
+++ b/openghg_inversions/models/components.py
@@ -35,6 +35,7 @@ import pytensor.tensor as pt
 import xarray as xr
 from pytensor.tensor.variable import TensorVariable
 
+from openghg_inversions.correlated_state import CorrelatedLognormalPrior
 from openghg_inversions.inversion_inputs import make_freq_indicator
 from openghg_inversions.models.coords import add_coords
 from openghg_inversions.models.priors import parse_prior
@@ -71,6 +72,23 @@ class StateVectorResult:
     latent: TensorVariable | None
     state: TensorVariable
     activity: ResolvedStateActivity
+
+
+@dataclass
+class CorrelatedStateResult:
+    """Objects created by ``add_correlated_lognormal_state``.
+
+    Attributes:
+        latent: Standard-normal whitened state used by the sampler.
+        state: Positive user-facing state with the requested arithmetic
+            LogNormal moments.
+        prior: Validated backend-neutral moment contract used to build the
+            graph.
+    """
+
+    latent: TensorVariable
+    state: TensorVariable
+    prior: CorrelatedLognormalPrior
 
 
 @dataclass
@@ -362,6 +380,49 @@ def add_state_vector(
         full_state = pt.set_subtensor(full_state[active_indices], active_state)
     state = pm.Deterministic(var_name, full_state, dims=state_dim)
     return StateVectorResult(latent=latent, state=state, activity=activity)
+
+
+def add_correlated_lognormal_state(
+    prior: CorrelatedLognormalPrior,
+    /,
+    *,
+    var_name: str,
+) -> CorrelatedStateResult:
+    """Add a whitened correlated LogNormal state to the active PyMC model.
+
+    Args:
+        prior: Validated labelled arithmetic and latent moment contract.
+        var_name: Name of the positive user-facing state. The whitened standard
+            normal is named ``{var_name}_latent``.
+
+    Returns:
+        The whitened latent, positive state, and supplied prior contract.
+
+    Notes:
+        Coherent marginalization must be completed before calling this helper,
+        using ``CorrelatedLognormalPrior.select_marginal``. This helper does not
+        accept ``StateActivity`` because fixed-state conditioning and joint-
+        prior marginalization are different statistical operations.
+    """
+    state_dim = prior.state_dim
+    add_coords(prior.mean.coords, model_dims=(state_dim,))
+    latent = pm.Normal(f"{var_name}_latent", 0.0, 1.0, dims=state_dim)
+    backend_latent_mean = np.asarray(pm.floatX(np.asarray(prior.latent_mean.values)))
+    backend_cholesky = np.asarray(pm.floatX(np.asarray(prior.latent_cholesky.values)))
+    if not np.isfinite(backend_latent_mean).all() or not np.isfinite(backend_cholesky).all():
+        raise ValueError("Correlated LogNormal moments must remain finite in the model float dtype.")
+    if (np.diag(backend_cholesky) <= 0).any():
+        raise ValueError(
+            "Correlated LogNormal Cholesky diagonal must remain positive in the model float dtype."
+        )
+    latent_mean = pt.as_tensor_variable(backend_latent_mean)
+    cholesky = pt.as_tensor_variable(backend_cholesky)
+    state = pm.Deterministic(
+        var_name,
+        pt.exp(latent_mean + pt.dot(cholesky, latent)),
+        dims=state_dim,
+    )
+    return CorrelatedStateResult(latent=latent, state=state, prior=prior)
 
 
 def add_state_linear_component(

--- a/openghg_inversions/models/components.py
+++ b/openghg_inversions/models/components.py
@@ -398,11 +398,25 @@ def add_correlated_lognormal_state(
     Returns:
         The whitened latent, positive state, and supplied prior contract.
 
+    Raises:
+        ValueError: If the arithmetic mean, latent moments, Cholesky diagonal,
+            or exponentiated central state is not finite and positive where
+            required in PyMC's configured floating-point dtype.
+
     Notes:
-        Coherent marginalization must be completed before calling this helper,
-        using ``CorrelatedLognormalPrior.select_marginal``. This helper does not
-        accept ``StateActivity`` because fixed-state conditioning and joint-
-        prior marginalization are different statistical operations.
+        This function must run in an active ``pm.Model`` context. After backend
+        dtype validation completes, it mutates that model by registering the
+        length-``p`` state coordinate, ``{var_name}_latent`` random variable,
+        and length-``p`` ``{var_name}`` deterministic state.
+
+        ``prior`` should contain reduced arithmetic moments produced together
+        with the matching forward operator and Gaussian unresolved-error term.
+        The coherent covariance, transformed-forward-model, and
+        aggregation-error identities are exact only for a jointly Gaussian
+        state. Reusing those first two moments with a LogNormal retained state
+        and Gaussian unresolved contribution is a moment-matched closure, not
+        exact LogNormal marginalization. Known-exact state fixing is handled
+        separately by ``StateActivity`` in the state-linear component builders.
     """
     state_dim = prior.state_dim
     mean = prior.mean

--- a/openghg_inversions/models/components.py
+++ b/openghg_inversions/models/components.py
@@ -405,16 +405,34 @@ def add_correlated_lognormal_state(
         prior marginalization are different statistical operations.
     """
     state_dim = prior.state_dim
-    add_coords(prior.mean.coords, model_dims=(state_dim,))
-    latent = pm.Normal(f"{var_name}_latent", 0.0, 1.0, dims=state_dim)
-    backend_latent_mean = np.asarray(pm.floatX(np.asarray(prior.latent_mean.values)))
-    backend_cholesky = np.asarray(pm.floatX(np.asarray(prior.latent_cholesky.values)))
+    mean = prior.mean
+    with np.errstate(over="ignore", under="ignore", invalid="ignore"):
+        backend_mean = np.asarray(pm.floatX(np.asarray(mean.values)))
+        backend_latent_mean = np.asarray(pm.floatX(np.asarray(prior.latent_mean.values)))
+        backend_cholesky = np.asarray(pm.floatX(np.asarray(prior.latent_cholesky.values)))
+    if not np.isfinite(backend_mean).all() or (backend_mean <= 0).any():
+        raise ValueError(
+            "Correlated LogNormal arithmetic means must remain finite and positive in the model float dtype."
+        )
     if not np.isfinite(backend_latent_mean).all() or not np.isfinite(backend_cholesky).all():
         raise ValueError("Correlated LogNormal moments must remain finite in the model float dtype.")
     if (np.diag(backend_cholesky) <= 0).any():
         raise ValueError(
             "Correlated LogNormal Cholesky diagonal must remain positive in the model float dtype."
         )
+    with np.errstate(over="ignore", under="ignore", invalid="ignore"):
+        backend_central_state = np.exp(backend_latent_mean)
+    if not np.isfinite(backend_central_state).all() or (backend_central_state <= 0).any():
+        raise ValueError(
+            "Correlated LogNormal central states must remain finite and positive "
+            "after exponentiation in the model float dtype."
+        )
+
+    # All predictable dtype validation must finish before the active model is
+    # changed.  In particular, failed validation must not leave a latent RV
+    # that makes a corrected retry impossible.
+    add_coords(mean.coords, model_dims=(state_dim,))
+    latent = pm.Normal(f"{var_name}_latent", 0.0, 1.0, dims=state_dim)
     latent_mean = pt.as_tensor_variable(backend_latent_mean)
     cholesky = pt.as_tensor_variable(backend_cholesky)
     state = pm.Deterministic(

--- a/openghg_inversions/models/coords.py
+++ b/openghg_inversions/models/coords.py
@@ -270,7 +270,7 @@ def restore_inferencedata_coords(
         if not isinstance(group, xr.Dataset):
             continue
 
-        restored_multiindex_dims: set[str] = set()
+        restored_multiindex_levels: set[str] = set()
         for dim, coord in original_coords.items():
             if dim not in group.dims:
                 continue
@@ -280,7 +280,7 @@ def restore_inferencedata_coords(
             # can be validated against the final dimension layout.
             if isinstance(coord, pd.MultiIndex):
                 group = group.assign_coords(xr.Coordinates.from_pandas_multiindex(coord, dim))
-                restored_multiindex_dims.add(dim)
+                restored_multiindex_levels.update(name for name in coord.names if name is not None)
             else:
                 group = group.assign_coords({dim: coord})
 
@@ -290,15 +290,16 @@ def restore_inferencedata_coords(
                     continue
                 if any(group.sizes[dim] != coord.sizes[dim] for dim in coord.dims):
                     continue
-                # Skip auxiliaries on restored MultiIndex dims because xarray
-                # has already recreated those level coords from the index itself.
-                if any(dim in restored_multiindex_dims for dim in coord.dims):
+                # Xarray has already recreated MultiIndex level coordinates,
+                # but unrelated auxiliaries on the same dimension still need
+                # to be restored.
+                if name in restored_multiindex_levels:
                     continue
                 # Assign positionally after restoring the scientific dimension
                 # coordinate.  Reusing the registry's range coordinate here
                 # would trigger xarray label alignment against the restored
                 # labels and silently replace ordinary auxiliaries with NaN.
-                group = group.assign_coords({name: (coord.dims, coord.values)})
+                group = group.assign_coords({name: (coord.dims, np.array(coord.values, copy=True))})
 
         setattr(idata, group_name, group)
 

--- a/openghg_inversions/models/coords.py
+++ b/openghg_inversions/models/coords.py
@@ -294,7 +294,11 @@ def restore_inferencedata_coords(
                 # has already recreated those level coords from the index itself.
                 if any(dim in restored_multiindex_dims for dim in coord.dims):
                     continue
-                group = group.assign_coords({name: coord})
+                # Assign positionally after restoring the scientific dimension
+                # coordinate.  Reusing the registry's range coordinate here
+                # would trigger xarray label alignment against the restored
+                # labels and silently replace ordinary auxiliaries with NaN.
+                group = group.assign_coords({name: (coord.dims, coord.values)})
 
         setattr(idata, group_name, group)
 

--- a/tests/models/test_coords.py
+++ b/tests/models/test_coords.py
@@ -101,3 +101,53 @@ def test_restore_inferencedata_coords_supports_registry_and_legacy_dict() -> Non
 
     restored2 = restore_inferencedata_coords(idata, {"nmeasure": multi_index})
     assert restored2.posterior.indexes["nmeasure"].equals(multi_index)
+
+
+def test_restore_inferencedata_auxiliary_coords_owns_group_values() -> None:
+    """Keep restored groups and registry auxiliary values mutation-isolated."""
+    auxiliary = xr.DataArray(
+        [50.0, 51.0],
+        dims=("state",),
+        coords={"state": np.arange(2)},
+        name="latitude",
+    )
+    registry = CoordRegistry(
+        original_coords={"state": pd.Index(["ocean", "ff"], name="state")},
+        auxiliary_coords={"latitude": auxiliary},
+    )
+    group = xr.Dataset(
+        data_vars={"x": (("chain", "draw", "state"), np.zeros((1, 1, 2)))},
+        coords={"chain": [0], "draw": [0], "state": np.arange(2)},
+    )
+    idata = az.InferenceData(posterior=group.copy(deep=True), prior=group.copy(deep=True))
+
+    restored = restore_inferencedata_coords(idata, registry)
+    restored.posterior["latitude"].values[0] = -999.0
+
+    np.testing.assert_array_equal(registry.auxiliary_coords["latitude"], [50.0, 51.0])
+    np.testing.assert_array_equal(restored.prior["latitude"], [50.0, 51.0])
+
+
+def test_restore_inferencedata_preserves_independent_auxiliary_on_multiindex() -> None:
+    """Restore non-level metadata attached to a MultiIndex state dimension."""
+    state_index = pd.MultiIndex.from_tuples(
+        [("ocean", "atlantic"), ("ff", "north")],
+        names=("source", "region"),
+    )
+    coords = xr.Coordinates.from_pandas_multiindex(state_index, "state")
+    mean = xr.DataArray(
+        [1.0, 1.0],
+        dims=("state",),
+        coords={**coords, "latitude": ("state", [50.0, 51.0])},
+    )
+    registry = CoordRegistry()
+    registry.add(mean.coords, model_dims=("state",))
+    posterior = xr.Dataset(
+        data_vars={"x": (("chain", "draw", "state"), np.zeros((1, 1, 2)))},
+        coords={"chain": [0], "draw": [0], "state": np.arange(2)},
+    )
+
+    restored = restore_inferencedata_coords(az.InferenceData(posterior=posterior), registry)
+
+    assert restored.posterior.indexes["state"].equals(state_index)
+    np.testing.assert_array_equal(restored.posterior["latitude"], [50.0, 51.0])

--- a/tests/models/test_correlated_state.py
+++ b/tests/models/test_correlated_state.py
@@ -1,0 +1,339 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pymc as pm
+import pytest
+import xarray as xr
+
+from openghg_inversions.correlated_state import (
+    CorrelatedLognormalPrior,
+    MarginalCorrelatedLognormalPrior,
+)
+from openghg_inversions.models import (
+    CoordRegistry,
+    add_correlated_lognormal_state,
+    attach_coord_registry,
+    restore_inferencedata_coords,
+)
+from openghg_inversions.models.priors import lognormal_mu_sigma
+from openghg_inversions.serialization import (
+    encode_multiindexes_for_storage,
+    restore_serialisation_multiindexes,
+)
+
+
+def _gathered_mean() -> xr.DataArray:
+    """Return a non-lexically ordered two-source state coordinate."""
+    index = pd.MultiIndex.from_tuples(
+        [("ocean", "atlantic"), ("ff", "north"), ("ff", "south")],
+        names=("source", "region_in_source"),
+    )
+    coords = xr.Coordinates.from_pandas_multiindex(index, "state")
+    return xr.DataArray(
+        [1.0, 1.0, 1.0],
+        dims=("state",),
+        coords=coords,
+        name="mean",
+        attrs={"units": "1"},
+    )
+
+
+def _arithmetic_covariance() -> np.ndarray:
+    """Return an SPD covariance with within- and cross-source terms."""
+    return np.array(
+        [
+            [0.16, 0.03, 0.01],
+            [0.03, 0.09, 0.02],
+            [0.01, 0.02, 0.25],
+        ]
+    )
+
+
+def _prior() -> CorrelatedLognormalPrior:
+    """Return the common gathered correlated prior fixture."""
+    return CorrelatedLognormalPrior.from_moments(_gathered_mean(), _arithmetic_covariance())
+
+
+def test_correlated_prior_requires_validated_factory_construction() -> None:
+    """Prevent callers from bypassing moment and coordinate validation."""
+    with pytest.raises(TypeError, match="from_moments"):
+        CorrelatedLognormalPrior()  # type: ignore[call-arg]
+
+
+def test_correlated_lognormal_matches_requested_arithmetic_moments() -> None:
+    """Convert arithmetic moments exactly and retain cross-source covariance."""
+    prior = _prior()
+    expected_latent_covariance = np.log1p(_arithmetic_covariance())
+    expected_latent_mean = -0.5 * np.diag(expected_latent_covariance)
+
+    np.testing.assert_allclose(prior.latent_covariance, expected_latent_covariance)
+    np.testing.assert_allclose(prior.latent_mean, expected_latent_mean)
+
+    latent_covariance = np.asarray(prior.latent_covariance)
+    latent_mean = np.asarray(prior.latent_mean)
+    reconstructed_mean = np.exp(latent_mean + 0.5 * np.diag(latent_covariance))
+    reconstructed_covariance = np.outer(reconstructed_mean, reconstructed_mean) * (
+        np.exp(latent_covariance) - 1.0
+    )
+    np.testing.assert_allclose(reconstructed_mean, _gathered_mean())
+    np.testing.assert_allclose(reconstructed_covariance, _arithmetic_covariance())
+    assert float(reconstructed_covariance[0, 1]) > 0.0
+
+
+def test_correlated_lognormal_supports_positive_nonunit_means() -> None:
+    """Use the general arithmetic moment map when state means are not one."""
+    mean = _gathered_mean().copy(data=[0.5, 2.0, 1.5])
+    covariance = 0.25 * _arithmetic_covariance()
+    prior = CorrelatedLognormalPrior.from_moments(mean, covariance)
+    latent_covariance = np.asarray(prior.latent_covariance)
+    latent_mean = np.asarray(prior.latent_mean)
+    reconstructed_mean = np.exp(latent_mean + 0.5 * np.diag(latent_covariance))
+    reconstructed_covariance = np.outer(reconstructed_mean, reconstructed_mean) * (
+        np.exp(latent_covariance) - 1.0
+    )
+
+    np.testing.assert_allclose(reconstructed_mean, mean)
+    np.testing.assert_allclose(reconstructed_covariance, covariance)
+
+
+def test_correlated_lognormal_monte_carlo_preserves_cross_source_moments() -> None:
+    """Whitened draws reproduce the requested non-diagonal arithmetic moments."""
+    prior = _prior()
+    rng = np.random.default_rng(9274)
+    whitened = rng.standard_normal((100_000, 3))
+    draws = np.exp(
+        np.asarray(prior.latent_mean)
+        + whitened @ np.asarray(prior.latent_cholesky).T
+    )
+
+    np.testing.assert_allclose(draws.mean(axis=0), np.ones(3), atol=0.01)
+    np.testing.assert_allclose(np.cov(draws, rowvar=False), _arithmetic_covariance(), atol=0.01)
+
+
+def test_diagonal_correlated_prior_matches_existing_lognormal_conversion() -> None:
+    """The joint component reduces to existing independent marginal moments."""
+    stdev = np.array([0.2, 0.3, 0.5])
+    prior = CorrelatedLognormalPrior.from_moments(_gathered_mean(), np.diag(stdev**2))
+    expected_mu, expected_sigma = lognormal_mu_sigma(np.ones(3), stdev)
+
+    np.testing.assert_allclose(prior.latent_mean, expected_mu)
+    np.testing.assert_allclose(np.diag(prior.latent_cholesky), expected_sigma)
+    np.testing.assert_allclose(
+        prior.latent_covariance - np.diag(np.diag(prior.latent_covariance)),
+        0.0,
+        atol=1e-15,
+    )
+
+
+@pytest.mark.parametrize(
+    ("mean_values", "covariance", "match"),
+    [
+        ([1.0, 0.0, 1.0], _arithmetic_covariance(), "positive"),
+        ([1.0, np.nan, 1.0], _arithmetic_covariance(), "finite"),
+        (
+            [1.0, 1.0, 1.0],
+            np.array([[0.16, 0.1, 0.0], [0.0, 0.09, 0.0], [0.0, 0.0, 0.25]]),
+            "symmetric",
+        ),
+        (
+            [1.0, 1.0, 1.0],
+            np.array([[1.0, -0.49, -0.49], [-0.49, 1.0, -0.49], [-0.49, -0.49, 1.0]]),
+            "latent covariance must be positive definite",
+        ),
+    ],
+)
+def test_correlated_lognormal_rejects_invalid_moments(
+    mean_values: list[float],
+    covariance: np.ndarray,
+    match: str,
+) -> None:
+    """Reject invalid arithmetic inputs and an invalid transformed covariance."""
+    mean = _gathered_mean().copy(data=mean_values)
+    with pytest.raises(ValueError, match=match):
+        CorrelatedLognormalPrior.from_moments(mean, covariance)
+
+
+def test_correlated_lognormal_rejects_reordered_row_or_column_labels() -> None:
+    """Never reinterpret an equal-sized covariance positionally after reordering."""
+    mean = _gathered_mean()
+    covariance_dim = "state_covariance"
+    column_labels = np.empty(3, dtype=object)
+    column_labels[:] = mean.indexes["state"].tolist()
+    covariance = xr.DataArray(
+        _arithmetic_covariance(),
+        dims=("state", covariance_dim),
+        coords={
+            **xr.Coordinates.from_pandas_multiindex(mean.indexes["state"], "state"),
+            covariance_dim: column_labels,
+        },
+    )
+
+    with pytest.raises(ValueError, match="row labels"):
+        CorrelatedLognormalPrior.from_moments(
+            mean,
+            covariance.isel(state=[1, 0, 2]),
+        )
+    with pytest.raises(ValueError, match="column labels"):
+        CorrelatedLognormalPrior.from_moments(
+            mean,
+            covariance.isel(state_covariance=[1, 0, 2]),
+        )
+
+
+def test_correlated_lognormal_rejects_covariance_dimension_coord_collision() -> None:
+    """Do not let the second matrix axis claim a MultiIndex level coordinate."""
+    with pytest.raises(ValueError, match="must not collide"):
+        CorrelatedLognormalPrior.from_moments(
+            _gathered_mean(),
+            _arithmetic_covariance(),
+            covariance_dim="source",
+        )
+
+
+def test_correlated_lognormal_canonicalizes_tolerance_level_asymmetry() -> None:
+    """Store the symmetric matrix actually used by the Cholesky factorization."""
+    covariance = _arithmetic_covariance()
+    covariance[0, 1] += 5.0e-11
+    prior = CorrelatedLognormalPrior.from_moments(_gathered_mean(), covariance)
+
+    np.testing.assert_array_equal(
+        prior.arithmetic_covariance,
+        np.asarray(prior.arithmetic_covariance).T,
+    )
+
+
+def test_select_marginal_takes_principal_submatrix_without_fixed_state() -> None:
+    """Marginalization keeps arithmetic moments and never restores a constant slot."""
+    prior = _prior()
+    retained = xr.DataArray(
+        [True, False, True],
+        dims=("state",),
+        coords={"state": prior.mean.coords["state"]},
+    )
+
+    selection = prior.select_marginal(retained)
+
+    np.testing.assert_allclose(selection.prior.mean, [1.0, 1.0])
+    np.testing.assert_allclose(
+        selection.prior.arithmetic_covariance,
+        _arithmetic_covariance()[np.ix_([0, 2], [0, 2])],
+    )
+    np.testing.assert_array_equal(selection.retained, [True, False, True])
+    np.testing.assert_array_equal(selection.omitted, [False, True, False])
+    assert selection.prior.mean.sizes["state"] == 2
+    assert not hasattr(selection, "fixed_value")
+
+
+def test_add_correlated_lognormal_state_builds_whitened_public_graph() -> None:
+    """Expose a standard-normal sampler state and positive effective state."""
+    prior = _prior()
+    registry = CoordRegistry()
+    with pm.Model() as model:
+        attach_coord_registry(model, registry)
+        result = add_correlated_lognormal_state(prior, var_name="x")
+
+    assert set(model.named_vars) == {"x_latent", "x"}
+    assert [rv.name for rv in model.free_RVs] == ["x_latent"]
+    assert result.latent is model.named_vars["x_latent"]
+    assert result.state is model.named_vars["x"]
+    assert result.prior is prior
+    assert registry.original_coords["state"].equals(prior.mean.indexes["state"])
+    assert list(registry.auxiliary_coords["source"].values) == ["ocean", "ff", "ff"]
+    draw = pm.draw(result.state, random_seed=42)
+    assert draw.shape == (3,)
+    assert (draw > 0).all()
+
+
+def test_add_correlated_lognormal_state_rejects_float32_cholesky_underflow() -> None:
+    """Fail rather than silently make a validated state deterministic in PyTensor."""
+    mean = _gathered_mean().isel(state=[0])
+    prior = CorrelatedLognormalPrior.from_moments(mean, np.array([[1.0e-100]]))
+
+    with pm.Model():
+        with pytest.raises(ValueError, match="remain positive in the model float dtype"):
+            add_correlated_lognormal_state(prior, var_name="x")
+
+
+def test_correlated_state_prior_predictive_restores_gathered_coordinate() -> None:
+    """Restore the exact non-lexical gathered coordinate on sampled state draws."""
+    prior = _prior()
+    registry = CoordRegistry()
+    with pm.Model() as model:
+        attach_coord_registry(model, registry)
+        add_correlated_lognormal_state(prior, var_name="x")
+        idata = pm.sample_prior_predictive(draws=4, random_seed=42)
+
+    restored = restore_inferencedata_coords(idata, registry)
+    assert restored.prior.indexes["state"].equals(prior.mean.indexes["state"])
+    assert list(restored.prior["source"].values) == ["ocean", "ff", "ff"]
+
+
+def test_correlated_prior_dataset_roundtrip_preserves_multiindex(tmp_path) -> None:
+    """Round-trip both moment spaces through the forgiving MultiIndex boundary."""
+    prior = _prior()
+    encoded = encode_multiindexes_for_storage(prior.to_dataset())
+    path = tmp_path / "correlated-prior.nc"
+    encoded.to_netcdf(path)
+    restored = restore_serialisation_multiindexes(xr.load_dataset(path), strict=True)
+    loaded = CorrelatedLognormalPrior.from_dataset(restored)
+
+    assert loaded.mean.indexes["state"].equals(prior.mean.indexes["state"])
+    xr.testing.assert_identical(loaded.mean, prior.mean)
+    xr.testing.assert_allclose(loaded.arithmetic_covariance, prior.arithmetic_covariance)
+    xr.testing.assert_allclose(loaded.latent_covariance, prior.latent_covariance)
+
+
+def test_marginal_prior_dataset_roundtrip_preserves_omitted_identity(tmp_path) -> None:
+    """Persist marginalization semantics and full-state retained labels."""
+    prior = _prior()
+    retained = xr.DataArray(
+        [True, False, True],
+        dims=("state",),
+        coords={"state": prior.mean.coords["state"]},
+    )
+    selection = prior.select_marginal(retained)
+    encoded = encode_multiindexes_for_storage(selection.to_dataset())
+    path = tmp_path / "marginal-correlated-prior.nc"
+    encoded.to_netcdf(path)
+    restored = restore_serialisation_multiindexes(xr.load_dataset(path), strict=True)
+
+    loaded = MarginalCorrelatedLognormalPrior.from_dataset(restored)
+
+    assert loaded.full_prior.mean.indexes["state"].equals(prior.mean.indexes["state"])
+    np.testing.assert_array_equal(loaded.retained, [True, False, True])
+    np.testing.assert_array_equal(loaded.omitted, [False, True, False])
+    np.testing.assert_allclose(
+        loaded.prior.arithmetic_covariance,
+        _arithmetic_covariance()[np.ix_([0, 2], [0, 2])],
+    )
+
+
+def test_correlated_prior_dataset_rejects_inconsistent_derived_moments() -> None:
+    """Do not trust serialized latent matrices that disagree with arithmetic moments."""
+    dataset = _prior().to_dataset()
+    dataset["latent_mean"].values[...] += 0.1
+
+    with pytest.raises(ValueError, match="latent_mean.*inconsistent"):
+        CorrelatedLognormalPrior.from_dataset(dataset)
+
+
+def test_correlated_prior_dataset_rejects_derived_dimension_tampering() -> None:
+    """Require semantic dimensions as well as equal positional values."""
+    dataset = _prior().to_dataset()
+    dataset["latent_mean"] = xr.DataArray(
+        dataset["latent_mean"].values,
+        dims=("unrelated_state",),
+    )
+
+    with pytest.raises(ValueError, match="latent_mean.*dimensions"):
+        CorrelatedLognormalPrior.from_dataset(dataset)
+
+
+def test_correlated_prior_dataset_rejects_column_identity_tampering() -> None:
+    """Bind the positional matrix axis to serialized scientific state labels."""
+    dataset = _prior().to_dataset()
+    dataset["state_covariance_label"].values[1] = '"tampered"'
+
+    with pytest.raises(ValueError, match="serialized column identity"):
+        CorrelatedLognormalPrior.from_dataset(dataset)

--- a/tests/models/test_correlated_state.py
+++ b/tests/models/test_correlated_state.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
+import warnings
+
 import numpy as np
 import pandas as pd
 import pymc as pm
 import pytest
 import xarray as xr
 
-from openghg_inversions.correlated_state import (
-    CorrelatedLognormalPrior,
-    MarginalCorrelatedLognormalPrior,
-)
+from openghg_inversions.correlated_state import CorrelatedLognormalPrior
 from openghg_inversions.models import (
     CoordRegistry,
     add_correlated_lognormal_state,
@@ -55,10 +54,51 @@ def _prior() -> CorrelatedLognormalPrior:
     return CorrelatedLognormalPrior.from_moments(_gathered_mean(), _arithmetic_covariance())
 
 
-def test_correlated_prior_requires_validated_factory_construction() -> None:
-    """Prevent callers from bypassing moment and coordinate validation."""
-    with pytest.raises(TypeError, match="from_moments"):
-        CorrelatedLognormalPrior()  # type: ignore[call-arg]
+def test_correlated_prior_constructor_matches_named_factory() -> None:
+    """Constructing directly or through ``from_moments`` gives the same prior."""
+    mean = _gathered_mean()
+    covariance = _arithmetic_covariance()
+
+    direct = CorrelatedLognormalPrior(mean, covariance)
+    factory = CorrelatedLognormalPrior.from_moments(mean, covariance)
+
+    xr.testing.assert_identical(direct.mean, factory.mean)
+    xr.testing.assert_identical(direct.arithmetic_covariance, factory.arithmetic_covariance)
+    xr.testing.assert_identical(direct.latent_mean, factory.latent_mean)
+    xr.testing.assert_identical(direct.latent_covariance, factory.latent_covariance)
+    xr.testing.assert_identical(direct.latent_cholesky, factory.latent_cholesky)
+
+
+def test_correlated_prior_warns_before_large_covariance_validation() -> None:
+    """Warn above the operational state-size threshold before covariance work."""
+    state_size = 1001
+    mean = xr.DataArray(
+        np.ones(state_size),
+        dims="state",
+        coords={"state": np.arange(state_size)},
+    )
+
+    with pytest.warns(
+        UserWarning,
+        match=r"already-reduced dense covariance.*operational threshold of 1000",
+    ):
+        with pytest.raises(ValueError, match="square and match the state length"):
+            CorrelatedLognormalPrior(mean, np.empty((0, 0)))
+
+
+def test_correlated_prior_does_not_warn_at_large_state_threshold() -> None:
+    """Do not warn when state size equals the documented operational threshold."""
+    state_size = 1000
+    mean = xr.DataArray(
+        np.ones(state_size),
+        dims="state",
+        coords={"state": np.arange(state_size)},
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        with pytest.raises(ValueError, match="square and match the state length"):
+            CorrelatedLognormalPrior(mean, np.empty((0, 0)))
 
 
 def test_correlated_prior_owns_inputs_and_returns_independent_arrays() -> None:
@@ -245,65 +285,6 @@ def test_correlated_lognormal_canonicalizes_tolerance_level_asymmetry() -> None:
     )
 
 
-def test_select_marginal_takes_principal_submatrix_without_fixed_state() -> None:
-    """Marginalization keeps arithmetic moments and never restores a constant slot."""
-    prior = _prior()
-    retained = xr.DataArray(
-        [True, False, True],
-        dims=("state",),
-        coords={"state": prior.mean.coords["state"]},
-    )
-
-    selection = prior.select_marginal(retained)
-
-    np.testing.assert_allclose(selection.prior.mean, [1.0, 1.0])
-    np.testing.assert_allclose(
-        selection.prior.arithmetic_covariance,
-        _arithmetic_covariance()[np.ix_([0, 2], [0, 2])],
-    )
-    np.testing.assert_array_equal(selection.retained, [True, False, True])
-    np.testing.assert_array_equal(selection.omitted, [False, True, False])
-    assert selection.prior.mean.sizes["state"] == 2
-    assert not hasattr(selection, "fixed_value")
-
-
-def test_marginal_prior_dataset_owns_retained_state_mask() -> None:
-    """Keep serialized mask mutations isolated from the validated selection."""
-    prior = _prior()
-    retained = xr.DataArray(
-        [True, False, True],
-        dims=("state",),
-        coords={"state": prior.mean.coords["state"]},
-    )
-    selection = prior.select_marginal(retained)
-
-    dataset = selection.to_dataset()
-    dataset["retained_state"].values[:] = False
-
-    np.testing.assert_array_equal(selection.retained, [True, False, True])
-    xr.testing.assert_identical(
-        selection.prior.mean,
-        prior.mean.isel(state=[0, 2]),
-    )
-
-
-def test_marginal_prior_requires_validated_selection() -> None:
-    """Prevent inconsistent public combinations of full, mask, and reduced prior."""
-    prior = _prior()
-    retained = xr.DataArray(
-        [True, False, True],
-        dims="state",
-        coords={"state": prior.mean.coords["state"]},
-    )
-
-    with pytest.raises(TypeError, match="select_marginal"):
-        MarginalCorrelatedLognormalPrior(
-            full_prior=prior,
-            retained=retained,
-            prior=prior,
-        )
-
-
 @pytest.mark.parametrize(
     "reserved_name",
     [
@@ -312,7 +293,6 @@ def test_marginal_prior_requires_validated_selection() -> None:
         "latent_mean",
         "latent_covariance",
         "latent_cholesky",
-        "retained_state",
     ],
 )
 def test_correlated_prior_rejects_reserved_serialization_coordinate_names(
@@ -436,31 +416,6 @@ def test_correlated_prior_dataset_roundtrip_preserves_multiindex(tmp_path) -> No
     xr.testing.assert_identical(loaded.mean, prior.mean)
     xr.testing.assert_allclose(loaded.arithmetic_covariance, prior.arithmetic_covariance)
     xr.testing.assert_allclose(loaded.latent_covariance, prior.latent_covariance)
-
-
-def test_marginal_prior_dataset_roundtrip_preserves_omitted_identity(tmp_path) -> None:
-    """Persist marginalization semantics and full-state retained labels."""
-    prior = _prior()
-    retained = xr.DataArray(
-        [True, False, True],
-        dims=("state",),
-        coords={"state": prior.mean.coords["state"]},
-    )
-    selection = prior.select_marginal(retained)
-    encoded = encode_multiindexes_for_storage(selection.to_dataset())
-    path = tmp_path / "marginal-correlated-prior.nc"
-    encoded.to_netcdf(path)
-    restored = restore_serialisation_multiindexes(xr.load_dataset(path), strict=True)
-
-    loaded = MarginalCorrelatedLognormalPrior.from_dataset(restored)
-
-    assert loaded.full_prior.mean.indexes["state"].equals(prior.mean.indexes["state"])
-    np.testing.assert_array_equal(loaded.retained, [True, False, True])
-    np.testing.assert_array_equal(loaded.omitted, [False, True, False])
-    np.testing.assert_allclose(
-        loaded.prior.arithmetic_covariance,
-        _arithmetic_covariance()[np.ix_([0, 2], [0, 2])],
-    )
 
 
 def test_correlated_prior_dataset_rejects_inconsistent_derived_moments() -> None:

--- a/tests/models/test_correlated_state.py
+++ b/tests/models/test_correlated_state.py
@@ -267,6 +267,26 @@ def test_select_marginal_takes_principal_submatrix_without_fixed_state() -> None
     assert not hasattr(selection, "fixed_value")
 
 
+def test_marginal_prior_dataset_owns_retained_state_mask() -> None:
+    """Keep serialized mask mutations isolated from the validated selection."""
+    prior = _prior()
+    retained = xr.DataArray(
+        [True, False, True],
+        dims=("state",),
+        coords={"state": prior.mean.coords["state"]},
+    )
+    selection = prior.select_marginal(retained)
+
+    dataset = selection.to_dataset()
+    dataset["retained_state"].values[:] = False
+
+    np.testing.assert_array_equal(selection.retained, [True, False, True])
+    xr.testing.assert_identical(
+        selection.prior.mean,
+        prior.mean.isel(state=[0, 2]),
+    )
+
+
 def test_marginal_prior_requires_validated_selection() -> None:
     """Prevent inconsistent public combinations of full, mask, and reduced prior."""
     prior = _prior()
@@ -282,6 +302,29 @@ def test_marginal_prior_requires_validated_selection() -> None:
             retained=retained,
             prior=prior,
         )
+
+
+@pytest.mark.parametrize(
+    "reserved_name",
+    [
+        "arithmetic_mean",
+        "arithmetic_covariance",
+        "latent_mean",
+        "latent_covariance",
+        "latent_cholesky",
+        "retained_state",
+    ],
+)
+def test_correlated_prior_rejects_reserved_serialization_coordinate_names(
+    reserved_name: str,
+) -> None:
+    """Reject auxiliary names that collide with serialized state variables."""
+    mean = _gathered_mean().assign_coords(
+        {reserved_name: ("state", np.arange(3))},
+    )
+
+    with pytest.raises(ValueError, match="reserved correlated-state"):
+        CorrelatedLognormalPrior.from_moments(mean, _arithmetic_covariance())
 
 
 def test_add_correlated_lognormal_state_builds_whitened_public_graph() -> None:

--- a/tests/models/test_correlated_state.py
+++ b/tests/models/test_correlated_state.py
@@ -51,22 +51,24 @@ def _arithmetic_covariance() -> np.ndarray:
 
 def _prior() -> CorrelatedLognormalPrior:
     """Return the common gathered correlated prior fixture."""
-    return CorrelatedLognormalPrior.from_moments(_gathered_mean(), _arithmetic_covariance())
+    return CorrelatedLognormalPrior(_gathered_mean(), _arithmetic_covariance())
 
 
-def test_correlated_prior_constructor_matches_named_factory() -> None:
-    """Constructing directly or through ``from_moments`` gives the same prior."""
+def test_correlated_prior_constructor_exposes_derived_arrays() -> None:
+    """Direct construction exposes labelled latent moments and their factor."""
     mean = _gathered_mean()
     covariance = _arithmetic_covariance()
 
-    direct = CorrelatedLognormalPrior(mean, covariance)
-    factory = CorrelatedLognormalPrior.from_moments(mean, covariance)
+    prior = CorrelatedLognormalPrior(mean, covariance)
 
-    xr.testing.assert_identical(direct.mean, factory.mean)
-    xr.testing.assert_identical(direct.arithmetic_covariance, factory.arithmetic_covariance)
-    xr.testing.assert_identical(direct.latent_mean, factory.latent_mean)
-    xr.testing.assert_identical(direct.latent_covariance, factory.latent_covariance)
-    xr.testing.assert_identical(direct.latent_cholesky, factory.latent_cholesky)
+    assert prior.latent_mean.dims == ("state",)
+    assert prior.latent_covariance.dims == ("state", "state_covariance")
+    assert prior.latent_cholesky.dims == ("state", "state_covariance")
+    cholesky = np.asarray(prior.latent_cholesky)
+    np.testing.assert_allclose(
+        cholesky @ cholesky.T,
+        prior.latent_covariance,
+    )
 
 
 def test_correlated_prior_warns_before_large_covariance_validation() -> None:
@@ -105,7 +107,7 @@ def test_correlated_prior_owns_inputs_and_returns_independent_arrays() -> None:
     """Keep the validated prior stable when caller-visible arrays are mutated."""
     mean = _gathered_mean()
     covariance = _arithmetic_covariance()
-    prior = CorrelatedLognormalPrior.from_moments(mean, covariance)
+    prior = CorrelatedLognormalPrior(mean, covariance)
 
     mean.values[0] = 7.0
     covariance[0, 0] = 8.0
@@ -147,7 +149,7 @@ def test_correlated_lognormal_supports_positive_nonunit_means() -> None:
     """Use the general arithmetic moment map when state means are not one."""
     mean = _gathered_mean().copy(data=[0.5, 2.0, 1.5])
     covariance = 0.25 * _arithmetic_covariance()
-    prior = CorrelatedLognormalPrior.from_moments(mean, covariance)
+    prior = CorrelatedLognormalPrior(mean, covariance)
     latent_covariance = np.asarray(prior.latent_covariance)
     latent_mean = np.asarray(prior.latent_mean)
     reconstructed_mean = np.exp(latent_mean + 0.5 * np.diag(latent_covariance))
@@ -173,7 +175,7 @@ def test_correlated_lognormal_monte_carlo_preserves_cross_source_moments() -> No
 def test_diagonal_correlated_prior_matches_existing_lognormal_conversion() -> None:
     """The joint component reduces to existing independent marginal moments."""
     stdev = np.array([0.2, 0.3, 0.5])
-    prior = CorrelatedLognormalPrior.from_moments(_gathered_mean(), np.diag(stdev**2))
+    prior = CorrelatedLognormalPrior(_gathered_mean(), np.diag(stdev**2))
     expected_mu, expected_sigma = lognormal_mu_sigma(np.ones(3), stdev)
 
     np.testing.assert_allclose(prior.latent_mean, expected_mu)
@@ -210,7 +212,7 @@ def test_correlated_lognormal_rejects_invalid_moments(
     """Reject invalid arithmetic inputs and an invalid transformed covariance."""
     mean = _gathered_mean().copy(data=mean_values)
     with pytest.raises(ValueError, match=match):
-        CorrelatedLognormalPrior.from_moments(mean, covariance)
+        CorrelatedLognormalPrior(mean, covariance)
 
 
 @pytest.mark.parametrize("target", ["mean", "covariance"])
@@ -225,7 +227,7 @@ def test_correlated_lognormal_rejects_complex_moments(target: str) -> None:
         covariance[0, 0] += 0.5j
 
     with pytest.raises(ValueError, match="real numeric"):
-        CorrelatedLognormalPrior.from_moments(mean, covariance)
+        CorrelatedLognormalPrior(mean, covariance)
 
 
 def test_correlated_lognormal_rejects_nonfinite_relative_covariance() -> None:
@@ -233,7 +235,7 @@ def test_correlated_lognormal_rejects_nonfinite_relative_covariance() -> None:
     mean = xr.DataArray([1.0e-200], dims="state", coords={"state": ["tiny"]})
 
     with pytest.raises(ValueError, match="finite relative covariance"):
-        CorrelatedLognormalPrior.from_moments(mean, np.array([[1.0]]))
+        CorrelatedLognormalPrior(mean, np.array([[1.0]]))
 
 
 def test_correlated_lognormal_rejects_reordered_row_or_column_labels() -> None:
@@ -252,12 +254,12 @@ def test_correlated_lognormal_rejects_reordered_row_or_column_labels() -> None:
     )
 
     with pytest.raises(ValueError, match="row labels"):
-        CorrelatedLognormalPrior.from_moments(
+        CorrelatedLognormalPrior(
             mean,
             covariance.isel(state=[1, 0, 2]),
         )
     with pytest.raises(ValueError, match="column labels"):
-        CorrelatedLognormalPrior.from_moments(
+        CorrelatedLognormalPrior(
             mean,
             covariance.isel(state_covariance=[1, 0, 2]),
         )
@@ -266,7 +268,7 @@ def test_correlated_lognormal_rejects_reordered_row_or_column_labels() -> None:
 def test_correlated_lognormal_rejects_covariance_dimension_coord_collision() -> None:
     """Do not let the second matrix axis claim a MultiIndex level coordinate."""
     with pytest.raises(ValueError, match="must not collide"):
-        CorrelatedLognormalPrior.from_moments(
+        CorrelatedLognormalPrior(
             _gathered_mean(),
             _arithmetic_covariance(),
             covariance_dim="source",
@@ -277,7 +279,7 @@ def test_correlated_lognormal_canonicalizes_tolerance_level_asymmetry() -> None:
     """Store the symmetric matrix actually used by the Cholesky factorization."""
     covariance = _arithmetic_covariance()
     covariance[0, 1] += 5.0e-11
-    prior = CorrelatedLognormalPrior.from_moments(_gathered_mean(), covariance)
+    prior = CorrelatedLognormalPrior(_gathered_mean(), covariance)
 
     np.testing.assert_array_equal(
         prior.arithmetic_covariance,
@@ -304,7 +306,7 @@ def test_correlated_prior_rejects_reserved_serialization_coordinate_names(
     )
 
     with pytest.raises(ValueError, match="reserved correlated-state"):
-        CorrelatedLognormalPrior.from_moments(mean, _arithmetic_covariance())
+        CorrelatedLognormalPrior(mean, _arithmetic_covariance())
 
 
 def test_add_correlated_lognormal_state_builds_whitened_public_graph() -> None:
@@ -330,13 +332,13 @@ def test_add_correlated_lognormal_state_builds_whitened_public_graph() -> None:
 def test_add_correlated_lognormal_state_rejects_float32_cholesky_underflow() -> None:
     """Fail atomically rather than leaving a deterministic or partial state."""
     mean = _gathered_mean().isel(state=[0])
-    prior = CorrelatedLognormalPrior.from_moments(mean, np.array([[1.0e-100]]))
+    prior = CorrelatedLognormalPrior(mean, np.array([[1.0e-100]]))
 
     with pm.Model() as model:
         with pytest.raises(ValueError, match="remain positive in the model float dtype"):
             add_correlated_lognormal_state(prior, var_name="x")
         assert model.named_vars == {}
-        valid_prior = CorrelatedLognormalPrior.from_moments(mean, np.array([[0.1]]))
+        valid_prior = CorrelatedLognormalPrior(mean, np.array([[0.1]]))
         add_correlated_lognormal_state(valid_prior, var_name="x")
 
     assert set(model.named_vars) == {"x_latent", "x"}
@@ -349,7 +351,7 @@ def test_add_correlated_lognormal_state_rejects_unrepresentable_float32_mean(
     """Reject obviously unusable backend scales before changing the model."""
     mean = xr.DataArray([mean_value], dims="state", coords={"state": ["scale"]})
     covariance = np.array([[(0.1 * mean_value) ** 2]])
-    prior = CorrelatedLognormalPrior.from_moments(mean, covariance)
+    prior = CorrelatedLognormalPrior(mean, covariance)
 
     with pm.Model() as model:
         with pytest.raises(ValueError, match="arithmetic means.*model float dtype"):
@@ -384,7 +386,7 @@ def test_correlated_prior_preserves_ordinary_state_auxiliary_coordinates(tmp_pat
             "latitude": ("state", [50.0, 51.0, 52.0]),
         },
     )
-    prior = CorrelatedLognormalPrior.from_moments(mean, _arithmetic_covariance())
+    prior = CorrelatedLognormalPrior(mean, _arithmetic_covariance())
     registry = CoordRegistry()
     with pm.Model() as model:
         attach_coord_registry(model, registry)

--- a/tests/models/test_correlated_state.py
+++ b/tests/models/test_correlated_state.py
@@ -61,6 +61,28 @@ def test_correlated_prior_requires_validated_factory_construction() -> None:
         CorrelatedLognormalPrior()  # type: ignore[call-arg]
 
 
+def test_correlated_prior_owns_inputs_and_returns_independent_arrays() -> None:
+    """Keep the validated prior stable when caller-visible arrays are mutated."""
+    mean = _gathered_mean()
+    covariance = _arithmetic_covariance()
+    prior = CorrelatedLognormalPrior.from_moments(mean, covariance)
+
+    mean.values[0] = 7.0
+    covariance[0, 0] = 8.0
+    exposed_mean = prior.mean
+    exposed_mean.values[1] = 9.0
+    dataset = prior.to_dataset()
+    dataset["arithmetic_mean"].values[2] = 10.0
+    dataset["latent_mean"].values[0] = 11.0
+
+    np.testing.assert_allclose(prior.mean, 1.0)
+    np.testing.assert_allclose(prior.arithmetic_covariance, _arithmetic_covariance())
+    np.testing.assert_allclose(
+        prior.latent_mean,
+        -0.5 * np.diag(np.log1p(_arithmetic_covariance())),
+    )
+
+
 def test_correlated_lognormal_matches_requested_arithmetic_moments() -> None:
     """Convert arithmetic moments exactly and retain cross-source covariance."""
     prior = _prior()
@@ -102,10 +124,7 @@ def test_correlated_lognormal_monte_carlo_preserves_cross_source_moments() -> No
     prior = _prior()
     rng = np.random.default_rng(9274)
     whitened = rng.standard_normal((100_000, 3))
-    draws = np.exp(
-        np.asarray(prior.latent_mean)
-        + whitened @ np.asarray(prior.latent_cholesky).T
-    )
+    draws = np.exp(np.asarray(prior.latent_mean) + whitened @ np.asarray(prior.latent_cholesky).T)
 
     np.testing.assert_allclose(draws.mean(axis=0), np.ones(3), atol=0.01)
     np.testing.assert_allclose(np.cov(draws, rowvar=False), _arithmetic_covariance(), atol=0.01)
@@ -152,6 +171,29 @@ def test_correlated_lognormal_rejects_invalid_moments(
     mean = _gathered_mean().copy(data=mean_values)
     with pytest.raises(ValueError, match=match):
         CorrelatedLognormalPrior.from_moments(mean, covariance)
+
+
+@pytest.mark.parametrize("target", ["mean", "covariance"])
+def test_correlated_lognormal_rejects_complex_moments(target: str) -> None:
+    """Reject imaginary components instead of silently discarding them."""
+    mean = _gathered_mean().astype(np.complex128)
+    covariance = _arithmetic_covariance().astype(np.complex128)
+    if target == "mean":
+        mean.values[0] += 0.5j
+    else:
+        mean = _gathered_mean()
+        covariance[0, 0] += 0.5j
+
+    with pytest.raises(ValueError, match="real numeric"):
+        CorrelatedLognormalPrior.from_moments(mean, covariance)
+
+
+def test_correlated_lognormal_rejects_nonfinite_relative_covariance() -> None:
+    """Fail clearly when finite inputs overflow during moment conversion."""
+    mean = xr.DataArray([1.0e-200], dims="state", coords={"state": ["tiny"]})
+
+    with pytest.raises(ValueError, match="finite relative covariance"):
+        CorrelatedLognormalPrior.from_moments(mean, np.array([[1.0]]))
 
 
 def test_correlated_lognormal_rejects_reordered_row_or_column_labels() -> None:
@@ -225,6 +267,23 @@ def test_select_marginal_takes_principal_submatrix_without_fixed_state() -> None
     assert not hasattr(selection, "fixed_value")
 
 
+def test_marginal_prior_requires_validated_selection() -> None:
+    """Prevent inconsistent public combinations of full, mask, and reduced prior."""
+    prior = _prior()
+    retained = xr.DataArray(
+        [True, False, True],
+        dims="state",
+        coords={"state": prior.mean.coords["state"]},
+    )
+
+    with pytest.raises(TypeError, match="select_marginal"):
+        MarginalCorrelatedLognormalPrior(
+            full_prior=prior,
+            retained=retained,
+            prior=prior,
+        )
+
+
 def test_add_correlated_lognormal_state_builds_whitened_public_graph() -> None:
     """Expose a standard-normal sampler state and positive effective state."""
     prior = _prior()
@@ -246,13 +305,34 @@ def test_add_correlated_lognormal_state_builds_whitened_public_graph() -> None:
 
 
 def test_add_correlated_lognormal_state_rejects_float32_cholesky_underflow() -> None:
-    """Fail rather than silently make a validated state deterministic in PyTensor."""
+    """Fail atomically rather than leaving a deterministic or partial state."""
     mean = _gathered_mean().isel(state=[0])
     prior = CorrelatedLognormalPrior.from_moments(mean, np.array([[1.0e-100]]))
 
-    with pm.Model():
+    with pm.Model() as model:
         with pytest.raises(ValueError, match="remain positive in the model float dtype"):
             add_correlated_lognormal_state(prior, var_name="x")
+        assert model.named_vars == {}
+        valid_prior = CorrelatedLognormalPrior.from_moments(mean, np.array([[0.1]]))
+        add_correlated_lognormal_state(valid_prior, var_name="x")
+
+    assert set(model.named_vars) == {"x_latent", "x"}
+
+
+@pytest.mark.parametrize("mean_value", [1.0e-100, 1.0e100])
+def test_add_correlated_lognormal_state_rejects_unrepresentable_float32_mean(
+    mean_value: float,
+) -> None:
+    """Reject obviously unusable backend scales before changing the model."""
+    mean = xr.DataArray([mean_value], dims="state", coords={"state": ["scale"]})
+    covariance = np.array([[(0.1 * mean_value) ** 2]])
+    prior = CorrelatedLognormalPrior.from_moments(mean, covariance)
+
+    with pm.Model() as model:
+        with pytest.raises(ValueError, match="arithmetic means.*model float dtype"):
+            add_correlated_lognormal_state(prior, var_name="x")
+
+    assert model.named_vars == {}
 
 
 def test_correlated_state_prior_predictive_restores_gathered_coordinate() -> None:
@@ -267,6 +347,37 @@ def test_correlated_state_prior_predictive_restores_gathered_coordinate() -> Non
     restored = restore_inferencedata_coords(idata, registry)
     assert restored.prior.indexes["state"].equals(prior.mean.indexes["state"])
     assert list(restored.prior["source"].values) == ["ocean", "ff", "ff"]
+
+
+def test_correlated_prior_preserves_ordinary_state_auxiliary_coordinates(tmp_path) -> None:
+    """Retain non-index scientific state metadata through graph and storage boundaries."""
+    mean = xr.DataArray(
+        np.ones(3),
+        dims="state",
+        coords={
+            "state": ["ocean-2", "ff-7", "ff-3"],
+            "source": ("state", ["ocean", "ff", "ff"]),
+            "region_in_source": ("state", [2, 7, 3]),
+            "latitude": ("state", [50.0, 51.0, 52.0]),
+        },
+    )
+    prior = CorrelatedLognormalPrior.from_moments(mean, _arithmetic_covariance())
+    registry = CoordRegistry()
+    with pm.Model() as model:
+        attach_coord_registry(model, registry)
+        add_correlated_lognormal_state(prior, var_name="x")
+        idata = pm.sample_prior_predictive(draws=2, random_seed=42)
+
+    restored_trace = restore_inferencedata_coords(idata, registry)
+    np.testing.assert_array_equal(restored_trace.prior["source"], mean["source"])
+    np.testing.assert_array_equal(restored_trace.prior["region_in_source"], mean["region_in_source"])
+    np.testing.assert_array_equal(restored_trace.prior["latitude"], mean["latitude"])
+
+    path = tmp_path / "ordinary-aux-coords.nc"
+    prior.to_dataset().to_netcdf(path)
+    loaded = CorrelatedLognormalPrior.from_dataset(xr.load_dataset(path))
+    for name in ("source", "region_in_source", "latitude"):
+        xr.testing.assert_identical(loaded.mean[name], mean[name])
 
 
 def test_correlated_prior_dataset_roundtrip_preserves_multiindex(tmp_path) -> None:


### PR DESCRIPTION
## What changed

This starts #565 with the independently mergeable correlated-state foundation:

- adds a backend-neutral `CorrelatedLognormalPrior` arithmetic-moment contract with one public validating constructor;
- validates gathered state labels, covariance row/column identity, symmetry, PSD, and transformed latent positive-definiteness;
- owns mutable xarray/NumPy inputs and returns independent array/dataset copies;
- converts general positive arithmetic means/covariance to a whitened correlated LogNormal state;
- explicitly accepts an already-reduced dense covariance and emits an operational warning above 1,000 sampled states;
- adds `add_correlated_lognormal_state` as a public PyMC component;
- serializes and revalidates both arithmetic and latent moment spaces through OGI's MultiIndex boundary;
- documents that coherent covariance/forward-model/aggregation-error identities are exact only for a jointly Gaussian state, while a LogNormal retained state plus Gaussian residual is a moment-matched closure;
- keeps known-exact `StateActivity` fixing distinct from uncertainty marginalization.

The earlier standalone prior-marginal selection and retained/omitted ledger have been removed. Prior transformation, state removal, forward-model transformation, and aggregation error must be implemented together.

## Why

The recent coherent 14-site RHIME runs use one gathered state with cross-region and cross-source covariance. Existing per-sector array LogNormal priors are independent.

This foundation lets a custom OGI model builder consume an already-reduced dense state covariance immediately. It does not accept or realize a native-grid covariance: native covariances with tens or hundreds of thousands of cells must remain structured (for example, as Kronecker products) and be projected without constructing the full dense native matrix.

## Validation

- focused correlated-state regression suite after the final API cleanup: 33 passed;
- broader correlated/state/coordinate regression suite: 73 passed;
- Ruff: passed;
- Pyright on the new correlated-state module: passed;
- source-tree Sphinx build: passed (unrelated existing import warnings remain);
- `git diff --check`: passed;
- full required `tox -p --parallel-no-spinner`: passed before the final alias-only cleanup; the focused suite was rerun afterward.

## Deliberately remaining in #565 / #566

This draft does not perform native-to-reduced uncertainty transformation, state-coordinate removal, or aggregation-error construction. #566 will own that coherent unit and its explicit Gaussian/moment-closure semantics.

It also does not yet make the joint state selectable through built-in `RhimeModelSpec`. A later slice will:

- bind a prepared correlated-prior artifact/reference into the model spec;
- create one gathered joint `x(state)` at the multisector flux-construction boundary;
- expose per-sector compatibility selectors/deterministics;
- persist variable roles and coherent-reduction provenance through the standard run output;
- add standard-runner save/load coverage.

The private compiler is intentionally not changed in this foundation; unequal source blocks and structured native covariance products need explicit labelled contracts first.

Part of #565.