### PR TITLE
[Superseded by #581–#583] Add coherent native covariance products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ## Code changes
 
+- Added labelled, matrix-free native covariance actions and coherent retained
+  covariance products for bucket scaling states. The new preparation API
+  supports separable spatial kernels, class-blocked and independent-source
+  covariance, covariance-compatible restriction/prolongation operators,
+  dense or diagonal observation covariance products, reproducible
+  serialization, and explicit documentation of the `Pi`, `U_*`, and
+  `U_bucket` roles. This is the native
+  covariance foundation tracked by Linear OPE-17; likelihood integration is
+  follow-up work.
+
 - Separated basis-group constraints from the algorithms applied within each
   group. The constrained module now owns masks, target allocation, per-group
   dispatch, and global relabelling; partition geometry, steps, policies, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,16 @@
 
 ## Code changes
 
-- Added labelled, matrix-free native covariance actions and coherent retained
-  covariance products for bucket scaling states. The new preparation API
+- Added labelled, matrix-free native covariance actions and
+  covariance-compatible retained product blocks for bucket scaling states. The
+  new preparation API
   supports separable spatial kernels, class-blocked and independent-source
   covariance, covariance-compatible restriction/prolongation operators,
   dense or diagonal observation covariance products, reproducible
   serialization, and explicit documentation of the `Pi`, `U_*`, and
-  `U_bucket` roles. This is the native
-  covariance foundation tracked by Linear OPE-17; likelihood integration is
-  follow-up work.
+  `U_bucket` roles. This is the low-level native covariance foundation tracked
+  by Linear OPE-17; centred coherent reduction, unresolved covariance, and
+  likelihood integration are follow-up work.
 
 - Separated basis-group constraints from the algorithms applied within each
   group. The constrained module now owns masks, target allocation, per-group

--- a/docs/reference/openghg_inversions.basis.covariance_products.rst
+++ b/docs/reference/openghg_inversions.basis.covariance_products.rst
@@ -1,0 +1,7 @@
+openghg\_inversions.basis.covariance\_products
+===============================================
+
+.. automodule:: openghg_inversions.basis.covariance_products
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/reference/openghg_inversions.basis.rst
+++ b/docs/reference/openghg_inversions.basis.rst
@@ -12,4 +12,5 @@ openghg\_inversions.basis
 
    openghg_inversions.basis.algorithms
    openghg_inversions.basis.basis_functions
+   openghg_inversions.basis.covariance_products
    openghg_inversions.basis.operators

--- a/docs/reference/openghg_inversions.native_covariance.rst
+++ b/docs/reference/openghg_inversions.native_covariance.rst
@@ -1,0 +1,7 @@
+openghg\_inversions.native\_covariance
+========================================
+
+.. automodule:: openghg_inversions.native_covariance
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/reference/openghg_inversions.rst
+++ b/docs/reference/openghg_inversions.rst
@@ -27,6 +27,8 @@ openghg\_inversions
    openghg_inversions.convert
    openghg_inversions.filters
    openghg_inversions.model_error
+   openghg_inversions.native_covariance
    openghg_inversions.rhime
    openghg_inversions.serialization
+   openghg_inversions.source_covariance
    openghg_inversions.utils

--- a/docs/reference/openghg_inversions.source_covariance.rst
+++ b/docs/reference/openghg_inversions.source_covariance.rst
@@ -1,0 +1,7 @@
+openghg\_inversions.source\_covariance
+========================================
+
+.. automodule:: openghg_inversions.source_covariance
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/usage/native_covariance.rst
+++ b/docs/usage/native_covariance.rst
@@ -1,0 +1,138 @@
+Native Covariance Projection
+============================
+
+The native covariance projection API prepares the covariance and observation
+products needed to reduce a gridded scaling state. It keeps three concerns
+separate: basis geometry, native covariance, and the scientific definition of
+the retained state. It is currently a low-level preparation API; integration
+with the RHIME likelihood is follow-up work.
+
+Component overview
+------------------
+
+The classes have the following distinct roles.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 28 72
+
+   * - Component
+     - Responsibility
+   * - ``BasisOperator``
+     - Owns basis geometry and retained-state labels. For a single source,
+       ``basis_matrix`` is the bucket prolongation :math:`U_{\mathrm{bucket}}`.
+       A gathered multisource matrix is a spatial template that the projection
+       code expands onto an explicit native source dimension.
+   * - ``InvertibleNativeCovarianceAction``
+     - Structural interface for applying :math:`B` and solving systems in
+       :math:`B` without constructing a dense native covariance matrix.
+   * - ``SeparableExponentialCovariance``
+     - Concrete latitude/longitude covariance action. Optional class labels
+       make cells in different classes uncorrelated.
+   * - ``IndependentSourceCovariance``
+     - Composes ordered, source-specific spatial covariances into a
+       block-diagonal native covariance. Its blocks currently must be
+       ``SeparableExponentialCovariance`` instances. It satisfies the same
+       covariance action interface, so product calculations use the common
+       :math:`B` apply/solve path; multisource basis geometry is still expanded
+       separately.
+   * - ``RetainedProjectionStrategy``
+     - Policy interface that chooses a coherent restriction :math:`\Pi` and
+       covariance-natural prolongation :math:`U_*`.
+   * - ``PreserveBucketProlongation``
+     - Current structural implementation of the strategy interface. It fixes
+       :math:`U_* = U_{\mathrm{bucket}}` and derives the compatible
+       :math:`\Pi_U`.
+   * - ``RetainedProjection``
+     - Frozen value dataclass returned by a strategy. It carries
+       :math:`(\Pi, U_*)` and the strategy identifier; it is not a protocol.
+       Its contained xarray objects remain mutable.
+   * - ``project_native_covariance``
+     - Validates and combines :math:`H`, :math:`B`, the basis geometry, and a
+       projection strategy.
+   * - ``NativeCovarianceProducts``
+     - Frozen result and serialization dataclass containing the labelled
+       reduced covariance and observation products. Its contained xarray
+       objects and provenance mapping remain mutable.
+
+The data flow is:
+
+.. code-block:: text
+
+   BasisOperator ──> U_bucket ─┐
+                              ├─> RetainedProjectionStrategy
+   covariance action ──> B ───┘              │
+                                             v
+                              RetainedProjection(Pi, U_*)
+                                             │
+   native sensitivity H ─────────────────────┤
+   covariance action B ──────────────────────┤
+                                             v
+                              project_native_covariance
+                                             │
+                                             v
+                              NativeCovarianceProducts
+
+``FluxWeightedBasis`` remains a data-preparation wrapper that pairs a basis
+operator with a flux field. It does not own :math:`\Pi`. By the time this API
+is called, :math:`H` already contains footprint times prior flux, so both the
+native state and retained state are multiplicative scalings.
+
+Projection notation
+-------------------
+
+For a centred native perturbation :math:`x`, retained coefficients are
+
+.. math::
+
+   \alpha = \Pi x,
+
+with retained covariance
+
+.. math::
+
+   C_\alpha = \Pi B \Pi^\mathsf{T}.
+
+The covariance-natural prolongation associated with a chosen restriction is
+
+.. math::
+
+   U_* = B \Pi^\mathsf{T} C_\alpha^{-1}.
+
+In general, :math:`U_*`, :math:`U_{\mathrm{bucket}}`, and
+:math:`\Pi^\mathsf{T}` are different operators. The initial strategy preserves
+the established bucket-scaling interpretation by choosing
+
+.. math::
+
+   \Pi_U =
+   \left(U_{\mathrm{bucket}}^\mathsf{T} B^{-1}
+   U_{\mathrm{bucket}}\right)^{-1}
+   U_{\mathrm{bucket}}^\mathsf{T} B^{-1}.
+
+This gives :math:`\Pi_U U_{\mathrm{bucket}} = I` and
+:math:`U_* = U_{\mathrm{bucket}}`. The resulting products are
+:math:`C_\alpha`, :math:`H U_*`, :math:`H B \Pi^\mathsf{T}`, and either dense
+:math:`H B H^\mathsf{T}` or its diagonal.
+
+Observation batching
+--------------------
+
+``observation_batch_size`` is an eager execution setting, not an xarray or
+Dask chunk size. The native sensitivity has already been materialized before
+batching begins. Each batch applies :math:`B` to a group of columns from
+:math:`H^\mathsf{T}` and then forms the corresponding output block. This limits
+the temporary native-grid-by-observation working set.
+
+The dense result is still concatenated into a complete
+:math:`H B H^\mathsf{T}` matrix and therefore requires quadratic
+observation-space storage. Requesting the diagonal avoids that dense output.
+The batch size is an execution choice and does not participate in the
+scientific content identity.
+
+API reference
+-------------
+
+See :mod:`openghg_inversions.native_covariance`,
+:mod:`openghg_inversions.source_covariance`, and
+:mod:`openghg_inversions.basis.covariance_products` for the public interfaces.

--- a/docs/usage/native_covariance.rst
+++ b/docs/usage/native_covariance.rst
@@ -203,6 +203,24 @@ Correspondence with ``verification-games``
 -------------------------------------------
 
 OPE-17 deliberately ports only the reusable lower-level prototype boundary.
+The recent 14-site production runs define retained coefficients with a
+source-blocked, absolute-prior-flux-weighted mean. For source :math:`s`, region
+:math:`r`, and native cell :math:`i`, let
+
+.. math::
+
+   q_{si} = \bar F^{\mathrm{UOB\,BASE}}_{si} A_i,
+   \qquad
+   \Pi_{(s,r),(s',i)} =
+   \mathbf 1[s=s']\,\mathbf 1[i\in r]\,
+   \frac{|q_{si}|}{\sum_{j\in r}|q_{sj}|}.
+
+Thus each row is nonnegative, sums to one, and averages native scaling factors
+within exactly one source and one active region. This physical restriction is
+chosen independently of :math:`B`; the covariance then determines
+:math:`C_\alpha` and :math:`U_*`. The prototype also supports a distinct
+signed-flux-total policy, but that is not the current 14-site production
+setting. Both policies require a supplied-:math:`\Pi`-first OGI strategy.
 
 .. list-table::
    :header-rows: 1
@@ -217,8 +235,9 @@ OPE-17 deliberately ports only the reusable lower-level prototype boundary.
      - Faithful port
      - Re-expressed as labelled xarray actions and product objects; OPE-17 also
        supports ordered independent-source blocks.
-   * - Choose a physical or flux-total restriction :math:`\Pi` first, then
-       derive its covariance-natural lift
+   * - Choose a physical restriction :math:`\Pi` first, then derive its
+       covariance-natural lift. Current 14-site production uses the
+       absolute-prior-flux-weighted regional mean above.
      - Deliberate difference
      - The first OPE-17 strategy is compatibility-oriented: it fixes
        :math:`U_{\mathrm{bucket}}` first and derives :math:`\Pi_U`. The strategy

--- a/docs/usage/native_covariance.rst
+++ b/docs/usage/native_covariance.rst
@@ -1,11 +1,13 @@
 Native Covariance Projection
 ============================
 
-The native covariance projection API prepares the covariance and observation
-products needed to reduce a gridded scaling state. It keeps three concerns
-separate: basis geometry, native covariance, and the scientific definition of
-the retained state. It is currently a low-level preparation API; integration
-with the RHIME likelihood is follow-up work.
+The native covariance projection API prepares labelled covariance and
+observation product blocks for reducing a gridded scaling state. It keeps basis
+geometry, native covariance, and retained-state semantics separate, and never
+constructs a dense native-grid covariance matrix. This is the low-level OPE-17
+boundary: it is not connected to RHIME input preparation or likelihoods, and
+its product blocks are not the complete coherent-reduction artifact planned by
+OPE-18.
 
 Component overview
 ------------------
@@ -22,22 +24,23 @@ The classes have the following distinct roles.
      - Owns basis geometry and retained-state labels. For a single source,
        ``basis_matrix`` is the bucket prolongation :math:`U_{\mathrm{bucket}}`.
        A gathered multisource matrix is a spatial template that the projection
-       code expands onto an explicit native source dimension.
+       code expands onto an explicit native source dimension. In both cases,
+       the transpose does not define the retained restriction :math:`\Pi`.
    * - ``InvertibleNativeCovarianceAction``
      - Structural interface for applying :math:`B` and solving systems in
        :math:`B` without constructing a dense native covariance matrix.
    * - ``SeparableExponentialCovariance``
      - Concrete latitude/longitude covariance action. Optional class labels
-       make cells in different classes uncorrelated.
+       set cross-class covariance to zero; this alone does not assert
+       probabilistic independence outside a joint Gaussian model.
    * - ``IndependentSourceCovariance``
      - Composes ordered, source-specific spatial covariances into a
        block-diagonal native covariance. Its blocks currently must be
-       ``SeparableExponentialCovariance`` instances. It satisfies the same
-       covariance action interface, so product calculations use the common
-       :math:`B` apply/solve path; multisource basis geometry is still expanded
-       separately.
+       ``SeparableExponentialCovariance`` instances. Covariance application
+       and solves use the common action interface; only multisource basis
+       expansion needs a separate source-aware path.
    * - ``RetainedProjectionStrategy``
-     - Policy interface that chooses a coherent restriction :math:`\Pi` and
+     - Policy interface that chooses a compatible restriction :math:`\Pi` and
        covariance-natural prolongation :math:`U_*`.
    * - ``PreserveBucketProlongation``
      - Current structural implementation of the strategy interface. It fixes
@@ -45,15 +48,15 @@ The classes have the following distinct roles.
        :math:`\Pi_U`.
    * - ``RetainedProjection``
      - Frozen value dataclass returned by a strategy. It carries
-       :math:`(\Pi, U_*)` and the strategy identifier; it is not a protocol.
-       Its contained xarray objects remain mutable.
+       :math:`(\Pi, U_*)` and the strategy identifier; it is not a protocol,
+       and its contained xarray objects remain mutable.
    * - ``project_native_covariance``
-     - Validates and combines :math:`H`, :math:`B`, the basis geometry, and a
+     - Validates and combines :math:`H`, :math:`B`, basis geometry, and a
        projection strategy.
    * - ``NativeCovarianceProducts``
      - Frozen result and serialization dataclass containing the labelled
-       reduced covariance and observation products. Its contained xarray
-       objects and provenance mapping remain mutable.
+       product blocks. Its contained xarray objects and provenance mapping
+       remain mutable.
 
 The data flow is:
 
@@ -73,31 +76,53 @@ The data flow is:
                                              v
                               NativeCovarianceProducts
 
-``FluxWeightedBasis`` remains a data-preparation wrapper that pairs a basis
-operator with a flux field. It does not own :math:`\Pi`. By the time this API
-is called, :math:`H` already contains footprint times prior flux, so both the
-native state and retained state are multiplicative scalings.
+``FluxWeightedBasis`` is a data-preparation wrapper that pairs an operator
+with a flux field for sensitivity projection and flux reconstruction. It does
+not define :math:`\Pi`, apply native covariance, or own covariance transforms.
+By the time this API is called, :math:`H` already contains footprint times
+prior flux, so both the native and retained states are multiplicative
+scalings.
 
-Projection notation
--------------------
+Projection and centring
+-----------------------
 
-For a centred native perturbation :math:`x`, retained coefficients are
+Let the native scaling state have mean :math:`m` and covariance :math:`B`:
+
+.. math::
+
+   \operatorname{E}[x] = m,
+   \qquad
+   \operatorname{Cov}(x) = B,
+   \qquad
+   \delta x = x - m.
+
+For a retained restriction :math:`\Pi`, define
 
 .. math::
 
    \alpha = \Pi x,
-
-with retained covariance
-
-.. math::
-
+   \qquad
+   \delta\alpha = \alpha - \Pi m = \Pi\,\delta x,
+   \qquad
    C_\alpha = \Pi B \Pi^\mathsf{T}.
 
-The covariance-natural prolongation associated with a chosen restriction is
+The covariance-natural prolongation associated with that restriction is
 
 .. math::
 
    U_* = B \Pi^\mathsf{T} C_\alpha^{-1}.
+
+The full affine lift is therefore
+
+.. math::
+
+   \widehat{x}(\alpha)
+   = m + U_*\delta\alpha
+   = m + U_*(\alpha - \Pi m),
+
+not the uncentred expression :math:`U_*\alpha`. For a joint Gaussian model
+this lift is :math:`\operatorname{E}[x\mid\alpha]`. Without Gaussianity it is
+the linear-Bayes lift determined by the first two moments.
 
 In general, :math:`U_*`, :math:`U_{\mathrm{bucket}}`, and
 :math:`\Pi^\mathsf{T}` are different operators. The initial strategy preserves
@@ -111,24 +136,99 @@ the established bucket-scaling interpretation by choosing
    U_{\mathrm{bucket}}^\mathsf{T} B^{-1}.
 
 This gives :math:`\Pi_U U_{\mathrm{bucket}} = I` and
-:math:`U_* = U_{\mathrm{bucket}}`. The resulting products are
-:math:`C_\alpha`, :math:`H U_*`, :math:`H B \Pi^\mathsf{T}`, and either dense
+:math:`U_* = U_{\mathrm{bucket}}`. OPE-17 returns :math:`C_\alpha`,
+:math:`H U_*`, :math:`H B \Pi^\mathsf{T}`, and either dense
 :math:`H B H^\mathsf{T}` or its diagonal.
 
-Observation batching
---------------------
+What OPE-17 does not construct
+------------------------------
+
+The exact Gaussian reduction also needs
+
+.. math::
+
+   B_\perp
+   = B - U_* C_\alpha U_*^\mathsf{T},
+
+and the centred conditional observation model
+
+.. math::
+
+   y \mid \alpha \sim \mathcal N\!\left(
+   Hm + H U_*(\alpha - \Pi m),
+   R + H B_\perp H^\mathsf{T}
+   \right).
+
+OPE-18 owns that solve-based transformation, unresolved covariance, and the
+single coherent artifact that binds prior, forward, residual, reconstruction,
+and state-treatment information. The OPE-17 product blocks are inputs to that
+work; they must not be described or persisted as though they were already the
+complete artifact. Arbitrary reporting-function products :math:`Q`,
+low-rank-plus-diagonal numerical views, and likelihood integration are also
+outside this API.
+
+Identity and serialization
+--------------------------
+
+``source_content_identity`` binds the shared :math:`B/H/\Pi/U_*` source
+content independently of the requested dense or diagonal observation product.
+``observation_covariance_view`` records that selector, and ``view_identity``
+is derived from it and the source identity. These values bind provenance and
+shared metadata; they are not load-time integrity checksums. Deserialization
+does not rehash product values to detect numeric tampering. The later
+coherent-reduction artifact can reference the OPE-17 source identity, but
+needs its own identity for the additional prior, affine-forward, residual,
+and reconstruction content.
+
+Memory and execution boundary
+-----------------------------
+
+The structured covariance action stores axis factors rather than dense native
+:math:`B`, but this API is otherwise eager. It materializes the native
+sensitivity, bucket prolongation, restriction/prolongation, reduced products,
+and requested observation product. For native size :math:`N`, retained size
+:math:`d`, and observation count :math:`M`, important dense storage includes
+:math:`M N` for :math:`H`, :math:`N d` for each native-by-retained array,
+:math:`d^2` for retained products, and either :math:`M^2` for dense
+:math:`H B H^\mathsf{T}` or :math:`M` for its diagonal.
 
 ``observation_batch_size`` is an eager execution setting, not an xarray or
-Dask chunk size. The native sensitivity has already been materialized before
-batching begins. Each batch applies :math:`B` to a group of columns from
-:math:`H^\mathsf{T}` and then forms the corresponding output block. This limits
-the temporary native-grid-by-observation working set.
+Dask chunk size. Each batch applies :math:`B` to a group of columns from
+:math:`H^\mathsf{T}`, limiting the temporary :math:`N`-by-batch working set.
+Dense batches still fill a preallocated complete quadratic observation
+covariance. Changing the batch size changes execution only, not the scientific
+inputs or requested numerical form.
 
-The dense result is still concatenated into a complete
-:math:`H B H^\mathsf{T}` matrix and therefore requires quadratic
-observation-space storage. Requesting the diagonal avoids that dense output.
-The batch size is an execution choice and does not participate in the
-scientific content identity.
+Correspondence with ``verification-games``
+-------------------------------------------
+
+OPE-17 deliberately ports only the reusable lower-level prototype boundary.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 31 21 48
+
+   * - Prototype capability
+     - OPE-17 status
+     - Correspondence
+   * - Separable exponential covariance action, optional class blocking, and
+       batched :math:`\Pi B\Pi^\mathsf{T}`,
+       :math:`H B\Pi^\mathsf{T}`, and :math:`H B H^\mathsf{T}` products
+     - Faithful port
+     - Re-expressed as labelled xarray actions and product objects; OPE-17 also
+       supports ordered independent-source blocks.
+   * - Choose a physical or flux-total restriction :math:`\Pi` first, then
+       derive its covariance-natural lift
+     - Deliberate difference
+     - The first OPE-17 strategy is compatibility-oriented: it fixes
+       :math:`U_{\mathrm{bucket}}` first and derives :math:`\Pi_U`. The strategy
+       interface leaves room for a future :math:`\Pi`-first policy.
+   * - Cross-source covariance, arbitrary reporting functionals :math:`Q`,
+       :math:`B_\perp` products, coherent likelihood reduction, reconstruction,
+       and covariance approximation
+     - Not ported
+     - These remain prototype or downstream OPE-18 work and must not be inferred
+       from the presence of OPE-17 product blocks.
 
 API reference
 -------------

--- a/docs/usage/rhime.rst
+++ b/docs/usage/rhime.rst
@@ -741,8 +741,8 @@ Kronecker product, whose projected products can be evaluated without realizing
 the full native covariance.
 
 The low-level :doc:`native_covariance` API supplies this structured native
-covariance action and its coherent projected product blocks. It is a
-preparation interface and is not yet connected to the RHIME likelihood.
+covariance action and its covariance-compatible projected product blocks. It
+is a preparation interface and is not yet connected to the RHIME likelihood.
 
 This component does **not** perform the native-to-reduced uncertainty
 transformation or remove state coordinates. That work must transform the prior

--- a/docs/usage/rhime.rst
+++ b/docs/usage/rhime.rst
@@ -740,6 +740,10 @@ than 100,000 cells require a structured covariance representation, such as a
 Kronecker product, whose projected products can be evaluated without realizing
 the full native covariance.
 
+The low-level :doc:`native_covariance` API supplies this structured native
+covariance action and its coherent projected product blocks. It is a
+preparation interface and is not yet connected to the RHIME likelihood.
+
 This component does **not** perform the native-to-reduced uncertainty
 transformation or remove state coordinates. That work must transform the prior
 uncertainty, forward operator, and aggregation error together. The coherent

--- a/docs/usage/usage.rst
+++ b/docs/usage/usage.rst
@@ -9,3 +9,4 @@ Using OpenGHG Inversions
    getting_started
    rhime
    concrete_rhime_model
+   native_covariance

--- a/openghg_inversions/basis/__init__.py
+++ b/openghg_inversions/basis/__init__.py
@@ -1,4 +1,20 @@
-"""Functions for creating basis functions and applying them to sensitivity matrices."""
+"""Basis construction, projection, and retained covariance-product interfaces.
+
+The package provides basis-generation functions, flux-weighted preparation
+wrappers, prior-width projection helpers, and the public OPE-17 retained
+covariance-product API. Basis operators own grid/state geometry: their bucket
+matrix is a prolongation from retained scalings to the native grid, not an
+automatic retained restriction. ``FluxWeightedBasis`` pairs that geometry with
+flux for sensitivity projection and reconstruction; it does not own native
+covariance transforms.
+
+Native covariance actions live in :mod:`openghg_inversions.native_covariance`
+and :mod:`openghg_inversions.source_covariance`. The interfaces re-exported
+here choose a compatible restriction/prolongation pair and prepare labelled
+product blocks. They are a low-level input to later coherent reduction and do
+not themselves construct the centred reduced likelihood, unresolved
+covariance, or a complete coherent-reduction artifact.
+"""
 
 from ._functions import (
     basis_weights_from_fp_all,

--- a/openghg_inversions/basis/__init__.py
+++ b/openghg_inversions/basis/__init__.py
@@ -27,6 +27,13 @@ from .prior_uncertainty import (
     calibrate_basis_prior_stdev,
     project_basis_prior_stdev,
 )
+from .covariance_products import (
+    NativeCovarianceProducts,
+    PreserveBucketProlongation,
+    RetainedProjection,
+    RetainedProjectionStrategy,
+    project_native_covariance,
+)
 
 __all__ = [
     "basis_functions_wrapper",
@@ -40,9 +47,14 @@ __all__ = [
     "load_intem_outer_regions",
     "MEAN_TOTAL_TARGET_STATISTIC",
     "MEDIAN_RELATIVE_TARGET_STATISTIC",
+    "NativeCovarianceProducts",
+    "PreserveBucketProlongation",
+    "RetainedProjection",
+    "RetainedProjectionStrategy",
     "make_basis_functions",
     "paired_abs_response_weights",
     "project_basis_prior_stdev",
+    "project_native_covariance",
     "quadtree_basis_from_weights",
     "quadtree_basis_function",
     "quadtreebasisfunction",

--- a/openghg_inversions/basis/covariance_products.py
+++ b/openghg_inversions/basis/covariance_products.py
@@ -46,6 +46,13 @@ The components have deliberately separate roles:
 4. :func:`project_native_covariance` combines those inputs into the frozen,
    serializable :class:`NativeCovarianceProducts` dataclass. Its contained
    xarray objects remain mutable.
+
+Projected artifacts carry a source identity derived from covariance
+configuration, projection strategy, and labelled ``Pi``, ``U``, and ``H``
+inputs, plus a view identity derived from that source identity and the requested
+dense/diagonal representation. These identities bind artifact metadata; they
+are not checksums of computed output values. Observation batching fills one
+preallocated eager result but does not reduce final dense quadratic storage.
 """
 
 from __future__ import annotations
@@ -88,7 +95,9 @@ class RetainedProjectionStrategy(Protocol):
 
     Implementations must return a full-rank ``Pi`` and the covariance-natural
     ``U_* = B Pi.T (Pi B Pi.T)^-1``. This invariant is what makes the returned
-    residual uncorrelated with the retained coefficients.
+    residual uncorrelated with the retained coefficients. Both arrays must use
+    native labels exactly matching the covariance grid in the same order, and
+    their retained-state labels must agree.
     """
 
     def projection(
@@ -253,7 +262,18 @@ class NativeCovarianceProducts:
         native_observation_covariance: Dense ``H B H.T`` with a collision-safe
             observation column dimension, or its labelled observation diagonal.
         strategy: Stable retained-projection strategy name.
-        content_identity: SHA-256 identity binding inputs and products.
+        source_content_identity: SHA-256 identity of the projection strategy,
+            covariance configuration or fallback representation, and labelled
+            ``Pi/U/H`` values, dimensions, and coordinates. It is independent
+            of the dense or diagonal numerical view.
+        view_identity: SHA-256 identity derived from the source identity and
+            requested observation-covariance view.
+        observation_covariance_view: Numerical view represented by
+            ``native_observation_covariance``.
+        covariance_configuration_digest: Digest declaring the covariance
+            configuration required to reproduce the source artifact. The
+            configuration content itself is stored separately in a DataTree
+            child.
         covariance_configuration: Reproducible serialized kernel/source configuration.
         basis_provenance: Stable basis implementation and dimension metadata.
     """
@@ -265,22 +285,30 @@ class NativeCovarianceProducts:
     observation_state_cross_covariance: xr.DataArray
     native_observation_covariance: xr.DataArray
     strategy: str
-    content_identity: str
+    source_content_identity: str
+    view_identity: str
+    observation_covariance_view: Literal["dense", "diagonal"]
+    covariance_configuration_digest: str = ""
     covariance_configuration: xr.Dataset | None = None
     basis_provenance: dict[str, str] = field(default_factory=dict)
 
     schema = "openghg_inversions.native_covariance_products"
-    schema_version = 1
+    schema_version = 2
 
     def to_dataset(self) -> xr.Dataset:
-        """Serialize all labelled product blocks and their shared identity.
+        """Serialize labelled product blocks and their source/view identities.
 
         Returns:
             A dataset containing every product array plus schema, strategy,
-            identity, and basis-provenance metadata. Native covariance
-            configuration is intentionally excluded because it occupies a
-            separate child node in :meth:`to_datatree`.
+            source/view identities, and basis-provenance metadata. Native
+            covariance configuration is intentionally excluded because it
+            occupies a separate child node in :meth:`to_datatree`.
+
+            The identities bind declared source and view metadata across the
+            artifact. They are not integrity checksums of the numerical output
+            variables, whose values are deliberately not re-hashed here.
         """
+        configuration_digest = self._validated_configuration_digest()
         return xr.Dataset(
             {
                 "restriction": self.restriction,
@@ -294,7 +322,10 @@ class NativeCovarianceProducts:
                 "schema": self.schema,
                 "schema_version": self.schema_version,
                 "strategy": self.strategy,
-                "content_identity": self.content_identity,
+                "source_content_identity": self.source_content_identity,
+                "view_identity": self.view_identity,
+                "observation_covariance_view": self.observation_covariance_view,
+                "covariance_configuration_digest": configuration_digest,
                 "basis_provenance": json.dumps(self.basis_provenance, sort_keys=True),
             },
         )
@@ -305,16 +336,35 @@ class NativeCovarianceProducts:
         Returns:
             A tree whose root contains :meth:`to_dataset` output and whose
             optional ``covariance_configuration`` child preserves the native
-            covariance constructor data.
+            covariance constructor data, source binding, and content digest.
         """
         from openghg_inversions.serialization import reset_serialisation_multiindexes
 
         tree = xr.DataTree(reset_serialisation_multiindexes(self.to_dataset()))
+        if self.covariance_configuration is None and self.covariance_configuration_digest:
+            raise ValueError(
+                "Cannot serialize covariance products as a DataTree without the declared "
+                "covariance configuration content"
+            )
         if self.covariance_configuration is not None:
+            configuration_digest = self._validated_configuration_digest()
             tree["covariance_configuration"] = xr.DataTree(
-                _encode_configuration_dataset(self.covariance_configuration)
+                _encode_configuration_dataset(
+                    self.covariance_configuration,
+                    source_content_identity=self.source_content_identity,
+                    configuration_digest=configuration_digest,
+                )
             )
         return tree
+
+    def _validated_configuration_digest(self) -> str:
+        """Return the declared digest after checking any attached configuration."""
+        if self.covariance_configuration is None:
+            return self.covariance_configuration_digest
+        actual_digest = _configuration_digest(self.covariance_configuration)
+        if self.covariance_configuration_digest and self.covariance_configuration_digest != actual_digest:
+            raise ValueError("Attached covariance configuration does not match its declared digest")
+        return actual_digest
 
     @classmethod
     def from_dataset(cls, dataset: xr.Dataset) -> NativeCovarianceProducts:
@@ -329,8 +379,9 @@ class NativeCovarianceProducts:
 
         Raises:
             ValueError: If the schema version, required variables, shared
-                content identity, projection strategy, or JSON-encoded basis
-                provenance is invalid.
+                source/view identity, projection strategy, numerical view, or
+                JSON-encoded basis provenance is invalid. Numerical variable
+                values are not checksummed by this metadata validation.
         """
         if dataset.attrs.get("schema") != cls.schema:
             raise ValueError(f"Expected product schema {cls.schema!r}")
@@ -347,13 +398,37 @@ class NativeCovarianceProducts:
         missing = [name for name in required if name not in dataset]
         if missing:
             raise ValueError(f"Serialized covariance products are missing variables {missing}")
-        content_identity = str(dataset.attrs.get("content_identity", ""))
+        source_content_identity = _validated_identity(
+            dataset.attrs.get("source_content_identity"),
+            name="source content identity",
+        )
+        view_identity = _validated_identity(
+            dataset.attrs.get("view_identity"),
+            name="view identity",
+        )
+        observation_covariance_view = dataset.attrs.get("observation_covariance_view")
+        if observation_covariance_view not in {"dense", "diagonal"}:
+            raise ValueError("Serialized covariance products have an invalid numerical view")
+        expected_view_identity = _view_identity(
+            source_content_identity,
+            cast(Literal["dense", "diagonal"], observation_covariance_view),
+        )
+        if view_identity != expected_view_identity:
+            raise ValueError("Serialized covariance products have an invalid derived view identity")
+        configuration_digest = dataset.attrs.get("covariance_configuration_digest")
+        if configuration_digest != "":
+            _validated_identity(
+                configuration_digest,
+                name="covariance configuration digest",
+            )
         strategy = str(dataset.attrs.get("strategy", ""))
-        if not content_identity or not strategy:
-            raise ValueError("Serialized covariance products are missing identity or strategy metadata")
+        if not strategy:
+            raise ValueError("Serialized covariance products are missing strategy metadata")
         for name in required:
-            if dataset[name].attrs.get("content_identity") != content_identity:
-                raise ValueError(f"Serialized product {name!r} does not share the root content identity")
+            if dataset[name].attrs.get("source_content_identity") != source_content_identity:
+                raise ValueError(f"Serialized product {name!r} does not share the root source identity")
+            if dataset[name].attrs.get("view_identity") != view_identity:
+                raise ValueError(f"Serialized product {name!r} does not share the root view identity")
             if dataset[name].attrs.get("projection_strategy") != strategy:
                 raise ValueError(f"Serialized product {name!r} does not share the root projection strategy")
         return cls(
@@ -364,8 +439,11 @@ class NativeCovarianceProducts:
             observation_state_cross_covariance=dataset["observation_state_cross_covariance"],
             native_observation_covariance=dataset["native_observation_covariance"],
             strategy=strategy,
-            content_identity=content_identity,
-            basis_provenance=json.loads(str(dataset.attrs.get("basis_provenance", "{}"))),
+            source_content_identity=source_content_identity,
+            view_identity=view_identity,
+            observation_covariance_view=cast(Literal["dense", "diagonal"], observation_covariance_view),
+            covariance_configuration_digest=str(configuration_digest),
+            basis_provenance=_decode_basis_provenance(dataset.attrs.get("basis_provenance")),
         )
 
     @classmethod
@@ -381,8 +459,9 @@ class NativeCovarianceProducts:
             arrays and mappings remain mutable.
 
         Raises:
-            ValueError: If the root product schema, shared identity, strategy,
-                MultiIndex metadata, or covariance configuration is invalid.
+            ValueError: If the root product schema, source/view identities,
+                strategy, MultiIndex metadata, or the covariance
+                configuration's source binding or content digest is invalid.
         """
         from openghg_inversions.serialization import (
             MULTIINDEX_DIMS_ATTR,
@@ -394,11 +473,19 @@ class NativeCovarianceProducts:
             root_dataset = restore_serialisation_multiindexes(root_dataset, strict=True)
         products = cls.from_dataset(root_dataset)
         if "covariance_configuration" not in tree:
+            if root_dataset.attrs.get("covariance_configuration_digest"):
+                raise ValueError("Serialized covariance products are missing covariance configuration")
             return products
+        configuration_digest = _validated_identity(
+            root_dataset.attrs.get("covariance_configuration_digest"),
+            name="covariance configuration digest",
+        )
         return replace(
             products,
             covariance_configuration=_decode_configuration_dataset(
-                cast(xr.DataTree, tree["covariance_configuration"]).to_dataset(inherit=False)
+                cast(xr.DataTree, tree["covariance_configuration"]).to_dataset(inherit=False),
+                expected_source_content_identity=products.source_content_identity,
+                expected_configuration_digest=configuration_digest,
             ),
         )
 
@@ -424,18 +511,21 @@ def project_native_covariance(
         observation_covariance: Return dense ``H B H.T`` or only its diagonal.
         observation_batch_size: Positive number of observation right-hand sides
             applied to ``B`` in each eager batch. This is independent of Dask
-            array chunking: each batch produces a result block and the blocks
-            are concatenated. Dense ``H B H.T`` is still fully materialized.
+            array chunking: each batch fills a slice of one preallocated result.
+            Dense ``H B H.T`` is still fully materialized.
         strategy: Retained projection choice. The default preserves bucket scalings.
 
     Returns:
-        Frozen product dataclass containing labelled blocks tied by one content
-        identity. Its contained arrays remain mutable. Inputs and products are
-        eagerly materialized; dense observation covariance has
-        quadratic observation-space storage. Full PSD eigendiagnostics are skipped
-        above 512 rows to avoid adding cubic observation-space work. Input attrs/units are not propagated:
-        product attrs are replaced by mathematical diagnostics because this API
-        does not implement unit algebra.
+        Frozen product dataclass whose arrays carry a shared source identity
+        and a view identity derived from the requested dense/diagonal
+        representation. These identities bind metadata and are not checksums
+        of computed output values. Its contained arrays remain mutable. Inputs
+        and products are eagerly materialized; dense observation covariance
+        has quadratic observation-space storage. Full PSD eigendiagnostics are
+        skipped above 512 rows to avoid adding cubic observation-space work.
+        Input attrs/units are not propagated: product attrs are replaced by
+        mathematical diagnostics because this API does not implement unit
+        algebra.
 
     Raises:
         ValueError: If labels, dimensions, values, or options are invalid.
@@ -474,6 +564,12 @@ def project_native_covariance(
     projection = projection_strategy.projection(
         covariance,
         basis_prolongation,
+        native_dims=native_dims,
+        state_dim=state_dim,
+    )
+    projection = _validated_projection(
+        projection,
+        native_reference=sensitivity,
         native_dims=native_dims,
         state_dim=state_dim,
     )
@@ -530,14 +626,14 @@ def project_native_covariance(
         output=observation_covariance,
         batch_size=batch_size,
     )
-    content_identity = _content_identity(
+    source_content_identity = _source_content_identity(
         covariance,
         projection.restriction,
         projection.prolongation,
         sensitivity,
         strategy=projection.strategy,
-        observation_covariance=observation_covariance,
     )
+    view_identity = _view_identity(source_content_identity, observation_covariance)
     covariance_to_dataset = getattr(covariance, "to_dataset", None)
     covariance_configuration = (
         cast(xr.Dataset, covariance_to_dataset()).copy(deep=True) if callable(covariance_to_dataset) else None
@@ -550,7 +646,8 @@ def project_native_covariance(
     }
     shared_attrs = {
         "projection_strategy": projection.strategy,
-        "content_identity": content_identity,
+        "source_content_identity": source_content_identity,
+        "view_identity": view_identity,
     }
     arrays = (
         projection.restriction,
@@ -571,7 +668,12 @@ def project_native_covariance(
         observation_state_cross_covariance=cross_covariance,
         native_observation_covariance=native_observation_covariance,
         strategy=projection.strategy,
-        content_identity=content_identity,
+        source_content_identity=source_content_identity,
+        view_identity=view_identity,
+        observation_covariance_view=observation_covariance,
+        covariance_configuration_digest=(
+            _configuration_digest(covariance_configuration) if covariance_configuration is not None else ""
+        ),
         covariance_configuration=covariance_configuration,
         basis_provenance=basis_provenance,
     )
@@ -589,9 +691,9 @@ def _observation_covariance(
     """Compute ``H B H.T`` in eager observation right-hand-side batches.
 
     Batching limits the size of the temporary native-space ``B H.T`` block;
-    it is not Dask chunking. Result blocks are concatenated along a distinct
-    observation-column dimension. Dense output therefore still materializes
-    the complete quadratic observation covariance, while diagonal output
+    it is not Dask chunking. The result is allocated once and filled by
+    observation-column batch. Dense output therefore still materializes the
+    complete quadratic observation covariance, while diagonal output
     materializes only its labelled diagonal.
 
     Args:
@@ -605,14 +707,20 @@ def _observation_covariance(
             covariance application.
 
     Returns:
-        Labelled dense ``H B H.T`` or ``diag(H B H.T)``.
+        Labelled dense ``H B H.T`` with dimensions ``(observation_dim,
+        collision-safe column dimension)``, or ``diag(H B H.T)`` with dimension
+        ``(observation_dim,)``. Observation-axis coordinates are preserved.
 
     Raises:
         ValueError: If covariance labels are incompatible or a dense result
             fails the symmetry diagnostic.
     """
     observation_column_dim = _matrix_column_dim(observation_dim, sensitivity.dims)
-    blocks: list[xr.DataArray] = []
+    observation_count = sensitivity.sizes[observation_dim]
+    result_values = np.empty(
+        (observation_count, observation_count) if output == "dense" else observation_count,
+        dtype=np.result_type(sensitivity.dtype, np.float64),
+    )
     for start in range(0, sensitivity.sizes[observation_dim], batch_size):
         stop = min(start + batch_size, sensitivity.sizes[observation_dim])
         rhs = _to_plain_column_axis(
@@ -626,23 +734,38 @@ def _observation_covariance(
             block = xr.dot(sensitivity, b_rhs, dim=list(native_dims)).transpose(
                 observation_dim, observation_column_dim
             )
+            result_values[:, start:stop] = np.asarray(block.values)
         else:
-            matching = _to_plain_column_axis(
-                sensitivity.isel({observation_dim: slice(start, stop)}),
+            block = (rhs * b_rhs).sum(dim=list(native_dims))
+            result_values[start:stop] = np.asarray(block.values)
+    if output == "dense":
+        coords = {
+            str(name): coordinate
+            for name, coordinate in sensitivity.coords.items()
+            if set(coordinate.dims).issubset({observation_dim})
+        }
+        coords.update(
+            _column_coordinates(
+                sensitivity,
                 row_dim=observation_dim,
                 column_dim=observation_column_dim,
-                leading_dims=native_dims,
             )
-            block = (matching * b_rhs).sum(dim=list(native_dims))
-        blocks.append(block)
-    combined = xr.concat(blocks, dim=observation_column_dim)
-    if output == "dense":
+        )
+        combined = xr.DataArray(
+            result_values,
+            dims=(observation_dim, observation_column_dim),
+            coords=coords,
+        )
         combined = _with_matrix_diagnostics(
             combined.rename("native_observation_covariance"), mathematical_name="H B H.T"
         )
     else:
-        combined = combined.rename({observation_column_dim: observation_dim})
-        combined = combined.assign_coords({observation_dim: sensitivity.coords[observation_dim]})
+        coords = {
+            str(name): coordinate
+            for name, coordinate in sensitivity.coords.items()
+            if set(coordinate.dims).issubset({observation_dim})
+        }
+        combined = xr.DataArray(result_values, dims=observation_dim, coords=coords)
         combined = combined.rename("native_observation_covariance").assign_attrs(
             mathematical_name="diag(H B H.T)",
             minimum_diagonal=float(combined.min().item()),
@@ -650,6 +773,92 @@ def _observation_covariance(
             diagnostic_tolerance=1e-10,
         )
     return combined
+
+
+def _validated_projection(
+    projection: RetainedProjection,
+    *,
+    native_reference: xr.DataArray,
+    native_dims: tuple[str, ...],
+    state_dim: str,
+) -> RetainedProjection:
+    """Validate custom strategy labels before any labelled contractions.
+
+    Args:
+        projection: Restriction/prolongation pair returned by a strategy.
+        native_reference: Validated sensitivity carrying canonical native
+            coordinates.
+        native_dims: Ordered native dimensions.
+        state_dim: Retained-state dimension.
+
+    Returns:
+        A projection with eager arrays in canonical dimension order.
+
+    Raises:
+        ValueError: If either array has invalid dimensions, values, or labels.
+            Native coordinates must exactly equal the reference coordinates;
+            xarray reordering or intersection is never used here.
+    """
+    restriction = projection.restriction
+    expected_restriction_dims = {state_dim, *native_dims}
+    if set(restriction.dims) != expected_restriction_dims or len(restriction.dims) != len(
+        expected_restriction_dims
+    ):
+        raise ValueError("Projection strategy restriction has invalid labelled dimensions")
+    restriction = _densify(restriction).transpose(state_dim, *native_dims)
+    if not np.all(np.isfinite(np.asarray(restriction.values))):
+        raise ValueError("Projection strategy restriction must contain only finite values")
+
+    prolongation = _validated_prolongation(
+        projection.prolongation,
+        native_dims=native_dims,
+        state_dim=state_dim,
+    )
+    for role, array in (("restriction", restriction), ("prolongation", prolongation)):
+        _validate_exact_native_coordinates(
+            array,
+            native_reference,
+            native_dims=native_dims,
+            role=role,
+        )
+    if state_dim not in restriction.coords or state_dim not in prolongation.coords:
+        raise ValueError("Projection strategy restriction and prolongation require state labels")
+    if not np.array_equal(
+        restriction.coords[state_dim].values,
+        prolongation.coords[state_dim].values,
+    ):
+        raise ValueError("Projection strategy restriction/prolongation state labels differ")
+    return replace(projection, restriction=restriction, prolongation=prolongation)
+
+
+def _validate_exact_native_coordinates(
+    array: xr.DataArray,
+    reference: xr.DataArray,
+    *,
+    native_dims: tuple[str, ...],
+    role: str,
+) -> None:
+    """Require exact native labels before product alignment or contraction.
+
+    Args:
+        array: Strategy-produced restriction or prolongation.
+        reference: Validated array carrying canonical native coordinates.
+        native_dims: Ordered native dimensions to compare.
+        role: Array role used in validation errors.
+
+    Raises:
+        ValueError: If a native coordinate is absent, reordered, or different.
+    """
+    for dim in native_dims:
+        if dim not in array.coords:
+            raise ValueError(f"Projection strategy {role} is missing native coordinate {dim!r}")
+        actual = np.asarray(array.coords[dim].values)
+        expected = np.asarray(reference.coords[dim].values)
+        if actual.shape != expected.shape or not np.array_equal(actual, expected):
+            raise ValueError(
+                f"Projection strategy {role} native coordinate {dim!r} must exactly match "
+                "the covariance grid in the same order"
+            )
 
 
 def _validate_projection_invariant(
@@ -675,19 +884,7 @@ def _validate_projection_invariant(
         ValueError: If dimensions, state labels, or values are invalid, or if
             ``B Pi.T`` and ``U_* C_alpha`` disagree beyond tolerance.
     """
-    prolongation = _validated_prolongation(
-        projection.prolongation,
-        native_dims=native_dims,
-        state_dim=state_dim,
-    )
-    restriction = projection.restriction
-    expected_dims = {state_dim, *native_dims}
-    if set(restriction.dims) != expected_dims or len(restriction.dims) != len(expected_dims):
-        raise ValueError("Projection strategy restriction has invalid labelled dimensions")
-    if not np.all(np.isfinite(np.asarray(restriction.values))):
-        raise ValueError("Projection strategy restriction must contain only finite values")
-    if not np.array_equal(restriction.coords[state_dim].values, prolongation.coords[state_dim].values):
-        raise ValueError("Projection strategy restriction/prolongation state labels differ")
+    prolongation = projection.prolongation
     u_c = xr.dot(prolongation, state_covariance, dim=state_dim).transpose(*native_dims, state_column_dim)
     left = np.asarray(b_restriction_transpose.values, dtype=np.float64)
     right = np.asarray(u_c.values, dtype=np.float64)
@@ -912,12 +1109,39 @@ def _column_coordinate(coordinate: xr.DataArray, column_dim: str) -> xr.DataArra
     source_values = list(coordinate.values)
     if any(isinstance(value, tuple) for value in source_values):
         values = np.asarray(
-            [json.dumps(list(value), separators=(",", ":")) for value in source_values],
+            [
+                json.dumps(
+                    list(value),
+                    separators=(",", ":"),
+                    default=_json_label_default,
+                )
+                for value in source_values
+            ],
             dtype=str,
         )
     else:
         values = np.asarray(source_values)
     return xr.DataArray(values, dims=column_dim, attrs=coordinate.attrs)
+
+
+def _json_label_default(value: object) -> str:
+    """Encode a rich tuple-label scalar as a stable string.
+
+    NumPy scalars are first converted to their Python equivalent. Datetime-like
+    objects use ``isoformat()``, while other objects use ``str()``.
+
+    Args:
+        value: Non-JSON-native coordinate-label value.
+
+    Returns:
+        Stable string suitable for a JSON tuple token.
+    """
+    if isinstance(value, np.generic):
+        value = value.item()
+    isoformat = getattr(value, "isoformat", None)
+    if callable(isoformat):
+        return str(isoformat())
+    return str(value)
 
 
 def _column_coordinates(
@@ -1024,37 +1248,65 @@ def _with_matrix_diagnostics(array: xr.DataArray, *, mathematical_name: str) -> 
     return array.assign_attrs(attrs)
 
 
-def _encode_configuration_dataset(dataset: xr.Dataset) -> xr.Dataset:
+def _encode_configuration_dataset(
+    dataset: xr.Dataset,
+    *,
+    source_content_identity: str,
+    configuration_digest: str,
+) -> xr.Dataset:
     """Namespace configuration dimensions before DataTree persistence.
 
     Args:
         dataset: Native covariance configuration to encode.
+        source_content_identity: Identity of the source content whose
+            covariance configuration this dataset describes.
+        configuration_digest: Digest of the decoded configuration content.
 
     Returns:
         A copy whose dimensions have a ``covariance_configuration__`` prefix.
         The reversible original-to-encoded mapping is stored in the
         ``openghg_inversions:configuration_dims`` attribute so parent DataTree
-        dimensions cannot absorb the child dimensions.
+        dimensions cannot absorb the child dimensions. The child also carries
+        the source identity so configurations from different artifacts cannot
+        be mixed silently.
     """
     rename = {str(dim): f"covariance_configuration__{dim}" for dim in dataset.dims}
     encoded = dataset.rename(rename).copy()
     encoded.attrs = dict(encoded.attrs)
     encoded.attrs["openghg_inversions:configuration_dims"] = json.dumps(rename, sort_keys=True)
+    encoded.attrs["openghg_inversions:source_content_identity"] = source_content_identity
+    encoded.attrs["openghg_inversions:configuration_digest"] = configuration_digest
     return encoded
 
 
-def _decode_configuration_dataset(dataset: xr.Dataset) -> xr.Dataset:
+def _decode_configuration_dataset(
+    dataset: xr.Dataset,
+    *,
+    expected_source_content_identity: str,
+    expected_configuration_digest: str,
+) -> xr.Dataset:
     """Restore namespaced configuration dimensions after persistence.
 
     Args:
         dataset: Encoded covariance configuration child dataset.
+        expected_source_content_identity: Source identity declared by the root
+            product dataset.
+        expected_configuration_digest: Configuration digest declared by the
+            root product dataset.
 
     Returns:
         A dataset with original dimension names and encoding metadata removed.
 
     Raises:
-        ValueError: If the dimension mapping metadata is absent or invalid.
+        ValueError: If the source binding or dimension mapping metadata is
+            absent or invalid.
     """
+    child_source_identity = dataset.attrs.get("openghg_inversions:source_content_identity")
+    if child_source_identity != expected_source_content_identity:
+        raise ValueError("Serialized covariance configuration does not share the root source identity")
+    child_configuration_digest = dataset.attrs.get("openghg_inversions:configuration_digest")
+    if child_configuration_digest != expected_configuration_digest:
+        raise ValueError("Serialized covariance configuration does not share the root digest")
     encoded_dims = dataset.attrs.get("openghg_inversions:configuration_dims")
     if not isinstance(encoded_dims, str):
         raise ValueError("Serialized covariance configuration is missing dimension metadata")
@@ -1064,35 +1316,122 @@ def _decode_configuration_dataset(dataset: xr.Dataset) -> xr.Dataset:
     restored = dataset.rename({str(encoded): str(original) for original, encoded in rename.items()})
     restored.attrs = dict(restored.attrs)
     del restored.attrs["openghg_inversions:configuration_dims"]
+    del restored.attrs["openghg_inversions:source_content_identity"]
+    del restored.attrs["openghg_inversions:configuration_digest"]
+    if _configuration_digest(restored) != expected_configuration_digest:
+        raise ValueError("Serialized covariance configuration content does not match its digest")
     return restored
 
 
-def _content_identity(
+def _configuration_digest(dataset: xr.Dataset) -> str:
+    """Hash decoded covariance configuration content into a stable digest.
+
+    Args:
+        dataset: Configuration in its decoded, original-dimension form.
+
+    Returns:
+        Lowercase hexadecimal SHA-256 digest stable across supported NetCDF
+        scalar and string coercions.
+    """
+    digest = hashlib.sha256()
+    digest.update(b"openghg_inversions.native_covariance_products.configuration.v1\0")
+    digest.update(_canonical_json(dataset.attrs).encode("utf-8"))
+    for name in sorted(str(name) for name in dataset.coords):
+        _update_configuration_array_digest(digest, dataset.coords[name])
+    for name in sorted(str(name) for name in dataset.data_vars):
+        _update_configuration_array_digest(digest, dataset[name])
+    return digest.hexdigest()
+
+
+def _update_configuration_array_digest(digest: _Digest, array: xr.DataArray) -> None:
+    """Hash one configuration array across NetCDF scalar/string coercions.
+
+    Args:
+        digest: Digest receiving canonical array metadata and values.
+        array: Configuration coordinate or data variable to hash.
+    """
+    digest.update(str(array.name).encode("utf-8"))
+    digest.update(_canonical_json(tuple(str(dim) for dim in array.dims)).encode("utf-8"))
+    digest.update(_canonical_json(array.attrs).encode("utf-8"))
+    values = np.ascontiguousarray(array.values)
+    digest.update(_canonical_json(values.shape).encode("utf-8"))
+    if values.dtype.hasobject or values.dtype.kind in {"U", "S"}:
+        digest.update(_canonical_json(values.tolist()).encode("utf-8"))
+    else:
+        digest.update(values.dtype.str.encode("ascii"))
+        digest.update(values.view(np.uint8).tobytes())
+
+
+def _canonical_json(value: object) -> str:
+    """Encode serialization-compatible metadata with normalized scalar types.
+
+    Args:
+        value: Metadata value accepted by JSON or
+            :func:`_canonical_json_default`.
+
+    Returns:
+        Compact, key-sorted JSON text.
+    """
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=_canonical_json_default,
+    )
+
+
+def _canonical_json_default(value: object) -> object:
+    """Normalize NumPy, byte, array, and datetime-like values for JSON.
+
+    Args:
+        value: Value rejected by the standard JSON encoder.
+
+    Returns:
+        A JSON-native scalar, list, or string.
+
+    Raises:
+        TypeError: If the value has no supported canonical representation.
+    """
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, bytes):
+        return value.decode("utf-8")
+    isoformat = getattr(value, "isoformat", None)
+    if callable(isoformat):
+        return isoformat()
+    raise TypeError(f"Cannot encode {type(value).__name__} in a configuration digest")
+
+
+def _source_content_identity(
     covariance: InvertibleNativeCovarianceAction,
     *arrays: xr.DataArray,
     strategy: str,
-    observation_covariance: str,
 ) -> str:
-    """Hash scientific inputs and configuration into a stable identity.
+    """Hash shared scientific inputs and configuration into a stable identity.
 
     Execution batching is deliberately excluded, because changing
     ``observation_batch_size`` does not change the requested scientific
-    product. Computed product values are also excluded to avoid binding the
-    identity to batch-dependent floating-point roundoff.
+    product. The dense/diagonal numerical view and computed product values are
+    also excluded. This identity binds source content, not stored-byte
+    integrity, and therefore does not detect numerical output tampering. A
+    covariance with ``to_dataset()`` contributes its configuration metadata,
+    coordinates, and variables; the custom-action fallback is stable only when
+    that object's ``repr`` is stable.
 
     Args:
         covariance: Native covariance action, preferably with serializable
             constructor configuration.
-        *arrays: Scientific input arrays to bind to the identity.
+        *arrays: Labelled restriction, prolongation, and sensitivity arrays;
+            their values, dimensions, and all coordinates are hashed.
         strategy: Stable retained-projection strategy name.
-        observation_covariance: Requested dense or diagonal output form.
 
     Returns:
         Lowercase hexadecimal SHA-256 digest.
     """
     digest = hashlib.sha256()
     digest.update(strategy.encode("utf-8"))
-    digest.update(observation_covariance.encode("utf-8"))
     to_dataset = getattr(covariance, "to_dataset", None)
     if callable(to_dataset):
         covariance_dataset = cast(xr.Dataset, to_dataset())
@@ -1108,6 +1447,76 @@ def _content_identity(
     for array in arrays:
         _update_array_digest(digest, array)
     return digest.hexdigest()
+
+
+def _view_identity(
+    source_content_identity: str,
+    observation_covariance_view: Literal["dense", "diagonal"],
+) -> str:
+    """Derive a numerical-view identity from source content and view kind.
+
+    Args:
+        source_content_identity: Identity shared by all numerical views of the
+            same ``B/H/Pi/U`` source.
+        observation_covariance_view: Requested dense or diagonal view.
+
+    Returns:
+        Lowercase hexadecimal SHA-256 digest for this derived view.
+    """
+    digest = hashlib.sha256()
+    digest.update(b"openghg_inversions.native_covariance_products.view.v1\0")
+    digest.update(source_content_identity.encode("ascii"))
+    digest.update(b"\0")
+    digest.update(observation_covariance_view.encode("ascii"))
+    return digest.hexdigest()
+
+
+def _validated_identity(value: object, *, name: str) -> str:
+    """Validate a lowercase hexadecimal SHA-256 identity.
+
+    Args:
+        value: Serialized identity candidate.
+        name: Human-readable identity name used in an error.
+
+    Returns:
+        The validated identity string.
+
+    Raises:
+        ValueError: If the value is not a 64-character lowercase hex digest.
+    """
+    if (
+        not isinstance(value, str)
+        or len(value) != 64
+        or any(character not in "0123456789abcdef" for character in value)
+    ):
+        raise ValueError(f"Serialized covariance products have an invalid {name}")
+    return value
+
+
+def _decode_basis_provenance(value: object) -> dict[str, str]:
+    """Decode and validate the serialized string-to-string provenance map.
+
+    Args:
+        value: JSON text from root dataset metadata.
+
+    Returns:
+        Decoded provenance mapping.
+
+    Raises:
+        ValueError: If the value is not valid JSON encoding an object with
+            string keys and string values.
+    """
+    if not isinstance(value, str):
+        raise ValueError("Serialized covariance products have invalid basis provenance JSON")
+    try:
+        decoded = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise ValueError("Serialized covariance products have invalid basis provenance JSON") from exc
+    if not isinstance(decoded, dict) or any(
+        not isinstance(key, str) or not isinstance(item, str) for key, item in decoded.items()
+    ):
+        raise ValueError("Serialized covariance products basis provenance must be a string mapping")
+    return decoded
 
 
 def _update_array_digest(digest: _Digest, array: xr.DataArray) -> None:

--- a/openghg_inversions/basis/covariance_products.py
+++ b/openghg_inversions/basis/covariance_products.py
@@ -1,0 +1,1132 @@
+"""Coherent native-covariance products for retained bucket scaling states.
+
+OpenGHG Inversions constructs a native observation operator ``H`` from
+footprint times prior flux, so the native vector ``x`` and retained vector
+``alpha = Pi x`` are multiplicative scalings. Their covariance algebra applies
+to the centred perturbations ``x - m`` and ``alpha - Pi m``. The existing
+:attr:`~openghg_inversions.basis.operators.BasisOperator.basis_matrix` supplies
+the single-source bucket prolongation ``U_bucket`` (native by retained), or the
+gathered spatial template expanded to source-native ``U_bucket`` here. It is
+not ``Pi.T``.
+
+This module's initial strategy preserves that established coefficient meaning.
+For native covariance ``B`` it derives the compatible restriction
+
+``Pi_U = (U.T B^-1 U)^-1 U.T B^-1``.
+
+Consequently ``Pi_U U = I``, ``C_alpha = Pi_U B Pi_U.T`` and the
+covariance-weighted prolongation
+``U_* = B Pi_U.T C_alpha^-1`` is exactly ``U_bucket``.  The retained
+observation operator is therefore ``H_alpha = H U_bucket``, matching the
+current bucket sensitivity.  The centred residual
+``r = (x - m) - U_bucket (alpha - Pi_U m)`` satisfies
+``Cov(r, alpha) = 0``. Under a joint Gaussian model this also gives the affine
+conditional mean ``m + U_bucket (alpha - Pi_U m)``.
+
+The public strategy protocol deliberately keeps ``Pi`` separate from basis
+geometry so a future strategy can instead define physical retained
+functionals and derive its covariance-weighted prolongation.  This foundation
+computes labelled ``C_alpha``, ``H B Pi.T``, and ``H B H.T`` (or its diagonal)
+without constructing dense native ``B``. Operations eagerly materialize
+``U``, ``H``, and the requested product matrices; dense ``H B H.T`` therefore
+uses quadratic observation-space storage. Constructing unresolved covariance
+and the coherent reduced likelihood belongs to OPE-18.
+
+The components have deliberately separate roles:
+
+1. :class:`~openghg_inversions.basis.operators.BasisOperator` supplies the
+   bucket geometry ``U_bucket``.
+2. :class:`~openghg_inversions.native_covariance.InvertibleNativeCovarianceAction`
+   supplies labelled applications of ``B`` and ``B^-1``; its protocol is
+   imported rather than redefined here.
+3. :class:`RetainedProjectionStrategy` chooses a coherent ``(Pi, U_*)`` pair
+   and returns it as the :class:`RetainedProjection` value object.
+   :class:`PreserveBucketProlongation` is the initial concrete structural
+   implementation of that strategy protocol.
+4. :func:`project_native_covariance` combines those inputs into the frozen,
+   serializable :class:`NativeCovarianceProducts` dataclass. Its contained
+   xarray objects remain mutable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+import hashlib
+import json
+from typing import Hashable, Literal, Protocol, cast
+
+import numpy as np
+from scipy.linalg import cho_factor, cho_solve
+import xarray as xr
+
+from openghg_inversions.basis.operators import BasisOperator
+from openghg_inversions.native_covariance import InvertibleNativeCovarianceAction
+
+MAX_DENSE_EIGEN_DIAGNOSTIC_SIZE = 512
+
+
+@dataclass(frozen=True, slots=True)
+class RetainedProjection:
+    """A labelled restriction/prolongation pair selected by one strategy.
+
+    Attributes:
+        restriction: ``Pi`` with dimensions ``(state_dim, *native_dims)``;
+            retained coefficients satisfy ``alpha = Pi x``.
+        prolongation: Covariance-compatible ``U_*`` with dimensions
+            ``(*native_dims, state_dim)`` and ``x_hat = U_* alpha`` in centred
+            coordinates.
+        strategy: Stable identifier for the scientific projection choice.
+    """
+
+    restriction: xr.DataArray
+    prolongation: xr.DataArray
+    strategy: str
+
+
+class RetainedProjectionStrategy(Protocol):
+    """Extension seam for choosing retained coefficients and their lift.
+
+    Implementations must return a full-rank ``Pi`` and the covariance-natural
+    ``U_* = B Pi.T (Pi B Pi.T)^-1``. This invariant is what makes the returned
+    residual uncorrelated with the retained coefficients.
+    """
+
+    def projection(
+        self,
+        covariance: InvertibleNativeCovarianceAction,
+        basis_prolongation: xr.DataArray,
+        *,
+        native_dims: tuple[str, ...],
+        state_dim: str,
+    ) -> RetainedProjection:
+        """Return a compatible labelled restriction and prolongation.
+
+        Args:
+            covariance: Invertible labelled action for the native covariance
+                ``B``.
+            basis_prolongation: Candidate bucket prolongation with dimensions
+                ``(*native_dims, state_dim)``.
+            native_dims: Ordered dimensions of the native state.
+            state_dim: Name of the retained-state dimension.
+
+        Returns:
+            A labelled :class:`RetainedProjection` whose restriction is
+            full-rank and whose prolongation satisfies
+            ``B Pi.T = U_* (Pi B Pi.T)``.
+
+        Raises:
+            ValueError: If the supplied arrays are invalid or a coherent,
+                full-rank projection cannot be constructed.
+        """
+        ...
+
+
+class _Digest(Protocol):
+    """Minimal hashlib digest surface used by identity helpers."""
+
+    def update(self, data: bytes, /) -> None:
+        """Add bytes to the digest."""
+        ...
+
+
+@dataclass(frozen=True, slots=True)
+class PreserveBucketProlongation:
+    """Derive ``Pi_U`` so covariance-weighted prolongation equals ``U_bucket``.
+
+    This class is a concrete structural implementation of
+    :class:`RetainedProjectionStrategy`. :class:`RetainedProjection` is the
+    value object returned by :meth:`projection`, not the protocol being
+    implemented.
+
+    Attributes:
+        name: Stable strategy identifier stored with projected products.
+
+    ``B`` must be positive definite and ``U_bucket`` must have full column rank.
+    """
+
+    name: str = "preserve_bucket_prolongation"
+
+    def projection(
+        self,
+        covariance: InvertibleNativeCovarianceAction,
+        basis_prolongation: xr.DataArray,
+        *,
+        native_dims: tuple[str, ...],
+        state_dim: str,
+    ) -> RetainedProjection:
+        """Construct the prior-precision-compatible restriction.
+
+        Args:
+            covariance: Invertible labelled action for the native covariance ``B``.
+            basis_prolongation: Current bucket prolongation ``U_bucket``.
+            native_dims: Ordered native dimensions.
+            state_dim: Retained-state dimension.
+
+        Returns:
+            A :class:`RetainedProjection` containing the labelled pair
+            ``(Pi_U, U_bucket)``.
+
+        Raises:
+            ValueError: If the prolongation is invalid or has redundant columns.
+        """
+        prolongation = _validated_prolongation(
+            basis_prolongation, native_dims=native_dims, state_dim=state_dim
+        )
+        state_column_dim = _matrix_column_dim(state_dim, prolongation.dims)
+        precision_prolongation = _to_plain_column_axis(
+            covariance.solve(prolongation),
+            row_dim=state_dim,
+            column_dim=state_column_dim,
+            leading_dims=native_dims,
+        )
+        gram = xr.dot(
+            prolongation,
+            precision_prolongation,
+            dim=list(native_dims),
+        ).transpose(state_dim, state_column_dim)
+        gram_values = np.asarray(gram.values, dtype=np.float64)
+        _validate_symmetric(gram_values, "U.T B^-1 U")
+        eigenvalues = np.linalg.eigvalsh((gram_values + gram_values.T) * 0.5)
+        largest_eigenvalue = float(eigenvalues[-1]) if eigenvalues.size else 0.0
+        if (
+            not eigenvalues.size
+            or largest_eigenvalue <= 0.0
+            or float(eigenvalues[0]) <= 1e-12 * largest_eigenvalue
+        ):
+            raise ValueError(
+                "The bucket prolongation contains redundant or numerically unsupported retained states; "
+                "U.T B^-1 U must be positive definite and full rank"
+            )
+        try:
+            factor = cho_factor(gram_values, lower=True, check_finite=True)
+        except np.linalg.LinAlgError as exc:
+            raise ValueError(
+                "The bucket prolongation contains redundant or unsupported retained states; "
+                "U.T B^-1 U must be positive definite"
+            ) from exc
+        covariance_values = cho_solve(factor, np.eye(gram_values.shape[0]), check_finite=False)
+        covariance_coords: dict[str, xr.DataArray] = {
+            state_dim: prolongation.coords[state_dim],
+        }
+        for name, coordinate in prolongation.coords.items():
+            if name != state_dim and tuple(coordinate.dims) == (state_dim,):
+                covariance_coords[str(name)] = coordinate
+        covariance_coords.update(
+            _column_coordinates(prolongation, row_dim=state_dim, column_dim=state_column_dim)
+        )
+        state_covariance = xr.DataArray(
+            covariance_values,
+            dims=(state_dim, state_column_dim),
+            coords=covariance_coords,
+        )
+        restriction = xr.dot(
+            state_covariance,
+            precision_prolongation,
+            dim=state_column_dim,
+        ).transpose(state_dim, *native_dims)
+        restriction = restriction.rename("restriction").assign_attrs(
+            mathematical_name="Pi_U",
+            definition="(U.T B^-1 U)^-1 U.T B^-1",
+            strategy=self.name,
+        )
+        prolongation = prolongation.rename("prolongation").assign_attrs(
+            mathematical_name="U_bucket",
+            strategy=self.name,
+        )
+        return RetainedProjection(
+            restriction=restriction,
+            prolongation=prolongation,
+            strategy=self.name,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class NativeCovarianceProducts:
+    """Labelled product blocks induced by one coherent ``(B, H, Pi, U)`` set.
+
+    Attributes:
+        restriction: Retained restriction ``Pi`` with dimensions retained by native.
+        prolongation: Covariance-compatible ``U_*`` with dimensions native by retained.
+        state_covariance: ``C_alpha = Pi B Pi.T``.
+        effective_observation_operator: ``H_alpha = H U_*``.
+        observation_state_cross_covariance: ``H B Pi.T``.
+        native_observation_covariance: Dense ``H B H.T`` with a collision-safe
+            observation column dimension, or its labelled observation diagonal.
+        strategy: Stable retained-projection strategy name.
+        content_identity: SHA-256 identity binding inputs and products.
+        covariance_configuration: Reproducible serialized kernel/source configuration.
+        basis_provenance: Stable basis implementation and dimension metadata.
+    """
+
+    restriction: xr.DataArray
+    prolongation: xr.DataArray
+    state_covariance: xr.DataArray
+    effective_observation_operator: xr.DataArray
+    observation_state_cross_covariance: xr.DataArray
+    native_observation_covariance: xr.DataArray
+    strategy: str
+    content_identity: str
+    covariance_configuration: xr.Dataset | None = None
+    basis_provenance: dict[str, str] = field(default_factory=dict)
+
+    schema = "openghg_inversions.native_covariance_products"
+    schema_version = 1
+
+    def to_dataset(self) -> xr.Dataset:
+        """Serialize all labelled product blocks and their shared identity.
+
+        Returns:
+            A dataset containing every product array plus schema, strategy,
+            identity, and basis-provenance metadata. Native covariance
+            configuration is intentionally excluded because it occupies a
+            separate child node in :meth:`to_datatree`.
+        """
+        return xr.Dataset(
+            {
+                "restriction": self.restriction,
+                "prolongation": self.prolongation,
+                "state_covariance": self.state_covariance,
+                "effective_observation_operator": self.effective_observation_operator,
+                "observation_state_cross_covariance": self.observation_state_cross_covariance,
+                "native_observation_covariance": self.native_observation_covariance,
+            },
+            attrs={
+                "schema": self.schema,
+                "schema_version": self.schema_version,
+                "strategy": self.strategy,
+                "content_identity": self.content_identity,
+                "basis_provenance": json.dumps(self.basis_provenance, sort_keys=True),
+            },
+        )
+
+    def to_datatree(self) -> xr.DataTree:
+        """Serialize products and reproducible covariance configuration.
+
+        Returns:
+            A tree whose root contains :meth:`to_dataset` output and whose
+            optional ``covariance_configuration`` child preserves the native
+            covariance constructor data.
+        """
+        from openghg_inversions.serialization import reset_serialisation_multiindexes
+
+        tree = xr.DataTree(reset_serialisation_multiindexes(self.to_dataset()))
+        if self.covariance_configuration is not None:
+            tree["covariance_configuration"] = xr.DataTree(
+                _encode_configuration_dataset(self.covariance_configuration)
+            )
+        return tree
+
+    @classmethod
+    def from_dataset(cls, dataset: xr.Dataset) -> NativeCovarianceProducts:
+        """Restore and validate :meth:`to_dataset` output.
+
+        Args:
+            dataset: Versioned product-block dataset.
+
+        Returns:
+            Restored frozen product dataclass. Its contained arrays remain
+            mutable.
+
+        Raises:
+            ValueError: If the schema version, required variables, shared
+                content identity, projection strategy, or JSON-encoded basis
+                provenance is invalid.
+        """
+        if dataset.attrs.get("schema") != cls.schema:
+            raise ValueError(f"Expected product schema {cls.schema!r}")
+        if dataset.attrs.get("schema_version") != cls.schema_version:
+            raise ValueError(f"Unsupported product schema version {dataset.attrs.get('schema_version')!r}")
+        required = (
+            "restriction",
+            "prolongation",
+            "state_covariance",
+            "effective_observation_operator",
+            "observation_state_cross_covariance",
+            "native_observation_covariance",
+        )
+        missing = [name for name in required if name not in dataset]
+        if missing:
+            raise ValueError(f"Serialized covariance products are missing variables {missing}")
+        content_identity = str(dataset.attrs.get("content_identity", ""))
+        strategy = str(dataset.attrs.get("strategy", ""))
+        if not content_identity or not strategy:
+            raise ValueError("Serialized covariance products are missing identity or strategy metadata")
+        for name in required:
+            if dataset[name].attrs.get("content_identity") != content_identity:
+                raise ValueError(f"Serialized product {name!r} does not share the root content identity")
+            if dataset[name].attrs.get("projection_strategy") != strategy:
+                raise ValueError(f"Serialized product {name!r} does not share the root projection strategy")
+        return cls(
+            restriction=dataset["restriction"],
+            prolongation=dataset["prolongation"],
+            state_covariance=dataset["state_covariance"],
+            effective_observation_operator=dataset["effective_observation_operator"],
+            observation_state_cross_covariance=dataset["observation_state_cross_covariance"],
+            native_observation_covariance=dataset["native_observation_covariance"],
+            strategy=strategy,
+            content_identity=content_identity,
+            basis_provenance=json.loads(str(dataset.attrs.get("basis_provenance", "{}"))),
+        )
+
+    @classmethod
+    def from_datatree(cls, tree: xr.DataTree) -> NativeCovarianceProducts:
+        """Restore products and covariance configuration from a data tree.
+
+        Args:
+            tree: Tree produced by :meth:`to_datatree`.
+
+        Returns:
+            Restored frozen product dataclass, including covariance
+            configuration when the child node is present. Its contained
+            arrays and mappings remain mutable.
+
+        Raises:
+            ValueError: If the root product schema, shared identity, strategy,
+                MultiIndex metadata, or covariance configuration is invalid.
+        """
+        from openghg_inversions.serialization import (
+            MULTIINDEX_DIMS_ATTR,
+            restore_serialisation_multiindexes,
+        )
+
+        root_dataset = tree.to_dataset(inherit=False)
+        if MULTIINDEX_DIMS_ATTR in root_dataset.attrs:
+            root_dataset = restore_serialisation_multiindexes(root_dataset, strict=True)
+        products = cls.from_dataset(root_dataset)
+        if "covariance_configuration" not in tree:
+            return products
+        return replace(
+            products,
+            covariance_configuration=_decode_configuration_dataset(
+                cast(xr.DataTree, tree["covariance_configuration"]).to_dataset(inherit=False)
+            ),
+        )
+
+
+def project_native_covariance(
+    *,
+    covariance: InvertibleNativeCovarianceAction,
+    basis_operator: BasisOperator,
+    native_sensitivity: xr.DataArray,
+    observation_dim: str,
+    observation_covariance: Literal["dense", "diagonal"] = "dense",
+    observation_batch_size: int = 64,
+    strategy: RetainedProjectionStrategy | None = None,
+) -> NativeCovarianceProducts:
+    """Compute coherent labelled native-covariance product blocks.
+
+    Args:
+        covariance: Labelled native covariance action with a compatible solve.
+        basis_operator: Basis whose matrix supplies the initial bucket prolongation.
+        native_sensitivity: Native ``H`` containing footprint times prior flux,
+            with dimensions ``(observation_dim, *native_dims)`` in any order.
+        observation_dim: Name of the observation dimension in ``native_sensitivity``.
+        observation_covariance: Return dense ``H B H.T`` or only its diagonal.
+        observation_batch_size: Positive number of observation right-hand sides
+            applied to ``B`` in each eager batch. This is independent of Dask
+            array chunking: each batch produces a result block and the blocks
+            are concatenated. Dense ``H B H.T`` is still fully materialized.
+        strategy: Retained projection choice. The default preserves bucket scalings.
+
+    Returns:
+        Frozen product dataclass containing labelled blocks tied by one content
+        identity. Its contained arrays remain mutable. Inputs and products are
+        eagerly materialized; dense observation covariance has
+        quadratic observation-space storage. Full PSD eigendiagnostics are skipped
+        above 512 rows to avoid adding cubic observation-space work. Input attrs/units are not propagated:
+        product attrs are replaced by mathematical diagnostics because this API
+        does not implement unit algebra.
+
+    Raises:
+        ValueError: If labels, dimensions, values, or options are invalid.
+    """
+    native_dims = tuple(covariance.native_dims)
+    state_dim = basis_operator.meta.state_dim
+    if len({*native_dims, state_dim, observation_dim}) != len(native_dims) + 2:
+        raise ValueError("Native, retained-state, and observation dimension names must be distinct")
+    basis_grid_dims = tuple(basis_operator.meta.grid_dims)
+    if basis_grid_dims != native_dims and not (
+        len(native_dims) == len(basis_grid_dims) + 1 and native_dims[1:] == basis_grid_dims
+    ):
+        raise ValueError(
+            "Basis grid dimensions must equal the covariance spatial dimensions; "
+            f"{basis_operator.meta.grid_dims!r} is incompatible with {native_dims!r}"
+        )
+    sensitivity = _validated_sensitivity(
+        native_sensitivity,
+        native_dims=native_dims,
+        observation_dim=observation_dim,
+        covariance=covariance,
+    )
+    batch_size = int(observation_batch_size)
+    if batch_size <= 0:
+        raise ValueError("observation_batch_size must be positive")
+    if observation_covariance not in {"dense", "diagonal"}:
+        raise ValueError("observation_covariance must be 'dense' or 'diagonal'")
+
+    basis_prolongation = _native_basis_prolongation(
+        basis_operator,
+        sensitivity,
+        native_dims=native_dims,
+        state_dim=state_dim,
+    )
+    projection_strategy = strategy or PreserveBucketProlongation()
+    projection = projection_strategy.projection(
+        covariance,
+        basis_prolongation,
+        native_dims=native_dims,
+        state_dim=state_dim,
+    )
+    state_column_dim = _matrix_column_dim(state_dim, projection.restriction.dims)
+    restriction_transpose = _to_plain_column_axis(
+        projection.restriction,
+        row_dim=state_dim,
+        column_dim=state_column_dim,
+        leading_dims=native_dims,
+    )
+    b_restriction_transpose = covariance.apply(restriction_transpose)
+
+    state_covariance = xr.dot(
+        projection.restriction,
+        b_restriction_transpose,
+        dim=list(native_dims),
+    ).transpose(state_dim, state_column_dim)
+    _validate_positive_definite(np.asarray(state_covariance.values), "C_alpha")
+    state_covariance = _with_matrix_diagnostics(
+        state_covariance.rename("state_covariance"), mathematical_name="C_alpha"
+    )
+    _validate_projection_invariant(
+        projection,
+        state_covariance,
+        b_restriction_transpose,
+        native_dims=native_dims,
+        state_dim=state_dim,
+        state_column_dim=state_column_dim,
+    )
+
+    effective_operator = xr.dot(
+        sensitivity,
+        projection.prolongation,
+        dim=list(native_dims),
+    ).transpose(observation_dim, state_dim)
+    effective_operator = effective_operator.rename("effective_observation_operator").assign_attrs(
+        mathematical_name="H_alpha",
+        definition="H U_*",
+    )
+    cross_covariance = xr.dot(
+        sensitivity,
+        b_restriction_transpose,
+        dim=list(native_dims),
+    ).transpose(observation_dim, state_column_dim)
+    cross_covariance = cross_covariance.rename("observation_state_cross_covariance").assign_attrs(
+        mathematical_name="H B Pi.T"
+    )
+
+    native_observation_covariance = _observation_covariance(
+        covariance,
+        sensitivity,
+        native_dims=native_dims,
+        observation_dim=observation_dim,
+        output=observation_covariance,
+        batch_size=batch_size,
+    )
+    content_identity = _content_identity(
+        covariance,
+        projection.restriction,
+        projection.prolongation,
+        sensitivity,
+        strategy=projection.strategy,
+        observation_covariance=observation_covariance,
+    )
+    covariance_to_dataset = getattr(covariance, "to_dataset", None)
+    covariance_configuration = (
+        cast(xr.Dataset, covariance_to_dataset()).copy(deep=True) if callable(covariance_to_dataset) else None
+    )
+    basis_provenance = {
+        "operator_type": f"{type(basis_operator).__module__}.{type(basis_operator).__qualname__}",
+        "operator_kind": str(getattr(basis_operator, "kind", "unknown")),
+        "grid_dims": repr(tuple(basis_operator.meta.grid_dims)),
+        "state_dim": state_dim,
+    }
+    shared_attrs = {
+        "projection_strategy": projection.strategy,
+        "content_identity": content_identity,
+    }
+    arrays = (
+        projection.restriction,
+        projection.prolongation,
+        state_covariance,
+        effective_operator,
+        cross_covariance,
+        native_observation_covariance,
+    )
+    for array in arrays:
+        array.attrs.update(shared_attrs)
+
+    return NativeCovarianceProducts(
+        restriction=projection.restriction,
+        prolongation=projection.prolongation,
+        state_covariance=state_covariance,
+        effective_observation_operator=effective_operator,
+        observation_state_cross_covariance=cross_covariance,
+        native_observation_covariance=native_observation_covariance,
+        strategy=projection.strategy,
+        content_identity=content_identity,
+        covariance_configuration=covariance_configuration,
+        basis_provenance=basis_provenance,
+    )
+
+
+def _observation_covariance(
+    covariance: InvertibleNativeCovarianceAction,
+    sensitivity: xr.DataArray,
+    *,
+    native_dims: tuple[str, ...],
+    observation_dim: str,
+    output: Literal["dense", "diagonal"],
+    batch_size: int,
+) -> xr.DataArray:
+    """Compute ``H B H.T`` in eager observation right-hand-side batches.
+
+    Batching limits the size of the temporary native-space ``B H.T`` block;
+    it is not Dask chunking. Result blocks are concatenated along a distinct
+    observation-column dimension. Dense output therefore still materializes
+    the complete quadratic observation covariance, while diagonal output
+    materializes only its labelled diagonal.
+
+    Args:
+        covariance: Labelled action implementing multiplication by ``B``.
+        sensitivity: Eager native sensitivity ``H`` with observation followed
+            by native dimensions.
+        native_dims: Ordered native dimensions contracted in the products.
+        observation_dim: Name of the observation row dimension.
+        output: Whether to return the dense covariance or only its diagonal.
+        batch_size: Positive number of observation columns processed per
+            covariance application.
+
+    Returns:
+        Labelled dense ``H B H.T`` or ``diag(H B H.T)``.
+
+    Raises:
+        ValueError: If covariance labels are incompatible or a dense result
+            fails the symmetry diagnostic.
+    """
+    observation_column_dim = _matrix_column_dim(observation_dim, sensitivity.dims)
+    blocks: list[xr.DataArray] = []
+    for start in range(0, sensitivity.sizes[observation_dim], batch_size):
+        stop = min(start + batch_size, sensitivity.sizes[observation_dim])
+        rhs = _to_plain_column_axis(
+            sensitivity.isel({observation_dim: slice(start, stop)}),
+            row_dim=observation_dim,
+            column_dim=observation_column_dim,
+            leading_dims=native_dims,
+        )
+        b_rhs = covariance.apply(rhs)
+        if output == "dense":
+            block = xr.dot(sensitivity, b_rhs, dim=list(native_dims)).transpose(
+                observation_dim, observation_column_dim
+            )
+        else:
+            matching = _to_plain_column_axis(
+                sensitivity.isel({observation_dim: slice(start, stop)}),
+                row_dim=observation_dim,
+                column_dim=observation_column_dim,
+                leading_dims=native_dims,
+            )
+            block = (matching * b_rhs).sum(dim=list(native_dims))
+        blocks.append(block)
+    combined = xr.concat(blocks, dim=observation_column_dim)
+    if output == "dense":
+        combined = _with_matrix_diagnostics(
+            combined.rename("native_observation_covariance"), mathematical_name="H B H.T"
+        )
+    else:
+        combined = combined.rename({observation_column_dim: observation_dim})
+        combined = combined.assign_coords({observation_dim: sensitivity.coords[observation_dim]})
+        combined = combined.rename("native_observation_covariance").assign_attrs(
+            mathematical_name="diag(H B H.T)",
+            minimum_diagonal=float(combined.min().item()),
+            diagonal_nonnegative=bool((combined >= -1e-10).all().item()),
+            diagnostic_tolerance=1e-10,
+        )
+    return combined
+
+
+def _validate_projection_invariant(
+    projection: RetainedProjection,
+    state_covariance: xr.DataArray,
+    b_restriction_transpose: xr.DataArray,
+    *,
+    native_dims: tuple[str, ...],
+    state_dim: str,
+    state_column_dim: str,
+) -> None:
+    """Require a strategy to return its covariance-natural prolongation.
+
+    Args:
+        projection: Restriction/prolongation pair returned by the strategy.
+        state_covariance: Labelled ``C_alpha = Pi B Pi.T``.
+        b_restriction_transpose: Labelled ``B Pi.T``.
+        native_dims: Ordered native dimensions.
+        state_dim: Retained-state row dimension.
+        state_column_dim: Collision-safe retained-state column dimension.
+
+    Raises:
+        ValueError: If dimensions, state labels, or values are invalid, or if
+            ``B Pi.T`` and ``U_* C_alpha`` disagree beyond tolerance.
+    """
+    prolongation = _validated_prolongation(
+        projection.prolongation,
+        native_dims=native_dims,
+        state_dim=state_dim,
+    )
+    restriction = projection.restriction
+    expected_dims = {state_dim, *native_dims}
+    if set(restriction.dims) != expected_dims or len(restriction.dims) != len(expected_dims):
+        raise ValueError("Projection strategy restriction has invalid labelled dimensions")
+    if not np.all(np.isfinite(np.asarray(restriction.values))):
+        raise ValueError("Projection strategy restriction must contain only finite values")
+    if not np.array_equal(restriction.coords[state_dim].values, prolongation.coords[state_dim].values):
+        raise ValueError("Projection strategy restriction/prolongation state labels differ")
+    u_c = xr.dot(prolongation, state_covariance, dim=state_dim).transpose(*native_dims, state_column_dim)
+    left = np.asarray(b_restriction_transpose.values, dtype=np.float64)
+    right = np.asarray(u_c.values, dtype=np.float64)
+    scale = max(
+        float(np.max(np.abs(left))) if left.size else 0.0,
+        float(np.max(np.abs(right))) if right.size else 0.0,
+        np.finfo(np.float64).tiny,
+    )
+    absolute_error = float(np.max(np.abs(left - right))) if left.size else 0.0
+    if absolute_error > 1e-9 * scale + 10.0 * np.finfo(np.float64).tiny:
+        raise ValueError("Projection strategy is incoherent: expected B Pi.T = U_* C_alpha")
+
+
+def _native_basis_prolongation(
+    basis_operator: BasisOperator,
+    sensitivity: xr.DataArray,
+    *,
+    native_dims: tuple[str, ...],
+    state_dim: str,
+) -> xr.DataArray:
+    """Return ``U_bucket`` on the full native space, including source blocks.
+
+    A single-source basis already spans every native dimension. For a gathered
+    multisource basis, the operator carries source identity on the ragged state
+    coordinate rather than as a matrix dimension. This helper expands it onto
+    the covariance action's explicit leading source dimension, setting all
+    cross-source state columns to zero while retaining canonical state order.
+
+    Args:
+        basis_operator: Spatial basis supplying the bucket matrix and metadata.
+        sensitivity: Native sensitivity whose leading source coordinate defines
+            source ordering for multisource inputs.
+        native_dims: Ordered native covariance dimensions.
+        state_dim: Retained-state dimension of the basis matrix.
+
+    Returns:
+        Eager ``U_bucket`` spanning ``(*native_dims, state_dim)``.
+
+    Raises:
+        ValueError: If a multisource basis lacks source labels or names a source
+            absent from the native sensitivity.
+    """
+    basis_grid_dims = tuple(basis_operator.meta.grid_dims)
+    basis_matrix = _densify(basis_operator.basis_matrix)
+    if native_dims == basis_grid_dims:
+        return basis_matrix
+
+    native_source_dim = native_dims[0]
+    basis_source_dim = getattr(basis_operator, "source_dim", None)
+    if not isinstance(basis_source_dim, str) or basis_source_dim not in basis_matrix.coords:
+        raise ValueError(
+            "A covariance with a leading native source dimension requires a gathered "
+            "multisource basis carrying source labels on its state coordinate"
+        )
+    state_sources = np.asarray(basis_matrix.coords[basis_source_dim].values)
+    native_sources = np.asarray(sensitivity.coords[native_source_dim].values)
+    missing = [label for label in state_sources if label not in set(native_sources.tolist())]
+    if missing:
+        raise ValueError(f"Basis state sources are absent from native sensitivity: {missing!r}")
+    base = basis_matrix.transpose(*basis_grid_dims, state_dim)
+    values = np.asarray(base.values)
+    source_mask = native_sources[:, np.newaxis] == state_sources[np.newaxis, :]
+    expanded = values[np.newaxis, ...] * source_mask.reshape(
+        (native_sources.size, *([1] * len(basis_grid_dims)), state_sources.size)
+    )
+    coords: dict[str, xr.DataArray] = {
+        native_source_dim: sensitivity.coords[native_source_dim],
+        **{dim: base.coords[dim] for dim in basis_grid_dims},
+        state_dim: base.coords[state_dim],
+    }
+    for name, coordinate in base.coords.items():
+        if name not in coords and set(coordinate.dims).issubset({state_dim}):
+            coords[str(name)] = coordinate
+    return xr.DataArray(
+        expanded,
+        dims=(*native_dims, state_dim),
+        coords=coords,
+        name="prolongation",
+        attrs={**basis_matrix.attrs, "mathematical_name": "U_bucket"},
+    )
+
+
+def _to_plain_column_axis(
+    array: xr.DataArray,
+    *,
+    row_dim: str,
+    column_dim: str,
+    leading_dims: tuple[str, ...],
+) -> xr.DataArray:
+    """Replace a rich row axis by a collision-safe plain column axis.
+
+    Args:
+        array: Labelled array containing the row and leading dimensions.
+        row_dim: Existing row dimension, possibly backed by a MultiIndex.
+        column_dim: New collision-safe plain dimension name.
+        leading_dims: Dimensions to retain before the new column dimension.
+
+    Returns:
+        An array sharing the input data and attributes, with row coordinates
+        copied onto the new plain column axis.
+    """
+    ordered = array.transpose(*leading_dims, row_dim)
+    coords = {dim: ordered.coords[dim] for dim in leading_dims}
+    coords.update(_column_coordinates(ordered, row_dim=row_dim, column_dim=column_dim))
+    return xr.DataArray(
+        ordered.data,
+        dims=(*leading_dims, column_dim),
+        coords=coords,
+        name=ordered.name,
+        attrs=ordered.attrs,
+    )
+
+
+def _validated_prolongation(
+    prolongation: xr.DataArray,
+    *,
+    native_dims: tuple[str, ...],
+    state_dim: str,
+) -> xr.DataArray:
+    """Materialize and validate a labelled native-by-retained prolongation.
+
+    Args:
+        prolongation: Candidate ``U_*`` or ``U_bucket`` array.
+        native_dims: Ordered native dimensions required on the array.
+        state_dim: Required retained-state dimension.
+
+    Returns:
+        A finite, eager array ordered as ``(*native_dims, state_dim)``.
+
+    Raises:
+        ValueError: If dimensions are missing or duplicated, values are not
+            finite, or a retained-state column is empty.
+    """
+    expected_dims = set((*native_dims, state_dim))
+    if set(prolongation.dims) != expected_dims or len(prolongation.dims) != len(expected_dims):
+        raise ValueError(
+            "prolongation must have exactly the native grid and retained-state dimensions; "
+            f"got {prolongation.dims!r}"
+        )
+    result = _densify(prolongation).transpose(*native_dims, state_dim)
+    values = np.asarray(result.values, dtype=np.float64)
+    if not np.all(np.isfinite(values)):
+        raise ValueError("prolongation must contain only finite values")
+    if result.sizes[state_dim] == 0 or np.any(np.all(values == 0.0, axis=tuple(range(len(native_dims))))):
+        raise ValueError("prolongation contains an empty retained state")
+    return result
+
+
+def _validated_sensitivity(
+    sensitivity: xr.DataArray,
+    *,
+    native_dims: tuple[str, ...],
+    observation_dim: str,
+    covariance: InvertibleNativeCovarianceAction,
+) -> xr.DataArray:
+    """Materialize and validate the labelled native sensitivity ``H``.
+
+    Args:
+        sensitivity: Candidate observation-by-native sensitivity array.
+        native_dims: Ordered native dimensions required on the array.
+        observation_dim: Required observation dimension.
+        covariance: Covariance action used to validate native grid labels.
+
+    Returns:
+        A finite, eager array ordered as ``(observation_dim, *native_dims)``.
+
+    Raises:
+        ValueError: If dimensions or observation labels are invalid, the array
+            is empty or non-finite, or covariance grid labels do not match.
+    """
+    expected_dims = set((*native_dims, observation_dim))
+    if set(sensitivity.dims) != expected_dims or len(sensitivity.dims) != len(expected_dims):
+        raise ValueError(
+            "native_sensitivity must have exactly one observation dimension and the native grid "
+            f"dimensions; got {sensitivity.dims!r}"
+        )
+    if observation_dim not in sensitivity.coords:
+        raise ValueError(f"native_sensitivity is missing observation coordinate {observation_dim!r}")
+    result = _densify(sensitivity).transpose(observation_dim, *native_dims)
+    # Applying B to one labelled column performs the covariance-grid label validation.
+    if result.sizes[observation_dim] == 0:
+        raise ValueError("native_sensitivity must contain at least one observation")
+    covariance.apply(result.isel({observation_dim: slice(0, 1)}))
+    values = np.asarray(result.values)
+    if not np.all(np.isfinite(values)):
+        raise ValueError("native_sensitivity must contain only finite values")
+    return result
+
+
+def _densify(array: xr.DataArray) -> xr.DataArray:
+    """Eagerly materialize an array and convert sparse storage to NumPy."""
+    materialized = array.compute()
+    data = materialized.data
+    if hasattr(data, "todense"):
+        data = data.todense()
+    return materialized.copy(data=np.asarray(data))
+
+
+def _matrix_column_dim(primary_dim: str, occupied_dims: tuple[Hashable, ...]) -> str:
+    """Return an unoccupied column-dimension name derived from a row name."""
+    candidate = f"{primary_dim}_cov"
+    index = 2
+    while candidate in occupied_dims:
+        candidate = f"{primary_dim}_cov_{index}"
+        index += 1
+    return candidate
+
+
+def _column_coordinate(coordinate: xr.DataArray, column_dim: str) -> xr.DataArray:
+    """Copy row labels onto a plain column coordinate.
+
+    Tuple-valued labels are encoded as compact JSON strings so xarray does not
+    reinterpret them as a two-dimensional coordinate.
+
+    Args:
+        coordinate: One-dimensional row coordinate to copy.
+        column_dim: Destination column dimension.
+
+    Returns:
+        A plain one-dimensional column coordinate preserving attributes.
+    """
+    source_values = list(coordinate.values)
+    if any(isinstance(value, tuple) for value in source_values):
+        values = np.asarray(
+            [json.dumps(list(value), separators=(",", ":")) for value in source_values],
+            dtype=str,
+        )
+    else:
+        values = np.asarray(source_values)
+    return xr.DataArray(values, dims=column_dim, attrs=coordinate.attrs)
+
+
+def _column_coordinates(
+    array: xr.DataArray,
+    *,
+    row_dim: str,
+    column_dim: str,
+) -> dict[str, xr.DataArray]:
+    """Build a plain column index and copies of row-axis metadata.
+
+    Args:
+        array: Source array containing the row coordinate and auxiliary labels.
+        row_dim: Row dimension whose coordinates are copied.
+        column_dim: Collision-safe column dimension receiving the copies.
+
+    Returns:
+        Coordinates for the new column axis. Auxiliary coordinate names gain a
+        ``_cov`` suffix, with numeric suffixes added to avoid collisions.
+    """
+    result = {column_dim: _column_coordinate(array.coords[row_dim], column_dim)}
+    for name, coordinate in array.coords.items():
+        if name == row_dim or tuple(coordinate.dims) != (row_dim,):
+            continue
+        column_name = f"{name}_cov"
+        suffix = 2
+        while column_name in array.coords or column_name in result:
+            column_name = f"{name}_cov_{suffix}"
+            suffix += 1
+        result[column_name] = xr.DataArray(
+            np.asarray(coordinate.values),
+            dims=column_dim,
+            attrs=coordinate.attrs,
+        )
+    return result
+
+
+def _validate_symmetric(values: np.ndarray, name: str, *, tolerance: float = 1e-10) -> None:
+    """Validate matrix symmetry relative to its largest absolute value.
+
+    Args:
+        values: Matrix values to validate.
+        name: Mathematical name used in an error message.
+        tolerance: Relative symmetry tolerance, with unit absolute scale floor.
+
+    Raises:
+        ValueError: If the maximum asymmetry exceeds the scaled tolerance.
+    """
+    asymmetry = float(np.max(np.abs(values - values.T))) if values.size else 0.0
+    scale = max(1.0, float(np.max(np.abs(values))) if values.size else 1.0)
+    if asymmetry > tolerance * scale:
+        raise ValueError(f"{name} is not symmetric within tolerance {tolerance:g}")
+
+
+def _validate_positive_definite(values: np.ndarray, name: str) -> None:
+    """Reject singular or numerically redundant covariance coordinates.
+
+    Args:
+        values: Symmetric covariance matrix to validate.
+        name: Mathematical name used in an error message.
+
+    Raises:
+        ValueError: If the matrix is asymmetric, empty, non-positive, or has a
+            smallest eigenvalue no larger than ``1e-12`` times the largest.
+    """
+    _validate_symmetric(values, name)
+    eigenvalues = np.linalg.eigvalsh((values + values.T) * 0.5)
+    largest = float(eigenvalues[-1]) if eigenvalues.size else 0.0
+    if not eigenvalues.size or largest <= 0.0 or float(eigenvalues[0]) <= 1e-12 * largest:
+        raise ValueError(f"{name} must be positive definite and full rank")
+
+
+def _with_matrix_diagnostics(array: xr.DataArray, *, mathematical_name: str) -> xr.DataArray:
+    """Attach symmetry and bounded-cost PSD diagnostics to a dense matrix.
+
+    Args:
+        array: Dense square labelled matrix.
+        mathematical_name: Mathematical label stored in the result attributes.
+
+    Returns:
+        The array with diagnostic attributes. Full eigenvalue diagnostics are
+        skipped when the matrix exceeds :data:`MAX_DENSE_EIGEN_DIAGNOSTIC_SIZE`.
+
+    Raises:
+        ValueError: If the matrix is not symmetric within tolerance.
+    """
+    values = np.asarray(array.values, dtype=np.float64)
+    _validate_symmetric(values, mathematical_name)
+    attrs: dict[str, object] = {
+        "mathematical_name": mathematical_name,
+        "symmetry_absolute_error": float(np.max(np.abs(values - values.T))) if values.size else 0.0,
+        "diagnostic_tolerance": 1e-10,
+    }
+    if values.shape[0] <= MAX_DENSE_EIGEN_DIAGNOSTIC_SIZE:
+        eigenvalues = np.linalg.eigvalsh((values + values.T) * 0.5)
+        attrs.update(
+            minimum_eigenvalue=float(eigenvalues.min()) if eigenvalues.size else 0.0,
+            psd_diagnostic="full_eigendecomposition",
+        )
+    else:
+        attrs.update(
+            minimum_eigenvalue=np.nan,
+            psd_diagnostic=(f"skipped_full_eigendecomposition_above_{MAX_DENSE_EIGEN_DIAGNOSTIC_SIZE}"),
+        )
+    return array.assign_attrs(attrs)
+
+
+def _encode_configuration_dataset(dataset: xr.Dataset) -> xr.Dataset:
+    """Namespace configuration dimensions before DataTree persistence.
+
+    Args:
+        dataset: Native covariance configuration to encode.
+
+    Returns:
+        A copy whose dimensions have a ``covariance_configuration__`` prefix.
+        The reversible original-to-encoded mapping is stored in the
+        ``openghg_inversions:configuration_dims`` attribute so parent DataTree
+        dimensions cannot absorb the child dimensions.
+    """
+    rename = {str(dim): f"covariance_configuration__{dim}" for dim in dataset.dims}
+    encoded = dataset.rename(rename).copy()
+    encoded.attrs = dict(encoded.attrs)
+    encoded.attrs["openghg_inversions:configuration_dims"] = json.dumps(rename, sort_keys=True)
+    return encoded
+
+
+def _decode_configuration_dataset(dataset: xr.Dataset) -> xr.Dataset:
+    """Restore namespaced configuration dimensions after persistence.
+
+    Args:
+        dataset: Encoded covariance configuration child dataset.
+
+    Returns:
+        A dataset with original dimension names and encoding metadata removed.
+
+    Raises:
+        ValueError: If the dimension mapping metadata is absent or invalid.
+    """
+    encoded_dims = dataset.attrs.get("openghg_inversions:configuration_dims")
+    if not isinstance(encoded_dims, str):
+        raise ValueError("Serialized covariance configuration is missing dimension metadata")
+    rename = json.loads(encoded_dims)
+    if not isinstance(rename, dict):
+        raise ValueError("Serialized covariance configuration dimension metadata is invalid")
+    restored = dataset.rename({str(encoded): str(original) for original, encoded in rename.items()})
+    restored.attrs = dict(restored.attrs)
+    del restored.attrs["openghg_inversions:configuration_dims"]
+    return restored
+
+
+def _content_identity(
+    covariance: InvertibleNativeCovarianceAction,
+    *arrays: xr.DataArray,
+    strategy: str,
+    observation_covariance: str,
+) -> str:
+    """Hash scientific inputs and configuration into a stable identity.
+
+    Execution batching is deliberately excluded, because changing
+    ``observation_batch_size`` does not change the requested scientific
+    product. Computed product values are also excluded to avoid binding the
+    identity to batch-dependent floating-point roundoff.
+
+    Args:
+        covariance: Native covariance action, preferably with serializable
+            constructor configuration.
+        *arrays: Scientific input arrays to bind to the identity.
+        strategy: Stable retained-projection strategy name.
+        observation_covariance: Requested dense or diagonal output form.
+
+    Returns:
+        Lowercase hexadecimal SHA-256 digest.
+    """
+    digest = hashlib.sha256()
+    digest.update(strategy.encode("utf-8"))
+    digest.update(observation_covariance.encode("utf-8"))
+    to_dataset = getattr(covariance, "to_dataset", None)
+    if callable(to_dataset):
+        covariance_dataset = cast(xr.Dataset, to_dataset())
+        digest.update(repr(sorted(covariance_dataset.attrs.items())).encode("utf-8"))
+        for name in sorted(str(name) for name in covariance_dataset.coords):
+            _update_array_digest(digest, covariance_dataset.coords[name])
+        for name in sorted(str(name) for name in covariance_dataset.data_vars):
+            _update_array_digest(digest, covariance_dataset[name])
+    else:
+        covariance_type = f"{type(covariance).__module__}.{type(covariance).__qualname__}"
+        digest.update(covariance_type.encode("utf-8"))
+        digest.update(repr(covariance).encode("utf-8"))
+    for array in arrays:
+        _update_array_digest(digest, array)
+    return digest.hexdigest()
+
+
+def _update_array_digest(digest: _Digest, array: xr.DataArray) -> None:
+    """Update a content digest with array data, dimensions, and coordinates."""
+    digest.update(str(array.name).encode("utf-8"))
+    digest.update(repr(tuple(array.dims)).encode("utf-8"))
+    values = np.ascontiguousarray(array.values)
+    digest.update(values.dtype.str.encode("ascii"))
+    digest.update(repr(values.shape).encode("ascii"))
+    if values.dtype.hasobject or values.dtype.kind in {"U", "S"}:
+        digest.update(repr(values.tolist()).encode("utf-8"))
+    else:
+        digest.update(values.view(np.uint8).tobytes())
+    for name in sorted(str(name) for name in array.coords):
+        coordinate = array.coords[name]
+        labels = np.asarray(coordinate.values)
+        digest.update(name.encode("utf-8"))
+        digest.update(repr(tuple(coordinate.dims)).encode("utf-8"))
+        if labels.dtype.hasobject or labels.dtype.kind in {"U", "S"}:
+            digest.update(repr(labels.tolist()).encode("utf-8"))
+        else:
+            digest.update(np.ascontiguousarray(labels).view(np.uint8).tobytes())

--- a/openghg_inversions/basis/operators.py
+++ b/openghg_inversions/basis/operators.py
@@ -1,55 +1,45 @@
-"""Basis operator classes
+"""Labelled basis geometry operators for retained scaling states.
 
-Design goals
-------------
-1) Separate the *bucket prolongation* (basis functions) from any *flux weighting*.
-   - For one source, ``basis_matrix`` is ``U_bucket`` with shape native-grid by
-     retained-state. A gathered multisource matrix is the spatial membership
-     template from which the source-native ``U_bucket`` is expanded. Neither
-     transpose is automatically the retained restriction ``Pi``.
-   - Flux weighting (multiplying by flux on the grid, interpolation to maps, covariance transforms)
-     is handled by ``FluxWeightedBasis`` so that:
-       * sensitivity(fp_x_flux) does not require flux (since fp_x_flux is already precomputed),
-       * but flux-aware operations remain available when needed.
+A :class:`BasisOperator` separates bucket geometry from flux weighting and
+native covariance. For one source, :attr:`BasisOperator.basis_matrix` is the
+bucket prolongation ``U_bucket`` with native-grid rows and retained-state
+columns. A gathered multisource matrix is the spatial membership template from
+which projection code expands a source-native ``U_bucket``. Its transpose is
+not automatically the retained restriction ``Pi``.
 
-2) Canonical "state" dimension.
-   - Operators expose a single state dimension (default name: "state").
-   - In multisource/multisector cases with ragged per-source region counts, the state coordinate
-     becomes a ragged MultiIndex over (source, region_in_source). This avoids padding with zeros.
+``FluxWeightedBasis`` handles flux weighting for sensitivity projection and
+flux reconstruction. Native covariance actions, retained restrictions, and
+covariance product transforms instead belong to
+:mod:`openghg_inversions.native_covariance`,
+:mod:`openghg_inversions.source_covariance`, and
+:mod:`openghg_inversions.basis.covariance_products`.
 
-3) Minimal metadata (BasisMeta).
-   - We only need to know which dims to dot over (grid_dims) and the state_dim name.
-   - Source-labeled arrays are aligned against the state MultiIndex by concrete
-     subclasses rather than inferred from metadata.
+Operators expose one canonical state dimension, named ``"state"`` by default.
+Multisource operators represent ragged per-source region counts with a
+MultiIndex over source and region-within-source, avoiding padded state arrays.
+:class:`BasisMeta` records only the grid dimensions and state-dimension name;
+concrete operators perform any source-label alignment.
 
-4) Serialization via xarray.DataTree.
-   - BasisOperator.to_datatree() returns a self-describing DataTree with schema/kind/version attrs.
-   - BasisOperator.decode_datatree(dt) dispatches to the correct registered subclass based on dt.attrs["kind"].
-   - For multisource operators, the canonical serialized representation stores one source-labelled
-     `basis_flat` array. Readers retain compatibility with the earlier per-source child layout.
+Serialization uses self-describing :class:`xarray.DataTree` objects with
+schema, kind, and version metadata. Multisource operators store one
+source-labelled ``basis_flat`` array while readers retain compatibility with
+the earlier per-source child layout.
 
-How to use
-----------
-- Construct a basis operator:
-    op = BucketBasisOperator(basis_flat)                         # single-sector
-    op = MultiSourceBucketBasisOperator({"a": bf_a, "b": bf_b})   # ragged multisource
+Examples:
+    Construct operators, compute a sensitivity, and round-trip one operator::
 
-- Compute sensitivities:
-    H = op.sensitivity(fp_x_flux)
+        op = BucketBasisOperator(basis_flat)
+        multisource_op = MultiSourceBucketBasisOperator({"a": bf_a, "b": bf_b})
+        sensitivity = op.sensitivity(fp_x_flux)
+        restored = BasisOperator.decode_datatree(op.to_datatree())
 
-  where fp_x_flux is an xarray.DataArray with at least the grid dims (lat, lon), and typically time.
-  In multisource workflows, fp_x_flux often has a separate dimension "source".
-  The multisource operator aligns those labels against the "source" level of
-  the state MultiIndex.
+    ``fp_x_flux`` contains the configured grid dimensions and typically time.
+    In multisource workflows it may also have a ``source`` dimension, whose
+    labels the multisource operator aligns to the state MultiIndex.
 
-- Serialize/deserialize:
-    dt = op.to_datatree()
-    op2 = BasisOperator.decode_datatree(dt)
-
-Notes
------
-- Currently, basis operators cannot have a time dimension. If the input flat array has
-  a time dimension with more than one coordinate value, an error is raised.
+Note:
+    Basis geometry cannot currently vary through time. A singleton time
+    dimension is dropped; a longer time dimension raises :class:`ValueError`.
 """
 
 from __future__ import annotations
@@ -163,14 +153,12 @@ class BasisMeta:
 class BasisOperator(ABC):
     """Abstract basis operator.
 
-    Concrete subclasses must define:
-    - meta (grid dims + state dim)
-    - basis_matrix: bucket prolongation ``U_bucket`` with dims
-      (*grid_dims, state_dim)
-    - to_datatree / from_datatree
+    Concrete subclasses provide operator metadata, a bucket prolongation
+    ``U_bucket`` whose ordered dimensions are the grid dimensions followed by
+    the state dimension, and DataTree serialization methods.
 
-    The default sensitivity implementation assumes fp_x_flux has the grid dims and
-    any extra dims (e.g. time, source) are preserved.
+    The default sensitivity implementation requires ``fp_x_flux`` to contain
+    the grid dimensions and preserves extra dimensions such as time or source.
     """
 
     # stable kind string used for serialization dispatch
@@ -190,8 +178,8 @@ class BasisOperator(ABC):
     def basis_matrix(self) -> xr.DataArray:
         """Return the bucket prolongation ``U_bucket`` from state to grid.
 
-        Expected dims: (*grid_dims, state_dim)
-        (state_dim may be a MultiIndex coordinate)
+        Its ordered dimensions are the configured grid dimensions followed by
+        the state dimension, which may carry a MultiIndex coordinate.
 
         Multiplying this matrix by a state vector reconstructs a native scaling
         field. Although its transpose has the shape of a restriction, it is not

--- a/openghg_inversions/basis/operators.py
+++ b/openghg_inversions/basis/operators.py
@@ -2,8 +2,11 @@
 
 Design goals
 ------------
-1) Separate the *partition/aggregation operator* (basis functions) from any *flux weighting*.
-   - The basis operator represents a linear map from a grid (lat/lon) to a reduced state space.
+1) Separate the *bucket prolongation* (basis functions) from any *flux weighting*.
+   - For one source, ``basis_matrix`` is ``U_bucket`` with shape native-grid by
+     retained-state. A gathered multisource matrix is the spatial membership
+     template from which the source-native ``U_bucket`` is expanded. Neither
+     transpose is automatically the retained restriction ``Pi``.
    - Flux weighting (multiplying by flux on the grid, interpolation to maps, covariance transforms)
      is handled by ``FluxWeightedBasis`` so that:
        * sensitivity(fp_x_flux) does not require flux (since fp_x_flux is already precomputed),
@@ -162,7 +165,8 @@ class BasisOperator(ABC):
 
     Concrete subclasses must define:
     - meta (grid dims + state dim)
-    - basis_matrix: one-hot/dummy matrix with dims (*grid_dims, state_dim)
+    - basis_matrix: bucket prolongation ``U_bucket`` with dims
+      (*grid_dims, state_dim)
     - to_datatree / from_datatree
 
     The default sensitivity implementation assumes fp_x_flux has the grid dims and
@@ -184,17 +188,21 @@ class BasisOperator(ABC):
     @property
     @abstractmethod
     def basis_matrix(self) -> xr.DataArray:
-        """Dummy matrix mapping grid -> state.
+        """Return the bucket prolongation ``U_bucket`` from state to grid.
 
         Expected dims: (*grid_dims, state_dim)
         (state_dim may be a MultiIndex coordinate)
+
+        Multiplying this matrix by a state vector reconstructs a native scaling
+        field. Although its transpose has the shape of a restriction, it is not
+        generally the covariance-compatible retained restriction ``Pi``.
         """
         raise NotImplementedError
 
     def sensitivity(self, fp_x_flux: xr.DataArray, fillna: bool = True) -> xr.DataArray:
         """Computes the sensitivity matrix ("H") by dotting over the grid.
 
-        This implements the common bucket-basis reduction:
+        This implements the common bucket-basis forward operator ``H U_bucket``:
 
         - `fp_x_flux` is a gridded quantity with dimensions that include
           `meta.grid_dims` (typically `lat` and `lon`) and usually a `time` dimension.
@@ -521,7 +529,11 @@ class BucketBasisOperator(BasisOperator):
 
     @property
     def basis_matrix(self) -> xr.DataArray:
-        """Basis matrix."""
+        """Return ``U_bucket``, mapping retained scalings to native scalings.
+
+        The dimensions are native grid by retained state. Its transpose is not
+        generally the compatible retained restriction ``Pi``.
+        """
         return self._basis_matrix
 
     @property
@@ -756,7 +768,13 @@ class MultiSourceBucketBasisOperator(BasisOperator):
 
     @property
     def basis_matrix(self) -> xr.DataArray:
-        """Basis matrix."""
+        """Return the gathered spatial template for multisource ``U_bucket``.
+
+        The dimensions are spatial grid by retained state; source identity is
+        carried by the ragged state coordinate. Projection code expands an
+        explicit source-native dimension and zeros cross-source columns. This
+        template's transpose is not the compatible retained restriction ``Pi``.
+        """
         return self._basis_matrix
 
     @property

--- a/openghg_inversions/native_covariance.py
+++ b/openghg_inversions/native_covariance.py
@@ -15,11 +15,14 @@ scientific constant.
 
 Both :meth:`SeparableExponentialCovariance.apply` and
 :meth:`SeparableExponentialCovariance.solve` preserve all input dimensions,
-coordinates, name, and attributes.  Only the two one-dimensional factors are
-materialised.  Optional native-grid class labels replace ``B`` by the blocked
-action ``B_class = sum_c M_c B M_c``, where ``M_c`` is the diagonal indicator
-for class ``c``.  This prevents covariance between cells in different classes
-without constructing either ``M_c`` or the dense native covariance.
+coordinates, name, and attributes.  An unblocked action materialises the two
+one-dimensional covariance factors and their Cholesky factors, rather than the
+dense native covariance. Optional native-grid class labels replace ``B`` by
+the blocked action ``B_class = sum_c M_c B M_c``, where ``M_c`` is the diagonal
+indicator for class ``c``. A blocked action additionally stores one native-grid
+boolean mask per class, but does not construct the diagonal ``M_c`` matrices or
+the dense native covariance. Apply and solve eagerly convert each labelled
+right-hand side to a NumPy array; they do not preserve lazy Dask execution.
 Unblocked solves use the separable Cholesky factors; multi-class solves use
 matrix-free conjugate gradients. Distances are coordinate-wise degrees, not
 geodesic or longitude-wrapped distances. A missing coordinate ``units`` attr
@@ -54,7 +57,17 @@ class NativeCovarianceAction(Protocol):
     def apply(self, rhs: xr.DataArray) -> xr.DataArray:
         """Apply ``B`` to labelled RHS arrays containing every native dimension.
 
-        All non-native dimensions and their labels must be preserved.
+        Args:
+            rhs: Labelled array containing every native dimension.
+
+        Returns:
+            The covariance action with the dimensions, coordinates, name, and
+            attributes of ``rhs`` preserved.
+
+        Raises:
+            TypeError: If ``rhs`` is not an xarray data array.
+            ValueError: If native dimensions or coordinates are missing or
+                misaligned, or if values are non-numeric or non-finite.
         """
         ...
 
@@ -63,7 +76,21 @@ class InvertibleNativeCovarianceAction(NativeCovarianceAction, Protocol):
     """Native covariance action that can also solve systems in ``B``."""
 
     def solve(self, rhs: xr.DataArray) -> xr.DataArray:
-        """Return labelled ``B^-1 rhs`` while preserving non-native dimensions."""
+        """Return labelled ``B^-1 rhs`` while preserving the input layout.
+
+        Args:
+            rhs: Labelled array containing every native dimension.
+
+        Returns:
+            The covariance solve with the dimensions, coordinates, name, and
+            attributes of ``rhs`` preserved.
+
+        Raises:
+            TypeError: If ``rhs`` is not an xarray data array.
+            ValueError: If native dimensions or coordinates are missing or
+                misaligned, or if values are non-numeric or non-finite.
+            numpy.linalg.LinAlgError: If an iterative solve fails.
+        """
         ...
 
 
@@ -84,7 +111,6 @@ class SeparableExponentialCovariance:
 
     Raises:
         ValueError: If coordinates, units, or covariance parameters are invalid.
-        numpy.linalg.LinAlgError: If a class-blocked iterative solve does not converge.
     """
 
     latitude: xr.DataArray
@@ -104,6 +130,17 @@ class SeparableExponentialCovariance:
     schema_version = 1
 
     def __post_init__(self) -> None:
+        """Validate constructor inputs and cache factors used by the actions.
+
+        Coordinates and class labels are defensively copied. The resolved
+        covariance parameters, separable factors, Cholesky factors, and class
+        masks are installed through ``object.__setattr__`` because instances
+        are frozen.
+
+        Raises:
+            ValueError: If coordinates, units, covariance parameters, or class
+                labels are invalid.
+        """
         latitude = _validate_coordinate(self.latitude, "latitude")
         longitude = _validate_coordinate(self.longitude, "longitude")
         if latitude.dims[0] == longitude.dims[0]:
@@ -126,6 +163,8 @@ class SeparableExponentialCovariance:
             latitude,
             longitude,
         )
+        # Frozen dataclasses require object.__setattr__ during __post_init__
+        # when replacing constructor inputs with their validated forms.
         object.__setattr__(self, "latitude", latitude)
         object.__setattr__(self, "longitude", longitude)
         object.__setattr__(self, "sigma", sigma)
@@ -147,12 +186,20 @@ class SeparableExponentialCovariance:
     def apply(self, rhs: xr.DataArray) -> xr.DataArray:
         """Apply ``B`` while preserving the labelled layout of ``rhs``.
 
+        The right-hand side is eagerly converted to a NumPy array before the
+        covariance action is evaluated.
+
         Args:
             rhs: Array containing both native dimensions and any number of
                 additional right-hand-side dimensions.
 
         Returns:
             ``B rhs`` with dimensions and coordinates identical to ``rhs``.
+
+        Raises:
+            TypeError: If ``rhs`` is not an xarray data array.
+            ValueError: If native dimensions or coordinates are missing or
+                misaligned, or if values are non-numeric or non-finite.
         """
         matrix, original_dims, rhs_dims = self._validated_matrix(rhs)
         applied = self._apply_matrix(matrix)
@@ -171,6 +218,13 @@ class SeparableExponentialCovariance:
 
         Returns:
             ``B^-1 rhs`` with dimensions and coordinates identical to ``rhs``.
+
+        Raises:
+            TypeError: If ``rhs`` is not an xarray data array.
+            ValueError: If native dimensions or coordinates are missing or
+                misaligned, or if values are non-numeric or non-finite.
+            numpy.linalg.LinAlgError: If a class-blocked iterative solve does
+                not converge.
         """
         matrix, original_dims, rhs_dims = self._validated_matrix(rhs)
         if len(self._class_masks) <= 1:
@@ -180,7 +234,13 @@ class SeparableExponentialCovariance:
         return self._restore(solved, rhs, original_dims, rhs_dims)
 
     def to_dataset(self) -> xr.Dataset:
-        """Serialize reproducible coordinates and resolved configuration."""
+        """Serialize reproducible coordinates and resolved configuration.
+
+        Returns:
+            A versioned dataset containing the native coordinates, resolved
+            covariance parameters, and optional class labels. Boolean blocked
+            state is represented as a NetCDF-safe ``0`` or ``1`` attribute.
+        """
         dataset = xr.Dataset(
             coords={
                 self.native_dims[0]: self.latitude,
@@ -195,7 +255,7 @@ class SeparableExponentialCovariance:
                 "correlation_length_degrees": self.correlation_length,
                 "latitude_correlation_length_degrees": self.latitude_correlation_length,
                 "longitude_correlation_length_degrees": self.longitude_correlation_length,
-                "class_blocked": self.class_labels is not None,
+                "class_blocked": int(self.class_labels is not None),
                 "class_labels_name": ""
                 if self.class_labels is None or self.class_labels.name is None
                 else str(self.class_labels.name),
@@ -214,6 +274,12 @@ class SeparableExponentialCovariance:
 
         Returns:
             Reconstructed covariance action.
+
+        Raises:
+            ValueError: If the schema or version is unsupported, required
+                coordinates are missing, or serialized constructor values are
+                invalid.
+            KeyError: If a required covariance parameter attribute is missing.
         """
         if dataset.attrs.get("schema") != cls.schema:
             raise ValueError(f"Expected covariance schema {cls.schema!r}")
@@ -248,7 +314,14 @@ class SeparableExponentialCovariance:
         )
 
     def _apply_matrix(self, matrix: np.ndarray) -> np.ndarray:
-        """Apply the configured unblocked or class-blocked covariance."""
+        """Apply the configured covariance to native-first right-hand sides.
+
+        Args:
+            matrix: Eager array shaped ``(latitude, longitude, rhs)``.
+
+        Returns:
+            Covariance-applied values with the same shape as ``matrix``.
+        """
         if not self._class_masks:
             return self._apply_separable(matrix)
         result = np.zeros_like(matrix, dtype=np.result_type(matrix.dtype, np.float64))
@@ -258,13 +331,27 @@ class SeparableExponentialCovariance:
         return result
 
     def _apply_separable(self, matrix: np.ndarray) -> np.ndarray:
-        """Apply the two one-dimensional covariance factors."""
+        """Apply the two one-dimensional covariance factors.
+
+        Args:
+            matrix: Eager array shaped ``(latitude, longitude, rhs)``.
+
+        Returns:
+            Separable covariance-applied values with the same shape.
+        """
         left_applied = np.einsum("ij,jkr->ikr", self._latitude_factor, matrix)
         applied = np.einsum("ikr,lk->ilr", left_applied, self._longitude_factor)
         return applied * self.sigma**2
 
     def _solve_separable(self, matrix: np.ndarray) -> np.ndarray:
-        """Solve the unblocked separable system using Cholesky factors."""
+        """Solve the unblocked separable system using Cholesky factors.
+
+        Args:
+            matrix: Eager array shaped ``(latitude, longitude, rhs)``.
+
+        Returns:
+            Solved values with the same shape as ``matrix``.
+        """
         n_lat, n_lon, n_rhs = matrix.shape
         latitude_solved = cho_solve(
             self._latitude_cholesky,
@@ -283,7 +370,18 @@ class SeparableExponentialCovariance:
         return longitude_solved / self.sigma**2
 
     def _solve_class_blocked(self, matrix: np.ndarray) -> np.ndarray:
-        """Solve a class-blocked system with matrix-free conjugate gradients."""
+        """Solve a class-blocked system with matrix-free conjugate gradients.
+
+        Args:
+            matrix: Eager array shaped ``(latitude, longitude, rhs)``.
+
+        Returns:
+            Solved values with the same shape as ``matrix``.
+
+        Raises:
+            numpy.linalg.LinAlgError: If conjugate gradients do not converge or
+                fail because of invalid input or numerical breakdown.
+        """
         n_lat, n_lon, n_rhs = matrix.shape
         native_size = n_lat * n_lon
 
@@ -312,6 +410,20 @@ class SeparableExponentialCovariance:
         return solved
 
     def _validated_matrix(self, rhs: xr.DataArray) -> tuple[np.ndarray, tuple[str, ...], tuple[str, ...]]:
+        """Validate and eagerly reshape a labelled right-hand side.
+
+        Args:
+            rhs: Candidate right-hand side containing the native dimensions.
+
+        Returns:
+            A native-first NumPy matrix, the original dimension order, and the
+            ordered non-native right-hand-side dimensions.
+
+        Raises:
+            TypeError: If ``rhs`` is not an xarray data array.
+            ValueError: If native dimensions or coordinates are missing or
+                misaligned, or if values are non-numeric or non-finite.
+        """
         if not isinstance(rhs, xr.DataArray):
             raise TypeError("rhs must be an xarray.DataArray")
         for dim, expected in zip(self.native_dims, (self.latitude, self.longitude), strict=True):
@@ -347,6 +459,18 @@ class SeparableExponentialCovariance:
         original_dims: tuple[str, ...],
         rhs_dims: tuple[str, ...],
     ) -> xr.DataArray:
+        """Restore eager native-first results to a labelled input layout.
+
+        Args:
+            values: Result values shaped as native axes followed by flattened
+                right-hand-side axes.
+            template: Input array supplying coordinates, name, and attributes.
+            original_dims: Original input dimension order.
+            rhs_dims: Ordered non-native right-hand-side dimensions.
+
+        Returns:
+            A labelled array matching the template layout and metadata.
+        """
         shape = tuple(template.sizes[dim] for dim in (*self.native_dims, *rhs_dims))
         result = xr.DataArray(
             values.reshape(shape),
@@ -359,8 +483,23 @@ class SeparableExponentialCovariance:
 
 
 def _validate_coordinate(coordinate: xr.DataArray, axis_name: str) -> xr.DataArray:
+    """Validate one native coordinate and return a defensive copy.
+
+    Args:
+        coordinate: Candidate one-dimensional labelled coordinate.
+        axis_name: Human-readable axis name used for validation and errors.
+
+    Returns:
+        A deep copy with an explicit self-coordinate.
+
+    Raises:
+        ValueError: If the coordinate is not one-dimensional and non-empty,
+            contains non-finite or duplicate values, or has non-degree units.
+    """
     if not isinstance(coordinate, xr.DataArray) or coordinate.ndim != 1 or len(coordinate.dims) != 1:
         raise ValueError(f"{axis_name} must be a one-dimensional labelled coordinate")
+    if coordinate.size == 0:
+        raise ValueError(f"{axis_name} coordinate must contain at least one value")
     dim = coordinate.dims[0]
     if dim not in coordinate.coords:
         coordinate = coordinate.assign_coords({dim: coordinate.values})
@@ -427,6 +566,19 @@ def _validate_class_labels(
 
 
 def _positive_finite(value: float, name: str) -> float:
+    """Resolve a covariance parameter to a positive finite float.
+
+    Args:
+        value: Candidate numeric value.
+        name: Parameter name used in validation errors.
+
+    Returns:
+        The validated floating-point value.
+
+    Raises:
+        TypeError: If ``value`` cannot be converted to a float.
+        ValueError: If the resolved value is non-finite or not strictly positive.
+    """
     resolved = float(value)
     if not np.isfinite(resolved) or resolved <= 0.0:
         raise ValueError(f"{name} must be finite and strictly positive")
@@ -434,5 +586,14 @@ def _positive_finite(value: float, name: str) -> float:
 
 
 def _exponential_factor(coordinates: np.ndarray, length_scale: float) -> np.ndarray:
+    """Construct one exponential covariance factor.
+
+    Args:
+        coordinates: Validated coordinate values for one native axis.
+        length_scale: Positive correlation length in coordinate units.
+
+    Returns:
+        The dense one-dimensional exponential covariance factor.
+    """
     values = np.asarray(coordinates, dtype=np.float64)
     return np.exp(-np.abs(values[:, np.newaxis] - values[np.newaxis, :]) / length_scale)

--- a/openghg_inversions/native_covariance.py
+++ b/openghg_inversions/native_covariance.py
@@ -1,0 +1,438 @@
+"""Labelled matrix-free covariance actions on a native latitude/longitude grid.
+
+The native scaling perturbation is denoted by ``x`` and its covariance by
+``B = Cov(x)``.  A covariance action applies ``B`` to labelled right-hand
+sides without constructing the dense native ``N x N`` matrix.  The initial
+implementation uses
+
+``B = sigma**2 * (K_lat kron K_lon)``,
+
+where ``K_axis[i, j] = exp(-abs(q_i - q_j) / ell_axis)``.  Grid
+arrays use row-major ``(latitude, longitude)`` vectorisation, so the action on
+a field ``X`` is ``K_lat @ X @ K_lon.T``.  The default correlation length is
+1.5 degrees; it is an introductory configurable value, not a universal
+scientific constant.
+
+Both :meth:`SeparableExponentialCovariance.apply` and
+:meth:`SeparableExponentialCovariance.solve` preserve all input dimensions,
+coordinates, name, and attributes.  Only the two one-dimensional factors are
+materialised.  Optional native-grid class labels replace ``B`` by the blocked
+action ``B_class = sum_c M_c B M_c``, where ``M_c`` is the diagonal indicator
+for class ``c``.  This prevents covariance between cells in different classes
+without constructing either ``M_c`` or the dense native covariance.
+Unblocked solves use the separable Cholesky factors; multi-class solves use
+matrix-free conjugate gradients. Distances are coordinate-wise degrees, not
+geodesic or longitude-wrapped distances. A missing coordinate ``units`` attr
+is interpreted as degrees for compatibility with existing OGI grids.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol
+
+import numpy as np
+from scipy.linalg import cho_factor, cho_solve
+from scipy.sparse.linalg import LinearOperator, cg
+import xarray as xr
+
+__all__ = [
+    "InvertibleNativeCovarianceAction",
+    "NativeCovarianceAction",
+    "SeparableExponentialCovariance",
+]
+
+
+class NativeCovarianceAction(Protocol):
+    """Structural interface for a labelled native covariance action."""
+
+    @property
+    def native_dims(self) -> tuple[str, ...]:
+        """Native dimensions consumed by the action."""
+        ...
+
+    def apply(self, rhs: xr.DataArray) -> xr.DataArray:
+        """Apply ``B`` to labelled RHS arrays containing every native dimension.
+
+        All non-native dimensions and their labels must be preserved.
+        """
+        ...
+
+
+class InvertibleNativeCovarianceAction(NativeCovarianceAction, Protocol):
+    """Native covariance action that can also solve systems in ``B``."""
+
+    def solve(self, rhs: xr.DataArray) -> xr.DataArray:
+        """Return labelled ``B^-1 rhs`` while preserving non-native dimensions."""
+        ...
+
+
+@dataclass(frozen=True, slots=True)
+class SeparableExponentialCovariance:
+    """Separable exponential covariance over labelled latitude and longitude.
+
+    Args:
+        latitude: One-dimensional latitude coordinate in degrees.
+        longitude: One-dimensional longitude coordinate in degrees.
+        sigma: Strictly positive native-cell marginal standard deviation, in
+            native-state units (dimensionless for RHIME scaling perturbations).
+        correlation_length: Shared fallback correlation length in degrees.
+        latitude_correlation_length: Optional latitude-specific length in degrees.
+        longitude_correlation_length: Optional longitude-specific length in degrees.
+        class_labels: Optional native-grid labels defining spatial covariance
+            blocks. Cells with different labels have zero cross-covariance.
+
+    Raises:
+        ValueError: If coordinates, units, or covariance parameters are invalid.
+        numpy.linalg.LinAlgError: If a class-blocked iterative solve does not converge.
+    """
+
+    latitude: xr.DataArray
+    longitude: xr.DataArray
+    sigma: float = 1.0
+    correlation_length: float = 1.5
+    latitude_correlation_length: float | None = None
+    longitude_correlation_length: float | None = None
+    class_labels: xr.DataArray | None = None
+    _latitude_factor: np.ndarray = field(init=False, repr=False, compare=False)
+    _longitude_factor: np.ndarray = field(init=False, repr=False, compare=False)
+    _latitude_cholesky: tuple[np.ndarray, bool] = field(init=False, repr=False, compare=False)
+    _longitude_cholesky: tuple[np.ndarray, bool] = field(init=False, repr=False, compare=False)
+    _class_masks: tuple[np.ndarray, ...] = field(init=False, repr=False, compare=False)
+
+    schema = "openghg_inversions.separable_exponential_covariance"
+    schema_version = 1
+
+    def __post_init__(self) -> None:
+        latitude = _validate_coordinate(self.latitude, "latitude")
+        longitude = _validate_coordinate(self.longitude, "longitude")
+        if latitude.dims[0] == longitude.dims[0]:
+            raise ValueError("latitude and longitude must use distinct dimension names")
+        sigma = _positive_finite(self.sigma, "sigma")
+        length = _positive_finite(self.correlation_length, "correlation_length")
+        latitude_length = _positive_finite(
+            length if self.latitude_correlation_length is None else self.latitude_correlation_length,
+            "latitude_correlation_length",
+        )
+        longitude_length = _positive_finite(
+            length if self.longitude_correlation_length is None else self.longitude_correlation_length,
+            "longitude_correlation_length",
+        )
+
+        latitude_factor = _exponential_factor(latitude.values, latitude_length)
+        longitude_factor = _exponential_factor(longitude.values, longitude_length)
+        class_labels, class_masks = _validate_class_labels(
+            self.class_labels,
+            latitude,
+            longitude,
+        )
+        object.__setattr__(self, "latitude", latitude)
+        object.__setattr__(self, "longitude", longitude)
+        object.__setattr__(self, "sigma", sigma)
+        object.__setattr__(self, "correlation_length", length)
+        object.__setattr__(self, "latitude_correlation_length", latitude_length)
+        object.__setattr__(self, "longitude_correlation_length", longitude_length)
+        object.__setattr__(self, "class_labels", class_labels)
+        object.__setattr__(self, "_latitude_factor", latitude_factor)
+        object.__setattr__(self, "_longitude_factor", longitude_factor)
+        object.__setattr__(self, "_latitude_cholesky", cho_factor(latitude_factor, lower=True))
+        object.__setattr__(self, "_longitude_cholesky", cho_factor(longitude_factor, lower=True))
+        object.__setattr__(self, "_class_masks", class_masks)
+
+    @property
+    def native_dims(self) -> tuple[str, str]:
+        """Latitude and longitude dimension names in vectorisation order."""
+        return (str(self.latitude.dims[0]), str(self.longitude.dims[0]))
+
+    def apply(self, rhs: xr.DataArray) -> xr.DataArray:
+        """Apply ``B`` while preserving the labelled layout of ``rhs``.
+
+        Args:
+            rhs: Array containing both native dimensions and any number of
+                additional right-hand-side dimensions.
+
+        Returns:
+            ``B rhs`` with dimensions and coordinates identical to ``rhs``.
+        """
+        matrix, original_dims, rhs_dims = self._validated_matrix(rhs)
+        applied = self._apply_matrix(matrix)
+        return self._restore(applied, rhs, original_dims, rhs_dims)
+
+    def solve(self, rhs: xr.DataArray) -> xr.DataArray:
+        """Solve ``B result = rhs`` without constructing the native matrix.
+
+        The separable case uses one-dimensional Cholesky factors. A covariance
+        with multiple classes uses conjugate gradients with a matrix-free
+        blocked covariance action.
+
+        Args:
+            rhs: Array containing both native dimensions and any number of
+                additional right-hand-side dimensions.
+
+        Returns:
+            ``B^-1 rhs`` with dimensions and coordinates identical to ``rhs``.
+        """
+        matrix, original_dims, rhs_dims = self._validated_matrix(rhs)
+        if len(self._class_masks) <= 1:
+            solved = self._solve_separable(matrix)
+        else:
+            solved = self._solve_class_blocked(matrix)
+        return self._restore(solved, rhs, original_dims, rhs_dims)
+
+    def to_dataset(self) -> xr.Dataset:
+        """Serialize reproducible coordinates and resolved configuration."""
+        dataset = xr.Dataset(
+            coords={
+                self.native_dims[0]: self.latitude,
+                self.native_dims[1]: self.longitude,
+            },
+            attrs={
+                "schema": self.schema,
+                "schema_version": self.schema_version,
+                "latitude_dim": self.native_dims[0],
+                "longitude_dim": self.native_dims[1],
+                "sigma": self.sigma,
+                "correlation_length_degrees": self.correlation_length,
+                "latitude_correlation_length_degrees": self.latitude_correlation_length,
+                "longitude_correlation_length_degrees": self.longitude_correlation_length,
+                "class_blocked": self.class_labels is not None,
+                "class_labels_name": ""
+                if self.class_labels is None or self.class_labels.name is None
+                else str(self.class_labels.name),
+            },
+        )
+        if self.class_labels is not None:
+            dataset["class_labels"] = self.class_labels
+        return dataset
+
+    @classmethod
+    def from_dataset(cls, dataset: xr.Dataset) -> SeparableExponentialCovariance:
+        """Restore a covariance action from :meth:`to_dataset` output.
+
+        Args:
+            dataset: Versioned covariance configuration dataset.
+
+        Returns:
+            Reconstructed covariance action.
+        """
+        if dataset.attrs.get("schema") != cls.schema:
+            raise ValueError(f"Expected covariance schema {cls.schema!r}")
+        if dataset.attrs.get("schema_version") != cls.schema_version:
+            raise ValueError(f"Unsupported covariance schema version {dataset.attrs.get('schema_version')!r}")
+        lat_dim = str(dataset.attrs.get("latitude_dim", ""))
+        lon_dim = str(dataset.attrs.get("longitude_dim", ""))
+        if lat_dim not in dataset.coords or lon_dim not in dataset.coords:
+            raise ValueError("Serialized covariance is missing latitude or longitude coordinates")
+        class_labels = dataset.get("class_labels")
+        if class_labels is not None:
+            serialized_name = str(dataset.attrs.get("class_labels_name", ""))
+            class_labels = class_labels.rename(serialized_name or None)
+        return cls(
+            latitude=dataset.coords[lat_dim],
+            longitude=dataset.coords[lon_dim],
+            sigma=float(dataset.attrs["sigma"]),
+            correlation_length=float(dataset.attrs["correlation_length_degrees"]),
+            latitude_correlation_length=float(
+                dataset.attrs.get(
+                    "latitude_correlation_length_degrees",
+                    dataset.attrs["correlation_length_degrees"],
+                )
+            ),
+            longitude_correlation_length=float(
+                dataset.attrs.get(
+                    "longitude_correlation_length_degrees",
+                    dataset.attrs["correlation_length_degrees"],
+                )
+            ),
+            class_labels=class_labels,
+        )
+
+    def _apply_matrix(self, matrix: np.ndarray) -> np.ndarray:
+        """Apply the configured unblocked or class-blocked covariance."""
+        if not self._class_masks:
+            return self._apply_separable(matrix)
+        result = np.zeros_like(matrix, dtype=np.result_type(matrix.dtype, np.float64))
+        for mask in self._class_masks:
+            masked = matrix * mask[..., np.newaxis]
+            result += self._apply_separable(masked) * mask[..., np.newaxis]
+        return result
+
+    def _apply_separable(self, matrix: np.ndarray) -> np.ndarray:
+        """Apply the two one-dimensional covariance factors."""
+        left_applied = np.einsum("ij,jkr->ikr", self._latitude_factor, matrix)
+        applied = np.einsum("ikr,lk->ilr", left_applied, self._longitude_factor)
+        return applied * self.sigma**2
+
+    def _solve_separable(self, matrix: np.ndarray) -> np.ndarray:
+        """Solve the unblocked separable system using Cholesky factors."""
+        n_lat, n_lon, n_rhs = matrix.shape
+        latitude_solved = cho_solve(
+            self._latitude_cholesky,
+            matrix.reshape(n_lat, n_lon * n_rhs),
+            check_finite=False,
+        ).reshape(n_lat, n_lon, n_rhs)
+        longitude_solved = (
+            cho_solve(
+                self._longitude_cholesky,
+                latitude_solved.transpose(1, 0, 2).reshape(n_lon, n_lat * n_rhs),
+                check_finite=False,
+            )
+            .reshape(n_lon, n_lat, n_rhs)
+            .transpose(1, 0, 2)
+        )
+        return longitude_solved / self.sigma**2
+
+    def _solve_class_blocked(self, matrix: np.ndarray) -> np.ndarray:
+        """Solve a class-blocked system with matrix-free conjugate gradients."""
+        n_lat, n_lon, n_rhs = matrix.shape
+        native_size = n_lat * n_lon
+
+        def matvec(vector: np.ndarray) -> np.ndarray:
+            """Apply the blocked covariance to one flattened right-hand side."""
+            native = vector.reshape(n_lat, n_lon, 1)
+            return self._apply_matrix(native).reshape(native_size)
+
+        operator = LinearOperator(
+            (native_size, native_size),
+            matvec,
+        )
+        solved = np.empty_like(matrix, dtype=np.result_type(matrix.dtype, np.float64))
+        for rhs_index in range(n_rhs):
+            solution, info = cg(
+                operator,
+                matrix[..., rhs_index].reshape(native_size),
+                rtol=1e-12,
+                atol=0.0,
+                maxiter=max(100, 10 * native_size),
+            )
+            if info != 0:
+                reason = "did not converge" if info > 0 else "failed with an illegal input or breakdown"
+                raise np.linalg.LinAlgError(f"Class-blocked covariance solve {reason} (CG info={info})")
+            solved[..., rhs_index] = solution.reshape(n_lat, n_lon)
+        return solved
+
+    def _validated_matrix(self, rhs: xr.DataArray) -> tuple[np.ndarray, tuple[str, ...], tuple[str, ...]]:
+        if not isinstance(rhs, xr.DataArray):
+            raise TypeError("rhs must be an xarray.DataArray")
+        for dim, expected in zip(self.native_dims, (self.latitude, self.longitude), strict=True):
+            if dim not in rhs.dims:
+                raise ValueError(f"rhs is missing native dimension {dim!r}")
+            if dim not in rhs.coords:
+                raise ValueError(f"rhs is missing coordinate labels for native dimension {dim!r}")
+            actual_values = np.asarray(rhs.coords[dim].values)
+            if actual_values.shape != expected.shape or not np.array_equal(actual_values, expected.values):
+                raise ValueError(f"rhs coordinate {dim!r} does not align with the covariance grid")
+        values = np.asarray(rhs.values)
+        if not np.issubdtype(values.dtype, np.number):
+            raise ValueError("rhs values must be numeric")
+        if not np.all(np.isfinite(values)):
+            raise ValueError("rhs values must be finite (no NaN or infinity)")
+        original_dims = tuple(str(dim) for dim in rhs.dims)
+        rhs_dims = tuple(dim for dim in original_dims if dim not in self.native_dims)
+        transposed = rhs.transpose(*self.native_dims, *rhs_dims)
+        n_lat = self.latitude.size
+        n_lon = self.longitude.size
+        return (
+            np.asarray(transposed.values, dtype=np.result_type(values.dtype, np.float64)).reshape(
+                n_lat, n_lon, -1
+            ),
+            original_dims,
+            rhs_dims,
+        )
+
+    def _restore(
+        self,
+        values: np.ndarray,
+        template: xr.DataArray,
+        original_dims: tuple[str, ...],
+        rhs_dims: tuple[str, ...],
+    ) -> xr.DataArray:
+        shape = tuple(template.sizes[dim] for dim in (*self.native_dims, *rhs_dims))
+        result = xr.DataArray(
+            values.reshape(shape),
+            dims=(*self.native_dims, *rhs_dims),
+            coords={name: coordinate for name, coordinate in template.coords.items()},
+            name=template.name,
+            attrs=template.attrs,
+        )
+        return result.transpose(*original_dims)
+
+
+def _validate_coordinate(coordinate: xr.DataArray, axis_name: str) -> xr.DataArray:
+    if not isinstance(coordinate, xr.DataArray) or coordinate.ndim != 1 or len(coordinate.dims) != 1:
+        raise ValueError(f"{axis_name} must be a one-dimensional labelled coordinate")
+    dim = coordinate.dims[0]
+    if dim not in coordinate.coords:
+        coordinate = coordinate.assign_coords({dim: coordinate.values})
+    values = np.asarray(coordinate.values)
+    if not np.issubdtype(values.dtype, np.number) or not np.all(np.isfinite(values)):
+        raise ValueError(f"{axis_name} coordinates must be finite numeric values")
+    if np.unique(values).size != values.size:
+        raise ValueError(f"{axis_name} coordinates must be unique; duplicate values were found")
+    units = str(coordinate.attrs.get("units", "")).strip().lower()
+    allowed_units = {"", "degree", "degrees"}
+    if axis_name == "latitude":
+        allowed_units.update({"degrees_north", "degree_north"})
+    else:
+        allowed_units.update({"degrees_east", "degree_east"})
+    if units not in allowed_units:
+        raise ValueError(f"{axis_name} coordinate units must be degrees, got {units!r}")
+    return coordinate.copy(deep=True)
+
+
+def _validate_class_labels(
+    class_labels: xr.DataArray | None,
+    latitude: xr.DataArray,
+    longitude: xr.DataArray,
+) -> tuple[xr.DataArray | None, tuple[np.ndarray, ...]]:
+    """Validate class labels and construct boolean masks in native-grid order.
+
+    Args:
+        class_labels: Optional array assigning every native grid cell to a class.
+        latitude: Validated latitude coordinate.
+        longitude: Validated longitude coordinate.
+
+    Returns:
+        A defensive copy of the labels and one native-grid boolean mask per
+        class. The empty mask tuple denotes an unblocked covariance.
+
+    Raises:
+        ValueError: If dimensions, coordinates, or label values are invalid.
+    """
+    if class_labels is None:
+        return None, ()
+    if not isinstance(class_labels, xr.DataArray):
+        raise ValueError("class_labels must be an xarray.DataArray")
+
+    native_dims = (latitude.dims[0], longitude.dims[0])
+    if set(class_labels.dims) != set(native_dims) or class_labels.ndim != 2:
+        raise ValueError(f"class_labels must have exactly the native dimensions {native_dims!r}")
+    for dim, expected in zip(native_dims, (latitude, longitude), strict=True):
+        if dim not in class_labels.coords:
+            raise ValueError(f"class_labels is missing coordinate labels for native dimension {dim!r}")
+        actual = np.asarray(class_labels.coords[dim].values)
+        if actual.shape != expected.shape or not np.array_equal(actual, expected.values):
+            raise ValueError(f"class_labels coordinate {dim!r} does not align with the covariance grid")
+    if bool(class_labels.isnull().any().item()):
+        raise ValueError("class_labels must assign a non-null class to every native grid cell")
+
+    labels = class_labels.transpose(*native_dims).copy(deep=True)
+    values = np.asarray(labels.values)
+    try:
+        unique_values = np.unique(values)
+    except TypeError as error:
+        raise ValueError("class_labels values must be mutually comparable scalar labels") from error
+    masks = tuple(values == value for value in unique_values)
+    return labels, masks
+
+
+def _positive_finite(value: float, name: str) -> float:
+    resolved = float(value)
+    if not np.isfinite(resolved) or resolved <= 0.0:
+        raise ValueError(f"{name} must be finite and strictly positive")
+    return resolved
+
+
+def _exponential_factor(coordinates: np.ndarray, length_scale: float) -> np.ndarray:
+    values = np.asarray(coordinates, dtype=np.float64)
+    return np.exp(-np.abs(values[:, np.newaxis] - values[np.newaxis, :]) / length_scale)

--- a/openghg_inversions/source_covariance.py
+++ b/openghg_inversions/source_covariance.py
@@ -1,0 +1,329 @@
+"""Independent labelled source blocks for native covariance actions.
+
+The first multisource covariance contract is block diagonal by source.  Each
+configured source owns a :class:`~openghg_inversions.native_covariance.SeparableExponentialCovariance`
+on the same spatial grid, so source-specific amplitudes, correlation lengths,
+and optional class masks remain explicit.  The action applies or solves each
+block independently and preserves the configured non-lexical source order.
+
+The leading native source dimension defaults to ``"native_source"``.  This is
+intentionally distinct from the ``"source"`` level on OGI's gathered retained
+state MultiIndex: xarray cannot represent a dimension and a MultiIndex level
+with the same name in one prolongation array.  Callers can rename a native
+``source`` dimension at this preparation boundary without changing its labels.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+from types import MappingProxyType
+from typing import Literal, Mapping
+
+import numpy as np
+import xarray as xr
+
+from openghg_inversions.native_covariance import SeparableExponentialCovariance
+
+__all__ = ["IndependentSourceCovariance"]
+
+
+@dataclass(frozen=True, slots=True)
+class IndependentSourceCovariance:
+    """Block-diagonal native covariance over an ordered source mapping.
+
+    Args:
+        source_covariances: Non-empty insertion-ordered mapping from source
+            labels to separable spatial covariance actions on the same grid.
+        source_dim: Explicit native source dimension. It should not collide
+            with a level name on the retained state MultiIndex.
+
+    Raises:
+        ValueError: If source labels, spatial dimensions, or grids differ.
+    """
+
+    source_covariances: Mapping[str, SeparableExponentialCovariance]
+    source_dim: str = "native_source"
+    _source_labels: tuple[str, ...] = field(init=False, repr=False)
+
+    schema = "openghg_inversions.independent_source_covariance"
+    schema_version = 1
+
+    def __post_init__(self) -> None:
+        covariances = dict(self.source_covariances)
+        if not covariances:
+            raise ValueError("source_covariances must contain at least one source block")
+        if not isinstance(self.source_dim, str) or not self.source_dim:
+            raise ValueError("source_dim must be a non-empty string")
+        if self.source_dim in next(iter(covariances.values())).native_dims:
+            raise ValueError("source_dim must be distinct from the spatial native dimensions")
+        if any(not isinstance(label, str) or not label for label in covariances):
+            raise ValueError("source covariance labels must be non-empty strings")
+
+        reference = next(iter(covariances.values()))
+        for label, covariance in covariances.items():
+            if not isinstance(covariance, SeparableExponentialCovariance):
+                raise TypeError(f"Source {label!r} must use SeparableExponentialCovariance")
+            if covariance.native_dims != reference.native_dims:
+                raise ValueError("All source covariance blocks must use the same spatial dimensions")
+            for dim, expected, actual in zip(
+                reference.native_dims,
+                (reference.latitude, reference.longitude),
+                (covariance.latitude, covariance.longitude),
+                strict=True,
+            ):
+                if not np.array_equal(expected.values, actual.values):
+                    raise ValueError(f"Source {label!r} covariance grid differs on {dim!r}")
+        object.__setattr__(self, "source_covariances", MappingProxyType(covariances))
+        object.__setattr__(self, "_source_labels", tuple(covariances))
+
+    @property
+    def source_labels(self) -> tuple[str, ...]:
+        """Configured source labels in canonical insertion order."""
+        return self._source_labels
+
+    @property
+    def native_dims(self) -> tuple[str, ...]:
+        """Explicit source dimension followed by the common spatial dimensions."""
+        first = self.source_covariances[self.source_labels[0]]
+        return (self.source_dim, *first.native_dims)
+
+    def apply(self, rhs: xr.DataArray) -> xr.DataArray:
+        """Apply independent source covariance blocks to labelled RHS arrays.
+
+        Args:
+            rhs: Array containing the exact source and spatial native labels;
+                all other right-hand-side dimensions are preserved.
+
+        Returns:
+            Blockwise ``B rhs`` in the original dimension order.
+        """
+        return self._operate(rhs, operation="apply")
+
+    def solve(self, rhs: xr.DataArray) -> xr.DataArray:
+        """Solve independent source covariance blocks for labelled RHS arrays.
+
+        Args:
+            rhs: Array containing the exact source and spatial native labels;
+                all other right-hand-side dimensions are preserved.
+
+        Returns:
+            Blockwise ``B^-1 rhs`` in the original dimension order.
+        """
+        return self._operate(rhs, operation="solve")
+
+    def to_dataset(self) -> xr.Dataset:
+        """Serialize source order and every reproducible component configuration."""
+        first = self.source_covariances[self.source_labels[0]]
+        source = xr.IndexVariable(self.source_dim, list(self.source_labels))
+        sigma = xr.DataArray(
+            [self.source_covariances[label].sigma for label in self.source_labels],
+            dims=self.source_dim,
+            coords={self.source_dim: source},
+        )
+        correlation_length = xr.DataArray(
+            [self.source_covariances[label].correlation_length for label in self.source_labels],
+            dims=self.source_dim,
+            coords={self.source_dim: source},
+        )
+        latitude_correlation_length = xr.DataArray(
+            [self.source_covariances[label].latitude_correlation_length for label in self.source_labels],
+            dims=self.source_dim,
+            coords={self.source_dim: source},
+        )
+        longitude_correlation_length = xr.DataArray(
+            [self.source_covariances[label].longitude_correlation_length for label in self.source_labels],
+            dims=self.source_dim,
+            coords={self.source_dim: source},
+        )
+        blocked = xr.DataArray(
+            [self.source_covariances[label].class_labels is not None for label in self.source_labels],
+            dims=self.source_dim,
+            coords={self.source_dim: source},
+        )
+        label_values = np.full(
+            (len(self.source_labels), first.latitude.size, first.longitude.size),
+            "",
+            dtype=object,
+        )
+        label_names: list[str] = []
+        label_attrs: list[str] = []
+        for index, label in enumerate(self.source_labels):
+            class_labels = self.source_covariances[label].class_labels
+            if class_labels is not None:
+                values = class_labels.transpose(*first.native_dims).values
+                label_values[index] = np.vectorize(_encode_class_label, otypes=[object])(values)
+                label_names.append(str(class_labels.name) if class_labels.name is not None else "")
+                label_attrs.append(json.dumps(class_labels.attrs, sort_keys=True, default=_json_default))
+            else:
+                label_names.append("")
+                label_attrs.append("{}")
+        return xr.Dataset(
+            {
+                "sigma": sigma,
+                "correlation_length": correlation_length,
+                "latitude_correlation_length": latitude_correlation_length,
+                "longitude_correlation_length": longitude_correlation_length,
+                "class_blocked": blocked,
+                "class_label_encoded": xr.DataArray(
+                    label_values,
+                    dims=(self.source_dim, *first.native_dims),
+                    coords={
+                        self.source_dim: source,
+                        first.native_dims[0]: first.latitude,
+                        first.native_dims[1]: first.longitude,
+                    },
+                ),
+                "class_label_name": xr.DataArray(
+                    label_names,
+                    dims=self.source_dim,
+                    coords={self.source_dim: source},
+                ),
+                "class_label_attrs": xr.DataArray(
+                    label_attrs,
+                    dims=self.source_dim,
+                    coords={self.source_dim: source},
+                ),
+            },
+            attrs={
+                "schema": self.schema,
+                "schema_version": self.schema_version,
+                "source_dim": self.source_dim,
+                "latitude_dim": first.native_dims[0],
+                "longitude_dim": first.native_dims[1],
+                "class_label_encoding": "tagged_json_v1",
+            },
+        )
+
+    @classmethod
+    def from_dataset(cls, dataset: xr.Dataset) -> IndependentSourceCovariance:
+        """Restore source blocks from :meth:`to_dataset` output.
+
+        Args:
+            dataset: Versioned independent-source covariance dataset.
+
+        Returns:
+            Reconstructed source-block covariance action with class-label
+            values, name, and JSON-compatible attributes restored.
+
+        Raises:
+            ValueError: If schema metadata or required variables are absent.
+        """
+        if dataset.attrs.get("schema") != cls.schema:
+            raise ValueError(f"Expected source covariance schema {cls.schema!r}")
+        if dataset.attrs.get("schema_version") != cls.schema_version:
+            raise ValueError("Unsupported independent-source covariance schema version")
+        source_dim = str(dataset.attrs.get("source_dim", ""))
+        latitude_dim = str(dataset.attrs.get("latitude_dim", ""))
+        longitude_dim = str(dataset.attrs.get("longitude_dim", ""))
+        required = {
+            "sigma",
+            "correlation_length",
+            "latitude_correlation_length",
+            "longitude_correlation_length",
+            "class_blocked",
+            "class_label_encoded",
+            "class_label_name",
+            "class_label_attrs",
+        }
+        missing = required.difference(dataset.data_vars)
+        if not source_dim or source_dim not in dataset.coords or missing:
+            raise ValueError(f"Serialized source covariance is missing labels or variables {sorted(missing)}")
+        covariances: dict[str, SeparableExponentialCovariance] = {}
+        for raw_label in dataset.coords[source_dim].values:
+            label = str(raw_label)
+            labels = None
+            if bool(dataset["class_blocked"].sel({source_dim: raw_label}).item()):
+                encoded = dataset["class_label_encoded"].sel({source_dim: raw_label}, drop=True)
+                decoded = np.vectorize(_decode_class_label, otypes=[object])(encoded.values)
+                name = str(dataset["class_label_name"].sel({source_dim: raw_label}).item()) or None
+                attrs = json.loads(str(dataset["class_label_attrs"].sel({source_dim: raw_label}).item()))
+                labels = encoded.copy(data=decoded).rename(name).assign_attrs(attrs)
+            covariances[label] = SeparableExponentialCovariance(
+                latitude=dataset.coords[latitude_dim],
+                longitude=dataset.coords[longitude_dim],
+                sigma=float(dataset["sigma"].sel({source_dim: raw_label}).item()),
+                correlation_length=float(dataset["correlation_length"].sel({source_dim: raw_label}).item()),
+                latitude_correlation_length=float(
+                    dataset["latitude_correlation_length"].sel({source_dim: raw_label}).item()
+                ),
+                longitude_correlation_length=float(
+                    dataset["longitude_correlation_length"].sel({source_dim: raw_label}).item()
+                ),
+                class_labels=labels,
+            )
+        return cls(covariances, source_dim=source_dim)
+
+    def _operate(
+        self,
+        rhs: xr.DataArray,
+        *,
+        operation: Literal["apply", "solve"],
+    ) -> xr.DataArray:
+        """Validate source labels and dispatch one covariance operation per block."""
+        if self.source_dim not in rhs.dims or self.source_dim not in rhs.coords:
+            raise ValueError(f"rhs must contain labelled source dimension {self.source_dim!r}")
+        actual_labels = tuple(str(label) for label in rhs.coords[self.source_dim].values)
+        if actual_labels != self.source_labels:
+            raise ValueError(
+                "rhs source labels/order do not match covariance configuration: "
+                f"{actual_labels!r} != {self.source_labels!r}"
+            )
+        original_dims = tuple(str(dim) for dim in rhs.dims)
+        results: list[xr.DataArray] = []
+        for label in self.source_labels:
+            source_rhs = rhs.sel({self.source_dim: label}, drop=True)
+            action = self.source_covariances[label]
+            results.append(getattr(action, operation)(source_rhs))
+        source_coordinate = xr.DataArray(
+            list(self.source_labels),
+            dims=self.source_dim,
+            coords={self.source_dim: list(self.source_labels)},
+            attrs=rhs.coords[self.source_dim].attrs,
+        )
+        combined = xr.concat(results, dim=source_coordinate)
+        combined.name = rhs.name
+        combined.attrs = rhs.attrs
+        return combined.transpose(*original_dims)
+
+
+def _encode_class_label(value: object) -> str:
+    """Encode common scalar/tuple class labels without losing their Python type."""
+    if isinstance(value, np.generic):
+        value = value.item()
+    if isinstance(value, tuple):
+        payload = ["tuple", [_encode_class_label(item) for item in value]]
+    elif isinstance(value, bool):
+        payload = ["bool", value]
+    elif isinstance(value, int):
+        payload = ["int", value]
+    elif isinstance(value, float):
+        payload = ["float", value]
+    elif isinstance(value, str):
+        payload = ["str", value]
+    else:
+        raise TypeError(f"Unsupported class-label type for serialization: {type(value).__name__}")
+    return json.dumps(payload, separators=(",", ":"))
+
+
+def _decode_class_label(encoded: str) -> object:
+    """Decode one tagged JSON class label produced by :func:`_encode_class_label`."""
+    kind, value = json.loads(str(encoded))
+    if kind == "tuple":
+        return tuple(_decode_class_label(item) for item in value)
+    if kind == "bool":
+        return bool(value)
+    if kind == "int":
+        return int(value)
+    if kind == "float":
+        return float(value)
+    if kind == "str":
+        return str(value)
+    raise ValueError(f"Unknown encoded class-label kind {kind!r}")
+
+
+def _json_default(value: object) -> object:
+    """Convert NumPy scalar attrs to JSON-compatible Python scalars."""
+    if isinstance(value, np.generic):
+        return value.item()
+    raise TypeError(f"Class-label attr {value!r} is not JSON serializable")

--- a/openghg_inversions/source_covariance.py
+++ b/openghg_inversions/source_covariance.py
@@ -1,16 +1,25 @@
-"""Independent labelled source blocks for native covariance actions.
+"""Compose labelled native covariance actions into independent source blocks.
 
-The first multisource covariance contract is block diagonal by source.  Each
-configured source owns a :class:`~openghg_inversions.native_covariance.SeparableExponentialCovariance`
-on the same spatial grid, so source-specific amplitudes, correlation lengths,
-and optional class masks remain explicit.  The action applies or solves each
-block independently and preserves the configured non-lexical source order.
+The multisource covariance represented here is block diagonal by source. Each
+configured source owns a
+:class:`~openghg_inversions.native_covariance.SeparableExponentialCovariance`
+on the same labelled spatial grid, while amplitudes, correlation lengths, and
+optional class masks may differ by source. Applying or solving the composite
+action dispatches to each source block independently, preserves all labelled
+right-hand-side dimensions, and never constructs a dense cross-source matrix.
 
-The leading native source dimension defaults to ``"native_source"``.  This is
-intentionally distinct from the ``"source"`` level on OGI's gathered retained
-state MultiIndex: xarray cannot represent a dimension and a MultiIndex level
-with the same name in one prolongation array.  Callers can rename a native
-``source`` dimension at this preparation boundary without changing its labels.
+Source labels are non-empty strings whose insertion order defines the canonical
+block order. Input arrays must carry exactly those string labels in that order;
+values are not coerced between types. The leading native source dimension
+defaults to ``"native_source"``. This is intentionally distinct from the
+``"source"`` level on OGI's gathered retained-state MultiIndex because xarray
+cannot represent a dimension and a MultiIndex level with the same name in one
+prolongation array.
+
+:class:`IndependentSourceCovariance` can serialize its complete reproducible
+configuration, including typed class labels, to an xarray dataset. Restoration
+validates the schema, source labels, required variables, and spatial coordinate
+metadata before reconstructing the component actions.
 """
 
 from __future__ import annotations
@@ -39,7 +48,11 @@ class IndependentSourceCovariance:
             with a level name on the retained state MultiIndex.
 
     Raises:
-        ValueError: If source labels, spatial dimensions, or grids differ.
+        TypeError: If a source block is not a
+            :class:`SeparableExponentialCovariance` or the source mapping cannot
+            be copied.
+        ValueError: If the mapping is empty, source labels or ``source_dim``
+            are invalid, or block spatial dimensions or grids differ.
     """
 
     source_covariances: Mapping[str, SeparableExponentialCovariance]
@@ -50,20 +63,36 @@ class IndependentSourceCovariance:
     schema_version = 1
 
     def __post_init__(self) -> None:
+        """Validate source blocks and freeze their canonical insertion order.
+
+        The complete block mapping is type-checked before any block attributes
+        are inspected. The validated copy is exposed through a read-only
+        mapping proxy so later mutations of the caller's mapping cannot change
+        the covariance configuration.
+
+        Raises:
+            TypeError: If ``source_covariances`` cannot be copied into a
+                mapping or any block is not a
+                :class:`SeparableExponentialCovariance`.
+            ValueError: If no blocks are supplied, source labels or
+                ``source_dim`` are invalid, or blocks do not share identical
+                labelled spatial grids.
+        """
         covariances = dict(self.source_covariances)
         if not covariances:
             raise ValueError("source_covariances must contain at least one source block")
         if not isinstance(self.source_dim, str) or not self.source_dim:
             raise ValueError("source_dim must be a non-empty string")
-        if self.source_dim in next(iter(covariances.values())).native_dims:
-            raise ValueError("source_dim must be distinct from the spatial native dimensions")
         if any(not isinstance(label, str) or not label for label in covariances):
             raise ValueError("source covariance labels must be non-empty strings")
-
-        reference = next(iter(covariances.values()))
         for label, covariance in covariances.items():
             if not isinstance(covariance, SeparableExponentialCovariance):
                 raise TypeError(f"Source {label!r} must use SeparableExponentialCovariance")
+
+        reference = next(iter(covariances.values()))
+        if self.source_dim in reference.native_dims:
+            raise ValueError("source_dim must be distinct from the spatial native dimensions")
+        for label, covariance in covariances.items():
             if covariance.native_dims != reference.native_dims:
                 raise ValueError("All source covariance blocks must use the same spatial dimensions")
             for dim, expected, actual in zip(
@@ -79,12 +108,20 @@ class IndependentSourceCovariance:
 
     @property
     def source_labels(self) -> tuple[str, ...]:
-        """Configured source labels in canonical insertion order."""
+        """Return configured source labels in canonical insertion order.
+
+        Returns:
+            Source labels defining the block order.
+        """
         return self._source_labels
 
     @property
     def native_dims(self) -> tuple[str, ...]:
-        """Explicit source dimension followed by the common spatial dimensions."""
+        """Return the source dimension followed by common spatial dimensions.
+
+        Returns:
+            Native dimensions in vectorisation order.
+        """
         first = self.source_covariances[self.source_labels[0]]
         return (self.source_dim, *first.native_dims)
 
@@ -97,6 +134,11 @@ class IndependentSourceCovariance:
 
         Returns:
             Blockwise ``B rhs`` in the original dimension order.
+
+        Raises:
+            TypeError: If ``rhs`` is not an xarray data array.
+            ValueError: If source or spatial dimensions, coordinates, labels,
+                or numerical values are missing or invalid.
         """
         return self._operate(rhs, operation="apply")
 
@@ -109,11 +151,27 @@ class IndependentSourceCovariance:
 
         Returns:
             Blockwise ``B^-1 rhs`` in the original dimension order.
+
+        Raises:
+            TypeError: If ``rhs`` is not an xarray data array.
+            ValueError: If source or spatial dimensions, coordinates, labels,
+                or numerical values are missing or invalid.
+            numpy.linalg.LinAlgError: If a class-blocked component solve does
+                not converge.
         """
         return self._operate(rhs, operation="solve")
 
     def to_dataset(self) -> xr.Dataset:
-        """Serialize source order and every reproducible component configuration."""
+        """Serialize source order and reproducible component configuration.
+
+        Returns:
+            Versioned dataset containing source-specific covariance parameters,
+            the common spatial coordinates, and any encoded class labels.
+
+        Raises:
+            TypeError: If a class label or class-label attribute cannot be
+                represented by the tagged JSON encoding.
+        """
         first = self.source_covariances[self.source_labels[0]]
         source = xr.IndexVariable(self.source_dim, list(self.source_labels))
         sigma = xr.DataArray(
@@ -207,7 +265,9 @@ class IndependentSourceCovariance:
             values, name, and JSON-compatible attributes restored.
 
         Raises:
-            ValueError: If schema metadata or required variables are absent.
+            ValueError: If schema metadata, source or spatial coordinates, or
+                required variables are absent or invalid, or encoded metadata
+                cannot be decoded.
         """
         if dataset.attrs.get("schema") != cls.schema:
             raise ValueError(f"Expected source covariance schema {cls.schema!r}")
@@ -227,28 +287,39 @@ class IndependentSourceCovariance:
             "class_label_attrs",
         }
         missing = required.difference(dataset.data_vars)
+        spatial_coordinates_valid = (
+            bool(latitude_dim)
+            and bool(longitude_dim)
+            and latitude_dim != longitude_dim
+            and latitude_dim in dataset.coords
+            and longitude_dim in dataset.coords
+        )
         if not source_dim or source_dim not in dataset.coords or missing:
             raise ValueError(f"Serialized source covariance is missing labels or variables {sorted(missing)}")
+        if not spatial_coordinates_valid:
+            raise ValueError("Serialized source covariance is missing latitude or longitude coordinates")
+        raw_source_labels = dataset.coords[source_dim].values.tolist()
+        if any(not isinstance(label, str) or not label for label in raw_source_labels):
+            raise ValueError("Serialized source covariance labels must be non-empty strings")
         covariances: dict[str, SeparableExponentialCovariance] = {}
-        for raw_label in dataset.coords[source_dim].values:
-            label = str(raw_label)
+        for label in raw_source_labels:
             labels = None
-            if bool(dataset["class_blocked"].sel({source_dim: raw_label}).item()):
-                encoded = dataset["class_label_encoded"].sel({source_dim: raw_label}, drop=True)
+            if bool(dataset["class_blocked"].sel({source_dim: label}).item()):
+                encoded = dataset["class_label_encoded"].sel({source_dim: label}, drop=True)
                 decoded = np.vectorize(_decode_class_label, otypes=[object])(encoded.values)
-                name = str(dataset["class_label_name"].sel({source_dim: raw_label}).item()) or None
-                attrs = json.loads(str(dataset["class_label_attrs"].sel({source_dim: raw_label}).item()))
+                name = str(dataset["class_label_name"].sel({source_dim: label}).item()) or None
+                attrs = json.loads(str(dataset["class_label_attrs"].sel({source_dim: label}).item()))
                 labels = encoded.copy(data=decoded).rename(name).assign_attrs(attrs)
             covariances[label] = SeparableExponentialCovariance(
                 latitude=dataset.coords[latitude_dim],
                 longitude=dataset.coords[longitude_dim],
-                sigma=float(dataset["sigma"].sel({source_dim: raw_label}).item()),
-                correlation_length=float(dataset["correlation_length"].sel({source_dim: raw_label}).item()),
+                sigma=float(dataset["sigma"].sel({source_dim: label}).item()),
+                correlation_length=float(dataset["correlation_length"].sel({source_dim: label}).item()),
                 latitude_correlation_length=float(
-                    dataset["latitude_correlation_length"].sel({source_dim: raw_label}).item()
+                    dataset["latitude_correlation_length"].sel({source_dim: label}).item()
                 ),
                 longitude_correlation_length=float(
-                    dataset["longitude_correlation_length"].sel({source_dim: raw_label}).item()
+                    dataset["longitude_correlation_length"].sel({source_dim: label}).item()
                 ),
                 class_labels=labels,
             )
@@ -260,11 +331,28 @@ class IndependentSourceCovariance:
         *,
         operation: Literal["apply", "solve"],
     ) -> xr.DataArray:
-        """Validate source labels and dispatch one covariance operation per block."""
+        """Validate labels and dispatch one covariance operation per source.
+
+        Args:
+            rhs: Candidate labelled right-hand side.
+            operation: Component method to invoke for every source block.
+
+        Returns:
+            Concatenated block results transposed to the input dimension order.
+
+        Raises:
+            TypeError: If ``rhs`` is not an xarray data array.
+            ValueError: If source or spatial labels are missing or do not
+                exactly match the configured labels, or values are invalid.
+            numpy.linalg.LinAlgError: If a requested class-blocked solve does
+                not converge.
+        """
+        if not isinstance(rhs, xr.DataArray):
+            raise TypeError("rhs must be an xarray.DataArray")
         if self.source_dim not in rhs.dims or self.source_dim not in rhs.coords:
             raise ValueError(f"rhs must contain labelled source dimension {self.source_dim!r}")
-        actual_labels = tuple(str(label) for label in rhs.coords[self.source_dim].values)
-        if actual_labels != self.source_labels:
+        actual_labels = tuple(rhs.coords[self.source_dim].values.tolist())
+        if any(not isinstance(label, str) for label in actual_labels) or actual_labels != self.source_labels:
             raise ValueError(
                 "rhs source labels/order do not match covariance configuration: "
                 f"{actual_labels!r} != {self.source_labels!r}"
@@ -288,7 +376,18 @@ class IndependentSourceCovariance:
 
 
 def _encode_class_label(value: object) -> str:
-    """Encode common scalar/tuple class labels without losing their Python type."""
+    """Encode a class label without losing its supported Python scalar type.
+
+    Args:
+        value: String, Boolean, integer, float, NumPy scalar, or nested tuple
+            composed from those types.
+
+    Returns:
+        Tagged compact JSON representation of ``value``.
+
+    Raises:
+        TypeError: If ``value`` has an unsupported type.
+    """
     if isinstance(value, np.generic):
         value = value.item()
     if isinstance(value, tuple):
@@ -307,7 +406,17 @@ def _encode_class_label(value: object) -> str:
 
 
 def _decode_class_label(encoded: str) -> object:
-    """Decode one tagged JSON class label produced by :func:`_encode_class_label`."""
+    """Decode one tagged JSON class label.
+
+    Args:
+        encoded: Tagged JSON produced by :func:`_encode_class_label`.
+
+    Returns:
+        Restored supported Python scalar or tuple value.
+
+    Raises:
+        ValueError: If the JSON is malformed or its type tag is unknown.
+    """
     kind, value = json.loads(str(encoded))
     if kind == "tuple":
         return tuple(_decode_class_label(item) for item in value)
@@ -323,7 +432,17 @@ def _decode_class_label(encoded: str) -> object:
 
 
 def _json_default(value: object) -> object:
-    """Convert NumPy scalar attrs to JSON-compatible Python scalars."""
+    """Convert a NumPy scalar attribute to a JSON-compatible scalar.
+
+    Args:
+        value: Attribute value rejected by JSON's standard encoder.
+
+    Returns:
+        Equivalent built-in Python scalar.
+
+    Raises:
+        TypeError: If ``value`` is not a NumPy scalar.
+    """
     if isinstance(value, np.generic):
         return value.item()
     raise TypeError(f"Class-label attr {value!r} is not JSON serializable")

--- a/tests/test_covariance_products.py
+++ b/tests/test_covariance_products.py
@@ -1,0 +1,533 @@
+"""Tests for covariance products that preserve bucket prolongation semantics."""
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+from openghg_inversions.basis.covariance_products import (
+    NativeCovarianceProducts,
+    PreserveBucketProlongation,
+    RetainedProjection,
+    RetainedProjectionStrategy,
+    project_native_covariance,
+)
+from openghg_inversions.basis.operators import BucketBasisOperator
+from openghg_inversions.native_covariance import SeparableExponentialCovariance
+
+
+def _problem() -> tuple[
+    SeparableExponentialCovariance,
+    BucketBasisOperator,
+    xr.DataArray,
+    np.ndarray,
+]:
+    """Return a labelled small-grid problem and its dense native covariance."""
+    latitude = xr.DataArray(
+        [-1.0, 0.5, 2.0],
+        dims="lat",
+        coords={"lat": [-1.0, 0.5, 2.0]},
+        attrs={"units": "degrees_north"},
+    )
+    longitude = xr.DataArray(
+        [10.0, 11.0],
+        dims="lon",
+        coords={"lon": [10.0, 11.0]},
+        attrs={"units": "degrees_east"},
+    )
+    covariance = SeparableExponentialCovariance(
+        latitude=latitude,
+        longitude=longitude,
+        sigma=1.4,
+        correlation_length=0.9,
+    )
+    basis_flat = xr.DataArray(
+        [[1, 1], [1, 2], [2, 2]],
+        dims=("lat", "lon"),
+        coords={"lat": latitude, "lon": longitude},
+        name="basis_flat",
+    )
+    basis_operator = BucketBasisOperator(basis_flat, state_dim="state")
+    native_sensitivity = xr.DataArray(
+        np.array(
+            [
+                [[0.2, -0.1], [0.4, 0.7], [0.3, -0.2]],
+                [[-0.3, 0.8], [0.1, -0.4], [0.9, 0.5]],
+                [[0.6, 0.2], [-0.7, 0.3], [0.2, 0.1]],
+            ]
+        ),
+        dims=("observation", "lat", "lon"),
+        coords={
+            "observation": ["MHD-1", "TAC-1", "RGL-1"],
+            "lat": latitude,
+            "lon": longitude,
+        },
+        name="native_sensitivity",
+    )
+    k_lat = np.exp(-np.abs(latitude.values[:, np.newaxis] - latitude.values[np.newaxis, :]) / 0.9)
+    k_lon = np.exp(-np.abs(longitude.values[:, np.newaxis] - longitude.values[np.newaxis, :]) / 0.9)
+    dense_b = 1.4**2 * np.kron(k_lat, k_lon)
+    return covariance, basis_operator, native_sensitivity, dense_b
+
+
+def _dense_operators(
+    basis_operator: BucketBasisOperator,
+    dense_b: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return dense-oracle prolongation, restriction, and retained covariance."""
+    matrix = basis_operator.basis_matrix.transpose("lat", "lon", "state").compute()
+    u = np.asarray(matrix.data.todense()).reshape(6, 2)
+    precision_u = np.linalg.solve(dense_b, u)
+    c_alpha = np.linalg.inv(u.T @ precision_u)
+    restriction = c_alpha @ precision_u.T
+    return u, restriction, c_alpha
+
+
+def _project(
+    covariance: SeparableExponentialCovariance,
+    basis_operator: BucketBasisOperator,
+    native_sensitivity: xr.DataArray,
+    **options,
+) -> NativeCovarianceProducts:
+    """Project the shared problem with its canonical observation dimension."""
+    return project_native_covariance(
+        covariance=covariance,
+        basis_operator=basis_operator,
+        native_sensitivity=native_sensitivity,
+        observation_dim="observation",
+        **options,
+    )
+
+
+def test_preserve_bucket_strategy_derives_compatible_restriction() -> None:
+    """The derived restriction satisfies Pi_U U_bucket = identity with stable labels."""
+    covariance, basis_operator, _, dense_b = _problem()
+    u, expected_pi, _ = _dense_operators(basis_operator, dense_b)
+
+    projection = PreserveBucketProlongation().projection(
+        covariance,
+        basis_operator.basis_matrix,
+        native_dims=covariance.native_dims,
+        state_dim="state",
+    )
+
+    assert projection.strategy == "preserve_bucket_prolongation"
+    assert projection.prolongation.dims == ("lat", "lon", "state")
+    assert projection.restriction.dims == ("state", "lat", "lon")
+    assert projection.restriction.state.values.tolist() == [0, 1]
+    np.testing.assert_allclose(
+        projection.restriction.values.reshape(2, 6), expected_pi, rtol=1e-11, atol=1e-11
+    )
+    np.testing.assert_allclose(
+        projection.restriction.values.reshape(2, 6) @ u,
+        np.eye(2),
+        rtol=1e-11,
+        atol=1e-11,
+    )
+
+
+def test_products_match_dense_oracle_and_coherent_forward_model() -> None:
+    """C_alpha, H_alpha, H B Pi.T, and H B H.T match dense coherent oracles."""
+    covariance, basis_operator, h, dense_b = _problem()
+    u, expected_pi, expected_c_alpha = _dense_operators(basis_operator, dense_b)
+    h_matrix = h.values.reshape(3, 6)
+
+    products = _project(covariance, basis_operator, h)
+
+    expected_h_alpha = h_matrix @ u
+    expected_hb_pi_t = h_matrix @ dense_b @ expected_pi.T
+    expected_hbht = h_matrix @ dense_b @ h_matrix.T
+    np.testing.assert_allclose(products.state_covariance, expected_c_alpha, rtol=1e-11, atol=1e-11)
+    np.testing.assert_allclose(
+        products.effective_observation_operator, expected_h_alpha, rtol=1e-11, atol=1e-11
+    )
+    np.testing.assert_allclose(
+        products.observation_state_cross_covariance,
+        expected_hb_pi_t,
+        rtol=1e-11,
+        atol=1e-11,
+    )
+    np.testing.assert_allclose(products.native_observation_covariance, expected_hbht, rtol=1e-11, atol=1e-11)
+    np.testing.assert_allclose(
+        products.observation_state_cross_covariance,
+        expected_h_alpha @ expected_c_alpha,
+        rtol=1e-11,
+        atol=1e-11,
+    )
+    assert products.state_covariance.dims == ("state", "state_cov")
+    assert products.effective_observation_operator.dims == ("observation", "state")
+    assert products.observation_state_cross_covariance.dims == ("observation", "state_cov")
+    assert products.native_observation_covariance.dims == ("observation", "observation_cov")
+    assert products.native_observation_covariance.observation.values.tolist() == [
+        "MHD-1",
+        "TAC-1",
+        "RGL-1",
+    ]
+    assert products.native_observation_covariance.observation_cov.values.tolist() == [
+        "MHD-1",
+        "TAC-1",
+        "RGL-1",
+    ]
+
+
+def test_covariance_natural_prolongation_is_the_bucket_prolongation() -> None:
+    """The compatible Pi makes B Pi.T C_alpha^-1 exactly equal U_bucket."""
+    covariance, basis_operator, h, dense_b = _problem()
+    u, _, _ = _dense_operators(basis_operator, dense_b)
+    products = _project(covariance, basis_operator, h)
+    pi = products.restriction.values.reshape(2, 6)
+
+    u_star = dense_b @ pi.T @ np.linalg.inv(products.state_covariance.values)
+
+    np.testing.assert_allclose(u_star, u, rtol=1e-11, atol=1e-11)
+
+
+def test_dense_and_diagonal_products_are_batch_invariant() -> None:
+    """Execution batch size changes neither covariance products nor their identity."""
+    covariance, basis_operator, h, _ = _problem()
+
+    full_batch = _project(
+        covariance,
+        basis_operator,
+        h,
+        observation_covariance="dense",
+        observation_batch_size=64,
+    )
+    single_observation_batches = _project(
+        covariance,
+        basis_operator,
+        h,
+        observation_covariance="dense",
+        observation_batch_size=1,
+    )
+    diagonal = _project(
+        covariance,
+        basis_operator,
+        h,
+        observation_covariance="diagonal",
+        observation_batch_size=2,
+    )
+
+    for batched, full in (
+        (single_observation_batches.restriction, full_batch.restriction),
+        (single_observation_batches.prolongation, full_batch.prolongation),
+        (single_observation_batches.state_covariance, full_batch.state_covariance),
+        (
+            single_observation_batches.effective_observation_operator,
+            full_batch.effective_observation_operator,
+        ),
+        (
+            single_observation_batches.observation_state_cross_covariance,
+            full_batch.observation_state_cross_covariance,
+        ),
+        (
+            single_observation_batches.native_observation_covariance,
+            full_batch.native_observation_covariance,
+        ),
+    ):
+        xr.testing.assert_allclose(batched, full)
+    assert single_observation_batches.content_identity == full_batch.content_identity
+    assert diagonal.native_observation_covariance.dims == ("observation",)
+    expected_diagonal = xr.DataArray(
+        np.diag(full_batch.native_observation_covariance.values),
+        dims="observation",
+        coords={"observation": h.observation},
+        name="native_observation_covariance",
+    )
+    np.testing.assert_allclose(diagonal.native_observation_covariance, expected_diagonal)
+
+
+def test_products_round_trip_with_labels_and_identity() -> None:
+    """Dataset serialization preserves all blocks, labels, strategy, and shared identity."""
+    covariance, basis_operator, h, _ = _problem()
+    products = _project(
+        covariance,
+        basis_operator,
+        h,
+        observation_batch_size=2,
+    )
+
+    restored = NativeCovarianceProducts.from_dataset(products.to_dataset())
+
+    xr.testing.assert_identical(restored.restriction, products.restriction)
+    xr.testing.assert_identical(restored.state_covariance, products.state_covariance)
+    xr.testing.assert_identical(
+        restored.effective_observation_operator, products.effective_observation_operator
+    )
+    xr.testing.assert_identical(
+        restored.observation_state_cross_covariance,
+        products.observation_state_cross_covariance,
+    )
+    xr.testing.assert_identical(
+        restored.native_observation_covariance, products.native_observation_covariance
+    )
+    assert restored.strategy == products.strategy
+    assert restored.content_identity == products.content_identity
+    assert len(products.content_identity) == 64
+    assert all(
+        array.attrs["content_identity"] == products.content_identity
+        for array in (
+            products.restriction,
+            products.state_covariance,
+            products.effective_observation_operator,
+            products.observation_state_cross_covariance,
+            products.native_observation_covariance,
+        )
+    )
+
+    restored_tree = NativeCovarianceProducts.from_datatree(products.to_datatree())
+    assert restored_tree.covariance_configuration is not None
+    assert products.covariance_configuration is not None
+    xr.testing.assert_identical(
+        restored_tree.covariance_configuration,
+        products.covariance_configuration,
+    )
+    assert restored_tree.basis_provenance == products.basis_provenance
+    assert restored_tree.prolongation.attrs["content_identity"] == products.content_identity
+
+
+def test_content_identity_changes_with_covariance_configuration() -> None:
+    """Kernel amplitudes and class maps participate in the stable product identity."""
+    covariance, basis_operator, h, _ = _problem()
+    baseline = _project(covariance, basis_operator, h)
+    rescaled = _project(
+        SeparableExponentialCovariance(
+            covariance.latitude,
+            covariance.longitude,
+            sigma=2.0,
+            correlation_length=covariance.correlation_length,
+        ),
+        basis_operator,
+        h,
+    )
+    classes = xr.DataArray(
+        [[0, 1], [0, 1], [1, 1]],
+        dims=("lat", "lon"),
+        coords={"lat": covariance.latitude, "lon": covariance.longitude},
+    )
+    blocked = _project(
+        SeparableExponentialCovariance(
+            covariance.latitude,
+            covariance.longitude,
+            sigma=covariance.sigma,
+            correlation_length=covariance.correlation_length,
+            class_labels=classes,
+        ),
+        basis_operator,
+        h,
+    )
+
+    assert baseline.content_identity != rescaled.content_identity
+    assert baseline.content_identity != blocked.content_identity
+
+
+def test_product_deserialization_rejects_mixed_content_identity() -> None:
+    """A block copied from another artifact cannot masquerade as coherent output."""
+    covariance, basis_operator, h, _ = _problem()
+    dataset = _project(covariance, basis_operator, h).to_dataset()
+    dataset["state_covariance"].attrs["content_identity"] = "0" * 64
+
+    with pytest.raises(ValueError, match="content identity"):
+        NativeCovarianceProducts.from_dataset(dataset)
+
+
+def test_projection_strategy_must_return_covariance_natural_prolongation() -> None:
+    """Custom strategies cannot return a Pi/U pair that violates B Pi.T = U C_alpha."""
+    covariance, basis_operator, h, _ = _problem()
+
+    class IncoherentStrategy:
+        """Perturb an otherwise compatible prolongation to violate the invariant."""
+
+        def projection(self, covariance, basis_prolongation, *, native_dims, state_dim):
+            """Return a deliberately incoherent restriction/prolongation pair."""
+            valid = PreserveBucketProlongation().projection(
+                covariance,
+                basis_prolongation,
+                native_dims=native_dims,
+                state_dim=state_dim,
+            )
+            return RetainedProjection(valid.restriction, 2.0 * valid.prolongation, "incoherent")
+
+    for sigma in (covariance.sigma, 1e-8):
+        scaled = SeparableExponentialCovariance(
+            covariance.latitude,
+            covariance.longitude,
+            sigma=sigma,
+            correlation_length=covariance.correlation_length,
+        )
+        with pytest.raises(ValueError, match="incoherent|B Pi"):
+            _project(scaled, basis_operator, h, strategy=IncoherentStrategy())
+
+
+def test_projection_strategy_protocol_accepts_structural_implementations() -> None:
+    """A compatible strategy is accepted without inheriting from the public protocol."""
+    covariance, basis_operator, h, _ = _problem()
+
+    class DelegatingStrategy:
+        """Delegate projection construction while exposing a distinct strategy name."""
+
+        def projection(self, covariance, basis_prolongation, *, native_dims, state_dim):
+            """Return a coherent projection using the established bucket strategy."""
+            projection = PreserveBucketProlongation().projection(
+                covariance,
+                basis_prolongation,
+                native_dims=native_dims,
+                state_dim=state_dim,
+            )
+            return RetainedProjection(
+                projection.restriction,
+                projection.prolongation,
+                "delegating_strategy",
+            )
+
+    strategy: RetainedProjectionStrategy = DelegatingStrategy()
+
+    products = _project(covariance, basis_operator, h, strategy=strategy)
+
+    assert products.strategy == "delegating_strategy"
+
+
+def test_projection_strategy_must_return_full_rank_restriction() -> None:
+    """A formally compatible zero Pi/U pair is rejected because C_alpha is singular."""
+    covariance, basis_operator, h, _ = _problem()
+
+    class SingularStrategy:
+        """Return a zero restriction and prolongation with the expected dimensions."""
+
+        def projection(self, covariance, basis_prolongation, *, native_dims, state_dim):
+            """Return a deliberately singular retained projection."""
+            return RetainedProjection(
+                xr.zeros_like(basis_prolongation.transpose(state_dim, *native_dims)),
+                xr.zeros_like(basis_prolongation),
+                "singular",
+            )
+
+    with pytest.raises(ValueError, match="positive definite|full rank"):
+        _project(covariance, basis_operator, h, strategy=SingularStrategy())
+
+
+def test_content_identity_includes_auxiliary_semantic_coordinates() -> None:
+    """Relabelling an auxiliary observation coordinate changes artifact identity."""
+    covariance, basis_operator, h, _ = _problem()
+    first = _project(
+        covariance,
+        basis_operator,
+        h.assign_coords(network=("observation", ["ICOS", "DECC", "DECC"])),
+    )
+    second = _project(
+        covariance,
+        basis_operator,
+        h.assign_coords(network=("observation", ["DECC", "DECC", "DECC"])),
+    )
+
+    assert first.content_identity != second.content_identity
+
+
+def test_redundant_bucket_states_are_rejected() -> None:
+    """Linearly dependent retained coordinates fail instead of being pseudoinverted."""
+    covariance, basis_operator, _, _ = _problem()
+    prolongation = basis_operator.basis_matrix.compute()
+    redundant = xr.concat(
+        [
+            prolongation.sel(state=0),
+            prolongation.sel(state=0),
+        ],
+        dim=xr.IndexVariable("state", ["west", "west-copy"]),
+    ).transpose("lat", "lon", "state")
+
+    with pytest.raises(ValueError, match="positive definite|redundant|rank"):
+        PreserveBucketProlongation().projection(
+            covariance,
+            redundant,
+            native_dims=covariance.native_dims,
+            state_dim="state",
+        )
+
+
+@pytest.mark.parametrize(
+    ("transform", "message"),
+    [
+        pytest.param(
+            lambda h: h.assign_coords(lon=h.lon[::-1]),
+            "coordinate|align|longitude|lon",
+            id="misordered-native-coordinate",
+        ),
+        pytest.param(
+            lambda h: h.where(h.observation != "TAC-1"),
+            "finite|NaN",
+            id="non-finite-sensitivity",
+        ),
+    ],
+)
+def test_products_reject_invalid_native_sensitivity(transform, message: str) -> None:
+    """Product construction rejects misaligned or non-finite native sensitivity."""
+    covariance, basis_operator, h, _ = _problem()
+
+    with pytest.raises(ValueError, match=message):
+        _project(covariance, basis_operator, transform(h))
+
+
+def test_class_blocked_products_match_dense_oracle() -> None:
+    """The compatible restriction and all products remain coherent with class masks."""
+    covariance, basis_operator, h, dense_unblocked = _problem()
+    labels = xr.DataArray(
+        [["land", "sea"], ["land", "sea"], ["sea", "sea"]],
+        dims=("lat", "lon"),
+        coords={"lat": covariance.latitude, "lon": covariance.longitude},
+    )
+    covariance = SeparableExponentialCovariance(
+        covariance.latitude,
+        covariance.longitude,
+        sigma=covariance.sigma,
+        correlation_length=covariance.correlation_length,
+        class_labels=labels,
+    )
+    flat_labels = labels.values.reshape(-1)
+    dense_b = dense_unblocked * (flat_labels[:, None] == flat_labels[None, :])
+    u, expected_pi, expected_c = _dense_operators(basis_operator, dense_b)
+    h_matrix = h.values.reshape(3, 6)
+
+    products = _project(covariance, basis_operator, h)
+
+    np.testing.assert_allclose(products.restriction.values.reshape(2, 6), expected_pi, atol=2e-10)
+    np.testing.assert_allclose(products.state_covariance, expected_c, atol=2e-10)
+    np.testing.assert_allclose(products.effective_observation_operator, h_matrix @ u, atol=2e-10)
+    np.testing.assert_allclose(
+        products.observation_state_cross_covariance,
+        h_matrix @ dense_b @ expected_pi.T,
+        atol=2e-10,
+    )
+    np.testing.assert_allclose(
+        products.native_observation_covariance,
+        h_matrix @ dense_b @ h_matrix.T,
+        atol=2e-10,
+    )
+
+
+def test_multiindex_observation_labels_are_preserved_on_both_matrix_axes() -> None:
+    """Dense observation products retain rich row labels and suffixed column metadata."""
+    covariance, basis_operator, h, _ = _problem()
+    observation_index = pd.MultiIndex.from_tuples(
+        [("MHD", "2020-01-01"), ("TAC", "2020-01-02"), ("RGL", "2020-01-03")],
+        names=("site", "date"),
+    )
+    h = h.drop_indexes("observation").drop_vars("observation")
+    h = h.assign_coords(xr.Coordinates.from_pandas_multiindex(observation_index, "observation"))
+
+    products = _project(covariance, basis_operator, h)
+
+    assert products.native_observation_covariance.coords["site"].values.tolist() == [
+        "MHD",
+        "TAC",
+        "RGL",
+    ]
+    assert products.native_observation_covariance.coords["site_cov"].values.tolist() == [
+        "MHD",
+        "TAC",
+        "RGL",
+    ]
+    assert products.native_observation_covariance.coords["date_cov"].values.tolist() == [
+        "2020-01-01",
+        "2020-01-02",
+        "2020-01-03",
+    ]

--- a/tests/test_covariance_products.py
+++ b/tests/test_covariance_products.py
@@ -1,4 +1,7 @@
-"""Tests for covariance products that preserve bucket prolongation semantics."""
+"""Test covariance projection, identities, eager batching, labels, and persistence."""
+
+from pathlib import Path
+from typing import cast
 
 import numpy as np
 import pandas as pd
@@ -182,8 +185,8 @@ def test_covariance_natural_prolongation_is_the_bucket_prolongation() -> None:
     np.testing.assert_allclose(u_star, u, rtol=1e-11, atol=1e-11)
 
 
-def test_dense_and_diagonal_products_are_batch_invariant() -> None:
-    """Execution batch size changes neither covariance products nor their identity."""
+def test_dense_and_diagonal_products_have_stable_source_and_derived_view_identities() -> None:
+    """Batching preserves identities while dense/diagonal views share only source identity."""
     covariance, basis_operator, h, _ = _problem()
 
     full_batch = _project(
@@ -226,7 +229,12 @@ def test_dense_and_diagonal_products_are_batch_invariant() -> None:
         ),
     ):
         xr.testing.assert_allclose(batched, full)
-    assert single_observation_batches.content_identity == full_batch.content_identity
+    assert single_observation_batches.source_content_identity == full_batch.source_content_identity
+    assert single_observation_batches.view_identity == full_batch.view_identity
+    assert diagonal.source_content_identity == full_batch.source_content_identity
+    assert diagonal.view_identity != full_batch.view_identity
+    assert full_batch.observation_covariance_view == "dense"
+    assert diagonal.observation_covariance_view == "diagonal"
     assert diagonal.native_observation_covariance.dims == ("observation",)
     expected_diagonal = xr.DataArray(
         np.diag(full_batch.native_observation_covariance.values),
@@ -237,8 +245,31 @@ def test_dense_and_diagonal_products_are_batch_invariant() -> None:
     np.testing.assert_allclose(diagonal.native_observation_covariance, expected_diagonal)
 
 
+def test_dense_batching_preallocates_instead_of_concatenating(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Dense observation batching avoids the former xr.concat block-assembly path."""
+    covariance, basis_operator, h, _ = _problem()
+
+    def reject_concat(*args: object, **kwargs: object) -> None:
+        """Fail if the former all-block concatenation path is used."""
+        raise AssertionError(f"unexpected xr.concat call: {args!r}, {kwargs!r}")
+
+    monkeypatch.setattr(xr, "concat", reject_concat)
+
+    products = _project(
+        covariance,
+        basis_operator,
+        h,
+        observation_covariance="dense",
+        observation_batch_size=1,
+    )
+
+    assert products.native_observation_covariance.shape == (3, 3)
+
+
 def test_products_round_trip_with_labels_and_identity() -> None:
-    """Dataset serialization preserves all blocks, labels, strategy, and shared identity."""
+    """Dataset and DataTree round trips preserve blocks, labels, identities, and config."""
     covariance, basis_operator, h, _ = _problem()
     products = _project(
         covariance,
@@ -262,10 +293,15 @@ def test_products_round_trip_with_labels_and_identity() -> None:
         restored.native_observation_covariance, products.native_observation_covariance
     )
     assert restored.strategy == products.strategy
-    assert restored.content_identity == products.content_identity
-    assert len(products.content_identity) == 64
+    assert restored.source_content_identity == products.source_content_identity
+    assert restored.view_identity == products.view_identity
+    assert restored.observation_covariance_view == products.observation_covariance_view
+    assert restored.covariance_configuration_digest == products.covariance_configuration_digest
+    assert len(products.source_content_identity) == 64
+    assert len(products.view_identity) == 64
     assert all(
-        array.attrs["content_identity"] == products.content_identity
+        array.attrs["source_content_identity"] == products.source_content_identity
+        and array.attrs["view_identity"] == products.view_identity
         for array in (
             products.restriction,
             products.state_covariance,
@@ -283,11 +319,24 @@ def test_products_round_trip_with_labels_and_identity() -> None:
         products.covariance_configuration,
     )
     assert restored_tree.basis_provenance == products.basis_provenance
-    assert restored_tree.prolongation.attrs["content_identity"] == products.content_identity
+    assert restored_tree.prolongation.attrs["source_content_identity"] == products.source_content_identity
 
 
-def test_content_identity_changes_with_covariance_configuration() -> None:
-    """Kernel amplitudes and class maps participate in the stable product identity."""
+def test_dataset_round_trip_cannot_silently_drop_covariance_configuration() -> None:
+    """A root-only restore preserves its config digest and refuses an incomplete tree."""
+    covariance, basis_operator, h, _ = _problem()
+    products = _project(covariance, basis_operator, h)
+
+    restored = NativeCovarianceProducts.from_dataset(products.to_dataset())
+
+    assert restored.covariance_configuration is None
+    assert restored.covariance_configuration_digest == products.covariance_configuration_digest
+    with pytest.raises(ValueError, match="without.*covariance configuration content"):
+        restored.to_datatree()
+
+
+def test_source_content_identity_changes_with_covariance_configuration() -> None:
+    """Kernel amplitudes and class maps participate in the stable source identity."""
     covariance, basis_operator, h, _ = _problem()
     baseline = _project(covariance, basis_operator, h)
     rescaled = _project(
@@ -317,18 +366,77 @@ def test_content_identity_changes_with_covariance_configuration() -> None:
         h,
     )
 
-    assert baseline.content_identity != rescaled.content_identity
-    assert baseline.content_identity != blocked.content_identity
+    assert baseline.source_content_identity != rescaled.source_content_identity
+    assert baseline.source_content_identity != blocked.source_content_identity
 
 
-def test_product_deserialization_rejects_mixed_content_identity() -> None:
-    """A block copied from another artifact cannot masquerade as coherent output."""
+def test_product_deserialization_rejects_mixed_source_identity() -> None:
+    """A product variable whose source identity differs from the root is rejected."""
     covariance, basis_operator, h, _ = _problem()
     dataset = _project(covariance, basis_operator, h).to_dataset()
-    dataset["state_covariance"].attrs["content_identity"] = "0" * 64
+    dataset["state_covariance"].attrs["source_content_identity"] = "0" * 64
 
-    with pytest.raises(ValueError, match="content identity"):
+    with pytest.raises(ValueError, match="source identity"):
         NativeCovarianceProducts.from_dataset(dataset)
+
+
+@pytest.mark.parametrize(
+    "encoded_provenance",
+    [None, "not-json", "[]", '{"operator_type": 1}'],
+)
+def test_product_deserialization_validates_basis_provenance_shape(
+    encoded_provenance: object,
+) -> None:
+    """Basis provenance must be a JSON encoding of a string-to-string mapping."""
+    covariance, basis_operator, h, _ = _problem()
+    dataset = _project(covariance, basis_operator, h).to_dataset()
+    dataset.attrs["basis_provenance"] = encoded_provenance
+
+    with pytest.raises(ValueError, match="basis provenance"):
+        NativeCovarianceProducts.from_dataset(dataset)
+
+
+def test_product_identity_metadata_is_not_a_numerical_checksum() -> None:
+    """Identity metadata binds source/view declarations but does not checksum output values."""
+    covariance, basis_operator, h, _ = _problem()
+    dataset = _project(covariance, basis_operator, h).to_dataset()
+    dataset["state_covariance"].values[0, 0] += 1.0
+
+    restored = NativeCovarianceProducts.from_dataset(dataset)
+
+    assert restored.state_covariance.values[0, 0] == dataset["state_covariance"].values[0, 0]
+
+
+def test_datatree_rejects_covariance_configuration_from_another_source() -> None:
+    """A covariance configuration child cannot be mixed into another source artifact."""
+    covariance, basis_operator, h, _ = _problem()
+    baseline_tree = _project(covariance, basis_operator, h).to_datatree()
+    other_covariance = SeparableExponentialCovariance(
+        covariance.latitude,
+        covariance.longitude,
+        sigma=2.0,
+        correlation_length=covariance.correlation_length,
+    )
+    other_tree = _project(other_covariance, basis_operator, h).to_datatree()
+    baseline_tree["covariance_configuration"] = xr.DataTree(
+        cast(xr.DataTree, other_tree["covariance_configuration"]).to_dataset(inherit=False).copy(deep=True)
+    )
+
+    with pytest.raises(ValueError, match="configuration.*root source identity"):
+        NativeCovarianceProducts.from_datatree(baseline_tree)
+
+
+def test_datatree_rejects_tampered_covariance_configuration_content() -> None:
+    """Configuration content is recomputed and checked against its bound root digest."""
+    covariance, basis_operator, h, _ = _problem()
+    tree = _project(covariance, basis_operator, h).to_datatree()
+    child = cast(xr.DataTree, tree["covariance_configuration"]).to_dataset(inherit=False).copy(deep=True)
+    latitude_dim = "covariance_configuration__lat"
+    child = child.assign_coords({latitude_dim: child.coords[latitude_dim] + 0.25})
+    tree["covariance_configuration"] = xr.DataTree(child)
+
+    with pytest.raises(ValueError, match="configuration content.*digest"):
+        NativeCovarianceProducts.from_datatree(tree)
 
 
 def test_projection_strategy_must_return_covariance_natural_prolongation() -> None:
@@ -387,6 +495,45 @@ def test_projection_strategy_protocol_accepts_structural_implementations() -> No
     assert products.strategy == "delegating_strategy"
 
 
+@pytest.mark.parametrize("role", ["restriction", "prolongation"])
+@pytest.mark.parametrize("coordinate_change", ["mismatch", "reordered", "empty-intersection"])
+def test_custom_projection_requires_exact_native_coordinates(
+    role: str,
+    coordinate_change: str,
+) -> None:
+    """Custom Pi and U native labels must match before product alignment or contraction."""
+    covariance, basis_operator, h, _ = _problem()
+
+    class RelabelledStrategy:
+        """Relabel one projection array to exercise strict native-coordinate checks."""
+
+        def projection(self, covariance, basis_prolongation, *, native_dims, state_dim):
+            """Return a coherent numeric pair with deliberately invalid latitude labels."""
+            valid = PreserveBucketProlongation().projection(
+                covariance,
+                basis_prolongation,
+                native_dims=native_dims,
+                state_dim=state_dim,
+            )
+            latitude = valid.restriction.coords["lat"].values
+            if coordinate_change == "reordered":
+                invalid_latitude = latitude[::-1]
+            elif coordinate_change == "empty-intersection":
+                invalid_latitude = latitude + 1000.0
+            else:
+                invalid_latitude = latitude + 0.25
+            restriction = valid.restriction
+            prolongation = valid.prolongation
+            if role == "restriction":
+                restriction = restriction.assign_coords(lat=invalid_latitude)
+            else:
+                prolongation = prolongation.assign_coords(lat=invalid_latitude)
+            return RetainedProjection(restriction, prolongation, "relabeled")
+
+    with pytest.raises(ValueError, match=r"native coordinate 'lat'.*exactly match"):
+        _project(covariance, basis_operator, h, strategy=RelabelledStrategy())
+
+
 def test_projection_strategy_must_return_full_rank_restriction() -> None:
     """A formally compatible zero Pi/U pair is rejected because C_alpha is singular."""
     covariance, basis_operator, h, _ = _problem()
@@ -402,12 +549,12 @@ def test_projection_strategy_must_return_full_rank_restriction() -> None:
                 "singular",
             )
 
-    with pytest.raises(ValueError, match="positive definite|full rank"):
+    with pytest.raises(ValueError, match="empty retained state|positive definite|full rank"):
         _project(covariance, basis_operator, h, strategy=SingularStrategy())
 
 
-def test_content_identity_includes_auxiliary_semantic_coordinates() -> None:
-    """Relabelling an auxiliary observation coordinate changes artifact identity."""
+def test_source_content_identity_includes_auxiliary_semantic_coordinates() -> None:
+    """Relabelling an auxiliary observation coordinate changes the source identity."""
     covariance, basis_operator, h, _ = _problem()
     first = _project(
         covariance,
@@ -420,7 +567,7 @@ def test_content_identity_includes_auxiliary_semantic_coordinates() -> None:
         h.assign_coords(network=("observation", ["DECC", "DECC", "DECC"])),
     )
 
-    assert first.content_identity != second.content_identity
+    assert first.source_content_identity != second.source_content_identity
 
 
 def test_redundant_bucket_states_are_rejected() -> None:
@@ -504,11 +651,14 @@ def test_class_blocked_products_match_dense_oracle() -> None:
     )
 
 
-def test_multiindex_observation_labels_are_preserved_on_both_matrix_axes() -> None:
-    """Dense observation products retain rich row labels and suffixed column metadata."""
+def test_datetime_multiindex_observation_labels_persist_on_both_matrix_axes(
+    tmp_path: Path,
+) -> None:
+    """Real Timestamp MultiIndex labels encode safely and persist through NetCDF."""
     covariance, basis_operator, h, _ = _problem()
-    observation_index = pd.MultiIndex.from_tuples(
-        [("MHD", "2020-01-01"), ("TAC", "2020-01-02"), ("RGL", "2020-01-03")],
+    dates = pd.to_datetime(["2020-01-01", "2020-01-02", "2020-01-03"])
+    observation_index = pd.MultiIndex.from_arrays(
+        [["MHD", "TAC", "RGL"], dates],
         names=("site", "date"),
     )
     h = h.drop_indexes("observation").drop_vars("observation")
@@ -526,8 +676,25 @@ def test_multiindex_observation_labels_are_preserved_on_both_matrix_axes() -> No
         "TAC",
         "RGL",
     ]
-    assert products.native_observation_covariance.coords["date_cov"].values.tolist() == [
-        "2020-01-01",
-        "2020-01-02",
-        "2020-01-03",
+    np.testing.assert_array_equal(
+        products.native_observation_covariance.coords["date_cov"].values,
+        dates.values,
+    )
+    assert products.native_observation_covariance.coords["observation_cov"].values.tolist() == [
+        '["MHD","2020-01-01T00:00:00"]',
+        '["TAC","2020-01-02T00:00:00"]',
+        '["RGL","2020-01-03T00:00:00"]',
     ]
+
+    path = tmp_path / "datetime-multiindex-products.nc"
+    products.to_datatree().to_netcdf(path, engine="h5netcdf")
+    with xr.open_datatree(path, engine="h5netcdf") as stored:
+        restored = NativeCovarianceProducts.from_datatree(stored.load())
+
+    restored_index = restored.native_observation_covariance.indexes["observation"]
+    assert isinstance(restored_index, pd.MultiIndex)
+    assert restored_index.equals(observation_index)
+    np.testing.assert_array_equal(
+        restored.native_observation_covariance.coords["observation_cov"].values,
+        products.native_observation_covariance.coords["observation_cov"].values,
+    )

--- a/tests/test_native_covariance.py
+++ b/tests/test_native_covariance.py
@@ -213,6 +213,19 @@ def test_constructor_rejects_invalid_native_coordinates(coordinate, message: str
         SeparableExponentialCovariance(latitude=latitude, longitude=longitude, sigma=1.0)
 
 
+@pytest.mark.parametrize("axis_name", ["latitude", "longitude"])
+def test_constructor_rejects_empty_native_axes(axis_name: str) -> None:
+    """Each native coordinate must contain at least one grid point."""
+    latitude, longitude = _coordinates()
+    if axis_name == "latitude":
+        latitude = latitude.isel(lat=slice(0, 0))
+    else:
+        longitude = longitude.isel(lon=slice(0, 0))
+
+    with pytest.raises(ValueError, match=rf"{axis_name}.*at least one"):
+        SeparableExponentialCovariance(latitude=latitude, longitude=longitude)
+
+
 @pytest.mark.parametrize(
     ("sigma", "correlation_length", "message"),
     [
@@ -250,6 +263,7 @@ def test_apply_does_not_construct_a_native_kronecker_matrix(monkeypatch) -> None
     )
 
     def fail_kron(*args, **kwargs):
+        """Fail if the matrix-free implementation constructs a Kronecker matrix."""
         raise AssertionError("the structured action must not call numpy.kron")
 
     monkeypatch.setattr(np, "kron", fail_kron)

--- a/tests/test_native_covariance.py
+++ b/tests/test_native_covariance.py
@@ -1,0 +1,260 @@
+"""Tests for labelled, matrix-free native-grid covariance actions."""
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from openghg_inversions.native_covariance import SeparableExponentialCovariance
+
+
+def _coordinates() -> tuple[xr.DataArray, xr.DataArray]:
+    """Return a small, irregular labelled latitude-longitude grid."""
+    latitude = xr.DataArray(
+        [-1.0, 0.25, 2.0],
+        dims="lat",
+        coords={"lat": [-1.0, 0.25, 2.0]},
+        attrs={"units": "degrees_north"},
+    )
+    longitude = xr.DataArray(
+        [10.0, 11.5],
+        dims="lon",
+        coords={"lon": [10.0, 11.5]},
+        attrs={"units": "degrees_east"},
+    )
+    return latitude, longitude
+
+
+def _dense_covariance(
+    latitude: xr.DataArray,
+    longitude: xr.DataArray,
+    *,
+    sigma: float,
+    correlation_length: float,
+) -> np.ndarray:
+    """Construct the small-grid Kronecker covariance used only as a test oracle."""
+    k_lat = np.exp(
+        -np.abs(latitude.values[:, np.newaxis] - latitude.values[np.newaxis, :]) / correlation_length
+    )
+    k_lon = np.exp(
+        -np.abs(longitude.values[:, np.newaxis] - longitude.values[np.newaxis, :]) / correlation_length
+    )
+    return sigma**2 * np.kron(k_lat, k_lon)
+
+
+def _covariance(*, sigma: float = 1.7, correlation_length: float = 0.8):
+    """Construct the covariance action shared by focused tests."""
+    latitude, longitude = _coordinates()
+    return SeparableExponentialCovariance(
+        latitude=latitude,
+        longitude=longitude,
+        sigma=sigma,
+        correlation_length=correlation_length,
+    )
+
+
+def test_apply_and_solve_match_dense_oracle_for_multiple_rhs() -> None:
+    """Apply and solve preserve labels while matching a dense multiple-RHS oracle."""
+    latitude, longitude = _coordinates()
+    covariance = _covariance()
+    rhs = xr.DataArray(
+        np.arange(24, dtype=float).reshape(2, 2, 3, 2) / 7.0,
+        dims=("draw", "lon", "lat", "component"),
+        coords={
+            "draw": ["a", "b"],
+            "lon": longitude,
+            "lat": latitude,
+            "component": ["east", "west"],
+        },
+        name="right_hand_side",
+        attrs={"units": "ppm"},
+    )
+    dense = _dense_covariance(latitude, longitude, sigma=1.7, correlation_length=0.8)
+    rhs_matrix = rhs.transpose("lat", "lon", "draw", "component").values.reshape(6, 4)
+
+    applied = covariance.apply(rhs)
+    solved = covariance.solve(rhs)
+
+    expected_applied = (dense @ rhs_matrix).reshape(3, 2, 2, 2)
+    expected_solved = np.linalg.solve(dense, rhs_matrix).reshape(3, 2, 2, 2)
+    assert applied.dims == rhs.dims
+    assert solved.dims == rhs.dims
+    xr.testing.assert_equal(applied.coords.to_dataset(), rhs.coords.to_dataset())
+    xr.testing.assert_equal(solved.coords.to_dataset(), rhs.coords.to_dataset())
+    np.testing.assert_allclose(
+        applied.transpose("lat", "lon", "draw", "component"),
+        expected_applied,
+        rtol=1e-12,
+        atol=1e-12,
+    )
+    np.testing.assert_allclose(
+        solved.transpose("lat", "lon", "draw", "component"),
+        expected_solved,
+        rtol=1e-11,
+        atol=1e-11,
+    )
+
+
+def test_single_rhs_round_trips_through_apply_and_solve() -> None:
+    """A labelled grid field round-trips without requiring a trailing RHS dimension."""
+    latitude, longitude = _coordinates()
+    covariance = _covariance()
+    rhs = xr.DataArray(
+        np.arange(6, dtype=float).reshape(3, 2),
+        dims=("lat", "lon"),
+        coords={"lat": latitude, "lon": longitude},
+    )
+
+    restored = covariance.solve(covariance.apply(rhs))
+
+    xr.testing.assert_allclose(restored, rhs, rtol=1e-11, atol=1e-11)
+
+
+def test_anisotropic_correlation_lengths_match_dense_oracle() -> None:
+    """Latitude and longitude length scales are independently configurable."""
+    latitude, longitude = _coordinates()
+    covariance = SeparableExponentialCovariance(
+        latitude,
+        longitude,
+        sigma=1.3,
+        latitude_correlation_length=0.6,
+        longitude_correlation_length=2.1,
+    )
+    rhs = xr.DataArray(
+        np.arange(6, dtype=float).reshape(3, 2),
+        dims=("lat", "lon"),
+        coords={"lat": latitude, "lon": longitude},
+    )
+    k_lat = np.exp(-np.abs(latitude.values[:, None] - latitude.values[None, :]) / 0.6)
+    k_lon = np.exp(-np.abs(longitude.values[:, None] - longitude.values[None, :]) / 2.1)
+    dense = 1.3**2 * np.kron(k_lat, k_lon)
+
+    np.testing.assert_allclose(covariance.apply(rhs).values.reshape(-1), dense @ rhs.values.reshape(-1))
+    np.testing.assert_allclose(
+        covariance.solve(rhs).values.reshape(-1), np.linalg.solve(dense, rhs.values.reshape(-1))
+    )
+
+
+def test_default_configuration_round_trips_through_dataset() -> None:
+    """Serialization records the resolved default and reconstructs an equivalent action."""
+    latitude, longitude = _coordinates()
+    covariance = SeparableExponentialCovariance(
+        latitude=latitude,
+        longitude=longitude,
+        sigma=2.5,
+    )
+    rhs = xr.DataArray(
+        np.arange(6, dtype=float).reshape(3, 2),
+        dims=("lat", "lon"),
+        coords={"lat": latitude, "lon": longitude},
+    )
+
+    restored = SeparableExponentialCovariance.from_dataset(covariance.to_dataset())
+
+    assert covariance.correlation_length == 1.5
+    assert restored.correlation_length == 1.5
+    assert restored.sigma == 2.5
+    assert restored.native_dims == ("lat", "lon")
+    np.testing.assert_array_equal(restored.latitude, covariance.latitude)
+    np.testing.assert_array_equal(restored.longitude, covariance.longitude)
+    assert restored.latitude.dims == covariance.latitude.dims
+    assert restored.longitude.dims == covariance.longitude.dims
+    assert restored.latitude.attrs == covariance.latitude.attrs
+    assert restored.longitude.attrs == covariance.longitude.attrs
+    xr.testing.assert_allclose(restored.apply(rhs), covariance.apply(rhs))
+
+
+@pytest.mark.parametrize(
+    ("bad_rhs", "message"),
+    [
+        pytest.param(
+            lambda rhs: rhs.assign_coords(lon=[11.5, 10.0]),
+            "coordinate|align|longitude|lon",
+            id="reordered-coordinate-labels",
+        ),
+        pytest.param(
+            lambda rhs: rhs.drop_indexes("lon").drop_vars("lon"),
+            "coordinate|longitude|lon",
+            id="missing-coordinate",
+        ),
+        pytest.param(
+            lambda rhs: rhs.where(~((rhs.lat == 0.25) & (rhs.lon == 10.0))),
+            "finite|NaN",
+            id="non-finite-values",
+        ),
+    ],
+)
+def test_action_rejects_invalid_rhs_labels_and_values(bad_rhs, message: str) -> None:
+    """The action rejects ambiguous alignment and non-finite numerical inputs."""
+    latitude, longitude = _coordinates()
+    covariance = _covariance()
+    rhs = xr.DataArray(
+        np.arange(6, dtype=float).reshape(3, 2),
+        dims=("lat", "lon"),
+        coords={"lat": latitude, "lon": longitude},
+    )
+
+    with pytest.raises(ValueError, match=message):
+        covariance.apply(bad_rhs(rhs))
+
+
+@pytest.mark.parametrize(
+    ("coordinate", "message"),
+    [
+        pytest.param([0.0, 0.0, 1.0], "unique|duplicate", id="duplicate"),
+        pytest.param([0.0, np.nan, 1.0], "finite", id="non-finite"),
+    ],
+)
+def test_constructor_rejects_invalid_native_coordinates(coordinate, message: str) -> None:
+    """Native coordinates must be finite and unique before factors are constructed."""
+    latitude, longitude = _coordinates()
+    latitude = latitude.assign_coords(lat=coordinate).copy(data=coordinate)
+
+    with pytest.raises(ValueError, match=message):
+        SeparableExponentialCovariance(latitude=latitude, longitude=longitude, sigma=1.0)
+
+
+@pytest.mark.parametrize(
+    ("sigma", "correlation_length", "message"),
+    [
+        pytest.param(0.0, 1.5, "sigma|positive", id="zero-sigma"),
+        pytest.param(-1.0, 1.5, "sigma|positive", id="negative-sigma"),
+        pytest.param(1.0, 0.0, "correlation_length|positive", id="zero-length"),
+        pytest.param(1.0, np.inf, "correlation_length|finite", id="infinite-length"),
+    ],
+)
+def test_constructor_rejects_invalid_covariance_parameters(
+    sigma: float,
+    correlation_length: float,
+    message: str,
+) -> None:
+    """Covariance scale and correlation length must be finite and strictly positive."""
+    latitude, longitude = _coordinates()
+
+    with pytest.raises(ValueError, match=message):
+        SeparableExponentialCovariance(
+            latitude=latitude,
+            longitude=longitude,
+            sigma=sigma,
+            correlation_length=correlation_length,
+        )
+
+
+def test_apply_does_not_construct_a_native_kronecker_matrix(monkeypatch) -> None:
+    """The production action uses separable factors without calling ``numpy.kron``."""
+    latitude, longitude = _coordinates()
+    covariance = _covariance()
+    rhs = xr.DataArray(
+        np.ones((3, 2, 2)),
+        dims=("lat", "lon", "rhs"),
+        coords={"lat": latitude, "lon": longitude, "rhs": [0, 1]},
+    )
+
+    def fail_kron(*args, **kwargs):
+        raise AssertionError("the structured action must not call numpy.kron")
+
+    monkeypatch.setattr(np, "kron", fail_kron)
+
+    result = covariance.apply(rhs)
+
+    assert result.shape == rhs.shape
+    assert np.isfinite(result).all()

--- a/tests/test_native_covariance_classes.py
+++ b/tests/test_native_covariance_classes.py
@@ -1,5 +1,7 @@
 """Tests for optional class blocking in native covariance actions."""
 
+from pathlib import Path
+
 import numpy as np
 import pytest
 import xarray as xr
@@ -115,6 +117,41 @@ def test_class_labels_round_trip_through_dataset(
     xr.testing.assert_identical(restored.class_labels, labels)
     rhs = xr.ones_like(labels, dtype=float)
     xr.testing.assert_allclose(restored.apply(rhs), original.apply(rhs))
+
+
+@pytest.mark.parametrize("class_blocked", [False, True])
+def test_covariance_round_trips_through_h5netcdf(
+    coordinates: tuple[xr.DataArray, xr.DataArray],
+    class_blocked: bool,
+    tmp_path: Path,
+) -> None:
+    """NetCDF persistence preserves blocked and unblocked covariance configuration."""
+    latitude, longitude = coordinates
+    class_labels = None
+    if class_blocked:
+        class_labels = xr.DataArray(
+            [[0, 1], [0, 1], [1, 1]],
+            dims=("lat", "lon"),
+            coords={"lat": latitude, "lon": longitude},
+            name="surface_class",
+        )
+    original = SeparableExponentialCovariance(
+        latitude,
+        longitude,
+        sigma=1.3,
+        class_labels=class_labels,
+    )
+    path = tmp_path / "covariance.nc"
+
+    original.to_dataset().to_netcdf(path, engine="h5netcdf")
+    with xr.open_dataset(path, engine="h5netcdf") as stored:
+        loaded = stored.load()
+    restored = SeparableExponentialCovariance.from_dataset(loaded)
+
+    assert loaded.attrs["class_blocked"] == int(class_blocked)
+    assert (restored.class_labels is not None) is class_blocked
+    if class_labels is not None:
+        xr.testing.assert_identical(restored.class_labels, class_labels)
 
 
 def test_single_class_uses_unblocked_covariance(

--- a/tests/test_native_covariance_classes.py
+++ b/tests/test_native_covariance_classes.py
@@ -1,0 +1,173 @@
+"""Tests for optional class blocking in native covariance actions."""
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from openghg_inversions.native_covariance import SeparableExponentialCovariance
+
+
+@pytest.fixture
+def coordinates() -> tuple[xr.DataArray, xr.DataArray]:
+    """Return a small irregular native grid with degree metadata."""
+    latitude = xr.DataArray(
+        [-1.0, 0.5, 2.0],
+        dims="lat",
+        coords={"lat": [-1.0, 0.5, 2.0]},
+        attrs={"units": "degrees_north"},
+    )
+    longitude = xr.DataArray(
+        [10.0, 11.0],
+        dims="lon",
+        coords={"lon": [10.0, 11.0]},
+        attrs={"units": "degrees_east"},
+    )
+    return latitude, longitude
+
+
+def _dense_blocked_covariance(
+    latitude: xr.DataArray,
+    longitude: xr.DataArray,
+    class_labels: xr.DataArray,
+    sigma: float,
+    correlation_length: float,
+) -> np.ndarray:
+    """Build the small dense class-blocked oracle used only by tests."""
+    lat_values = np.asarray(latitude.values)
+    lon_values = np.asarray(longitude.values)
+    lat_factor = np.exp(-np.abs(lat_values[:, None] - lat_values[None, :]) / correlation_length)
+    lon_factor = np.exp(-np.abs(lon_values[:, None] - lon_values[None, :]) / correlation_length)
+    unblocked = sigma**2 * np.kron(lat_factor, lon_factor)
+    labels = np.asarray(class_labels.transpose("lat", "lon").values).reshape(-1)
+    return unblocked * (labels[:, None] == labels[None, :])
+
+
+def test_class_blocked_apply_and_solve_match_dense_oracle(
+    coordinates: tuple[xr.DataArray, xr.DataArray],
+) -> None:
+    """Class-blocked actions match a dense oracle for multiple RHS layouts."""
+    latitude, longitude = coordinates
+    labels = xr.DataArray(
+        [["land", "sea"], ["land", "sea"], ["sea", "sea"]],
+        dims=("lat", "lon"),
+        coords={"lat": latitude, "lon": longitude},
+        name="region_class",
+    )
+    covariance = SeparableExponentialCovariance(
+        latitude,
+        longitude,
+        sigma=1.7,
+        correlation_length=1.2,
+        class_labels=labels,
+    )
+    rhs = xr.DataArray(
+        np.arange(12, dtype=float).reshape(2, 2, 3) / 7.0,
+        dims=("realisation", "lon", "lat"),
+        coords={"realisation": ["a", "b"], "lat": latitude, "lon": longitude},
+        name="rhs",
+        attrs={"units": "1"},
+    )
+
+    dense = _dense_blocked_covariance(latitude, longitude, labels, 1.7, 1.2)
+    native_rhs = rhs.transpose("lat", "lon", "realisation").values.reshape(6, 2)
+    expected_apply = dense @ native_rhs
+    expected_solve = np.linalg.solve(dense, native_rhs)
+
+    applied = covariance.apply(rhs)
+    solved = covariance.solve(rhs)
+
+    assert applied.dims == rhs.dims
+    assert solved.dims == rhs.dims
+    assert applied.name == rhs.name
+    assert applied.attrs == rhs.attrs
+    xr.testing.assert_identical(applied.coords.to_dataset(), rhs.coords.to_dataset())
+    np.testing.assert_allclose(
+        applied.transpose("lat", "lon", "realisation").values.reshape(6, 2),
+        expected_apply,
+        rtol=1e-12,
+        atol=1e-12,
+    )
+    np.testing.assert_allclose(
+        solved.transpose("lat", "lon", "realisation").values.reshape(6, 2),
+        expected_solve,
+        rtol=1e-10,
+        atol=1e-11,
+    )
+    xr.testing.assert_allclose(covariance.apply(solved), rhs, rtol=1e-10, atol=1e-11)
+
+
+def test_class_labels_round_trip_through_dataset(
+    coordinates: tuple[xr.DataArray, xr.DataArray],
+) -> None:
+    """Serialization retains class labels and reproduces the blocked action."""
+    latitude, longitude = coordinates
+    labels = xr.DataArray(
+        [[0, 1], [0, 1], [1, 1]],
+        dims=("lat", "lon"),
+        coords={"lat": latitude, "lon": longitude},
+        attrs={"meaning": "surface class"},
+    )
+    original = SeparableExponentialCovariance(latitude, longitude, class_labels=labels)
+
+    restored = SeparableExponentialCovariance.from_dataset(original.to_dataset())
+
+    assert restored.class_labels is not None
+    xr.testing.assert_identical(restored.class_labels, labels)
+    rhs = xr.ones_like(labels, dtype=float)
+    xr.testing.assert_allclose(restored.apply(rhs), original.apply(rhs))
+
+
+def test_single_class_uses_unblocked_covariance(
+    coordinates: tuple[xr.DataArray, xr.DataArray],
+) -> None:
+    """A single class is algebraically identical to the separable covariance."""
+    latitude, longitude = coordinates
+    labels = xr.DataArray(
+        np.full((3, 2), "all"),
+        dims=("lat", "lon"),
+        coords={"lat": latitude, "lon": longitude},
+    )
+    blocked = SeparableExponentialCovariance(latitude, longitude, class_labels=labels)
+    unblocked = SeparableExponentialCovariance(latitude, longitude)
+    rhs = xr.DataArray(
+        np.arange(6, dtype=float).reshape(3, 2),
+        dims=("lat", "lon"),
+        coords={"lat": latitude, "lon": longitude},
+    )
+
+    xr.testing.assert_allclose(blocked.apply(rhs), unblocked.apply(rhs))
+    xr.testing.assert_allclose(blocked.solve(rhs), unblocked.solve(rhs))
+
+
+@pytest.mark.parametrize("invalid_value", [None, np.nan])
+def test_class_labels_reject_unassigned_cells(
+    coordinates: tuple[xr.DataArray, xr.DataArray],
+    invalid_value: object,
+) -> None:
+    """Every native cell must have a non-null class assignment."""
+    latitude, longitude = coordinates
+    values = np.full((3, 2), "land", dtype=object)
+    values[0, 0] = invalid_value
+    labels = xr.DataArray(
+        values,
+        dims=("lat", "lon"),
+        coords={"lat": latitude, "lon": longitude},
+    )
+
+    with pytest.raises(ValueError, match="non-null class"):
+        SeparableExponentialCovariance(latitude, longitude, class_labels=labels)
+
+
+def test_class_labels_require_exact_grid_alignment(
+    coordinates: tuple[xr.DataArray, xr.DataArray],
+) -> None:
+    """Class labels cannot be silently reordered against the covariance grid."""
+    latitude, longitude = coordinates
+    labels = xr.DataArray(
+        np.zeros((3, 2), dtype=int),
+        dims=("lat", "lon"),
+        coords={"lat": latitude[::-1], "lon": longitude},
+    )
+
+    with pytest.raises(ValueError, match="does not align"):
+        SeparableExponentialCovariance(latitude, longitude, class_labels=labels)

--- a/tests/test_source_covariance.py
+++ b/tests/test_source_covariance.py
@@ -1,8 +1,10 @@
 """Tests for ordered independent-source native covariance blocks."""
 
 from pathlib import Path
+from typing import cast
 
 import numpy as np
+import pytest
 import xarray as xr
 
 from openghg_inversions.basis.covariance_products import (
@@ -101,6 +103,43 @@ def test_independent_source_action_and_serialization_preserve_order() -> None:
     np.testing.assert_allclose(applied.values.reshape(8, 3), dense @ matrix)
     np.testing.assert_allclose(solved.values.reshape(8, 3), np.linalg.solve(dense, matrix))
     xr.testing.assert_allclose(restored.apply(rhs), applied)
+
+
+def test_constructor_validates_every_block_type_before_inspecting_dimensions() -> None:
+    """Invalid blocks raise ``TypeError`` before any native dimensions are read."""
+    covariance, _, _ = _problem()
+    valid = covariance.source_covariances["z-source"]
+    invalid = cast(SeparableExponentialCovariance, object())
+
+    with pytest.raises(TypeError, match="bad.*SeparableExponentialCovariance"):
+        IndependentSourceCovariance({"bad": invalid})
+
+    with pytest.raises(TypeError, match="bad.*SeparableExponentialCovariance"):
+        IndependentSourceCovariance(
+            {"valid": valid, "bad": invalid},
+            source_dim="lat",
+        )
+
+
+def test_action_rejects_numeric_source_label_matching_only_after_string_coercion() -> None:
+    """A numeric source label cannot masquerade as the configured string label."""
+    covariance, _, native_sensitivity = _problem()
+    component = covariance.source_covariances["z-source"]
+    numeric_named_covariance = IndependentSourceCovariance({"1": component})
+    rhs = native_sensitivity.isel(native_source=[0]).assign_coords(native_source=[1])
+
+    with pytest.raises(ValueError, match="source labels/order"):
+        numeric_named_covariance.apply(rhs)
+
+
+@pytest.mark.parametrize("spatial_dim", ["lat", "lon"])
+def test_deserialization_rejects_missing_spatial_coordinates(spatial_dim: str) -> None:
+    """Missing serialized spatial labels raise a clear validation error."""
+    covariance, _, _ = _problem()
+    dataset = covariance.to_dataset().drop_indexes(spatial_dim).drop_vars(spatial_dim)
+
+    with pytest.raises(ValueError, match="missing latitude or longitude coordinates"):
+        IndependentSourceCovariance.from_dataset(dataset)
 
 
 def test_source_serialization_preserves_class_label_identity() -> None:

--- a/tests/test_source_covariance.py
+++ b/tests/test_source_covariance.py
@@ -1,0 +1,202 @@
+"""Tests for ordered independent-source native covariance blocks."""
+
+from pathlib import Path
+
+import numpy as np
+import xarray as xr
+
+from openghg_inversions.basis.covariance_products import (
+    NativeCovarianceProducts,
+    project_native_covariance,
+)
+from openghg_inversions.basis.operators import MultiSourceBucketBasisOperator
+from openghg_inversions.native_covariance import SeparableExponentialCovariance
+from openghg_inversions.source_covariance import IndependentSourceCovariance
+
+
+def _problem():
+    """Return a small non-lexically ordered gathered-source problem."""
+    latitude = xr.DataArray(
+        [-1.0, 0.5],
+        dims="lat",
+        coords={"lat": [-1.0, 0.5]},
+        attrs={"units": "degrees_north"},
+    )
+    longitude = xr.DataArray(
+        [10.0, 11.0],
+        dims="lon",
+        coords={"lon": [10.0, 11.0]},
+        attrs={"units": "degrees_east"},
+    )
+    components = {
+        "z-source": SeparableExponentialCovariance(
+            latitude,
+            longitude,
+            sigma=1.6,
+            latitude_correlation_length=0.7,
+            longitude_correlation_length=2.2,
+        ),
+        "a-source": SeparableExponentialCovariance(latitude, longitude, sigma=0.7),
+    }
+    covariance = IndependentSourceCovariance(components)
+    basis = MultiSourceBucketBasisOperator(
+        {
+            "z-source": xr.DataArray(
+                [[1, 1], [2, 2]],
+                dims=("lat", "lon"),
+                coords={"lat": latitude, "lon": longitude},
+            ),
+            "a-source": xr.DataArray(
+                [[1, 1], [1, 1]],
+                dims=("lat", "lon"),
+                coords={"lat": latitude, "lon": longitude},
+            ),
+        },
+        state_dim="state",
+    )
+    native_sensitivity = xr.DataArray(
+        np.arange(24, dtype=float).reshape(3, 2, 2, 2) / 9.0,
+        dims=("observation", "native_source", "lat", "lon"),
+        coords={
+            "observation": ["obs-1", "obs-2", "obs-3"],
+            "native_source": ["z-source", "a-source"],
+            "lat": latitude,
+            "lon": longitude,
+        },
+    )
+    return covariance, basis, native_sensitivity
+
+
+def _dense_block_diagonal(covariance: IndependentSourceCovariance) -> np.ndarray:
+    """Construct the small dense independent-source oracle."""
+    blocks = []
+    for source in covariance.source_labels:
+        component = covariance.source_covariances[source]
+        lat = component.latitude.values
+        lon = component.longitude.values
+        k_lat = np.exp(-np.abs(lat[:, None] - lat[None, :]) / component.latitude_correlation_length)
+        k_lon = np.exp(-np.abs(lon[:, None] - lon[None, :]) / component.longitude_correlation_length)
+        blocks.append(component.sigma**2 * np.kron(k_lat, k_lon))
+    result = np.zeros((sum(block.shape[0] for block in blocks),) * 2)
+    offset = 0
+    for block in blocks:
+        stop = offset + block.shape[0]
+        result[offset:stop, offset:stop] = block
+        offset = stop
+    return result
+
+
+def test_independent_source_action_and_serialization_preserve_order() -> None:
+    """Block action, solve, and serialization retain configured non-lexical order."""
+    covariance, _, native_sensitivity = _problem()
+    rhs = native_sensitivity.transpose("native_source", "lat", "lon", "observation")
+    dense = _dense_block_diagonal(covariance)
+    matrix = rhs.values.reshape(8, 3)
+
+    applied = covariance.apply(rhs)
+    solved = covariance.solve(rhs)
+    restored = IndependentSourceCovariance.from_dataset(covariance.to_dataset())
+
+    assert covariance.source_labels == ("z-source", "a-source")
+    np.testing.assert_allclose(applied.values.reshape(8, 3), dense @ matrix)
+    np.testing.assert_allclose(solved.values.reshape(8, 3), np.linalg.solve(dense, matrix))
+    xr.testing.assert_allclose(restored.apply(rhs), applied)
+
+
+def test_source_serialization_preserves_class_label_identity() -> None:
+    """Class-blocked source round trips retain typed labels, name, and attributes."""
+    covariance, _, _ = _problem()
+    original_component = covariance.source_covariances["z-source"]
+    class_labels = xr.DataArray(
+        [[1, 2], [1, 2]],
+        dims=("lat", "lon"),
+        coords={"lat": original_component.latitude, "lon": original_component.longitude},
+        name="surface_class",
+        attrs={"description": "typed test classes", "version": np.int64(2)},
+    )
+    blocked_component = SeparableExponentialCovariance(
+        original_component.latitude,
+        original_component.longitude,
+        sigma=original_component.sigma,
+        latitude_correlation_length=original_component.latitude_correlation_length,
+        longitude_correlation_length=original_component.longitude_correlation_length,
+        class_labels=class_labels,
+    )
+    blocked = IndependentSourceCovariance(
+        {
+            "z-source": blocked_component,
+            "a-source": covariance.source_covariances["a-source"],
+        }
+    )
+
+    restored = IndependentSourceCovariance.from_dataset(blocked.to_dataset())
+
+    restored_labels = restored.source_covariances["z-source"].class_labels
+    assert restored_labels is not None
+    xr.testing.assert_identical(restored_labels, class_labels.assign_attrs(version=2))
+
+
+def test_gathered_source_products_match_block_diagonal_dense_oracle() -> None:
+    """Ragged source states keep insertion order and zero cross-source covariance."""
+    covariance, basis, native_sensitivity = _problem()
+    products = project_native_covariance(
+        covariance=covariance,
+        basis_operator=basis,
+        native_sensitivity=native_sensitivity,
+        observation_dim="observation",
+        observation_batch_size=1,
+    )
+    dense_b = _dense_block_diagonal(covariance)
+    h = native_sensitivity.values.reshape(3, 8)
+
+    base = basis.basis_matrix.transpose("lat", "lon", "state").compute()
+    base_values = np.asarray(base.data.todense())
+    state_sources = np.asarray(base.coords["source"].values)
+    u = np.zeros((2, 2, 2, base.sizes["state"]))
+    for source_index, source in enumerate(covariance.source_labels):
+        u[source_index] = base_values * (state_sources == source)[None, None, :]
+    u = u.reshape(8, base.sizes["state"])
+    c_alpha = np.linalg.inv(u.T @ np.linalg.solve(dense_b, u))
+    pi = c_alpha @ np.linalg.solve(dense_b, u).T
+
+    assert products.state_covariance.coords["source"].values.tolist() == [
+        "z-source",
+        "z-source",
+        "a-source",
+    ]
+    np.testing.assert_allclose(products.restriction.values.reshape(3, 8), pi, atol=1e-11)
+    np.testing.assert_allclose(products.state_covariance, c_alpha, atol=1e-11)
+    np.testing.assert_allclose(products.effective_observation_operator, h @ u, atol=1e-11)
+    np.testing.assert_allclose(
+        products.observation_state_cross_covariance,
+        h @ dense_b @ pi.T,
+        atol=1e-11,
+    )
+    np.testing.assert_allclose(products.native_observation_covariance, h @ dense_b @ h.T, atol=1e-11)
+    np.testing.assert_allclose(pi @ u, np.eye(3), atol=1e-11)
+
+
+def test_gathered_source_product_datatree_persists_multiindex(tmp_path: Path) -> None:
+    """Ragged state labels and covariance configuration survive NetCDF persistence."""
+    covariance, basis, native_sensitivity = _problem()
+    products = project_native_covariance(
+        covariance=covariance,
+        basis_operator=basis,
+        native_sensitivity=native_sensitivity,
+        observation_dim="observation",
+    )
+    path = tmp_path / "source-products.nc"
+
+    products.to_datatree().to_netcdf(path, engine="h5netcdf")
+    with xr.open_datatree(path, engine="h5netcdf") as stored:
+        restored = NativeCovarianceProducts.from_datatree(stored.load())
+
+    assert restored.state_covariance.coords["source"].values.tolist() == [
+        "z-source",
+        "z-source",
+        "a-source",
+    ]
+    assert restored.covariance_configuration is not None
+    assert products.covariance_configuration is not None
+    xr.testing.assert_identical(restored.covariance_configuration, products.covariance_configuration)
+    xr.testing.assert_allclose(restored.state_covariance, products.state_covariance)


### PR DESCRIPTION
> [!IMPORTANT]
> **Superseded by the reviewable stack [#581](https://github.com/openghg/openghg_inversions/pull/581) → [#582](https://github.com/openghg/openghg_inversions/pull/582) → [#583](https://github.com/openghg/openghg_inversions/pull/583). Do not merge this aggregate draft.**
>
> This PR is retained as the original OPE-17 discussion and production-validation record. The stacked PRs include additional independent-review hardening.

## Summary

- add labelled, matrix-free native covariance actions with separable exponential kernels, optional class blocking, anisotropic correlation lengths, and ordered independent-source blocks
- add the retained projection strategy boundary and the covariance-compatible restriction
  `Pi_U = (U_bucket.T B^-1 U_bucket)^-1 U_bucket.T B^-1`, preserving `U_* = U_bucket`
- compute and serialize coherent `C_alpha`, `H U_*`, `H B Pi.T`, and dense or diagonal `H B H.T` products with stable labels and separate source/view identities
- document the distinction between `Pi`, `U_*`, `U_bucket`, basis geometry, covariance actions, affine centring, and eager observation batching
- add dense-oracle, multisource, class-blocking, strict-coordinate, real datetime MultiIndex, NetCDF persistence, identity-binding, and protocol-extension tests

This is the low-level native covariance preparation foundation tracked by Linear OPE-17. It does not yet construct `B_perp`, unresolved covariance, arbitrary reporting-functional products, or the coherent reduced RHIME likelihood; those remain downstream OPE-18 work.

## Verification-games production comparison

Verification-games commit [`b976de2`](https://github.com/openghg/verification-games/commit/b976de23e11a77d1708fe89ae26acefd8d919705) tested exact PR revision `946db07f57c66e4b47a5fe787298d4ebf4ae2f02` through the public `RetainedProjectionStrategy` seam.

The January 2021 coherent 14-site production restriction is the source-blocked absolute-UOB-BASE-prior-flux-weighted regional mean

`Pi_(s,r),(s',i) = 1[s=s'] 1[i in r] |F_UOB_BASE_si A_i| / sum_(j in r) |F_UOB_BASE_sj A_j|`.

BASE is the fixed prior/reference flux in every case. Each row is nonnegative, sums to one, uses one source and one active region, and is chosen independently of `B`. Signed regional flux totals are reconstructed through the stored conditional reporting functional; the prototype's `signed-flux-total` restriction is a separate alternative, not this production setting.

The production check covered all 361 retained states (GPP 115, TER 115, FF 74, ocean 57), seven covariance classes, calibrated source amplitudes, and one real datetime observation from each of 14 sites.

| Check | Result |
|---|---:|
| Worst OGI/VG product relative Frobenius difference | `5.44e-16` |
| OGI vs cached production `C_alpha` and `H_alpha` | floating-point precision |
| `Pi U_* - I`, worst source-wise relative difference | `6.27e-16` |
| `U_*^absolute` vs `U_bucket`, relative difference | `0.716` |
| `H U_*^absolute` vs `H U_bucket`, 14-site relative difference | `0.526` |

The production-labelled datetime `(site, time)` MultiIndex and product identities round-tripped through NetCDF. Verification-games reported 66 passing tests; the focused OGI run reported 78 passing tests, and its sole transient HDF5 failure passed in isolation. SLURM job `18419864` completed successfully.

Therefore:

- #578's numerical products and public strategy protocol are production-capable for a supplied physical `Pi`;
- the bucket-first `PreserveBucketProlongation` policy is not production-equivalent;
- OGI should still package a concrete, policy-neutral supplied-`Pi`-first strategy, with the absolute-flux-weighted restriction as the immediate production case.

The reproducible production diagnostic and its generating script are recorded by verification-games commit [`b976de2`](https://github.com/openghg/verification-games/commit/b976de23e11a77d1708fe89ae26acefd8d919705).

The prototype also contains capabilities intentionally absent here: cross-source covariance, arbitrary `Q` functionals, `B_perp`, coherent likelihood reduction, reconstruction, and posterior/evidence parity workflows.

## Review-driven hardening

Independent code, architecture, scientific-array, documentation, and test reviews were run. The follow-up fixes include:

- exact native-coordinate checks for custom `Pi/U_*` strategies
- full-rank positive-definite retained covariance checks
- NetCDF-safe blocked-covariance metadata and datetime MultiIndex persistence
- source/view identity separation aligned with the updated ADR
- covariance-configuration digest binding and incomplete-tree rejection
- preallocated dense/diagonal observation products
- clearer frozen-dataclass, memory, centring, and serialization documentation

The PR remains draft because the updated delivery plan recommends splitting the no-class covariance action from class/source/product slices if review size grows.

## User and developer impact

The package gains a new low-level API for projecting structured native-grid covariance without constructing dense native `B`. Existing bucket sensitivity semantics are preserved. Existing inversion entry points are unchanged.

## Validation

- `tox -p --parallel-no-spinner` — current OpenGHG environment and lint passed
- focused OPE-17 suite — 63 passed
- Ruff check and format check — passed
- Pyright on the covariance modules — 0 errors
- `git diff --check` — passed
- `tox -e docs` — passed with existing repository warnings
- verification-games production validation at `946db07` — 66 passed; focused OGI validation reported 78 passed, with one transient HDF5 failure passing in isolation; SLURM job `18419864` completed successfully

## Checklist

- [ ] Closes a GitHub issue — tracked in Linear as OPE-17 instead
- [x] Tests added and passing
- [x] Documentation and tutorials updated/added
- [x] Added an entry to `CHANGELOG.md`
- [x] No new requirements
