### PR TITLE
Add matrix-free separable native covariance

### DIFF
--- a/docs/reference/openghg_inversions.native_covariance.rst
+++ b/docs/reference/openghg_inversions.native_covariance.rst
@@ -1,0 +1,7 @@
+openghg\_inversions.native\_covariance
+========================================
+
+.. automodule:: openghg_inversions.native_covariance
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/reference/openghg_inversions.rst
+++ b/docs/reference/openghg_inversions.rst
@@ -28,6 +28,7 @@ openghg\_inversions
    openghg_inversions.convert
    openghg_inversions.filters
    openghg_inversions.model_error
+   openghg_inversions.native_covariance
    openghg_inversions.rhime
    openghg_inversions.serialization
    openghg_inversions.utils

--- a/openghg_inversions/native_covariance.py
+++ b/openghg_inversions/native_covariance.py
@@ -1,0 +1,460 @@
+"""Labelled matrix-free covariance actions on a native latitude/longitude grid.
+
+The native scaling perturbation is denoted by ``x`` and its covariance by
+``B = Cov(x)``.  A covariance action applies ``B`` to labelled right-hand
+sides without constructing the dense native ``N x N`` matrix.  The initial
+implementation uses
+
+``B = sigma**2 * (K_lat kron K_lon)``,
+
+where ``K_axis[i, j] = exp(-abs(q_i - q_j) / ell_axis)``.  Grid
+arrays use row-major ``(latitude, longitude)`` vectorisation, so the action on
+a field ``X`` is ``K_lat @ X @ K_lon.T``.  The default correlation length is
+1.5 degrees; it is an introductory configurable value, not a universal
+scientific constant.
+
+Both :meth:`SeparableExponentialCovariance.apply` and
+:meth:`SeparableExponentialCovariance.solve` preserve all input dimensions,
+coordinates, name, and attributes. The action materialises the two
+one-dimensional covariance factors and their Cholesky factors, rather than the
+dense native covariance. Apply and solve eagerly convert each labelled
+right-hand side to a NumPy array; they do not preserve lazy Dask execution.
+Distances are coordinate-wise degrees, not geodesic or longitude-wrapped
+distances. A missing coordinate ``units`` attr is interpreted as degrees for
+compatibility with existing OGI grids.
+
+``SeparableExponentialCovariance`` is an ordinary slotted, identity-based
+object. Construction owns eager coordinate copies; coordinate properties
+return borrowed arrays whose in-place mutation is unsupported. Scalar
+configuration properties are read-only, so changed parameters require explicit
+reconstruction.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+import numpy as np
+from scipy.linalg import cho_factor, cho_solve  # type: ignore[import-untyped]
+import xarray as xr
+
+from openghg_inversions.borrowed import BorrowedDataArray, borrow
+
+__all__ = [
+    "InvertibleNativeCovarianceAction",
+    "NativeCovarianceAction",
+    "SeparableExponentialCovariance",
+]
+
+
+class NativeCovarianceAction(Protocol):
+    """Structural interface for a labelled native covariance action."""
+
+    @property
+    def native_dims(self) -> tuple[str, ...]:
+        """Native dimensions consumed by the action."""
+        ...
+
+    def apply(self, rhs: xr.DataArray) -> xr.DataArray:
+        """Apply ``B`` to labelled RHS arrays containing every native dimension.
+
+        Args:
+            rhs: Labelled array containing every native dimension.
+
+        Returns:
+            The covariance action with the dimensions, coordinates, name, and
+            attributes of ``rhs`` preserved.
+
+        Raises:
+            TypeError: If ``rhs`` is not an xarray data array.
+            ValueError: If native dimensions or coordinates are missing or
+                misaligned, or if values are non-numeric or non-finite.
+        """
+        ...
+
+
+class InvertibleNativeCovarianceAction(NativeCovarianceAction, Protocol):
+    """Native covariance action that can also solve systems in ``B``."""
+
+    def solve(self, rhs: xr.DataArray) -> xr.DataArray:
+        """Return labelled ``B^-1 rhs`` while preserving the input layout.
+
+        Args:
+            rhs: Labelled array containing every native dimension.
+
+        Returns:
+            The covariance solve with the dimensions, coordinates, name, and
+            attributes of ``rhs`` preserved.
+
+        Raises:
+            TypeError: If ``rhs`` is not an xarray data array.
+            ValueError: If native dimensions or coordinates are missing or
+                misaligned, or if values are non-numeric or non-finite.
+            numpy.linalg.LinAlgError: If the covariance factorization fails.
+        """
+        ...
+
+
+class SeparableExponentialCovariance:
+    """Separable exponential covariance over labelled latitude and longitude.
+
+    Args:
+        latitude: One-dimensional latitude coordinate in degrees.
+        longitude: One-dimensional longitude coordinate in degrees.
+        sigma: Strictly positive native-cell marginal standard deviation, in
+            native-state units (dimensionless for RHIME scaling perturbations).
+        correlation_length: Shared fallback correlation length in degrees.
+        latitude_correlation_length: Optional latitude-specific length in degrees.
+        longitude_correlation_length: Optional longitude-specific length in degrees.
+
+    Notes:
+        Construction copies and owns the two small coordinate vectors because
+        cached covariance factors depend on them. Coordinate properties return
+        borrowed arrays; callers must not mutate them in place. Configuration
+        properties are read-only. Instances are ordinary slotted objects with
+        identity-based equality and hashing.
+
+    Raises:
+        ValueError: If coordinates, units, or covariance parameters are invalid.
+        numpy.linalg.LinAlgError: If a one-dimensional covariance factor is not
+            numerically positive definite.
+    """
+
+    __slots__ = (
+        "_correlation_length",
+        "_latitude",
+        "_latitude_cholesky",
+        "_latitude_correlation_length",
+        "_latitude_correlation_length_override",
+        "_latitude_factor",
+        "_longitude",
+        "_longitude_cholesky",
+        "_longitude_correlation_length",
+        "_longitude_correlation_length_override",
+        "_longitude_factor",
+        "_sigma",
+    )
+
+    def __init__(
+        self,
+        latitude: xr.DataArray | None = None,
+        longitude: xr.DataArray | None = None,
+        sigma: float = 1.0,
+        correlation_length: float = 1.5,
+        latitude_correlation_length: float | None = None,
+        longitude_correlation_length: float | None = None,
+    ) -> None:
+        """Validate constructor inputs and cache factors used by the actions.
+
+        Coordinates are copied once. The resolved covariance parameters,
+        separable factors, and Cholesky factors become owned eager state.
+
+        Raises:
+            ValueError: If coordinates, units, or covariance parameters are
+                invalid.
+        """
+        latitude = _validate_coordinate(latitude, "latitude")
+        longitude = _validate_coordinate(longitude, "longitude")
+        if latitude.dims[0] == longitude.dims[0]:
+            raise ValueError("latitude and longitude must use distinct dimension names")
+        sigma = _positive_finite(sigma, "sigma")
+        length = _positive_finite(correlation_length, "correlation_length")
+        latitude_override = (
+            None
+            if latitude_correlation_length is None
+            else _positive_finite(latitude_correlation_length, "latitude_correlation_length")
+        )
+        longitude_override = (
+            None
+            if longitude_correlation_length is None
+            else _positive_finite(longitude_correlation_length, "longitude_correlation_length")
+        )
+        latitude_length = length if latitude_override is None else latitude_override
+        longitude_length = length if longitude_override is None else longitude_override
+
+        latitude_factor = _exponential_factor(latitude.values, latitude_length)
+        longitude_factor = _exponential_factor(longitude.values, longitude_length)
+        self._latitude = latitude
+        self._longitude = longitude
+        self._sigma = sigma
+        self._correlation_length = length
+        self._latitude_correlation_length_override = latitude_override
+        self._longitude_correlation_length_override = longitude_override
+        self._latitude_correlation_length = latitude_length
+        self._longitude_correlation_length = longitude_length
+        self._latitude_factor = latitude_factor
+        self._longitude_factor = longitude_factor
+        self._latitude_cholesky = cho_factor(latitude_factor, lower=True)
+        self._longitude_cholesky = cho_factor(longitude_factor, lower=True)
+
+    @property
+    def latitude(self) -> BorrowedDataArray:
+        """Borrow the owned latitude coordinate; in-place mutation is unsupported."""
+        return borrow(self._latitude)
+
+    @property
+    def longitude(self) -> BorrowedDataArray:
+        """Borrow the owned longitude coordinate; in-place mutation is unsupported."""
+        return borrow(self._longitude)
+
+    @property
+    def sigma(self) -> float:
+        """Read-only native-cell marginal standard deviation."""
+        return self._sigma
+
+    @property
+    def correlation_length(self) -> float:
+        """Read-only shared fallback correlation length in degrees."""
+        return self._correlation_length
+
+    @property
+    def latitude_correlation_length(self) -> float:
+        """Read-only resolved latitude correlation length in degrees."""
+        return self._latitude_correlation_length
+
+    @property
+    def longitude_correlation_length(self) -> float:
+        """Read-only resolved longitude correlation length in degrees."""
+        return self._longitude_correlation_length
+
+    @property
+    def native_dims(self) -> tuple[str, str]:
+        """Latitude and longitude dimension names in vectorisation order."""
+        return (str(self._latitude.dims[0]), str(self._longitude.dims[0]))
+
+    def apply(self, rhs: xr.DataArray) -> xr.DataArray:
+        """Apply ``B`` while preserving the labelled layout of ``rhs``.
+
+        The right-hand side is eagerly converted to a NumPy array before the
+        covariance action is evaluated.
+
+        Args:
+            rhs: Array containing both native dimensions and any number of
+                additional right-hand-side dimensions.
+
+        Returns:
+            ``B rhs`` with dimensions and coordinates identical to ``rhs``.
+
+        Raises:
+            TypeError: If ``rhs`` is not an xarray data array.
+            ValueError: If native dimensions or coordinates are missing or
+                misaligned, or if values are non-numeric or non-finite.
+        """
+        matrix, original_dims, rhs_dims = self._validated_matrix(rhs)
+        applied = self._apply_separable(matrix)
+        return self._restore(applied, rhs, original_dims, rhs_dims)
+
+    def solve(self, rhs: xr.DataArray) -> xr.DataArray:
+        """Solve ``B result = rhs`` without constructing the native matrix.
+
+        The separable solve uses one-dimensional Cholesky factors.
+
+        Args:
+            rhs: Array containing both native dimensions and any number of
+                additional right-hand-side dimensions.
+
+        Returns:
+            ``B^-1 rhs`` with dimensions and coordinates identical to ``rhs``.
+
+        Raises:
+            TypeError: If ``rhs`` is not an xarray data array.
+            ValueError: If native dimensions or coordinates are missing or
+                misaligned, or if values are non-numeric or non-finite.
+        """
+        matrix, original_dims, rhs_dims = self._validated_matrix(rhs)
+        solved = self._solve_separable(matrix)
+        return self._restore(solved, rhs, original_dims, rhs_dims)
+
+    def _apply_separable(self, matrix: np.ndarray) -> np.ndarray:
+        """Apply the two one-dimensional covariance factors.
+
+        Args:
+            matrix: Eager array shaped ``(latitude, longitude, rhs)``.
+
+        Returns:
+            Separable covariance-applied values with the same shape.
+        """
+        left_applied = np.einsum("ij,jkr->ikr", self._latitude_factor, matrix)
+        applied = np.einsum("ikr,lk->ilr", left_applied, self._longitude_factor)
+        return applied * self.sigma**2
+
+    def _solve_separable(self, matrix: np.ndarray) -> np.ndarray:
+        """Solve the separable system using Cholesky factors.
+
+        Args:
+            matrix: Eager array shaped ``(latitude, longitude, rhs)``.
+
+        Returns:
+            Solved values with the same shape as ``matrix``.
+        """
+        n_lat, n_lon, n_rhs = matrix.shape
+        latitude_solved = cho_solve(
+            self._latitude_cholesky,
+            matrix.reshape(n_lat, n_lon * n_rhs),
+            check_finite=False,
+        ).reshape(n_lat, n_lon, n_rhs)
+        longitude_solved = (
+            cho_solve(
+                self._longitude_cholesky,
+                latitude_solved.transpose(1, 0, 2).reshape(n_lon, n_lat * n_rhs),
+                check_finite=False,
+            )
+            .reshape(n_lon, n_lat, n_rhs)
+            .transpose(1, 0, 2)
+        )
+        return longitude_solved / self.sigma**2
+
+    def _validated_matrix(self, rhs: xr.DataArray) -> tuple[np.ndarray, tuple[str, ...], tuple[str, ...]]:
+        """Validate and eagerly reshape a labelled right-hand side.
+
+        Args:
+            rhs: Candidate right-hand side containing the native dimensions.
+
+        Returns:
+            A native-first NumPy matrix, the original dimension order, and the
+            ordered non-native right-hand-side dimensions.
+
+        Raises:
+            TypeError: If ``rhs`` is not an xarray data array.
+            ValueError: If native dimensions or coordinates are missing or
+                misaligned, or if values are non-numeric or non-finite.
+        """
+        if not isinstance(rhs, xr.DataArray):
+            raise TypeError("rhs must be an xarray.DataArray")
+        for dim, expected in zip(self.native_dims, (self._latitude, self._longitude), strict=True):
+            if dim not in rhs.dims:
+                raise ValueError(f"rhs is missing native dimension {dim!r}")
+            if dim not in rhs.coords:
+                raise ValueError(f"rhs is missing coordinate labels for native dimension {dim!r}")
+            actual_values = np.asarray(rhs.coords[dim].values)
+            if actual_values.shape != expected.shape or not np.array_equal(actual_values, expected.values):
+                raise ValueError(f"rhs coordinate {dim!r} does not align with the covariance grid")
+        original_dims = tuple(str(dim) for dim in rhs.dims)
+        rhs_dims = tuple(dim for dim in original_dims if dim not in self.native_dims)
+        transposed = rhs.transpose(*self.native_dims, *rhs_dims)
+        values = np.asarray(transposed.values)
+        if not np.issubdtype(values.dtype, np.number):
+            raise ValueError("rhs values must be numeric")
+        if not np.all(np.isfinite(values)):
+            raise ValueError("rhs values must be finite (no NaN or infinity)")
+        n_lat = self._latitude.size
+        n_lon = self._longitude.size
+        n_rhs = int(np.prod([transposed.sizes[dim] for dim in rhs_dims], dtype=np.intp))
+        return (
+            np.asarray(values, dtype=np.result_type(values.dtype, np.float64)).reshape(n_lat, n_lon, n_rhs),
+            original_dims,
+            rhs_dims,
+        )
+
+    def _restore(
+        self,
+        values: np.ndarray,
+        template: xr.DataArray,
+        original_dims: tuple[str, ...],
+        rhs_dims: tuple[str, ...],
+    ) -> xr.DataArray:
+        """Restore eager native-first results to a labelled input layout.
+
+        Args:
+            values: Result values shaped as native axes followed by flattened
+                right-hand-side axes.
+            template: Input array supplying coordinates, name, and attributes.
+            original_dims: Original input dimension order.
+            rhs_dims: Ordered non-native right-hand-side dimensions.
+
+        Returns:
+            A labelled array matching the template layout and metadata.
+        """
+        shape = tuple(template.sizes[dim] for dim in (*self.native_dims, *rhs_dims))
+        result = xr.DataArray(
+            values.reshape(shape),
+            dims=(*self.native_dims, *rhs_dims),
+            coords={name: coordinate for name, coordinate in template.coords.items()},
+            name=template.name,
+            attrs=template.attrs,
+        )
+        return result.transpose(*original_dims)
+
+
+def _validate_coordinate(coordinate: xr.DataArray | None, axis_name: str) -> xr.DataArray:
+    """Validate one native coordinate and return an owned copy.
+
+    Args:
+        coordinate: Candidate one-dimensional labelled coordinate.
+        axis_name: Human-readable axis name used for validation and errors.
+
+    Returns:
+        An eager owned copy with an explicit self-coordinate.
+
+    Raises:
+        ValueError: If the coordinate is not one-dimensional and non-empty,
+            contains non-finite or duplicate values, or has non-degree units.
+    """
+    if not isinstance(coordinate, xr.DataArray) or coordinate.ndim != 1 or len(coordinate.dims) != 1:
+        raise ValueError(f"{axis_name} must be a one-dimensional labelled coordinate")
+    if coordinate.size == 0:
+        raise ValueError(f"{axis_name} coordinate must contain at least one value")
+    # This is the explicit eager ownership boundary for the small coordinate
+    # vector. Compute the data and coordinates together, then take an
+    # independent copy so cached factors cannot be invalidated through the
+    # constructor argument.
+    coordinate = coordinate.compute().copy(deep=True)
+    dim = coordinate.dims[0]
+    values = np.asarray(coordinate.data)
+    if (
+        not np.issubdtype(values.dtype, np.number)
+        or np.iscomplexobj(values)
+        or not np.all(np.isfinite(values))
+    ):
+        raise ValueError(f"{axis_name} coordinates must be finite real numeric values")
+    if dim in coordinate.coords:
+        labels = np.asarray(coordinate.coords[dim].data)
+        if labels.shape != values.shape or not np.array_equal(labels, values):
+            raise ValueError(f"{axis_name} coordinate data must match its {dim!r} dimension labels")
+    else:
+        coordinate = coordinate.assign_coords({dim: values})
+    if np.unique(values).size != values.size:
+        raise ValueError(f"{axis_name} coordinates must be unique; duplicate values were found")
+    units = str(coordinate.attrs.get("units", "")).strip().lower()
+    allowed_units = {"", "degree", "degrees"}
+    if axis_name == "latitude":
+        allowed_units.update({"degrees_north", "degree_north"})
+    else:
+        allowed_units.update({"degrees_east", "degree_east"})
+    if units not in allowed_units:
+        raise ValueError(f"{axis_name} coordinate units must be degrees, got {units!r}")
+    return coordinate
+
+
+def _positive_finite(value: float, name: str) -> float:
+    """Resolve a covariance parameter to a positive finite float.
+
+    Args:
+        value: Candidate numeric value.
+        name: Parameter name used in validation errors.
+
+    Returns:
+        The validated floating-point value.
+
+    Raises:
+        TypeError: If ``value`` cannot be converted to a float.
+        ValueError: If the resolved value is non-finite or not strictly positive.
+    """
+    resolved = float(value)
+    if not np.isfinite(resolved) or resolved <= 0.0:
+        raise ValueError(f"{name} must be finite and strictly positive")
+    return resolved
+
+
+def _exponential_factor(coordinates: np.ndarray, length_scale: float) -> np.ndarray:
+    """Construct one exponential covariance factor.
+
+    Args:
+        coordinates: Validated coordinate values for one native axis.
+        length_scale: Positive correlation length in coordinate units.
+
+    Returns:
+        The dense one-dimensional exponential covariance factor.
+    """
+    values = np.asarray(coordinates, dtype=np.float64)
+    return np.exp(-np.abs(values[:, np.newaxis] - values[np.newaxis, :]) / length_scale)

--- a/tests/test_native_covariance.py
+++ b/tests/test_native_covariance.py
@@ -1,0 +1,344 @@
+"""Tests for labelled, matrix-free native-grid covariance actions."""
+
+import dask.array as da
+import numpy as np
+import pytest
+import xarray as xr
+
+from openghg_inversions.native_covariance import SeparableExponentialCovariance
+
+
+def _coordinates() -> tuple[xr.DataArray, xr.DataArray]:
+    """Return a small, irregular labelled latitude-longitude grid."""
+    latitude = xr.DataArray(
+        [-1.0, 0.25, 2.0],
+        dims="lat",
+        coords={"lat": [-1.0, 0.25, 2.0]},
+        attrs={"units": "degrees_north"},
+    )
+    longitude = xr.DataArray(
+        [10.0, 11.5],
+        dims="lon",
+        coords={"lon": [10.0, 11.5]},
+        attrs={"units": "degrees_east"},
+    )
+    return latitude, longitude
+
+
+def _dense_covariance(
+    latitude: xr.DataArray,
+    longitude: xr.DataArray,
+    *,
+    sigma: float,
+    correlation_length: float,
+) -> np.ndarray:
+    """Construct the small-grid Kronecker covariance used only as a test oracle."""
+    k_lat = np.exp(
+        -np.abs(latitude.values[:, np.newaxis] - latitude.values[np.newaxis, :]) / correlation_length
+    )
+    k_lon = np.exp(
+        -np.abs(longitude.values[:, np.newaxis] - longitude.values[np.newaxis, :]) / correlation_length
+    )
+    return sigma**2 * np.kron(k_lat, k_lon)
+
+
+def _covariance(*, sigma: float = 1.7, correlation_length: float = 0.8):
+    """Construct the covariance action shared by focused tests."""
+    latitude, longitude = _coordinates()
+    return SeparableExponentialCovariance(
+        latitude=latitude,
+        longitude=longitude,
+        sigma=sigma,
+        correlation_length=correlation_length,
+    )
+
+
+def test_apply_and_solve_match_dense_oracle_for_multiple_rhs() -> None:
+    """Apply and solve preserve labels while matching a dense multiple-RHS oracle."""
+    latitude, longitude = _coordinates()
+    covariance = _covariance()
+    rhs = xr.DataArray(
+        np.arange(24, dtype=float).reshape(2, 2, 3, 2) / 7.0,
+        dims=("draw", "lon", "lat", "component"),
+        coords={
+            "draw": ["a", "b"],
+            "lon": longitude,
+            "lat": latitude,
+            "component": ["east", "west"],
+        },
+        name="right_hand_side",
+        attrs={"units": "ppm"},
+    )
+    dense = _dense_covariance(latitude, longitude, sigma=1.7, correlation_length=0.8)
+    rhs_matrix = rhs.transpose("lat", "lon", "draw", "component").values.reshape(6, 4)
+
+    applied = covariance.apply(rhs)
+    solved = covariance.solve(rhs)
+
+    expected_applied = (dense @ rhs_matrix).reshape(3, 2, 2, 2)
+    expected_solved = np.linalg.solve(dense, rhs_matrix).reshape(3, 2, 2, 2)
+    assert applied.dims == rhs.dims
+    assert solved.dims == rhs.dims
+    assert applied.name == rhs.name
+    assert solved.name == rhs.name
+    assert applied.attrs == rhs.attrs
+    assert solved.attrs == rhs.attrs
+    xr.testing.assert_equal(applied.coords.to_dataset(), rhs.coords.to_dataset())
+    xr.testing.assert_equal(solved.coords.to_dataset(), rhs.coords.to_dataset())
+    np.testing.assert_allclose(
+        applied.transpose("lat", "lon", "draw", "component"),
+        expected_applied,
+        rtol=1e-12,
+        atol=1e-12,
+    )
+    np.testing.assert_allclose(
+        solved.transpose("lat", "lon", "draw", "component"),
+        expected_solved,
+        rtol=1e-11,
+        atol=1e-11,
+    )
+
+
+def test_single_rhs_round_trips_through_apply_and_solve() -> None:
+    """A labelled grid field round-trips without requiring a trailing RHS dimension."""
+    latitude, longitude = _coordinates()
+    covariance = _covariance()
+    rhs = xr.DataArray(
+        np.arange(6, dtype=float).reshape(3, 2),
+        dims=("lat", "lon"),
+        coords={"lat": latitude, "lon": longitude},
+    )
+
+    restored = covariance.solve(covariance.apply(rhs))
+
+    xr.testing.assert_allclose(restored, rhs, rtol=1e-11, atol=1e-11)
+
+
+def test_anisotropic_correlation_lengths_match_dense_oracle() -> None:
+    """Latitude and longitude length scales are independently configurable."""
+    latitude, longitude = _coordinates()
+    covariance = SeparableExponentialCovariance(
+        latitude,
+        longitude,
+        sigma=1.3,
+        latitude_correlation_length=0.6,
+        longitude_correlation_length=2.1,
+    )
+    rhs = xr.DataArray(
+        np.arange(6, dtype=float).reshape(3, 2),
+        dims=("lat", "lon"),
+        coords={"lat": latitude, "lon": longitude},
+    )
+    k_lat = np.exp(-np.abs(latitude.values[:, None] - latitude.values[None, :]) / 0.6)
+    k_lon = np.exp(-np.abs(longitude.values[:, None] - longitude.values[None, :]) / 2.1)
+    dense = 1.3**2 * np.kron(k_lat, k_lon)
+
+    np.testing.assert_allclose(covariance.apply(rhs).values.reshape(-1), dense @ rhs.values.reshape(-1))
+    np.testing.assert_allclose(
+        covariance.solve(rhs).values.reshape(-1), np.linalg.solve(dense, rhs.values.reshape(-1))
+    )
+
+
+@pytest.mark.parametrize(
+    ("bad_rhs", "message"),
+    [
+        pytest.param(
+            lambda rhs: rhs.assign_coords(lon=[11.5, 10.0]),
+            "coordinate|align|longitude|lon",
+            id="reordered-coordinate-labels",
+        ),
+        pytest.param(
+            lambda rhs: rhs.drop_indexes("lon").drop_vars("lon"),
+            "coordinate|longitude|lon",
+            id="missing-coordinate",
+        ),
+        pytest.param(
+            lambda rhs: rhs.where(~((rhs.lat == 0.25) & (rhs.lon == 10.0))),
+            "finite|NaN",
+            id="non-finite-values",
+        ),
+    ],
+)
+def test_action_rejects_invalid_rhs_labels_and_values(bad_rhs, message: str) -> None:
+    """The action rejects ambiguous alignment and non-finite numerical inputs."""
+    latitude, longitude = _coordinates()
+    covariance = _covariance()
+    rhs = xr.DataArray(
+        np.arange(6, dtype=float).reshape(3, 2),
+        dims=("lat", "lon"),
+        coords={"lat": latitude, "lon": longitude},
+    )
+
+    with pytest.raises(ValueError, match=message):
+        covariance.apply(bad_rhs(rhs))
+
+
+@pytest.mark.parametrize(
+    ("coordinate", "message"),
+    [
+        pytest.param([0.0, 0.0, 1.0], "unique|duplicate", id="duplicate"),
+        pytest.param([0.0, np.nan, 1.0], "finite", id="non-finite"),
+    ],
+)
+def test_constructor_rejects_invalid_native_coordinates(coordinate, message: str) -> None:
+    """Native coordinates must be finite and unique before factors are constructed."""
+    latitude, longitude = _coordinates()
+    latitude = latitude.assign_coords(lat=coordinate).copy(data=coordinate)
+
+    with pytest.raises(ValueError, match=message):
+        SeparableExponentialCovariance(latitude=latitude, longitude=longitude, sigma=1.0)
+
+
+def test_constructor_rejects_coordinate_data_that_disagree_with_dimension_labels() -> None:
+    """A coordinate cannot advertise labels that differ from its numeric grid data."""
+    latitude, longitude = _coordinates()
+    latitude = latitude.assign_coords(lat=[40.0, 50.0, 60.0])
+
+    with pytest.raises(ValueError, match="data.*dimension labels"):
+        SeparableExponentialCovariance(latitude=latitude, longitude=longitude)
+
+
+def test_constructor_rejects_complex_degree_coordinates() -> None:
+    """Complex coordinates are not silently truncated when constructing degree distances."""
+    latitude, longitude = _coordinates()
+    values = np.asarray(latitude.values, dtype=np.complex128) + 1j
+    latitude = latitude.copy(data=values).assign_coords(lat=values)
+
+    with pytest.raises(ValueError, match="real numeric"):
+        SeparableExponentialCovariance(latitude=latitude, longitude=longitude)
+
+
+@pytest.mark.parametrize("axis_name", ["latitude", "longitude"])
+def test_constructor_rejects_empty_native_axes(axis_name: str) -> None:
+    """Each native coordinate must contain at least one grid point."""
+    latitude, longitude = _coordinates()
+    if axis_name == "latitude":
+        latitude = latitude.isel(lat=slice(0, 0))
+    else:
+        longitude = longitude.isel(lon=slice(0, 0))
+
+    with pytest.raises(ValueError, match=rf"{axis_name}.*at least one"):
+        SeparableExponentialCovariance(latitude=latitude, longitude=longitude)
+
+
+@pytest.mark.parametrize(
+    ("sigma", "correlation_length", "message"),
+    [
+        pytest.param(0.0, 1.5, "sigma|positive", id="zero-sigma"),
+        pytest.param(-1.0, 1.5, "sigma|positive", id="negative-sigma"),
+        pytest.param(1.0, 0.0, "correlation_length|positive", id="zero-length"),
+        pytest.param(1.0, np.inf, "correlation_length|finite", id="infinite-length"),
+    ],
+)
+def test_constructor_rejects_invalid_covariance_parameters(
+    sigma: float,
+    correlation_length: float,
+    message: str,
+) -> None:
+    """Covariance scale and correlation length must be finite and strictly positive."""
+    latitude, longitude = _coordinates()
+
+    with pytest.raises(ValueError, match=message):
+        SeparableExponentialCovariance(
+            latitude=latitude,
+            longitude=longitude,
+            sigma=sigma,
+            correlation_length=correlation_length,
+        )
+
+
+def test_actions_do_not_construct_a_native_kronecker_matrix(monkeypatch) -> None:
+    """Production apply and solve use separable factors without calling ``numpy.kron``."""
+    latitude, longitude = _coordinates()
+    rhs = xr.DataArray(
+        np.ones((3, 2, 2)),
+        dims=("lat", "lon", "rhs"),
+        coords={"lat": latitude, "lon": longitude, "rhs": [0, 1]},
+    )
+
+    def fail_kron(*args, **kwargs):
+        """Fail if the matrix-free implementation constructs a Kronecker matrix."""
+        raise AssertionError("the structured action must not call numpy.kron")
+
+    monkeypatch.setattr(np, "kron", fail_kron)
+
+    covariance = _covariance()
+    applied = covariance.apply(rhs)
+    solved = covariance.solve(rhs)
+
+    assert applied.shape == rhs.shape
+    assert solved.shape == rhs.shape
+    assert np.isfinite(applied).all()
+    assert np.isfinite(solved).all()
+
+
+def test_constructor_owns_coordinates_and_properties_are_borrowed() -> None:
+    """Construction owns coordinate copies, properties borrow them, and identity is retained."""
+    latitude, longitude = _coordinates()
+    covariance = SeparableExponentialCovariance(latitude, longitude)
+    equivalent = SeparableExponentialCovariance(latitude, longitude)
+
+    latitude.values[1] = 777.0
+
+    np.testing.assert_array_equal(covariance.latitude.values, [-1.0, 0.25, 2.0])
+    assert covariance.latitude is covariance.latitude
+    assert covariance.longitude is covariance.longitude
+    assert covariance.latitude is not latitude
+    assert covariance.longitude is not longitude
+    assert covariance != equivalent
+    assert isinstance(hash(covariance), int)
+
+
+def test_constructor_materializes_lazy_coordinates_once() -> None:
+    """Lazy coordinate vectors become owned eager arrays at construction."""
+    latitude, longitude = _coordinates()
+    lazy_latitude = latitude.copy(data=da.from_array(latitude.to_numpy(), chunks=2))
+    lazy_longitude = longitude.copy(data=da.from_array(longitude.to_numpy(), chunks=1))
+
+    covariance = SeparableExponentialCovariance(lazy_latitude, lazy_longitude)
+
+    assert isinstance(covariance.latitude.data, np.ndarray)
+    assert isinstance(covariance.longitude.data, np.ndarray)
+    assert covariance.latitude is covariance.latitude
+    assert covariance.longitude is covariance.longitude
+
+
+def test_configuration_is_read_only_and_reconstruction_rebuilds_cached_factors() -> None:
+    """Reconstruction changes parameters while the original slotted configuration stays read-only."""
+    latitude, longitude = _coordinates()
+    covariance = SeparableExponentialCovariance(latitude, longitude, sigma=1.0)
+    scaled = SeparableExponentialCovariance(covariance.latitude, covariance.longitude, sigma=2.0)
+    longer = SeparableExponentialCovariance(
+        covariance.latitude,
+        covariance.longitude,
+        correlation_length=3.0,
+    )
+    rhs = xr.DataArray(
+        np.ones((3, 2)),
+        dims=("lat", "lon"),
+        coords={"lat": latitude, "lon": longitude},
+    )
+
+    with pytest.raises(AttributeError):
+        covariance.correlation_length = 3.0  # type: ignore[misc]
+
+    assert not hasattr(covariance, "__dict__")
+    xr.testing.assert_allclose(scaled.apply(rhs), 4.0 * covariance.apply(rhs))
+    assert longer.latitude_correlation_length == 3.0
+    assert longer.longitude_correlation_length == 3.0
+    assert not np.allclose(longer.apply(rhs), covariance.apply(rhs))
+
+
+def test_zero_length_rhs_axis_is_preserved() -> None:
+    """An empty non-native RHS axis remains a valid labelled batch."""
+    latitude, longitude = _coordinates()
+    covariance = _covariance()
+    rhs = xr.DataArray(
+        np.empty((3, 2, 0)),
+        dims=("lat", "lon", "rhs"),
+        coords={"lat": latitude, "lon": longitude, "rhs": []},
+    )
+
+    applied = covariance.apply(rhs)
+
+    assert applied.shape == rhs.shape

--- a/tests/typing/borrowed_negative.py.txt
+++ b/tests/typing/borrowed_negative.py.txt
@@ -4,6 +4,7 @@ import numpy as np
 import xarray as xr
 
 from openghg_inversions.borrowed import borrow
+from openghg_inversions.native_covariance import SeparableExponentialCovariance
 
 
 borrowed_array = borrow(np.arange(3))
@@ -20,3 +21,10 @@ borrowed_data_array.to_numpy()[0] = 10  # expect-error: dataarray-numpy-item
 
 shallow_copy = borrowed_data_array.copy(deep=False)
 shallow_copy[0] = 10  # expect-error: shallow-copy-item
+
+covariance = SeparableExponentialCovariance(
+    xr.DataArray([0.0, 1.0], dims="lat"),
+    xr.DataArray([10.0, 11.0], dims="lon"),
+)
+covariance.latitude[0] = 20.0  # expect-error: dataarray-item
+covariance.longitude.values[0] = 20.0  # expect-error: dataarray-values-item

--- a/tests/typing/borrowed_positive.py.txt
+++ b/tests/typing/borrowed_positive.py.txt
@@ -7,6 +7,7 @@ import xarray as xr
 from typing_extensions import assert_type
 
 from openghg_inversions.borrowed import BorrowedDataArray, BorrowedNDArray, borrow
+from openghg_inversions.native_covariance import SeparableExponentialCovariance
 
 
 array = np.arange(3)
@@ -21,6 +22,13 @@ assert_type(borrowed_data_array.values, BorrowedNDArray)
 assert_type(borrowed_data_array.to_numpy(), BorrowedNDArray)
 assert_type(borrowed_data_array.copy(deep=False), BorrowedDataArray)
 assert_type(borrowed_data_array.copy(deep=True), xr.DataArray)
+
+covariance = SeparableExponentialCovariance(
+    xr.DataArray([0.0, 1.0], dims="lat"),
+    xr.DataArray([10.0, 11.0], dims="lon"),
+)
+assert_type(covariance.latitude, BorrowedDataArray)
+assert_type(covariance.longitude, BorrowedDataArray)
 
 # Copies that own their buffers remain mutable to both checkers.
 mutable_array = borrowed_array.copy()


### PR DESCRIPTION
## Stack

1. **This PR — Slice A:** no-class separable native covariance action
2. [#582 — Slice B: class/source covariance and serialization](https://github.com/openghg/openghg_inversions/pull/582)
3. [#583 — Slice C: retained projection and covariance-product artifacts](https://github.com/openghg/openghg_inversions/pull/583)

Base: `devel`. Review this PR as the foundation of the stack.

## Summary of changes

- add labelled `NativeCovarianceAction` and `InvertibleNativeCovarianceAction` protocols
- add a matrix-free separable exponential covariance action with anisotropic length scales
- support labelled single and multiple right-hand sides for apply and direct Cholesky solve
- use an ordinary slotted, identity-based computational object rather than an array-bearing dataclass
- copy the small coordinate vectors once at the explicit eager constructor boundary; return latitude/longitude through PR #586's static `BorrowedDataArray` marker with unchanged runtime identity, alongside read-only scalar configuration
- require explicit reconstruction when parameters change, with no `dataclasses.replace` or `with_parameters` contract
- add dense-oracle, ownership, eager-boundary, and API documentation coverage

This is Slice A of [OPE-32](https://linear.app/openghg-inversions/issue/OPE-32/split-ope-17-pr-578-into-a-stacked-pr-series), delivering the first part of [OPE-17](https://linear.app/openghg-inversions/issue/OPE-17/foundation-labelled-native-covariance-actions-and-product-blocks). It supersedes the corresponding foundation portion of draft #578 and preserves the design discussion from #528.

## Review notes

Rebased onto merged #586 and updated for the ownership and execution-boundary guidance now on `devel`: the covariance action owns eager coordinate copies at construction, exposes latitude/longitude through the static borrowed-reference marker without copy-on-access or runtime wrapping, keeps scalar configuration read-only, and remains a narrow behavioural action. Independent review also drove fixes for conflicting labels, zero-sized RHS axes, eager materialization, and cached-factor consistency.

## Validation

- focused Slice A suite — 21 passed
- cumulative OPE-32 suite — 104 passed
- Ruff — passed
- Pyright covariance modules — 0 errors
- borrowed-reference Pyright/Mypy probes — 4 passed
- full `tox -p --parallel-no-spinner` on the assembled stack — passed, including lint

## Checklist

- [ ] Closes a GitHub issue — tracked in Linear as OPE-32/OPE-17
- [x] Tests added and passing
- [x] Documentation updated
- [ ] CHANGELOG entry — included in Slice C
- [x] No new requirements
