### PR TITLE
Add class-blocked and source covariance actions

### DIFF
--- a/docs/reference/openghg_inversions.rst
+++ b/docs/reference/openghg_inversions.rst
@@ -31,4 +31,5 @@ openghg\_inversions
    openghg_inversions.native_covariance
    openghg_inversions.rhime
    openghg_inversions.serialization
+   openghg_inversions.source_covariance
    openghg_inversions.utils

--- a/docs/reference/openghg_inversions.source_covariance.rst
+++ b/docs/reference/openghg_inversions.source_covariance.rst
@@ -1,0 +1,7 @@
+openghg\_inversions.source\_covariance
+========================================
+
+.. automodule:: openghg_inversions.source_covariance
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/openghg_inversions/_serialization_codecs.py
+++ b/openghg_inversions/_serialization_codecs.py
@@ -1,0 +1,102 @@
+"""Lightweight private codecs shared by versioned artifact schemas."""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+
+
+_TAGGED_JSON_VALUE_ENCODING = "tagged_json_v1"
+
+
+def _encode_tagged_json_value(value: object) -> str:
+    """Encode a supported scalar or nested tuple as compact tagged JSON.
+
+    Args:
+        value: String, Boolean, integer, float, NumPy scalar, or nested tuple
+            composed from those types.
+
+    Returns:
+        Tagged compact JSON representation of ``value``.
+
+    Raises:
+        TypeError: If ``value`` has an unsupported type.
+    """
+    if isinstance(value, np.generic):
+        value = value.item()
+    payload: list[object]
+    if isinstance(value, tuple):
+        payload = ["tuple", [_encode_tagged_json_value(item) for item in value]]
+    elif isinstance(value, bool):
+        payload = ["bool", value]
+    elif isinstance(value, int):
+        payload = ["int", value]
+    elif isinstance(value, float):
+        payload = ["float", value]
+    elif isinstance(value, str):
+        payload = ["str", value]
+    else:
+        raise TypeError(f"Unsupported tagged JSON value type: {type(value).__name__}")
+    return json.dumps(payload, separators=(",", ":"))
+
+
+def _decode_tagged_json_value(encoded: str) -> object:
+    """Strictly decode a value produced by :func:`_encode_tagged_json_value`.
+
+    Args:
+        encoded: Tagged compact JSON value.
+
+    Returns:
+        Restored supported Python scalar or tuple value.
+
+    Raises:
+        ValueError: If the JSON, tag, or tagged payload is malformed.
+    """
+    if not isinstance(encoded, str):
+        raise ValueError("Encoded tagged JSON value must be a string")
+    try:
+        payload = json.loads(encoded)
+    except (json.JSONDecodeError, TypeError) as error:
+        raise ValueError("Encoded tagged JSON value is not valid JSON") from error
+    if not isinstance(payload, list) or len(payload) != 2 or not isinstance(payload[0], str):
+        raise ValueError("Encoded tagged JSON value must be a two-item tagged array")
+
+    kind, value = payload
+    if kind == "tuple":
+        if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+            raise ValueError("Encoded tagged JSON tuple must contain encoded string elements")
+        return tuple(_decode_tagged_json_value(item) for item in value)
+    if kind == "bool":
+        if not isinstance(value, bool):
+            raise ValueError("Encoded tagged JSON bool must contain a Boolean")
+        return value
+    if kind == "int":
+        if not isinstance(value, int) or isinstance(value, bool):
+            raise ValueError("Encoded tagged JSON int must contain an integer")
+        return value
+    if kind == "float":
+        if not isinstance(value, float):
+            raise ValueError("Encoded tagged JSON float must contain a float")
+        return value
+    if kind == "str":
+        if not isinstance(value, str):
+            raise ValueError("Encoded tagged JSON str must contain a string")
+        return value
+    raise ValueError(f"Unknown encoded tagged JSON value kind {kind!r}")
+
+
+def _numpy_scalar_json_default(value: object) -> object:
+    """Convert a NumPy scalar to its JSON-compatible Python scalar."""
+    if isinstance(value, np.generic):
+        return value.item()
+    raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
+
+
+def _decode_serialized_bool(value: object, name: str) -> bool:
+    """Decode a serialized Boolean represented only by Boolean or integer 0/1."""
+    if isinstance(value, (bool, np.bool_)):
+        return bool(value)
+    if isinstance(value, (int, np.integer)) and int(value) in (0, 1):
+        return bool(value)
+    raise ValueError(f"Serialized {name} must be Boolean or integer 0/1")

--- a/openghg_inversions/native_covariance.py
+++ b/openghg_inversions/native_covariance.py
@@ -24,7 +24,15 @@ boolean mask per class, but does not construct the diagonal ``M_c`` matrices or
 the dense native covariance. Apply and solve eagerly convert each labelled
 right-hand side to a NumPy array; they do not preserve lazy Dask execution.
 Unblocked solves use the separable Cholesky factors; multi-class solves use
-matrix-free conjugate gradients. Distances are coordinate-wise degrees, not
+matrix-free conjugate gradients. The linear operator reports the flattened
+``N x N`` shape required by SciPy but does not materialise that matrix: each
+iteration applies the separable kernel once per class through masked native-grid
+work arrays. Grouping coordinates by class would expose a block-diagonal
+matrix, but arbitrary class blocks are dense principal submatrices and are not
+generally separable. The iterative solve therefore preserves the
+``O(N + n_lat**2 + n_lon**2)`` storage bound, at the cost of repeated
+per-class kernel applications; highly imbalanced classes can consequently have
+noticeable computational overhead. Distances are coordinate-wise degrees, not
 geodesic or longitude-wrapped distances. A missing coordinate ``units`` attr
 is interpreted as degrees for compatibility with existing OGI grids.
 

--- a/openghg_inversions/native_covariance.py
+++ b/openghg_inversions/native_covariance.py
@@ -15,30 +15,41 @@ scientific constant.
 
 Both :meth:`SeparableExponentialCovariance.apply` and
 :meth:`SeparableExponentialCovariance.solve` preserve all input dimensions,
-coordinates, name, and attributes. The action materialises the two
+coordinates, name, and attributes.  An unblocked action materialises the two
 one-dimensional covariance factors and their Cholesky factors, rather than the
-dense native covariance. Apply and solve eagerly convert each labelled
+dense native covariance. Optional native-grid class labels replace ``B`` by
+the blocked action ``B_class = sum_c M_c B M_c``, where ``M_c`` is the diagonal
+indicator for class ``c``. A blocked action additionally stores one native-grid
+boolean mask per class, but does not construct the diagonal ``M_c`` matrices or
+the dense native covariance. Apply and solve eagerly convert each labelled
 right-hand side to a NumPy array; they do not preserve lazy Dask execution.
-Distances are coordinate-wise degrees, not geodesic or longitude-wrapped
-distances. A missing coordinate ``units`` attr is interpreted as degrees for
-compatibility with existing OGI grids.
+Unblocked solves use the separable Cholesky factors; multi-class solves use
+matrix-free conjugate gradients. Distances are coordinate-wise degrees, not
+geodesic or longitude-wrapped distances. A missing coordinate ``units`` attr
+is interpreted as degrees for compatibility with existing OGI grids.
 
 ``SeparableExponentialCovariance`` is an ordinary slotted, identity-based
-object. Construction owns eager coordinate copies; coordinate properties
-return borrowed arrays whose in-place mutation is unsupported. Scalar
-configuration properties are read-only, so changed parameters require explicit
-reconstruction.
+object. Construction owns eager coordinate and class-label copies; array
+properties return borrowed values whose in-place mutation is unsupported.
+Scalar configuration properties are read-only, so changed parameters require
+explicit reconstruction.
 """
 
 from __future__ import annotations
 
-from typing import Protocol
+import inspect
+import json
+from typing import Callable, Protocol, cast
 
 import numpy as np
 from scipy.linalg import cho_factor, cho_solve  # type: ignore[import-untyped]
+from scipy.sparse.linalg import LinearOperator, cg  # type: ignore[import-untyped]
 import xarray as xr
 
 from openghg_inversions.borrowed import BorrowedDataArray, borrow
+
+_CG_RELATIVE_TOLERANCE = "rtol" if "rtol" in inspect.signature(cg).parameters else "tol"
+_NATIVE_SERIALIZED_VARIABLE_NAMES = {"class_label_encoded"}
 
 __all__ = [
     "InvertibleNativeCovarianceAction",
@@ -90,7 +101,7 @@ class InvertibleNativeCovarianceAction(NativeCovarianceAction, Protocol):
             TypeError: If ``rhs`` is not an xarray data array.
             ValueError: If native dimensions or coordinates are missing or
                 misaligned, or if values are non-numeric or non-finite.
-            numpy.linalg.LinAlgError: If the covariance factorization fails.
+            numpy.linalg.LinAlgError: If an iterative solve fails.
         """
         ...
 
@@ -106,13 +117,15 @@ class SeparableExponentialCovariance:
         correlation_length: Shared fallback correlation length in degrees.
         latitude_correlation_length: Optional latitude-specific length in degrees.
         longitude_correlation_length: Optional longitude-specific length in degrees.
+        class_labels: Optional native-grid labels defining spatial covariance
+            blocks. Cells with different labels have zero cross-covariance.
 
     Notes:
-        Construction copies and owns the two small coordinate vectors because
-        cached covariance factors depend on them. Coordinate properties return
-        borrowed arrays; callers must not mutate them in place. Configuration
-        properties are read-only. Instances are ordinary slotted objects with
-        identity-based equality and hashing.
+        Construction copies and owns the two small coordinate vectors and any
+        class labels because cached factors and masks depend on them. Array
+        properties return borrowed values; callers must not mutate them in
+        place. Configuration properties are read-only. Instances are ordinary
+        slotted objects with identity-based equality and hashing.
 
     Raises:
         ValueError: If coordinates, units, or covariance parameters are invalid.
@@ -121,6 +134,8 @@ class SeparableExponentialCovariance:
     """
 
     __slots__ = (
+        "_class_labels",
+        "_class_masks",
         "_correlation_length",
         "_latitude",
         "_latitude_cholesky",
@@ -135,6 +150,9 @@ class SeparableExponentialCovariance:
         "_sigma",
     )
 
+    schema = "openghg_inversions.separable_exponential_covariance"
+    schema_version = 1
+
     def __init__(
         self,
         latitude: xr.DataArray | None = None,
@@ -143,20 +161,28 @@ class SeparableExponentialCovariance:
         correlation_length: float = 1.5,
         latitude_correlation_length: float | None = None,
         longitude_correlation_length: float | None = None,
+        class_labels: xr.DataArray | None = None,
     ) -> None:
         """Validate constructor inputs and cache factors used by the actions.
 
-        Coordinates are copied once. The resolved covariance parameters,
-        separable factors, and Cholesky factors become owned eager state.
+        Coordinates and class labels are copied once. The resolved covariance
+        parameters, separable factors, Cholesky factors, and class masks become
+        owned eager state.
 
         Raises:
-            ValueError: If coordinates, units, or covariance parameters are
-                invalid.
+            ValueError: If coordinates, units, covariance parameters, or class
+                labels are invalid.
         """
         latitude = _validate_coordinate(latitude, "latitude")
         longitude = _validate_coordinate(longitude, "longitude")
         if latitude.dims[0] == longitude.dims[0]:
             raise ValueError("latitude and longitude must use distinct dimension names")
+        reserved_dims = _NATIVE_SERIALIZED_VARIABLE_NAMES.intersection(
+            (str(latitude.dims[0]), str(longitude.dims[0]))
+        )
+        if reserved_dims:
+            reserved = sorted(reserved_dims)[0]
+            raise ValueError(f"native dimension {reserved!r} is reserved by the serialized schema")
         sigma = _positive_finite(sigma, "sigma")
         length = _positive_finite(correlation_length, "correlation_length")
         latitude_override = (
@@ -174,6 +200,7 @@ class SeparableExponentialCovariance:
 
         latitude_factor = _exponential_factor(latitude.values, latitude_length)
         longitude_factor = _exponential_factor(longitude.values, longitude_length)
+        class_labels, class_masks = _validate_class_labels(class_labels, latitude, longitude)
         self._latitude = latitude
         self._longitude = longitude
         self._sigma = sigma
@@ -186,6 +213,8 @@ class SeparableExponentialCovariance:
         self._longitude_factor = longitude_factor
         self._latitude_cholesky = cho_factor(latitude_factor, lower=True)
         self._longitude_cholesky = cho_factor(longitude_factor, lower=True)
+        self._class_labels = class_labels
+        self._class_masks = class_masks
 
     @property
     def latitude(self) -> BorrowedDataArray:
@@ -218,6 +247,22 @@ class SeparableExponentialCovariance:
         return self._longitude_correlation_length
 
     @property
+    def latitude_correlation_length_explicit(self) -> bool:
+        """Whether the latitude length was configured independently."""
+        return self._latitude_correlation_length_override is not None
+
+    @property
+    def longitude_correlation_length_explicit(self) -> bool:
+        """Whether the longitude length was configured independently."""
+        return self._longitude_correlation_length_override is not None
+
+    @property
+    def class_labels(self) -> BorrowedDataArray | None:
+        """Borrow the owned class labels, if any; in-place mutation is unsupported."""
+        labels = self._class_labels
+        return None if labels is None else borrow(labels)
+
+    @property
     def native_dims(self) -> tuple[str, str]:
         """Latitude and longitude dimension names in vectorisation order."""
         return (str(self._latitude.dims[0]), str(self._longitude.dims[0]))
@@ -241,13 +286,15 @@ class SeparableExponentialCovariance:
                 misaligned, or if values are non-numeric or non-finite.
         """
         matrix, original_dims, rhs_dims = self._validated_matrix(rhs)
-        applied = self._apply_separable(matrix)
+        applied = self._apply_matrix(matrix)
         return self._restore(applied, rhs, original_dims, rhs_dims)
 
     def solve(self, rhs: xr.DataArray) -> xr.DataArray:
         """Solve ``B result = rhs`` without constructing the native matrix.
 
-        The separable solve uses one-dimensional Cholesky factors.
+        The separable case uses one-dimensional Cholesky factors. A covariance
+        with multiple classes uses conjugate gradients with a matrix-free
+        blocked covariance action.
 
         Args:
             rhs: Array containing both native dimensions and any number of
@@ -260,10 +307,152 @@ class SeparableExponentialCovariance:
             TypeError: If ``rhs`` is not an xarray data array.
             ValueError: If native dimensions or coordinates are missing or
                 misaligned, or if values are non-numeric or non-finite.
+            numpy.linalg.LinAlgError: If a class-blocked iterative solve does
+                not converge.
         """
         matrix, original_dims, rhs_dims = self._validated_matrix(rhs)
-        solved = self._solve_separable(matrix)
+        if len(self._class_masks) <= 1:
+            solved = self._solve_separable(matrix)
+        else:
+            solved = self._solve_class_blocked(matrix)
         return self._restore(solved, rhs, original_dims, rhs_dims)
+
+    def to_dataset(self) -> xr.Dataset:
+        """Serialize reproducible coordinates and resolved configuration.
+
+        Returns:
+            A versioned dataset containing the native coordinates, resolved
+            covariance parameters, and optional class labels. Boolean blocked
+            state is represented as a NetCDF-safe ``0`` or ``1`` attribute.
+        """
+        dataset = xr.Dataset(
+            coords={
+                self.native_dims[0]: self._latitude.copy(deep=True),
+                self.native_dims[1]: self._longitude.copy(deep=True),
+            },
+            attrs={
+                "schema": self.schema,
+                "schema_version": self.schema_version,
+                "latitude_dim": self.native_dims[0],
+                "longitude_dim": self.native_dims[1],
+                "sigma": self.sigma,
+                "correlation_length_degrees": self.correlation_length,
+                "latitude_correlation_length_degrees": self.latitude_correlation_length,
+                "longitude_correlation_length_degrees": self.longitude_correlation_length,
+                "latitude_correlation_length_explicit": int(self.latitude_correlation_length_explicit),
+                "longitude_correlation_length_explicit": int(self.longitude_correlation_length_explicit),
+                "class_blocked": int(self._class_labels is not None),
+                "class_label_encoding": "tagged_json_v1" if self._class_labels is not None else "",
+                "class_labels_name": ""
+                if self._class_labels is None or self._class_labels.name is None
+                else str(self._class_labels.name),
+                "class_labels_attrs": "{}"
+                if self._class_labels is None
+                else json.dumps(self._class_labels.attrs, sort_keys=True, default=_json_default),
+            },
+        )
+        if self._class_labels is not None:
+            encoded = np.frompyfunc(_encode_class_label, 1, 1)(self._class_labels.values)
+            dataset["class_label_encoded"] = self._class_labels.copy(data=np.asarray(encoded, dtype=str))
+        return dataset
+
+    @classmethod
+    def from_dataset(cls, dataset: xr.Dataset) -> SeparableExponentialCovariance:
+        """Restore a covariance action from :meth:`to_dataset` output.
+
+        Args:
+            dataset: Versioned covariance configuration dataset.
+
+        Returns:
+            Reconstructed covariance action.
+
+        Raises:
+            ValueError: If the schema or version is unsupported, required
+                coordinates are missing, or serialized constructor values are
+                invalid.
+            KeyError: If a required covariance parameter attribute is missing.
+        """
+        if dataset.attrs.get("schema") != cls.schema:
+            raise ValueError(f"Expected covariance schema {cls.schema!r}")
+        if dataset.attrs.get("schema_version") != cls.schema_version:
+            raise ValueError(f"Unsupported covariance schema version {dataset.attrs.get('schema_version')!r}")
+        lat_dim = str(dataset.attrs.get("latitude_dim", ""))
+        lon_dim = str(dataset.attrs.get("longitude_dim", ""))
+        if lat_dim not in dataset.coords or lon_dim not in dataset.coords:
+            raise ValueError("Serialized covariance is missing latitude or longitude coordinates")
+        try:
+            latitude_length_explicit = _serialized_boolean(
+                dataset.attrs["latitude_correlation_length_explicit"],
+                "latitude_correlation_length_explicit",
+            )
+            longitude_length_explicit = _serialized_boolean(
+                dataset.attrs["longitude_correlation_length_explicit"],
+                "longitude_correlation_length_explicit",
+            )
+        except KeyError as error:
+            raise ValueError("Serialized covariance has invalid correlation-length metadata") from error
+        try:
+            class_blocked = _serialized_boolean(dataset.attrs["class_blocked"], "class_blocked")
+        except KeyError as error:
+            raise ValueError("Serialized covariance has an invalid class_blocked flag") from error
+        correlation_length = _positive_finite(
+            float(dataset.attrs["correlation_length_degrees"]),
+            "serialized correlation_length_degrees",
+        )
+        latitude_length = _positive_finite(
+            float(dataset.attrs["latitude_correlation_length_degrees"]),
+            "serialized latitude_correlation_length_degrees",
+        )
+        longitude_length = _positive_finite(
+            float(dataset.attrs["longitude_correlation_length_degrees"]),
+            "serialized longitude_correlation_length_degrees",
+        )
+        if not latitude_length_explicit and latitude_length != correlation_length:
+            raise ValueError("Serialized implicit latitude correlation length contradicts the fallback")
+        if not longitude_length_explicit and longitude_length != correlation_length:
+            raise ValueError("Serialized implicit longitude correlation length contradicts the fallback")
+        has_class_labels = "class_label_encoded" in dataset
+        if class_blocked != has_class_labels:
+            raise ValueError("Serialized class_blocked flag contradicts class-label data")
+        class_labels = None
+        if class_blocked:
+            if dataset.attrs.get("class_label_encoding") != "tagged_json_v1":
+                raise ValueError("Unsupported covariance class-label encoding")
+            encoded = dataset["class_label_encoded"]
+            decoded = np.frompyfunc(_decode_class_label, 1, 1)(encoded.values)
+            serialized_name = str(dataset.attrs.get("class_labels_name", ""))
+            try:
+                serialized_attrs = json.loads(str(dataset.attrs.get("class_labels_attrs", "{}")))
+            except json.JSONDecodeError as error:
+                raise ValueError("Serialized covariance has invalid class-label attributes") from error
+            class_labels = encoded.copy(data=decoded).rename(serialized_name or None)
+            class_labels.attrs = serialized_attrs
+        return cls(
+            latitude=dataset.coords[lat_dim],
+            longitude=dataset.coords[lon_dim],
+            sigma=float(dataset.attrs["sigma"]),
+            correlation_length=correlation_length,
+            latitude_correlation_length=latitude_length if latitude_length_explicit else None,
+            longitude_correlation_length=longitude_length if longitude_length_explicit else None,
+            class_labels=class_labels,
+        )
+
+    def _apply_matrix(self, matrix: np.ndarray) -> np.ndarray:
+        """Apply the configured covariance to native-first right-hand sides.
+
+        Args:
+            matrix: Eager array shaped ``(latitude, longitude, rhs)``.
+
+        Returns:
+            Covariance-applied values with the same shape as ``matrix``.
+        """
+        if not self._class_masks:
+            return self._apply_separable(matrix)
+        result = np.zeros_like(matrix, dtype=np.result_type(matrix.dtype, np.float64))
+        for mask in self._class_masks:
+            masked = matrix * mask[..., np.newaxis]
+            result += self._apply_separable(masked) * mask[..., np.newaxis]
+        return result
 
     def _apply_separable(self, matrix: np.ndarray) -> np.ndarray:
         """Apply the two one-dimensional covariance factors.
@@ -279,7 +468,7 @@ class SeparableExponentialCovariance:
         return applied * self.sigma**2
 
     def _solve_separable(self, matrix: np.ndarray) -> np.ndarray:
-        """Solve the separable system using Cholesky factors.
+        """Solve the unblocked separable system using Cholesky factors.
 
         Args:
             matrix: Eager array shaped ``(latitude, longitude, rhs)``.
@@ -303,6 +492,47 @@ class SeparableExponentialCovariance:
             .transpose(1, 0, 2)
         )
         return longitude_solved / self.sigma**2
+
+    def _solve_class_blocked(self, matrix: np.ndarray) -> np.ndarray:
+        """Solve a class-blocked system with matrix-free conjugate gradients.
+
+        Args:
+            matrix: Eager array shaped ``(latitude, longitude, rhs)``.
+
+        Returns:
+            Solved values with the same shape as ``matrix``.
+
+        Raises:
+            numpy.linalg.LinAlgError: If conjugate gradients do not converge or
+                fail because of invalid input or numerical breakdown.
+        """
+        n_lat, n_lon, n_rhs = matrix.shape
+        native_size = n_lat * n_lon
+
+        def matvec(vector: np.ndarray) -> np.ndarray:
+            """Apply the blocked covariance to one flattened right-hand side."""
+            native = vector.reshape(n_lat, n_lon, 1)
+            return self._apply_matrix(native).reshape(native_size)
+
+        operator = LinearOperator(
+            (native_size, native_size),
+            matvec,
+        )
+        solved = np.empty_like(matrix, dtype=np.result_type(matrix.dtype, np.float64))
+        cg_function = cast(Callable[..., tuple[np.ndarray, int]], cg)
+        for rhs_index in range(n_rhs):
+            solution, info = cg_function(
+                operator,
+                matrix[..., rhs_index].reshape(native_size),
+                atol=0.0,
+                maxiter=max(100, 10 * native_size),
+                **{_CG_RELATIVE_TOLERANCE: 1e-12},
+            )
+            if info != 0:
+                reason = "did not converge" if info > 0 else "failed with an illegal input or breakdown"
+                raise np.linalg.LinAlgError(f"Class-blocked covariance solve {reason} (CG info={info})")
+            solved[..., rhs_index] = solution.reshape(n_lat, n_lon)
+        return solved
 
     def _validated_matrix(self, rhs: xr.DataArray) -> tuple[np.ndarray, tuple[str, ...], tuple[str, ...]]:
         """Validate and eagerly reshape a labelled right-hand side.
@@ -424,6 +654,123 @@ def _validate_coordinate(coordinate: xr.DataArray | None, axis_name: str) -> xr.
     if units not in allowed_units:
         raise ValueError(f"{axis_name} coordinate units must be degrees, got {units!r}")
     return coordinate
+
+
+def _validate_class_labels(
+    class_labels: xr.DataArray | None,
+    latitude: xr.DataArray,
+    longitude: xr.DataArray,
+) -> tuple[xr.DataArray | None, tuple[np.ndarray, ...]]:
+    """Validate class labels and construct boolean masks in native-grid order.
+
+    Args:
+        class_labels: Optional array assigning every native grid cell to a class.
+        latitude: Validated latitude coordinate.
+        longitude: Validated longitude coordinate.
+
+    Returns:
+        One owned eager label array and one native-grid boolean mask per class.
+        The empty mask tuple denotes an unblocked covariance.
+
+    Raises:
+        ValueError: If dimensions, coordinates, or label values are invalid.
+    """
+    if class_labels is None:
+        return None, ()
+    if not isinstance(class_labels, xr.DataArray):
+        raise ValueError("class_labels must be an xarray.DataArray")
+
+    native_dims = (latitude.dims[0], longitude.dims[0])
+    if set(class_labels.dims) != set(native_dims) or class_labels.ndim != 2:
+        raise ValueError(f"class_labels must have exactly the native dimensions {native_dims!r}")
+    for dim, expected in zip(native_dims, (latitude, longitude), strict=True):
+        if dim not in class_labels.coords:
+            raise ValueError(f"class_labels is missing coordinate labels for native dimension {dim!r}")
+        actual = np.asarray(class_labels.coords[dim].data)
+        if actual.shape != expected.shape or not np.array_equal(actual, expected.data):
+            raise ValueError(f"class_labels coordinate {dim!r} does not align with the covariance grid")
+    labels = class_labels.transpose(*native_dims).compute().copy(deep=True)
+    if bool(labels.isnull().any().item()):
+        raise ValueError("class_labels must assign a non-null class to every native grid cell")
+
+    values = np.asarray(labels.data)
+    unique_values: list[object] = []
+    for value in values.reshape(-1):
+        matches = [_scalar_label_equal(value, unique) for unique in unique_values]
+        if not any(matches):
+            unique_values.append(value)
+    masks = tuple(
+        np.fromiter(
+            (_scalar_label_equal(value, unique) for value in values.reshape(-1)),
+            dtype=bool,
+            count=values.size,
+        ).reshape(values.shape)
+        for unique in unique_values
+    )
+    return labels, masks
+
+
+def _scalar_label_equal(left: object, right: object) -> bool:
+    """Compare two class labels without NumPy broadcasting tuple values."""
+    try:
+        result = left == right
+    except (TypeError, ValueError) as error:
+        raise ValueError("class_labels values must be mutually comparable scalar labels") from error
+    if isinstance(result, (bool, np.bool_)):
+        return bool(result)
+    raise ValueError("class_labels values must be mutually comparable scalar labels")
+
+
+def _serialized_boolean(value: object, name: str) -> bool:
+    """Decode a serialized Boolean represented only by Boolean or integer 0/1."""
+    if isinstance(value, (bool, np.bool_)):
+        return bool(value)
+    if isinstance(value, (int, np.integer)) and int(value) in (0, 1):
+        return bool(value)
+    raise ValueError(f"Serialized {name} must be Boolean or integer 0/1")
+
+
+def _encode_class_label(value: object) -> str:
+    """Encode a supported scalar or nested tuple class label as tagged JSON."""
+    if isinstance(value, np.generic):
+        value = value.item()
+    payload: list[object]
+    if isinstance(value, tuple):
+        payload = ["tuple", [_encode_class_label(item) for item in value]]
+    elif isinstance(value, bool):
+        payload = ["bool", value]
+    elif isinstance(value, int):
+        payload = ["int", value]
+    elif isinstance(value, float):
+        payload = ["float", value]
+    elif isinstance(value, str):
+        payload = ["str", value]
+    else:
+        raise TypeError(f"Unsupported class-label type for serialization: {type(value).__name__}")
+    return json.dumps(payload, separators=(",", ":"))
+
+
+def _decode_class_label(encoded: str) -> object:
+    """Decode a class label produced by :func:`_encode_class_label`."""
+    kind, value = json.loads(str(encoded))
+    if kind == "tuple":
+        return tuple(_decode_class_label(item) for item in value)
+    if kind == "bool":
+        return bool(value)
+    if kind == "int":
+        return int(value)
+    if kind == "float":
+        return float(value)
+    if kind == "str":
+        return str(value)
+    raise ValueError(f"Unknown encoded class-label kind {kind!r}")
+
+
+def _json_default(value: object) -> object:
+    """Convert a NumPy scalar class-label attribute to a JSON scalar."""
+    if isinstance(value, np.generic):
+        return value.item()
+    raise TypeError(f"Class-label attr {value!r} is not JSON serializable")
 
 
 def _positive_finite(value: float, name: str) -> float:

--- a/openghg_inversions/native_covariance.py
+++ b/openghg_inversions/native_covariance.py
@@ -55,6 +55,13 @@ from scipy.sparse.linalg import LinearOperator, cg  # type: ignore[import-untype
 import xarray as xr
 
 from openghg_inversions.borrowed import BorrowedDataArray, borrow
+from openghg_inversions._serialization_codecs import (
+    _TAGGED_JSON_VALUE_ENCODING,
+    _decode_serialized_bool,
+    _decode_tagged_json_value,
+    _encode_tagged_json_value,
+    _numpy_scalar_json_default,
+)
 
 _CG_RELATIVE_TOLERANCE = "rtol" if "rtol" in inspect.signature(cg).parameters else "tol"
 _NATIVE_SERIALIZED_VARIABLE_NAMES = {"class_label_encoded"}
@@ -350,17 +357,21 @@ class SeparableExponentialCovariance:
                 "latitude_correlation_length_explicit": int(self.latitude_correlation_length_explicit),
                 "longitude_correlation_length_explicit": int(self.longitude_correlation_length_explicit),
                 "class_blocked": int(self._class_labels is not None),
-                "class_label_encoding": "tagged_json_v1" if self._class_labels is not None else "",
+                "class_label_encoding": _TAGGED_JSON_VALUE_ENCODING if self._class_labels is not None else "",
                 "class_labels_name": ""
                 if self._class_labels is None or self._class_labels.name is None
                 else str(self._class_labels.name),
                 "class_labels_attrs": "{}"
                 if self._class_labels is None
-                else json.dumps(self._class_labels.attrs, sort_keys=True, default=_json_default),
+                else json.dumps(
+                    self._class_labels.attrs,
+                    sort_keys=True,
+                    default=_numpy_scalar_json_default,
+                ),
             },
         )
         if self._class_labels is not None:
-            encoded = np.frompyfunc(_encode_class_label, 1, 1)(self._class_labels.values)
+            encoded = np.frompyfunc(_encode_tagged_json_value, 1, 1)(self._class_labels.values)
             dataset["class_label_encoded"] = self._class_labels.copy(data=np.asarray(encoded, dtype=str))
         return dataset
 
@@ -389,18 +400,18 @@ class SeparableExponentialCovariance:
         if lat_dim not in dataset.coords or lon_dim not in dataset.coords:
             raise ValueError("Serialized covariance is missing latitude or longitude coordinates")
         try:
-            latitude_length_explicit = _serialized_boolean(
+            latitude_length_explicit = _decode_serialized_bool(
                 dataset.attrs["latitude_correlation_length_explicit"],
                 "latitude_correlation_length_explicit",
             )
-            longitude_length_explicit = _serialized_boolean(
+            longitude_length_explicit = _decode_serialized_bool(
                 dataset.attrs["longitude_correlation_length_explicit"],
                 "longitude_correlation_length_explicit",
             )
         except KeyError as error:
             raise ValueError("Serialized covariance has invalid correlation-length metadata") from error
         try:
-            class_blocked = _serialized_boolean(dataset.attrs["class_blocked"], "class_blocked")
+            class_blocked = _decode_serialized_bool(dataset.attrs["class_blocked"], "class_blocked")
         except KeyError as error:
             raise ValueError("Serialized covariance has an invalid class_blocked flag") from error
         correlation_length = _positive_finite(
@@ -424,10 +435,10 @@ class SeparableExponentialCovariance:
             raise ValueError("Serialized class_blocked flag contradicts class-label data")
         class_labels = None
         if class_blocked:
-            if dataset.attrs.get("class_label_encoding") != "tagged_json_v1":
+            if dataset.attrs.get("class_label_encoding") != _TAGGED_JSON_VALUE_ENCODING:
                 raise ValueError("Unsupported covariance class-label encoding")
             encoded = dataset["class_label_encoded"]
-            decoded = np.frompyfunc(_decode_class_label, 1, 1)(encoded.values)
+            decoded = np.frompyfunc(_decode_tagged_json_value, 1, 1)(encoded.values)
             serialized_name = str(dataset.attrs.get("class_labels_name", ""))
             try:
                 serialized_attrs = json.loads(str(dataset.attrs.get("class_labels_attrs", "{}")))
@@ -727,58 +738,6 @@ def _scalar_label_equal(left: object, right: object) -> bool:
     if isinstance(result, (bool, np.bool_)):
         return bool(result)
     raise ValueError("class_labels values must be mutually comparable scalar labels")
-
-
-def _serialized_boolean(value: object, name: str) -> bool:
-    """Decode a serialized Boolean represented only by Boolean or integer 0/1."""
-    if isinstance(value, (bool, np.bool_)):
-        return bool(value)
-    if isinstance(value, (int, np.integer)) and int(value) in (0, 1):
-        return bool(value)
-    raise ValueError(f"Serialized {name} must be Boolean or integer 0/1")
-
-
-def _encode_class_label(value: object) -> str:
-    """Encode a supported scalar or nested tuple class label as tagged JSON."""
-    if isinstance(value, np.generic):
-        value = value.item()
-    payload: list[object]
-    if isinstance(value, tuple):
-        payload = ["tuple", [_encode_class_label(item) for item in value]]
-    elif isinstance(value, bool):
-        payload = ["bool", value]
-    elif isinstance(value, int):
-        payload = ["int", value]
-    elif isinstance(value, float):
-        payload = ["float", value]
-    elif isinstance(value, str):
-        payload = ["str", value]
-    else:
-        raise TypeError(f"Unsupported class-label type for serialization: {type(value).__name__}")
-    return json.dumps(payload, separators=(",", ":"))
-
-
-def _decode_class_label(encoded: str) -> object:
-    """Decode a class label produced by :func:`_encode_class_label`."""
-    kind, value = json.loads(str(encoded))
-    if kind == "tuple":
-        return tuple(_decode_class_label(item) for item in value)
-    if kind == "bool":
-        return bool(value)
-    if kind == "int":
-        return int(value)
-    if kind == "float":
-        return float(value)
-    if kind == "str":
-        return str(value)
-    raise ValueError(f"Unknown encoded class-label kind {kind!r}")
-
-
-def _json_default(value: object) -> object:
-    """Convert a NumPy scalar class-label attribute to a JSON scalar."""
-    if isinstance(value, np.generic):
-        return value.item()
-    raise TypeError(f"Class-label attr {value!r} is not JSON serializable")
 
 
 def _positive_finite(value: float, name: str) -> float:

--- a/openghg_inversions/source_covariance.py
+++ b/openghg_inversions/source_covariance.py
@@ -1,0 +1,566 @@
+"""Compose labelled native covariance actions into independent source blocks.
+
+The multisource covariance represented here is block diagonal by source. Each
+configured source owns a
+:class:`~openghg_inversions.native_covariance.SeparableExponentialCovariance`
+on the same labelled spatial grid, while amplitudes, correlation lengths, and
+optional class masks may differ by source. Applying or solving the composite
+action dispatches to each source block independently, preserves all labelled
+right-hand-side dimensions, and never constructs a dense cross-source matrix.
+
+Source labels are non-empty strings whose insertion order defines the canonical
+block order. Input arrays must carry exactly those string labels in that order;
+values are not coerced between types. The leading native source dimension
+defaults to ``"native_source"``. This is intentionally distinct from the
+``"source"`` level on OGI's gathered retained-state MultiIndex because xarray
+cannot represent a dimension and a MultiIndex level with the same name in one
+prolongation array.
+
+:class:`IndependentSourceCovariance` can serialize its complete reproducible
+configuration, including typed class labels, to an xarray dataset. Restoration
+validates the schema, source labels, required variables, and spatial coordinate
+metadata before reconstructing the component actions.
+
+``IndependentSourceCovariance`` is an ordinary slotted, identity-based action.
+It copies the source mapping once and exposes it through a read-only proxy;
+component actions and their borrowed coordinate properties are not copied on
+ordinary access.
+"""
+
+from __future__ import annotations
+
+import json
+from types import MappingProxyType
+from typing import Literal, Mapping, SupportsFloat
+
+import numpy as np
+import xarray as xr
+
+from openghg_inversions.native_covariance import SeparableExponentialCovariance
+
+__all__ = ["IndependentSourceCovariance"]
+
+_SERIALIZED_VARIABLE_NAMES = {
+    "sigma",
+    "correlation_length",
+    "latitude_correlation_length",
+    "longitude_correlation_length",
+    "latitude_correlation_length_explicit",
+    "longitude_correlation_length_explicit",
+    "class_blocked",
+    "class_label_encoded",
+    "class_label_name",
+    "class_label_attrs",
+}
+
+
+class IndependentSourceCovariance:
+    """Block-diagonal native covariance over an ordered source mapping.
+
+    Args:
+        source_covariances: Non-empty insertion-ordered mapping from source
+            labels to separable spatial covariance actions on the same grid.
+        source_dim: Explicit native source dimension. It should not collide
+            with a level name on the retained state MultiIndex.
+
+    Raises:
+        TypeError: If a source block is not a
+            :class:`SeparableExponentialCovariance` or the source mapping cannot
+            be copied.
+        ValueError: If the mapping is empty, source labels or ``source_dim``
+            are invalid, or block spatial dimensions or grids differ.
+
+    Notes:
+        The source mapping and source-dimension properties are read-only.
+        Changed configuration requires explicit reconstruction.
+    """
+
+    __slots__ = ("_source_covariances", "_source_dim", "_source_labels")
+
+    schema = "openghg_inversions.independent_source_covariance"
+    schema_version = 1
+
+    def __init__(
+        self,
+        source_covariances: Mapping[str, SeparableExponentialCovariance],
+        source_dim: str = "native_source",
+    ) -> None:
+        """Validate source blocks and retain their canonical insertion order.
+
+        The complete block mapping is type-checked before any block attributes
+        are inspected. The validated copy is exposed through a read-only
+        mapping proxy so later mutations of the caller's mapping cannot change
+        the covariance configuration.
+
+        Raises:
+            TypeError: If ``source_covariances`` cannot be copied into a
+                mapping or any block is not a
+                :class:`SeparableExponentialCovariance`.
+            ValueError: If no blocks are supplied, source labels or
+                ``source_dim`` are invalid, or blocks do not share identical
+                labelled spatial grids.
+        """
+        covariances = dict(source_covariances)
+        if not covariances:
+            raise ValueError("source_covariances must contain at least one source block")
+        if not isinstance(source_dim, str) or not source_dim:
+            raise ValueError("source_dim must be a non-empty string")
+        if source_dim in _SERIALIZED_VARIABLE_NAMES:
+            raise ValueError(f"source_dim {source_dim!r} is reserved by the serialized schema")
+        if any(not isinstance(label, str) or not label for label in covariances):
+            raise ValueError("source covariance labels must be non-empty strings")
+        for label, covariance in covariances.items():
+            if not isinstance(covariance, SeparableExponentialCovariance):
+                raise TypeError(f"Source {label!r} must use SeparableExponentialCovariance")
+
+        reference = next(iter(covariances.values()))
+        if source_dim in reference.native_dims:
+            raise ValueError("source_dim must be distinct from the spatial native dimensions")
+        reserved_spatial_dims = _SERIALIZED_VARIABLE_NAMES.intersection(reference.native_dims)
+        if reserved_spatial_dims:
+            reserved = sorted(reserved_spatial_dims)[0]
+            raise ValueError(f"spatial dimension {reserved!r} is reserved by the serialized schema")
+        for label, covariance in covariances.items():
+            if covariance.native_dims != reference.native_dims:
+                raise ValueError("All source covariance blocks must use the same spatial dimensions")
+            for dim, expected, actual in zip(
+                reference.native_dims,
+                (reference.latitude, reference.longitude),
+                (covariance.latitude, covariance.longitude),
+                strict=True,
+            ):
+                if not expected.identical(actual):
+                    raise ValueError(f"Source {label!r} covariance grid differs on {dim!r}")
+        self._source_covariances = MappingProxyType(covariances)
+        self._source_dim = source_dim
+        self._source_labels = tuple(covariances)
+
+    @property
+    def source_covariances(self) -> Mapping[str, SeparableExponentialCovariance]:
+        """Return the read-only source-to-covariance mapping."""
+        return self._source_covariances
+
+    @property
+    def source_dim(self) -> str:
+        """Return the read-only native source dimension name."""
+        return self._source_dim
+
+    @property
+    def source_labels(self) -> tuple[str, ...]:
+        """Return configured source labels in canonical insertion order.
+
+        Returns:
+            Source labels defining the block order.
+        """
+        return self._source_labels
+
+    @property
+    def native_dims(self) -> tuple[str, ...]:
+        """Return the source dimension followed by common spatial dimensions.
+
+        Returns:
+            Native dimensions in vectorisation order.
+        """
+        first = self.source_covariances[self.source_labels[0]]
+        return (self.source_dim, *first.native_dims)
+
+    def apply(self, rhs: xr.DataArray) -> xr.DataArray:
+        """Apply independent source covariance blocks to labelled RHS arrays.
+
+        Args:
+            rhs: Array containing the exact source and spatial native labels;
+                all other right-hand-side dimensions are preserved.
+
+        Returns:
+            Blockwise ``B rhs`` in the original dimension order.
+
+        Raises:
+            TypeError: If ``rhs`` is not an xarray data array.
+            ValueError: If source or spatial dimensions, coordinates, labels,
+                or numerical values are missing or invalid.
+        """
+        return self._operate(rhs, operation="apply")
+
+    def solve(self, rhs: xr.DataArray) -> xr.DataArray:
+        """Solve independent source covariance blocks for labelled RHS arrays.
+
+        Args:
+            rhs: Array containing the exact source and spatial native labels;
+                all other right-hand-side dimensions are preserved.
+
+        Returns:
+            Blockwise ``B^-1 rhs`` in the original dimension order.
+
+        Raises:
+            TypeError: If ``rhs`` is not an xarray data array.
+            ValueError: If source or spatial dimensions, coordinates, labels,
+                or numerical values are missing or invalid.
+            numpy.linalg.LinAlgError: If a class-blocked component solve does
+                not converge.
+        """
+        return self._operate(rhs, operation="solve")
+
+    def to_dataset(self) -> xr.Dataset:
+        """Serialize source order and reproducible component configuration.
+
+        Returns:
+            Versioned dataset containing source-specific covariance parameters,
+            independent eager copies of the common spatial coordinates, and
+            any encoded class labels. The returned dataset may be mutated
+            without changing component actions.
+
+        Raises:
+            TypeError: If a class label or class-label attribute cannot be
+                represented by the tagged JSON encoding.
+        """
+        first = self.source_covariances[self.source_labels[0]]
+        latitude = first.latitude.copy(deep=True)
+        longitude = first.longitude.copy(deep=True)
+        source = xr.IndexVariable(self.source_dim, list(self.source_labels))
+        sigma = xr.DataArray(
+            [self.source_covariances[label].sigma for label in self.source_labels],
+            dims=self.source_dim,
+            coords={self.source_dim: source},
+        )
+        correlation_length = xr.DataArray(
+            [self.source_covariances[label].correlation_length for label in self.source_labels],
+            dims=self.source_dim,
+            coords={self.source_dim: source},
+        )
+        latitude_correlation_length = xr.DataArray(
+            [self.source_covariances[label].latitude_correlation_length for label in self.source_labels],
+            dims=self.source_dim,
+            coords={self.source_dim: source},
+        )
+        longitude_correlation_length = xr.DataArray(
+            [self.source_covariances[label].longitude_correlation_length for label in self.source_labels],
+            dims=self.source_dim,
+            coords={self.source_dim: source},
+        )
+        latitude_correlation_length_explicit = xr.DataArray(
+            [
+                self.source_covariances[label].latitude_correlation_length_explicit
+                for label in self.source_labels
+            ],
+            dims=self.source_dim,
+            coords={self.source_dim: source},
+        )
+        longitude_correlation_length_explicit = xr.DataArray(
+            [
+                self.source_covariances[label].longitude_correlation_length_explicit
+                for label in self.source_labels
+            ],
+            dims=self.source_dim,
+            coords={self.source_dim: source},
+        )
+        blocked = xr.DataArray(
+            [self.source_covariances[label].class_labels is not None for label in self.source_labels],
+            dims=self.source_dim,
+            coords={self.source_dim: source},
+        )
+        label_values = np.full(
+            (len(self.source_labels), first.latitude.size, first.longitude.size),
+            "",
+            dtype=object,
+        )
+        label_names: list[str] = []
+        label_attrs: list[str] = []
+        for index, label in enumerate(self.source_labels):
+            class_labels = self.source_covariances[label].class_labels
+            if class_labels is not None:
+                values = class_labels.transpose(*first.native_dims).values
+                label_values[index] = np.vectorize(_encode_class_label, otypes=[object])(values)
+                label_names.append(str(class_labels.name) if class_labels.name is not None else "")
+                label_attrs.append(json.dumps(class_labels.attrs, sort_keys=True, default=_json_default))
+            else:
+                label_names.append("")
+                label_attrs.append("{}")
+        return xr.Dataset(
+            {
+                "sigma": sigma,
+                "correlation_length": correlation_length,
+                "latitude_correlation_length": latitude_correlation_length,
+                "longitude_correlation_length": longitude_correlation_length,
+                "latitude_correlation_length_explicit": latitude_correlation_length_explicit,
+                "longitude_correlation_length_explicit": longitude_correlation_length_explicit,
+                "class_blocked": blocked,
+                "class_label_encoded": xr.DataArray(
+                    label_values,
+                    dims=(self.source_dim, *first.native_dims),
+                    coords={
+                        self.source_dim: source,
+                        first.native_dims[0]: latitude,
+                        first.native_dims[1]: longitude,
+                    },
+                ),
+                "class_label_name": xr.DataArray(
+                    label_names,
+                    dims=self.source_dim,
+                    coords={self.source_dim: source},
+                ),
+                "class_label_attrs": xr.DataArray(
+                    label_attrs,
+                    dims=self.source_dim,
+                    coords={self.source_dim: source},
+                ),
+            },
+            attrs={
+                "schema": self.schema,
+                "schema_version": self.schema_version,
+                "source_dim": self.source_dim,
+                "latitude_dim": first.native_dims[0],
+                "longitude_dim": first.native_dims[1],
+                "class_label_encoding": "tagged_json_v1",
+            },
+        )
+
+    @classmethod
+    def from_dataset(cls, dataset: xr.Dataset) -> IndependentSourceCovariance:
+        """Restore source blocks from :meth:`to_dataset` output.
+
+        Args:
+            dataset: Versioned independent-source covariance dataset.
+
+        Returns:
+            Reconstructed source-block covariance action with class-label
+            values, name, and JSON-compatible attributes restored.
+
+        Raises:
+            ValueError: If schema metadata, source or spatial coordinates, or
+                required variables are absent or invalid, or encoded metadata
+                cannot be decoded.
+        """
+        if dataset.attrs.get("schema") != cls.schema:
+            raise ValueError(f"Expected source covariance schema {cls.schema!r}")
+        if dataset.attrs.get("schema_version") != cls.schema_version:
+            raise ValueError("Unsupported independent-source covariance schema version")
+        if dataset.attrs.get("class_label_encoding") != "tagged_json_v1":
+            raise ValueError("Unsupported independent-source class-label encoding")
+        source_dim = str(dataset.attrs.get("source_dim", ""))
+        latitude_dim = str(dataset.attrs.get("latitude_dim", ""))
+        longitude_dim = str(dataset.attrs.get("longitude_dim", ""))
+        required = {
+            "sigma",
+            "correlation_length",
+            "latitude_correlation_length",
+            "longitude_correlation_length",
+            "latitude_correlation_length_explicit",
+            "longitude_correlation_length_explicit",
+            "class_blocked",
+            "class_label_encoded",
+            "class_label_name",
+            "class_label_attrs",
+        }
+        missing = required.difference(dataset.data_vars)
+        spatial_coordinates_valid = (
+            bool(latitude_dim)
+            and bool(longitude_dim)
+            and latitude_dim != longitude_dim
+            and latitude_dim in dataset.coords
+            and longitude_dim in dataset.coords
+        )
+        if not source_dim or source_dim not in dataset.coords or missing:
+            raise ValueError(f"Serialized source covariance is missing labels or variables {sorted(missing)}")
+        if not spatial_coordinates_valid:
+            raise ValueError("Serialized source covariance is missing latitude or longitude coordinates")
+        raw_source_labels = dataset.coords[source_dim].values.tolist()
+        if any(not isinstance(label, str) or not label for label in raw_source_labels):
+            raise ValueError("Serialized source covariance labels must be non-empty strings")
+        covariances: dict[str, SeparableExponentialCovariance] = {}
+        for label in raw_source_labels:
+            labels = None
+            blocked = _serialized_boolean(
+                dataset["class_blocked"].sel({source_dim: label}).item(),
+                f"class_blocked flag for source {label!r}",
+            )
+            encoded = dataset["class_label_encoded"].sel({source_dim: label}, drop=True)
+            encoded_values = np.asarray(encoded.values, dtype=str)
+            has_encoded_labels = bool(np.any(encoded_values != ""))
+            if blocked != has_encoded_labels:
+                raise ValueError(
+                    f"Serialized class_blocked flag for source {label!r} contradicts encoded labels"
+                )
+            if blocked:
+                decoded = np.vectorize(_decode_class_label, otypes=[object])(encoded.values)
+                name = str(dataset["class_label_name"].sel({source_dim: label}).item()) or None
+                attrs = json.loads(str(dataset["class_label_attrs"].sel({source_dim: label}).item()))
+                labels = encoded.copy(data=decoded).rename(name).assign_attrs(attrs)
+            correlation_length = _positive_finite(
+                dataset["correlation_length"].sel({source_dim: label}).item(),
+                f"correlation length for source {label!r}",
+            )
+            latitude_length = _positive_finite(
+                dataset["latitude_correlation_length"].sel({source_dim: label}).item(),
+                f"latitude correlation length for source {label!r}",
+            )
+            longitude_length = _positive_finite(
+                dataset["longitude_correlation_length"].sel({source_dim: label}).item(),
+                f"longitude correlation length for source {label!r}",
+            )
+            latitude_explicit = _serialized_boolean(
+                dataset["latitude_correlation_length_explicit"].sel({source_dim: label}).item(),
+                f"latitude correlation-length flag for source {label!r}",
+            )
+            longitude_explicit = _serialized_boolean(
+                dataset["longitude_correlation_length_explicit"].sel({source_dim: label}).item(),
+                f"longitude correlation-length flag for source {label!r}",
+            )
+            if not latitude_explicit and latitude_length != correlation_length:
+                raise ValueError(
+                    f"Implicit latitude correlation length for source {label!r} contradicts the fallback"
+                )
+            if not longitude_explicit and longitude_length != correlation_length:
+                raise ValueError(
+                    f"Implicit longitude correlation length for source {label!r} contradicts the fallback"
+                )
+            covariances[label] = SeparableExponentialCovariance(
+                latitude=dataset.coords[latitude_dim],
+                longitude=dataset.coords[longitude_dim],
+                sigma=float(dataset["sigma"].sel({source_dim: label}).item()),
+                correlation_length=correlation_length,
+                latitude_correlation_length=latitude_length if latitude_explicit else None,
+                longitude_correlation_length=longitude_length if longitude_explicit else None,
+                class_labels=labels,
+            )
+        return cls(covariances, source_dim=source_dim)
+
+    def _operate(
+        self,
+        rhs: xr.DataArray,
+        *,
+        operation: Literal["apply", "solve"],
+    ) -> xr.DataArray:
+        """Validate labels and dispatch one covariance operation per source.
+
+        Args:
+            rhs: Candidate labelled right-hand side.
+            operation: Component method to invoke for every source block.
+
+        Returns:
+            Concatenated block results transposed to the input dimension order.
+
+        Raises:
+            TypeError: If ``rhs`` is not an xarray data array.
+            ValueError: If source or spatial labels are missing or do not
+                exactly match the configured labels, or values are invalid.
+            numpy.linalg.LinAlgError: If a requested class-blocked solve does
+                not converge.
+        """
+        if not isinstance(rhs, xr.DataArray):
+            raise TypeError("rhs must be an xarray.DataArray")
+        if self.source_dim not in rhs.dims or self.source_dim not in rhs.coords:
+            raise ValueError(f"rhs must contain labelled source dimension {self.source_dim!r}")
+        actual_labels = tuple(rhs.coords[self.source_dim].values.tolist())
+        if any(not isinstance(label, str) for label in actual_labels) or actual_labels != self.source_labels:
+            raise ValueError(
+                "rhs source labels/order do not match covariance configuration: "
+                f"{actual_labels!r} != {self.source_labels!r}"
+            )
+        original_dims = tuple(str(dim) for dim in rhs.dims)
+        results: list[xr.DataArray] = []
+        for label in self.source_labels:
+            source_rhs = rhs.sel({self.source_dim: label}, drop=True)
+            action = self.source_covariances[label]
+            results.append(getattr(action, operation)(source_rhs))
+        source_coordinate = xr.DataArray(
+            list(self.source_labels),
+            dims=self.source_dim,
+            coords={self.source_dim: list(self.source_labels)},
+            attrs=rhs.coords[self.source_dim].attrs,
+        )
+        combined = xr.concat(results, dim=source_coordinate)
+        combined = combined.assign_coords({name: coordinate for name, coordinate in rhs.coords.items()})
+        combined.name = rhs.name
+        combined.attrs = rhs.attrs
+        return combined.transpose(*original_dims)
+
+
+def _encode_class_label(value: object) -> str:
+    """Encode a class label without losing its supported Python scalar type.
+
+    Args:
+        value: String, Boolean, integer, float, NumPy scalar, or nested tuple
+            composed from those types.
+
+    Returns:
+        Tagged compact JSON representation of ``value``.
+
+    Raises:
+        TypeError: If ``value`` has an unsupported type.
+    """
+    if isinstance(value, np.generic):
+        value = value.item()
+    payload: list[object]
+    if isinstance(value, tuple):
+        payload = ["tuple", [_encode_class_label(item) for item in value]]
+    elif isinstance(value, bool):
+        payload = ["bool", value]
+    elif isinstance(value, int):
+        payload = ["int", value]
+    elif isinstance(value, float):
+        payload = ["float", value]
+    elif isinstance(value, str):
+        payload = ["str", value]
+    else:
+        raise TypeError(f"Unsupported class-label type for serialization: {type(value).__name__}")
+    return json.dumps(payload, separators=(",", ":"))
+
+
+def _decode_class_label(encoded: str) -> object:
+    """Decode one tagged JSON class label.
+
+    Args:
+        encoded: Tagged JSON produced by :func:`_encode_class_label`.
+
+    Returns:
+        Restored supported Python scalar or tuple value.
+
+    Raises:
+        ValueError: If the JSON is malformed or its type tag is unknown.
+    """
+    kind, value = json.loads(str(encoded))
+    if kind == "tuple":
+        return tuple(_decode_class_label(item) for item in value)
+    if kind == "bool":
+        return bool(value)
+    if kind == "int":
+        return int(value)
+    if kind == "float":
+        return float(value)
+    if kind == "str":
+        return str(value)
+    raise ValueError(f"Unknown encoded class-label kind {kind!r}")
+
+
+def _json_default(value: object) -> object:
+    """Convert a NumPy scalar attribute to a JSON-compatible scalar.
+
+    Args:
+        value: Attribute value rejected by JSON's standard encoder.
+
+    Returns:
+        Equivalent built-in Python scalar.
+
+    Raises:
+        TypeError: If ``value`` is not a NumPy scalar.
+    """
+    if isinstance(value, np.generic):
+        return value.item()
+    raise TypeError(f"Class-label attr {value!r} is not JSON serializable")
+
+
+def _positive_finite(value: SupportsFloat, name: str) -> float:
+    """Decode one serialized positive finite covariance parameter."""
+    resolved = float(value)
+    if not np.isfinite(resolved) or resolved <= 0.0:
+        raise ValueError(f"Serialized {name} must be finite and strictly positive")
+    return resolved
+
+
+def _serialized_boolean(value: object, name: str) -> bool:
+    """Decode a serialized Boolean represented only by Boolean or integer 0/1."""
+    if isinstance(value, (bool, np.bool_)):
+        return bool(value)
+    if isinstance(value, (int, np.integer)) and int(value) in (0, 1):
+        return bool(value)
+    raise ValueError(f"Serialized {name} must be Boolean or integer 0/1")

--- a/openghg_inversions/source_covariance.py
+++ b/openghg_inversions/source_covariance.py
@@ -21,6 +21,12 @@ configuration, including typed class labels, to an xarray dataset. Restoration
 validates the schema, source labels, required variables, and spatial coordinate
 metadata before reconstructing the component actions.
 
+Source dispatch intentionally uses eager per-source ``sel``, component
+operator, and ``concat`` calls. A source-only ``apply_ufunc`` or source
+chunking is not equivalent: each component consumes the full labelled spatial
+grid and owns an explicit eager NumPy boundary, rather than acting pointwise
+along a source vector.
+
 ``IndependentSourceCovariance`` is an ordinary slotted, identity-based action.
 It copies the source mapping once and exposes it through a read-only proxy;
 component actions and their borrowed coordinate properties are not copied on
@@ -37,6 +43,13 @@ import numpy as np
 import xarray as xr
 
 from openghg_inversions.native_covariance import SeparableExponentialCovariance
+from openghg_inversions._serialization_codecs import (
+    _TAGGED_JSON_VALUE_ENCODING,
+    _decode_serialized_bool,
+    _decode_tagged_json_value,
+    _encode_tagged_json_value,
+    _numpy_scalar_json_default,
+)
 
 __all__ = ["IndependentSourceCovariance"]
 
@@ -269,9 +282,15 @@ class IndependentSourceCovariance:
             class_labels = self.source_covariances[label].class_labels
             if class_labels is not None:
                 values = class_labels.transpose(*first.native_dims).values
-                label_values[index] = np.vectorize(_encode_class_label, otypes=[object])(values)
+                label_values[index] = np.vectorize(_encode_tagged_json_value, otypes=[object])(values)
                 label_names.append(str(class_labels.name) if class_labels.name is not None else "")
-                label_attrs.append(json.dumps(class_labels.attrs, sort_keys=True, default=_json_default))
+                label_attrs.append(
+                    json.dumps(
+                        class_labels.attrs,
+                        sort_keys=True,
+                        default=_numpy_scalar_json_default,
+                    )
+                )
             else:
                 label_names.append("")
                 label_attrs.append("{}")
@@ -310,7 +329,7 @@ class IndependentSourceCovariance:
                 "source_dim": self.source_dim,
                 "latitude_dim": first.native_dims[0],
                 "longitude_dim": first.native_dims[1],
-                "class_label_encoding": "tagged_json_v1",
+                "class_label_encoding": _TAGGED_JSON_VALUE_ENCODING,
             },
         )
 
@@ -334,7 +353,7 @@ class IndependentSourceCovariance:
             raise ValueError(f"Expected source covariance schema {cls.schema!r}")
         if dataset.attrs.get("schema_version") != cls.schema_version:
             raise ValueError("Unsupported independent-source covariance schema version")
-        if dataset.attrs.get("class_label_encoding") != "tagged_json_v1":
+        if dataset.attrs.get("class_label_encoding") != _TAGGED_JSON_VALUE_ENCODING:
             raise ValueError("Unsupported independent-source class-label encoding")
         source_dim = str(dataset.attrs.get("source_dim", ""))
         latitude_dim = str(dataset.attrs.get("latitude_dim", ""))
@@ -369,7 +388,7 @@ class IndependentSourceCovariance:
         covariances: dict[str, SeparableExponentialCovariance] = {}
         for label in raw_source_labels:
             labels = None
-            blocked = _serialized_boolean(
+            blocked = _decode_serialized_bool(
                 dataset["class_blocked"].sel({source_dim: label}).item(),
                 f"class_blocked flag for source {label!r}",
             )
@@ -381,7 +400,7 @@ class IndependentSourceCovariance:
                     f"Serialized class_blocked flag for source {label!r} contradicts encoded labels"
                 )
             if blocked:
-                decoded = np.vectorize(_decode_class_label, otypes=[object])(encoded.values)
+                decoded = np.vectorize(_decode_tagged_json_value, otypes=[object])(encoded.values)
                 name = str(dataset["class_label_name"].sel({source_dim: label}).item()) or None
                 attrs = json.loads(str(dataset["class_label_attrs"].sel({source_dim: label}).item()))
                 labels = encoded.copy(data=decoded).rename(name).assign_attrs(attrs)
@@ -397,11 +416,11 @@ class IndependentSourceCovariance:
                 dataset["longitude_correlation_length"].sel({source_dim: label}).item(),
                 f"longitude correlation length for source {label!r}",
             )
-            latitude_explicit = _serialized_boolean(
+            latitude_explicit = _decode_serialized_bool(
                 dataset["latitude_correlation_length_explicit"].sel({source_dim: label}).item(),
                 f"latitude correlation-length flag for source {label!r}",
             )
-            longitude_explicit = _serialized_boolean(
+            longitude_explicit = _decode_serialized_bool(
                 dataset["longitude_correlation_length_explicit"].sel({source_dim: label}).item(),
                 f"longitude correlation-length flag for source {label!r}",
             )
@@ -449,104 +468,31 @@ class IndependentSourceCovariance:
         if not isinstance(rhs, xr.DataArray):
             raise TypeError("rhs must be an xarray.DataArray")
         if self.source_dim not in rhs.dims or self.source_dim not in rhs.coords:
-            raise ValueError(f"rhs must contain labelled source dimension {self.source_dim!r}")
-        actual_labels = tuple(rhs.coords[self.source_dim].values.tolist())
-        if any(not isinstance(label, str) for label in actual_labels) or actual_labels != self.source_labels:
-            raise ValueError(
-                "rhs source labels/order do not match covariance configuration: "
-                f"{actual_labels!r} != {self.source_labels!r}"
-            )
-        original_dims = tuple(str(dim) for dim in rhs.dims)
-        results: list[xr.DataArray] = []
-        for label in self.source_labels:
-            source_rhs = rhs.sel({self.source_dim: label}, drop=True)
-            action = self.source_covariances[label]
-            results.append(getattr(action, operation)(source_rhs))
-        source_coordinate = xr.DataArray(
+            raise ValueError(f"rhs must contain labelled source dimension coordinate {self.source_dim!r}")
+        expected = xr.DataArray(
             list(self.source_labels),
             dims=self.source_dim,
             coords={self.source_dim: list(self.source_labels)},
-            attrs=rhs.coords[self.source_dim].attrs,
         )
-        combined = xr.concat(results, dim=source_coordinate)
-        combined = combined.assign_coords({name: coordinate for name, coordinate in rhs.coords.items()})
-        combined.name = rhs.name
-        combined.attrs = rhs.attrs
-        return combined.transpose(*original_dims)
+        try:
+            aligned_rhs, _ = xr.align(rhs, expected, join="exact", copy=False)
+        except xr.AlignmentError as error:
+            raise ValueError("rhs source labels/order do not match covariance configuration") from error
 
-
-def _encode_class_label(value: object) -> str:
-    """Encode a class label without losing its supported Python scalar type.
-
-    Args:
-        value: String, Boolean, integer, float, NumPy scalar, or nested tuple
-            composed from those types.
-
-    Returns:
-        Tagged compact JSON representation of ``value``.
-
-    Raises:
-        TypeError: If ``value`` has an unsupported type.
-    """
-    if isinstance(value, np.generic):
-        value = value.item()
-    payload: list[object]
-    if isinstance(value, tuple):
-        payload = ["tuple", [_encode_class_label(item) for item in value]]
-    elif isinstance(value, bool):
-        payload = ["bool", value]
-    elif isinstance(value, int):
-        payload = ["int", value]
-    elif isinstance(value, float):
-        payload = ["float", value]
-    elif isinstance(value, str):
-        payload = ["str", value]
-    else:
-        raise TypeError(f"Unsupported class-label type for serialization: {type(value).__name__}")
-    return json.dumps(payload, separators=(",", ":"))
-
-
-def _decode_class_label(encoded: str) -> object:
-    """Decode one tagged JSON class label.
-
-    Args:
-        encoded: Tagged JSON produced by :func:`_encode_class_label`.
-
-    Returns:
-        Restored supported Python scalar or tuple value.
-
-    Raises:
-        ValueError: If the JSON is malformed or its type tag is unknown.
-    """
-    kind, value = json.loads(str(encoded))
-    if kind == "tuple":
-        return tuple(_decode_class_label(item) for item in value)
-    if kind == "bool":
-        return bool(value)
-    if kind == "int":
-        return int(value)
-    if kind == "float":
-        return float(value)
-    if kind == "str":
-        return str(value)
-    raise ValueError(f"Unknown encoded class-label kind {kind!r}")
-
-
-def _json_default(value: object) -> object:
-    """Convert a NumPy scalar attribute to a JSON-compatible scalar.
-
-    Args:
-        value: Attribute value rejected by JSON's standard encoder.
-
-    Returns:
-        Equivalent built-in Python scalar.
-
-    Raises:
-        TypeError: If ``value`` is not a NumPy scalar.
-    """
-    if isinstance(value, np.generic):
-        return value.item()
-    raise TypeError(f"Class-label attr {value!r} is not JSON serializable")
+        original_dims = tuple(str(dim) for dim in rhs.dims)
+        results: list[xr.DataArray] = []
+        for label in self.source_labels:
+            source_rhs = aligned_rhs.sel({self.source_dim: label})
+            action = self.source_covariances[label]
+            results.append(getattr(action, operation)(source_rhs))
+        combined = xr.concat(
+            results,
+            dim=aligned_rhs.coords[self.source_dim],
+            coords="minimal",
+            compat="override",
+        )
+        restored_data = combined.transpose(*original_dims, transpose_coords=False).data
+        return rhs.copy(data=restored_data, deep=False)
 
 
 def _positive_finite(value: SupportsFloat, name: str) -> float:
@@ -555,12 +501,3 @@ def _positive_finite(value: SupportsFloat, name: str) -> float:
     if not np.isfinite(resolved) or resolved <= 0.0:
         raise ValueError(f"Serialized {name} must be finite and strictly positive")
     return resolved
-
-
-def _serialized_boolean(value: object, name: str) -> bool:
-    """Decode a serialized Boolean represented only by Boolean or integer 0/1."""
-    if isinstance(value, (bool, np.bool_)):
-        return bool(value)
-    if isinstance(value, (int, np.integer)) and int(value) in (0, 1):
-        return bool(value)
-    raise ValueError(f"Serialized {name} must be Boolean or integer 0/1")

--- a/tests/test_native_covariance.py
+++ b/tests/test_native_covariance.py
@@ -139,6 +139,35 @@ def test_anisotropic_correlation_lengths_match_dense_oracle() -> None:
     )
 
 
+def test_default_configuration_round_trips_through_dataset() -> None:
+    """Serialization records the resolved default and reconstructs an equivalent action."""
+    latitude, longitude = _coordinates()
+    covariance = SeparableExponentialCovariance(
+        latitude=latitude,
+        longitude=longitude,
+        sigma=2.5,
+    )
+    rhs = xr.DataArray(
+        np.arange(6, dtype=float).reshape(3, 2),
+        dims=("lat", "lon"),
+        coords={"lat": latitude, "lon": longitude},
+    )
+
+    restored = SeparableExponentialCovariance.from_dataset(covariance.to_dataset())
+
+    assert covariance.correlation_length == 1.5
+    assert restored.correlation_length == 1.5
+    assert restored.sigma == 2.5
+    assert restored.native_dims == ("lat", "lon")
+    np.testing.assert_array_equal(restored.latitude, covariance.latitude)
+    np.testing.assert_array_equal(restored.longitude, covariance.longitude)
+    assert restored.latitude.dims == covariance.latitude.dims
+    assert restored.longitude.dims == covariance.longitude.dims
+    assert restored.latitude.attrs == covariance.latitude.attrs
+    assert restored.longitude.attrs == covariance.longitude.attrs
+    xr.testing.assert_allclose(restored.apply(rhs), covariance.apply(rhs))
+
+
 @pytest.mark.parametrize(
     ("bad_rhs", "message"),
     [

--- a/tests/test_native_covariance_classes.py
+++ b/tests/test_native_covariance_classes.py
@@ -1,0 +1,407 @@
+"""Tests for optional class blocking in native covariance actions."""
+
+from pathlib import Path
+
+import dask.array as da
+import numpy as np
+import pytest
+import xarray as xr
+
+import openghg_inversions.native_covariance as native_covariance_module
+from openghg_inversions.native_covariance import SeparableExponentialCovariance
+
+
+@pytest.fixture
+def coordinates() -> tuple[xr.DataArray, xr.DataArray]:
+    """Return a small irregular native grid with degree metadata."""
+    latitude = xr.DataArray(
+        [-1.0, 0.5, 2.0],
+        dims="lat",
+        coords={"lat": [-1.0, 0.5, 2.0]},
+        attrs={"units": "degrees_north"},
+    )
+    longitude = xr.DataArray(
+        [10.0, 11.0],
+        dims="lon",
+        coords={"lon": [10.0, 11.0]},
+        attrs={"units": "degrees_east"},
+    )
+    return latitude, longitude
+
+
+def _dense_blocked_covariance(
+    latitude: xr.DataArray,
+    longitude: xr.DataArray,
+    class_labels: xr.DataArray,
+    sigma: float,
+    correlation_length: float,
+) -> np.ndarray:
+    """Build the small dense class-blocked oracle used only by tests."""
+    lat_values = np.asarray(latitude.values)
+    lon_values = np.asarray(longitude.values)
+    lat_factor = np.exp(-np.abs(lat_values[:, None] - lat_values[None, :]) / correlation_length)
+    lon_factor = np.exp(-np.abs(lon_values[:, None] - lon_values[None, :]) / correlation_length)
+    unblocked = sigma**2 * np.kron(lat_factor, lon_factor)
+    labels = np.asarray(class_labels.transpose("lat", "lon").values).reshape(-1)
+    same_class = np.fromiter(
+        (left == right for left in labels for right in labels),
+        dtype=bool,
+        count=labels.size**2,
+    ).reshape(labels.size, labels.size)
+    return unblocked * same_class
+
+
+def test_class_blocked_apply_and_solve_match_dense_oracle(
+    coordinates: tuple[xr.DataArray, xr.DataArray],
+) -> None:
+    """Class-blocked actions match a dense oracle for multiple RHS layouts."""
+    latitude, longitude = coordinates
+    labels = xr.DataArray(
+        [["land", "sea"], ["land", "sea"], ["sea", "sea"]],
+        dims=("lat", "lon"),
+        coords={"lat": latitude, "lon": longitude},
+        name="region_class",
+    )
+    covariance = SeparableExponentialCovariance(
+        latitude,
+        longitude,
+        sigma=1.7,
+        correlation_length=1.2,
+        class_labels=labels,
+    )
+    rhs = xr.DataArray(
+        np.arange(12, dtype=float).reshape(2, 2, 3) / 7.0,
+        dims=("realisation", "lon", "lat"),
+        coords={"realisation": ["a", "b"], "lat": latitude, "lon": longitude},
+        name="rhs",
+        attrs={"units": "1"},
+    )
+
+    dense = _dense_blocked_covariance(latitude, longitude, labels, 1.7, 1.2)
+    native_rhs = rhs.transpose("lat", "lon", "realisation").values.reshape(6, 2)
+    expected_apply = dense @ native_rhs
+    expected_solve = np.linalg.solve(dense, native_rhs)
+
+    applied = covariance.apply(rhs)
+    solved = covariance.solve(rhs)
+
+    assert applied.dims == rhs.dims
+    assert solved.dims == rhs.dims
+    assert applied.name == rhs.name
+    assert applied.attrs == rhs.attrs
+    xr.testing.assert_identical(applied.coords.to_dataset(), rhs.coords.to_dataset())
+    np.testing.assert_allclose(
+        applied.transpose("lat", "lon", "realisation").values.reshape(6, 2),
+        expected_apply,
+        rtol=1e-12,
+        atol=1e-12,
+    )
+    np.testing.assert_allclose(
+        solved.transpose("lat", "lon", "realisation").values.reshape(6, 2),
+        expected_solve,
+        rtol=1e-10,
+        atol=1e-11,
+    )
+    xr.testing.assert_allclose(covariance.apply(solved), rhs, rtol=1e-10, atol=1e-11)
+
+
+def test_class_blocked_solve_supports_legacy_cg_tolerance_keyword(
+    coordinates: tuple[xr.DataArray, xr.DataArray],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The compatibility dispatch uses ``tol`` with pre-1.12 SciPy CG signatures."""
+    latitude, longitude = coordinates
+    labels = xr.DataArray(
+        [["land", "sea"], ["land", "sea"], ["sea", "sea"]],
+        dims=("lat", "lon"),
+        coords={"lat": latitude, "lon": longitude},
+    )
+    covariance = SeparableExponentialCovariance(latitude, longitude, class_labels=labels)
+    rhs = xr.ones_like(labels, dtype=float)
+    current_cg = native_covariance_module.cg
+
+    def legacy_cg(operator, vector, *, tol, atol, maxiter):
+        """Expose the legacy keyword while delegating to the installed SciPy."""
+        return current_cg(operator, vector, rtol=tol, atol=atol, maxiter=maxiter)
+
+    monkeypatch.setattr(native_covariance_module, "cg", legacy_cg)
+    monkeypatch.setattr(native_covariance_module, "_CG_RELATIVE_TOLERANCE", "tol")
+
+    solved = covariance.solve(rhs)
+
+    xr.testing.assert_allclose(covariance.apply(solved), rhs, rtol=1e-10, atol=1e-11)
+
+
+def test_class_labels_round_trip_through_dataset(
+    coordinates: tuple[xr.DataArray, xr.DataArray],
+) -> None:
+    """Serialization retains class labels and reproduces the blocked action."""
+    latitude, longitude = coordinates
+    labels = xr.DataArray(
+        [[0, 1], [0, 1], [1, 1]],
+        dims=("lat", "lon"),
+        coords={"lat": latitude, "lon": longitude},
+        attrs={"meaning": "surface class"},
+    )
+    original = SeparableExponentialCovariance(latitude, longitude, class_labels=labels)
+
+    restored = SeparableExponentialCovariance.from_dataset(original.to_dataset())
+
+    assert restored.class_labels is not None
+    xr.testing.assert_identical(restored.class_labels, labels)
+    rhs = xr.ones_like(labels, dtype=float)
+    xr.testing.assert_allclose(restored.apply(rhs), original.apply(rhs))
+
+
+def test_tuple_class_labels_match_dense_oracle_and_round_trip_through_netcdf(
+    coordinates: tuple[xr.DataArray, xr.DataArray],
+    tmp_path: Path,
+) -> None:
+    """Composite scalar labels define correct masks and use NetCDF-safe tagged encoding."""
+    latitude, longitude = coordinates
+    values = np.empty((3, 2), dtype=object)
+    tuple_labels = [
+        ("biosphere", 1),
+        ("ocean", 2),
+        ("biosphere", 1),
+        ("ocean", 2),
+        ("ocean", 2),
+        ("ocean", 2),
+    ]
+    for index, label in enumerate(tuple_labels):
+        values.flat[index] = label
+    labels = xr.DataArray(
+        values,
+        dims=("lat", "lon"),
+        coords={"lat": latitude, "lon": longitude},
+        name="surface_class",
+        attrs={"version": np.int64(2)},
+    )
+    covariance = SeparableExponentialCovariance(
+        latitude,
+        longitude,
+        sigma=1.4,
+        correlation_length=1.1,
+        class_labels=labels,
+    )
+    rhs = xr.DataArray(
+        np.arange(6, dtype=float).reshape(3, 2),
+        dims=("lat", "lon"),
+        coords={"lat": latitude, "lon": longitude},
+    )
+    dense = _dense_blocked_covariance(latitude, longitude, labels, 1.4, 1.1)
+    path = tmp_path / "tuple-label-covariance.nc"
+
+    np.testing.assert_allclose(covariance.apply(rhs).values.reshape(-1), dense @ rhs.values.reshape(-1))
+    np.testing.assert_allclose(
+        covariance.solve(rhs).values.reshape(-1),
+        np.linalg.solve(dense, rhs.values.reshape(-1)),
+    )
+    covariance.to_dataset().to_netcdf(path, engine="h5netcdf")
+    with xr.open_dataset(path, engine="h5netcdf") as stored:
+        restored = SeparableExponentialCovariance.from_dataset(stored.load())
+
+    restored_labels = restored.class_labels
+    assert restored_labels is not None
+    xr.testing.assert_identical(restored_labels, labels.assign_attrs(version=2))
+
+
+@pytest.mark.parametrize("class_blocked", [False, True])
+def test_covariance_round_trips_through_h5netcdf(
+    coordinates: tuple[xr.DataArray, xr.DataArray],
+    class_blocked: bool,
+    tmp_path: Path,
+) -> None:
+    """NetCDF persistence preserves blocked and unblocked covariance configuration."""
+    latitude, longitude = coordinates
+    class_labels = None
+    if class_blocked:
+        class_labels = xr.DataArray(
+            [[0, 1], [0, 1], [1, 1]],
+            dims=("lat", "lon"),
+            coords={"lat": latitude, "lon": longitude},
+            name="surface_class",
+        )
+    original = SeparableExponentialCovariance(
+        latitude,
+        longitude,
+        sigma=1.3,
+        class_labels=class_labels,
+    )
+    path = tmp_path / "covariance.nc"
+
+    original.to_dataset().to_netcdf(path, engine="h5netcdf")
+    with xr.open_dataset(path, engine="h5netcdf") as stored:
+        loaded = stored.load()
+    restored = SeparableExponentialCovariance.from_dataset(loaded)
+
+    assert loaded.attrs["class_blocked"] == int(class_blocked)
+    assert (restored.class_labels is not None) is class_blocked
+    if class_labels is not None:
+        xr.testing.assert_identical(restored.class_labels, class_labels)
+    replaced = SeparableExponentialCovariance(
+        restored.latitude,
+        restored.longitude,
+        sigma=restored.sigma,
+        correlation_length=3.0,
+        class_labels=restored.class_labels,
+    )
+    assert replaced.latitude_correlation_length == 3.0
+    assert replaced.longitude_correlation_length == 3.0
+
+
+def test_single_class_uses_unblocked_covariance(
+    coordinates: tuple[xr.DataArray, xr.DataArray],
+) -> None:
+    """A single class is algebraically identical to the separable covariance."""
+    latitude, longitude = coordinates
+    labels = xr.DataArray(
+        np.full((3, 2), "all"),
+        dims=("lat", "lon"),
+        coords={"lat": latitude, "lon": longitude},
+    )
+    blocked = SeparableExponentialCovariance(latitude, longitude, class_labels=labels)
+    unblocked = SeparableExponentialCovariance(latitude, longitude)
+    rhs = xr.DataArray(
+        np.arange(6, dtype=float).reshape(3, 2),
+        dims=("lat", "lon"),
+        coords={"lat": latitude, "lon": longitude},
+    )
+
+    xr.testing.assert_allclose(blocked.apply(rhs), unblocked.apply(rhs))
+    xr.testing.assert_allclose(blocked.solve(rhs), unblocked.solve(rhs))
+
+
+def test_constructor_copies_class_labels_and_property_borrows_owned_labels(
+    coordinates: tuple[xr.DataArray, xr.DataArray],
+) -> None:
+    """Construction isolates labels while ordinary access returns the owned array."""
+    latitude, longitude = coordinates
+    labels = xr.DataArray(
+        [["land", "ocean"], ["land", "ocean"], ["land", "ocean"]],
+        dims=("lat", "lon"),
+        coords={"lat": latitude, "lon": longitude},
+    )
+    covariance = SeparableExponentialCovariance(latitude, longitude, class_labels=labels)
+    exposed = covariance.class_labels
+
+    assert exposed is not None
+    labels.values[1, 0] = "ocean"
+    assert covariance.class_labels is exposed
+    np.testing.assert_array_equal(
+        exposed.values,
+        [["land", "ocean"], ["land", "ocean"], ["land", "ocean"]],
+    )
+
+    unblocked = SeparableExponentialCovariance(
+        covariance.latitude,
+        covariance.longitude,
+        sigma=covariance.sigma,
+        correlation_length=covariance.correlation_length,
+        class_labels=None,
+    )
+    assert unblocked.class_labels is None
+
+
+def test_constructor_materializes_lazy_class_labels_once(
+    coordinates: tuple[xr.DataArray, xr.DataArray],
+) -> None:
+    """Lazy labels become one owned eager array used by cached masks."""
+    latitude, longitude = coordinates
+    labels = xr.DataArray(
+        da.from_array(
+            np.asarray([["land", "ocean"], ["land", "ocean"], ["land", "ocean"]]),
+            chunks=(2, 1),
+        ),
+        dims=("lat", "lon"),
+        coords={"lat": latitude, "lon": longitude},
+    )
+
+    covariance = SeparableExponentialCovariance(latitude, longitude, class_labels=labels)
+
+    assert covariance.class_labels is not None
+    assert isinstance(covariance.class_labels.data, np.ndarray)
+    assert covariance.class_labels is covariance.class_labels
+
+
+def test_native_dimension_cannot_collide_with_serialized_class_labels() -> None:
+    """The component schema rejects its reserved class-label variable name."""
+    latitude = xr.DataArray([0.0, 1.0], dims="class_label_encoded")
+    longitude = xr.DataArray([10.0, 11.0], dims="lon")
+
+    with pytest.raises(ValueError, match="reserved by the serialized schema"):
+        SeparableExponentialCovariance(latitude, longitude)
+
+
+def test_deserialization_rejects_contradictory_implicit_length(
+    coordinates: tuple[xr.DataArray, xr.DataArray],
+) -> None:
+    """A fallback-derived axis length must match the serialized fallback."""
+    latitude, longitude = coordinates
+    dataset = SeparableExponentialCovariance(latitude, longitude).to_dataset()
+    dataset.attrs["latitude_correlation_length_degrees"] = 99.0
+
+    with pytest.raises(ValueError, match="implicit latitude.*contradicts"):
+        SeparableExponentialCovariance.from_dataset(dataset)
+
+
+@pytest.mark.parametrize("invalid_value", [None, np.nan])
+def test_class_labels_reject_unassigned_cells(
+    coordinates: tuple[xr.DataArray, xr.DataArray],
+    invalid_value: object,
+) -> None:
+    """Every native cell must have a non-null class assignment."""
+    latitude, longitude = coordinates
+    values = np.full((3, 2), "land", dtype=object)
+    values[0, 0] = invalid_value
+    labels = xr.DataArray(
+        values,
+        dims=("lat", "lon"),
+        coords={"lat": latitude, "lon": longitude},
+    )
+
+    with pytest.raises(ValueError, match="non-null class"):
+        SeparableExponentialCovariance(latitude, longitude, class_labels=labels)
+
+
+def test_class_labels_require_exact_grid_alignment(
+    coordinates: tuple[xr.DataArray, xr.DataArray],
+) -> None:
+    """Class labels cannot be silently reordered against the covariance grid."""
+    latitude, longitude = coordinates
+    labels = xr.DataArray(
+        np.zeros((3, 2), dtype=int),
+        dims=("lat", "lon"),
+        coords={"lat": latitude[::-1], "lon": longitude},
+    )
+
+    with pytest.raises(ValueError, match="does not align"):
+        SeparableExponentialCovariance(latitude, longitude, class_labels=labels)
+
+
+@pytest.mark.parametrize(
+    ("class_blocked", "include_labels"),
+    [(1, False), (0, True)],
+)
+def test_deserialization_rejects_contradictory_blocked_state(
+    coordinates: tuple[xr.DataArray, xr.DataArray],
+    class_blocked: int,
+    include_labels: bool,
+) -> None:
+    """The serialized blocked flag must agree with the presence of encoded labels."""
+    latitude, longitude = coordinates
+    labels = xr.DataArray(
+        np.zeros((3, 2), dtype=int),
+        dims=("lat", "lon"),
+        coords={"lat": latitude, "lon": longitude},
+    )
+    covariance = SeparableExponentialCovariance(
+        latitude,
+        longitude,
+        class_labels=labels if include_labels else None,
+    )
+    dataset = covariance.to_dataset()
+    dataset.attrs["class_blocked"] = class_blocked
+
+    with pytest.raises(ValueError, match="contradicts"):
+        SeparableExponentialCovariance.from_dataset(dataset)

--- a/tests/test_serialization_codecs.py
+++ b/tests/test_serialization_codecs.py
@@ -1,0 +1,249 @@
+"""Tests for the private serialization codecs shared by artifact schemas."""
+
+import json
+
+import dask.array as da
+import numpy as np
+import pytest
+import xarray as xr
+
+from openghg_inversions.native_covariance import SeparableExponentialCovariance
+from openghg_inversions._serialization_codecs import (
+    _TAGGED_JSON_VALUE_ENCODING,
+    _decode_serialized_bool,
+    _decode_tagged_json_value,
+    _encode_tagged_json_value,
+    _numpy_scalar_json_default,
+)
+from openghg_inversions.source_covariance import IndependentSourceCovariance
+
+
+def _source_covariance() -> IndependentSourceCovariance:
+    """Return a small two-source covariance for dispatch tests."""
+    latitude = xr.DataArray([50.0, 51.0], dims="latitude")
+    longitude = xr.DataArray([-2.0, -1.0], dims="longitude")
+    return IndependentSourceCovariance(
+        {
+            "inventory-b": SeparableExponentialCovariance(latitude, longitude, sigma=1.5),
+            "inventory-a": SeparableExponentialCovariance(latitude, longitude, sigma=0.5),
+        }
+    )
+
+
+def _source_rhs(source_labels: list[object]) -> xr.DataArray:
+    """Return a labelled source right-hand side with non-native dimension order."""
+    return xr.DataArray(
+        np.arange(3 * 2 * len(source_labels) * 2, dtype=float).reshape(3, 2, len(source_labels), 2),
+        dims=("observation", "longitude", "native_source", "latitude"),
+        coords={
+            "observation": ["obs-1", "obs-2", "obs-3"],
+            "longitude": [-2.0, -1.0],
+            "native_source": xr.DataArray(
+                source_labels,
+                dims="native_source",
+                attrs={"long_name": "emissions inventory"},
+            ),
+            "latitude": [50.0, 51.0],
+            "inventory_kind": ("native_source", [f"kind-{index}" for index in range(len(source_labels))]),
+            "quality": (
+                ("observation", "native_source"),
+                np.arange(len(source_labels) * 3).reshape(3, len(source_labels)),
+            ),
+            "mixed_order": (
+                ("longitude", "native_source", "observation"),
+                np.arange(2 * len(source_labels) * 3).reshape(2, len(source_labels), 3),
+            ),
+        },
+        name="native_rhs",
+        attrs={"units": "arbitrary"},
+    )
+
+
+def test_tagged_json_scalar_encoding_name_is_versioned() -> None:
+    """The persisted tagged-scalar codec name remains explicitly versioned."""
+    assert _TAGGED_JSON_VALUE_ENCODING == "tagged_json_v1"
+
+
+@pytest.mark.parametrize(
+    ("value", "encoded"),
+    [
+        ("land", '["str","land"]'),
+        (True, '["bool",true]'),
+        (False, '["bool",false]'),
+        (7, '["int",7]'),
+        (-2, '["int",-2]'),
+        (1.25, '["float",1.25]'),
+        (
+            ("outer", (np.int64(3), np.bool_(False)), 2.5),
+            r'["tuple",["[\"str\",\"outer\"]","[\"tuple\",[\"[\\\"int\\\",3]\",'
+            r'\"[\\\"bool\\\",false]\"]]","[\"float\",2.5]"]]',
+        ),
+    ],
+)
+def test_tagged_json_scalar_has_stable_bytes_and_roundtrips(value: object, encoded: str) -> None:
+    """Supported Python scalars and nested tuples retain type and stable bytes."""
+    assert _encode_tagged_json_value(value) == encoded
+    assert _decode_tagged_json_value(encoded) == value
+
+
+@pytest.mark.parametrize(
+    ("value", "encoded", "expected"),
+    [
+        (np.str_("sea"), '["str","sea"]', "sea"),
+        (np.bool_(True), '["bool",true]', True),
+        (np.int32(4), '["int",4]', 4),
+        (np.float32(1.5), '["float",1.5]', 1.5),
+    ],
+)
+def test_tagged_json_scalar_normalises_numpy_scalars(
+    value: np.generic,
+    encoded: str,
+    expected: object,
+) -> None:
+    """NumPy scalar labels serialize as their equivalent built-in types."""
+    actual_encoded = _encode_tagged_json_value(value)
+
+    assert actual_encoded == encoded
+    decoded = _decode_tagged_json_value(actual_encoded)
+    assert decoded == expected
+    assert type(decoded) is type(expected)
+
+
+@pytest.mark.parametrize("value", [None, [1, 2], {"label": 1}, 1 + 2j, np.array(1)])
+def test_tagged_json_scalar_rejects_unsupported_values(value: object) -> None:
+    """The tagged codec rejects values outside its documented scalar algebra."""
+    with pytest.raises(TypeError, match="Unsupported"):
+        _encode_tagged_json_value(value)
+
+
+@pytest.mark.parametrize(
+    "encoded",
+    [
+        "not JSON",
+        "null",
+        "{}",
+        "[]",
+        '["int"]',
+        '["int",1,2]',
+        "[1,1]",
+        '["future",1]',
+        '["bool",0]',
+        '["int",true]',
+        '["int",1.0]',
+        '["float","1.0"]',
+        '["str",1]',
+        '["tuple","not-a-list"]',
+        '["tuple",[["int",1]]]',
+    ],
+)
+def test_tagged_json_scalar_rejects_malformed_json_tags_and_payloads(encoded: str) -> None:
+    """Malformed JSON, envelopes, tags, and tag-specific payloads fail closed."""
+    with pytest.raises(ValueError):
+        _decode_tagged_json_value(encoded)
+
+
+@pytest.mark.parametrize("encoded", [None, 1, b'["int",1]', ["int", 1]])
+def test_tagged_json_scalar_requires_serialized_text(encoded: object) -> None:
+    """The decoder does not coerce arbitrary objects into serialized text."""
+    with pytest.raises((TypeError, ValueError)):
+        _decode_tagged_json_value(encoded)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (np.bool_(True), True),
+        (np.int16(5), 5),
+        (np.float32(2.5), 2.5),
+        (np.str_("coast"), "coast"),
+    ],
+)
+def test_numpy_scalar_json_default_returns_builtin_scalar(value: np.generic, expected: object) -> None:
+    """The JSON default hook converts NumPy scalars into built-in JSON values."""
+    actual = _numpy_scalar_json_default(value)
+
+    assert actual == expected
+    assert type(actual) is type(expected)
+    assert json.loads(json.dumps({"value": value}, default=_numpy_scalar_json_default)) == {"value": expected}
+
+
+@pytest.mark.parametrize("value", [object(), np.array([1]), [np.int64(1)]])
+def test_numpy_scalar_json_default_rejects_other_values(value: object) -> None:
+    """The NumPy JSON hook refuses non-scalar values instead of guessing."""
+    with pytest.raises(TypeError, match="not JSON serializable"):
+        _numpy_scalar_json_default(value)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (False, False),
+        (True, True),
+        (0, False),
+        (1, True),
+        (np.bool_(False), False),
+        (np.int8(0), False),
+        (np.uint64(1), True),
+    ],
+)
+def test_serialized_bool_accepts_only_booleans_and_integer_bits(value: object, expected: bool) -> None:
+    """Serialized Boolean decoding accepts Boolean values and integer zero or one."""
+    actual = _decode_serialized_bool(value, "enabled")
+
+    assert actual is expected
+
+
+@pytest.mark.parametrize("value", [-1, 2, 0.0, 1.0, "0", "true", None, np.float64(1.0)])
+def test_serialized_bool_rejects_coercible_but_noncanonical_values(value: object) -> None:
+    """Serialized Boolean decoding rejects values that merely coerce to Boolean."""
+    with pytest.raises(ValueError, match="Serialized enabled must be Boolean or integer 0/1"):
+        _decode_serialized_bool(value, "enabled")
+
+
+@pytest.mark.parametrize(
+    "source_labels",
+    [
+        ["inventory-a", "inventory-b"],
+        ["inventory-b"],
+        ["inventory-b", "inventory-a", "inventory-extra"],
+        ["inventory-b", "inventory-b"],
+        [1, 2],
+    ],
+    ids=["reordered", "missing", "extra", "duplicate", "wrong-type"],
+)
+def test_source_dispatch_requires_the_exact_configured_index(source_labels: list[object]) -> None:
+    """Xarray exact alignment rejects reordered, missing, extra, duplicate, or mistyped labels."""
+    covariance = _source_covariance()
+
+    with pytest.raises(ValueError, match="source labels/order do not match covariance configuration"):
+        covariance.apply(_source_rhs(source_labels))
+
+
+def test_source_dispatch_preserves_labelled_array_identity() -> None:
+    """Per-source selection and concat preserve dimensions, metadata, and auxiliary coordinates."""
+    covariance = _source_covariance()
+    rhs = _source_rhs(list(covariance.source_labels))
+
+    result = covariance.apply(rhs)
+
+    assert result.dims == rhs.dims
+    assert result.name == rhs.name
+    assert result.attrs == rhs.attrs
+    xr.testing.assert_identical(result.coords.to_dataset(), rhs.coords.to_dataset())
+
+
+def test_source_dispatch_does_not_compute_lazy_source_coordinates() -> None:
+    """Concat bypasses comparisons of source-dependent auxiliary coordinates."""
+    covariance = _source_covariance()
+    rhs = _source_rhs(list(covariance.source_labels)).assign_coords(
+        lazy_equal=(
+            ("native_source", "observation"),
+            da.from_array(np.ones((2, 3)), chunks=(1, 2)),
+        )
+    )
+
+    result = covariance.apply(rhs)
+
+    assert isinstance(result.coords["lazy_equal"].data, da.Array)
+    assert result.coords["lazy_equal"].data is rhs.coords["lazy_equal"].data
+    assert result.coords["lazy_equal"].dims == ("native_source", "observation")

--- a/tests/test_source_covariance.py
+++ b/tests/test_source_covariance.py
@@ -1,0 +1,279 @@
+"""Tests for ordered independent-source native covariance blocks."""
+
+from dataclasses import is_dataclass
+from typing import cast
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from openghg_inversions.native_covariance import SeparableExponentialCovariance
+from openghg_inversions.source_covariance import IndependentSourceCovariance
+
+
+def _problem():
+    """Return a small non-lexically ordered gathered-source problem."""
+    latitude = xr.DataArray(
+        [-1.0, 0.5],
+        dims="lat",
+        coords={"lat": [-1.0, 0.5]},
+        attrs={"units": "degrees_north"},
+    )
+    longitude = xr.DataArray(
+        [10.0, 11.0],
+        dims="lon",
+        coords={"lon": [10.0, 11.0]},
+        attrs={"units": "degrees_east"},
+    )
+    components = {
+        "z-source": SeparableExponentialCovariance(
+            latitude,
+            longitude,
+            sigma=1.6,
+            latitude_correlation_length=0.7,
+            longitude_correlation_length=2.2,
+        ),
+        "a-source": SeparableExponentialCovariance(latitude, longitude, sigma=0.7),
+    }
+    covariance = IndependentSourceCovariance(components)
+    native_sensitivity = xr.DataArray(
+        np.arange(24, dtype=float).reshape(3, 2, 2, 2) / 9.0,
+        dims=("observation", "native_source", "lat", "lon"),
+        coords={
+            "observation": ["obs-1", "obs-2", "obs-3"],
+            "native_source": ["z-source", "a-source"],
+            "lat": latitude,
+            "lon": longitude,
+        },
+    )
+    return covariance, native_sensitivity
+
+
+def _dense_block_diagonal(covariance: IndependentSourceCovariance) -> np.ndarray:
+    """Construct the small dense independent-source oracle."""
+    blocks = []
+    for source in covariance.source_labels:
+        component = covariance.source_covariances[source]
+        lat = component.latitude.values
+        lon = component.longitude.values
+        k_lat = np.exp(-np.abs(lat[:, None] - lat[None, :]) / component.latitude_correlation_length)
+        k_lon = np.exp(-np.abs(lon[:, None] - lon[None, :]) / component.longitude_correlation_length)
+        blocks.append(component.sigma**2 * np.kron(k_lat, k_lon))
+    result = np.zeros((sum(block.shape[0] for block in blocks),) * 2)
+    offset = 0
+    for block in blocks:
+        stop = offset + block.shape[0]
+        result[offset:stop, offset:stop] = block
+        offset = stop
+    return result
+
+
+def test_independent_source_action_and_serialization_preserve_order() -> None:
+    """Block action, solve, and serialization retain configured non-lexical order."""
+    covariance, native_sensitivity = _problem()
+    rhs = native_sensitivity.transpose("native_source", "lat", "lon", "observation")
+    dense = _dense_block_diagonal(covariance)
+    matrix = rhs.values.reshape(8, 3)
+
+    applied = covariance.apply(rhs)
+    solved = covariance.solve(rhs)
+    restored = IndependentSourceCovariance.from_dataset(covariance.to_dataset())
+
+    assert covariance.source_labels == ("z-source", "a-source")
+    np.testing.assert_allclose(applied.values.reshape(8, 3), dense @ matrix)
+    np.testing.assert_allclose(solved.values.reshape(8, 3), np.linalg.solve(dense, matrix))
+    xr.testing.assert_allclose(restored.apply(rhs), applied)
+    component = restored.source_covariances["a-source"]
+    replaced = SeparableExponentialCovariance(
+        component.latitude,
+        component.longitude,
+        sigma=component.sigma,
+        correlation_length=3.0,
+        class_labels=component.class_labels,
+    )
+    assert replaced.latitude_correlation_length == 3.0
+    assert replaced.longitude_correlation_length == 3.0
+
+
+def test_constructor_validates_every_block_type_before_inspecting_dimensions() -> None:
+    """Invalid blocks raise ``TypeError`` before any native dimensions are read."""
+    covariance, _ = _problem()
+    valid = covariance.source_covariances["z-source"]
+    invalid = cast(SeparableExponentialCovariance, object())
+
+    with pytest.raises(TypeError, match="bad.*SeparableExponentialCovariance"):
+        IndependentSourceCovariance({"bad": invalid})
+
+    with pytest.raises(TypeError, match="bad.*SeparableExponentialCovariance"):
+        IndependentSourceCovariance(
+            {"valid": valid, "bad": invalid},
+            source_dim="lat",
+        )
+
+    with pytest.raises(ValueError, match="reserved"):
+        IndependentSourceCovariance({"valid": valid}, source_dim="sigma")
+
+
+def test_source_action_is_a_slotted_identity_object_with_read_only_configuration() -> None:
+    """The computational action avoids dataclass replacement semantics."""
+    covariance, _ = _problem()
+    equivalent, _ = _problem()
+
+    assert not is_dataclass(covariance)
+    assert not hasattr(covariance, "__dict__")
+    assert covariance != equivalent
+    assert isinstance(hash(covariance), int)
+    with pytest.raises(AttributeError):
+        covariance.source_dim = "source"  # type: ignore[misc]
+
+
+def test_source_schema_rejects_reserved_spatial_dimension() -> None:
+    """Spatial dimensions cannot overwrite source configuration variables."""
+    latitude = xr.DataArray([0.0, 1.0], dims="sigma")
+    longitude = xr.DataArray([10.0, 11.0], dims="lon")
+    component = SeparableExponentialCovariance(latitude, longitude)
+
+    with pytest.raises(ValueError, match="spatial dimension.*reserved"):
+        IndependentSourceCovariance({"source": component})
+
+
+def test_source_blocks_require_identical_coordinate_metadata() -> None:
+    """Source serialization cannot silently choose one block's grid metadata."""
+    covariance, _ = _problem()
+    original = covariance.source_covariances["a-source"]
+    changed_latitude = original.latitude.copy(deep=True)
+    changed_latitude.attrs["description"] = "different grid metadata"
+    changed = SeparableExponentialCovariance(changed_latitude, original.longitude)
+
+    with pytest.raises(ValueError, match="grid differs"):
+        IndependentSourceCovariance({"first": original, "second": changed})
+
+
+def test_action_rejects_numeric_source_label_matching_only_after_string_coercion() -> None:
+    """A numeric source label cannot masquerade as the configured string label."""
+    covariance, native_sensitivity = _problem()
+    component = covariance.source_covariances["z-source"]
+    numeric_named_covariance = IndependentSourceCovariance({"1": component})
+    rhs = native_sensitivity.isel(native_source=[0]).assign_coords(native_source=[1])
+
+    with pytest.raises(ValueError, match="source labels/order"):
+        numeric_named_covariance.apply(rhs)
+
+
+@pytest.mark.parametrize("spatial_dim", ["lat", "lon"])
+def test_deserialization_rejects_missing_spatial_coordinates(spatial_dim: str) -> None:
+    """Missing serialized spatial labels raise a clear validation error."""
+    covariance, _ = _problem()
+    dataset = covariance.to_dataset().drop_indexes(spatial_dim).drop_vars(spatial_dim)
+
+    with pytest.raises(ValueError, match="missing latitude or longitude coordinates"):
+        IndependentSourceCovariance.from_dataset(dataset)
+
+
+def test_source_serialization_preserves_class_label_identity() -> None:
+    """Class-blocked source round trips retain typed labels, name, and attributes."""
+    covariance, _ = _problem()
+    original_component = covariance.source_covariances["z-source"]
+    class_labels = xr.DataArray(
+        [[1, 2], [1, 2]],
+        dims=("lat", "lon"),
+        coords={"lat": original_component.latitude, "lon": original_component.longitude},
+        name="surface_class",
+        attrs={"description": "typed test classes", "version": np.int64(2)},
+    )
+    blocked_component = SeparableExponentialCovariance(
+        original_component.latitude,
+        original_component.longitude,
+        sigma=original_component.sigma,
+        latitude_correlation_length=original_component.latitude_correlation_length,
+        longitude_correlation_length=original_component.longitude_correlation_length,
+        class_labels=class_labels,
+    )
+    blocked = IndependentSourceCovariance(
+        {
+            "z-source": blocked_component,
+            "a-source": covariance.source_covariances["a-source"],
+        }
+    )
+
+    restored = IndependentSourceCovariance.from_dataset(blocked.to_dataset())
+
+    restored_labels = restored.source_covariances["z-source"].class_labels
+    assert restored_labels is not None
+    xr.testing.assert_identical(restored_labels, class_labels.assign_attrs(version=2))
+
+
+def test_source_serialization_coordinates_do_not_alias_component_state() -> None:
+    """Mutating an export cannot invalidate a component's cached factors."""
+    covariance, _ = _problem()
+    component = covariance.source_covariances["z-source"]
+    original_latitude = component.latitude.to_numpy().copy()
+
+    dataset = covariance.to_dataset()
+    dataset.coords["lat"].values[0] = 999.0
+
+    np.testing.assert_array_equal(component.latitude, original_latitude)
+
+
+def test_source_deserialization_rejects_contradictory_implicit_length() -> None:
+    """Fallback-derived source lengths must match their serialized fallback."""
+    covariance, _ = _problem()
+    dataset = covariance.to_dataset()
+    dataset["latitude_correlation_length"].loc[{covariance.source_dim: "a-source"}] = 99.0
+
+    with pytest.raises(ValueError, match="Implicit latitude.*contradicts"):
+        IndependentSourceCovariance.from_dataset(dataset)
+
+
+def test_source_operations_preserve_auxiliary_source_coordinates() -> None:
+    """Block dispatch restores semantic coordinates attached to the source axis."""
+    covariance, native_sensitivity = _problem()
+    rhs = native_sensitivity.transpose("native_source", "lat", "lon", "observation").assign_coords(
+        inventory=("native_source", ["bottom-up", "top-down"])
+    )
+
+    applied = covariance.apply(rhs)
+    solved = covariance.solve(rhs)
+
+    xr.testing.assert_identical(applied.coords["inventory"], rhs.coords["inventory"])
+    xr.testing.assert_identical(solved.coords["inventory"], rhs.coords["inventory"])
+
+
+def test_deserialization_rejects_unknown_class_label_encoding() -> None:
+    """Source covariance schema readers reject unknown typed-label codecs."""
+    covariance, _ = _problem()
+    dataset = covariance.to_dataset()
+    dataset.attrs["class_label_encoding"] = "future_codec"
+
+    with pytest.raises(ValueError, match="class-label encoding"):
+        IndependentSourceCovariance.from_dataset(dataset)
+
+
+def test_deserialization_rejects_contradictory_source_blocked_state() -> None:
+    """A source flag cannot silently discard an existing encoded class grid."""
+    covariance, _ = _problem()
+    component = covariance.source_covariances["z-source"]
+    labels = xr.DataArray(
+        [[1, 2], [1, 2]],
+        dims=("lat", "lon"),
+        coords={"lat": component.latitude, "lon": component.longitude},
+    )
+    blocked = IndependentSourceCovariance(
+        {
+            "z-source": SeparableExponentialCovariance(
+                component.latitude,
+                component.longitude,
+                sigma=component.sigma,
+                correlation_length=component.correlation_length,
+                latitude_correlation_length=component.latitude_correlation_length,
+                longitude_correlation_length=component.longitude_correlation_length,
+                class_labels=labels,
+            ),
+            "a-source": covariance.source_covariances["a-source"],
+        }
+    )
+    dataset = blocked.to_dataset()
+    dataset["class_blocked"].loc[{blocked.source_dim: "z-source"}] = False
+
+    with pytest.raises(ValueError, match="contradicts"):
+        IndependentSourceCovariance.from_dataset(dataset)

--- a/tests/typing/borrowed_negative.py.txt
+++ b/tests/typing/borrowed_negative.py.txt
@@ -28,3 +28,13 @@ covariance = SeparableExponentialCovariance(
 )
 covariance.latitude[0] = 20.0  # expect-error: dataarray-item
 covariance.longitude.values[0] = 20.0  # expect-error: dataarray-values-item
+
+blocked_covariance = SeparableExponentialCovariance(
+    covariance.latitude,
+    covariance.longitude,
+    class_labels=xr.DataArray([["land", "sea"], ["land", "sea"]], dims=("lat", "lon")),
+)
+class_labels = blocked_covariance.class_labels
+assert class_labels is not None
+class_labels[0, 0] = "sea"  # expect-error: dataarray-item
+class_labels.values[0, 0] = "sea"  # expect-error: dataarray-values-item

--- a/tests/typing/borrowed_positive.py.txt
+++ b/tests/typing/borrowed_positive.py.txt
@@ -30,6 +30,16 @@ covariance = SeparableExponentialCovariance(
 assert_type(covariance.latitude, BorrowedDataArray)
 assert_type(covariance.longitude, BorrowedDataArray)
 
+blocked_covariance = SeparableExponentialCovariance(
+    covariance.latitude,
+    covariance.longitude,
+    class_labels=xr.DataArray([["land", "sea"], ["land", "sea"]], dims=("lat", "lon")),
+)
+assert_type(blocked_covariance.class_labels, BorrowedDataArray | None)
+class_labels = blocked_covariance.class_labels
+assert class_labels is not None
+assert_type(class_labels, BorrowedDataArray)
+
 # Copies that own their buffers remain mutable to both checkers.
 mutable_array = borrowed_array.copy()
 mutable_array[0] = 10


### PR DESCRIPTION
## Stack

1. [#581 — Slice A: no-class separable native covariance](https://github.com/openghg/openghg_inversions/pull/581) — merged
2. **This PR — Slice B:** class blocking, ordered independent-source blocks, and serialization
3. [#583 — Slice C: retained projection and covariance-product artifacts](https://github.com/openghg/openghg_inversions/pull/583)

Base: `devel`, including merged #581. Review the Slice B changes in this PR.

## Summary of changes

- extend the separable covariance action with class-blocked application and iterative solve
- add ordered `IndependentSourceCovariance` dispatch across source-native blocks
- keep both computational actions as ordinary slotted, identity-based objects with read-only configuration
- materialize class labels once into owned eager state while validating indexed coordinates before execution; expose optional labels through PR #586's static `BorrowedDataArray` marker with unchanged runtime identity
- add versioned, typed xarray serialization for native, class, and source covariance configurations
- return independently mutable export coordinates and reject schema-name collisions or contradictory serialized lengths
- preserve source/class label identity and auxiliary coordinates through NetCDF-safe round trips
- add class/source dense-oracle, ownership, Dask-boundary, and serialization regression tests plus API documentation

This is Slice B of [OPE-32](https://linear.app/openghg-inversions/issue/OPE-32/split-ope-17-pr-578-into-a-stacked-pr-series), continuing [OPE-17](https://linear.app/openghg-inversions/issue/OPE-17/foundation-labelled-native-covariance-actions-and-product-blocks). It supersedes the class/source/serialization portion of draft #578.

## Review notes

Rebased onto the #581 marker integration. Independent review confirmed that optional class labels narrow correctly to `BorrowedDataArray`, property access remains an identity-only cast, and serialization consumes the borrowed reference observationally. Earlier review drove fixes for typed tuple/scalar labels, source dimension validation, SciPy CG compatibility, serialized state flags, auxiliary-coordinate preservation, Dask-backed class labels, export aliasing, schema collisions, and explicit-versus-fallback length consistency. The final re-review found no blocking issues.

The class-blocked solve remains matrix-free: SciPy's flattened `N x N` operator shape is virtual, and each CG iteration applies the separable kernel through masked native-grid work arrays. The module documentation now records the repeated per-class computational cost, especially for highly imbalanced masks. Improving that case without sacrificing the memory bound is tracked as [OPE-39](https://linear.app/openghg-inversions/issue/OPE-39/improve-matrix-free-class-blocked-covariance-solves-for-imbalanced).

## Validation

- focused cumulative Slice A+B plus borrowed runtime suite — 58 passed
- cumulative OPE-32 suite — 104 passed
- Ruff — passed
- Pyright covariance modules — 0 errors
- borrowed-reference Pyright/Mypy probes — 4 passed
- full `tox -p --parallel-no-spinner` on the assembled stack — passed, including lint

## Checklist

- [ ] Closes a GitHub issue — tracked in Linear as OPE-32/OPE-17
- [x] Tests added and passing
- [x] Documentation updated
- [ ] CHANGELOG entry — included in Slice C
- [x] No new requirements
