### PR TITLE
Add retained native covariance product artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@
   while allowing Pyright and Mypy to diagnose selected in-place mutations;
   they deliberately do not claim runtime immutability. [OPE-38](https://linear.app/openghg-inversions/issue/OPE-38/add-experimental-borrowed-numpyxarray-type-markers)
 
+- Added labelled, matrix-free native covariance actions and
+  covariance-compatible retained product blocks for bucket scaling states. The
+  new preparation API
+  supports separable spatial kernels, class-blocked and independent-source
+  covariance, covariance-compatible restriction/prolongation operators,
+  dense or diagonal observation covariance products, reproducible
+  serialization, and explicit documentation of the `Pi`, `U_*`, and
+  `U_bucket` roles. This is the low-level native covariance foundation tracked
+  by Linear OPE-17; centred coherent reduction, unresolved covariance, and
+  likelihood integration are follow-up work.
+
 - Separated basis-group constraints from the algorithms applied within each
   group. The constrained module now owns masks, target allocation, per-group
   dispatch, and global relabelling; partition geometry, steps, policies, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,12 @@
   new preparation API
   supports separable spatial kernels, class-blocked and independent-source
   covariance, covariance-compatible restriction/prolongation operators,
-  dense or diagonal observation covariance products, reproducible
-  serialization, and explicit documentation of the `Pi`, `U_*`, and
-  `U_bucket` roles. This is the low-level native covariance foundation tracked
-  by Linear OPE-17; centred coherent reduction, unresolved covariance, and
-  likelihood integration are follow-up work.
+  dense or diagonal observation covariance products, a basis-owned canonical
+  multisource expansion, explicit eager execution boundaries, and a units
+  contract for dimensionless scaling states. Product persistence and durable
+  identities are deferred to OPE-40. This is the low-level native covariance
+  foundation tracked by Linear OPE-17; centred coherent reduction, unresolved
+  covariance, and likelihood integration are follow-up work.
 
 - Separated basis-group constraints from the algorithms applied within each
   group. The constrained module now owns masks, target allocation, per-group

--- a/docs/reference/openghg_inversions.basis.covariance_products.rst
+++ b/docs/reference/openghg_inversions.basis.covariance_products.rst
@@ -1,0 +1,7 @@
+openghg\_inversions.basis.covariance\_products
+===============================================
+
+.. automodule:: openghg_inversions.basis.covariance_products
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/reference/openghg_inversions.basis.rst
+++ b/docs/reference/openghg_inversions.basis.rst
@@ -12,4 +12,5 @@ openghg\_inversions.basis
 
    openghg_inversions.basis.algorithms
    openghg_inversions.basis.basis_functions
+   openghg_inversions.basis.covariance_products
    openghg_inversions.basis.operators

--- a/docs/usage/native_covariance.rst
+++ b/docs/usage/native_covariance.rst
@@ -185,8 +185,10 @@ The structured covariance action stores axis factors rather than dense native
 :math:`B`, but the numerical product kernel is otherwise eager. The upstream
 pipeline must materialize the related sensitivity and canonical basis
 prolongation together before calling it; lazy inputs are rejected rather than
-computed implicitly. Custom restrictions may remain sparse or Dask-backed and
-are densified only in explicit retained-state right-hand-side blocks. For
+computed implicitly. A custom restriction may remain sparse or Dask-backed
+until the explicit projection boundary, where it is materialized and densified
+once. The eager restriction is then reused across retained-state
+right-hand-side blocks, avoiding repeated execution of its lazy graph. For
 native size :math:`N`, retained size
 :math:`d`, and observation count :math:`M`, important dense storage includes
 :math:`M N` for :math:`H`, :math:`N d` for each native-by-retained array,

--- a/docs/usage/native_covariance.rst
+++ b/docs/usage/native_covariance.rst
@@ -28,8 +28,10 @@ The classes have the following distinct roles.
        native source dimension. In both cases, the transpose does not define
        the retained restriction :math:`\Pi`.
    * - ``InvertibleNativeCovarianceAction``
-     - Structural interface for applying :math:`B` and solving systems in
-       :math:`B` without constructing a dense native covariance matrix.
+     - Structural interface for a labelled, self-adjoint positive-definite
+       :math:`B`, including its compatible inverse solve, without constructing
+       a dense native covariance matrix. The kernel trusts this semantic
+       contract rather than globally certifying a matrix-free action.
    * - ``SeparableExponentialCovariance``
      - Concrete latitude/longitude covariance action. Optional class labels
        set cross-class covariance to zero; this alone does not assert
@@ -41,16 +43,18 @@ The classes have the following distinct roles.
        and solves use the common action interface; only multisource basis
        expansion needs a separate source-aware path.
    * - ``RetainedProjectionStrategy``
-     - Policy interface that chooses a compatible restriction :math:`\Pi` and
-       covariance-natural prolongation :math:`U_*`.
+     - Pi-first policy interface that chooses the authoritative labelled
+       restriction :math:`\Pi`. The kernel derives its covariance-natural
+       prolongation :math:`U_*`.
    * - ``PreserveBucketProlongation``
-     - Current structural implementation of the strategy interface. It fixes
-       :math:`U_* = U_{\mathrm{bucket}}` and derives the compatible
-       :math:`\Pi_U`.
+     - Current strategy implementation. It uses
+       :math:`U_{\mathrm{bucket}}` to derive the compatible authoritative
+       restriction :math:`\Pi_U`; the kernel still derives :math:`U_*` from
+       that returned restriction.
    * - ``RetainedProjection``
      - Frozen value dataclass returned by a strategy. It carries
-       :math:`(\Pi, U_*)` and the strategy identifier; it is not a protocol,
-       and its contained xarray objects remain mutable.
+       :math:`\Pi` and the strategy identifier; it is not a protocol, and its
+       contained xarray object remains mutable.
    * - ``project_native_covariance``
      - Validates and combines :math:`H`, :math:`B`, basis geometry, and a
        projection strategy.
@@ -67,7 +71,7 @@ The data flow is:
                               ├─> RetainedProjectionStrategy
    covariance action ──> B ───┘              │
                                              v
-                              RetainedProjection(Pi, U_*)
+                              RetainedProjection(Pi)
                                              │
    native sensitivity H ─────────────────────┤
    covariance action B ──────────────────────┤
@@ -137,7 +141,9 @@ the established bucket-scaling interpretation by choosing
    U_{\mathrm{bucket}}^\mathsf{T} B^{-1}.
 
 This gives :math:`\Pi_U U_{\mathrm{bucket}} = I` and
-:math:`U_* = U_{\mathrm{bucket}}`. OPE-17 returns :math:`C_\alpha`,
+:math:`U_* = U_{\mathrm{bucket}}`; the latter identity follows from the
+kernel's generic derivation :math:`U_* = B\Pi^\mathsf{T}C_\alpha^{-1}`, not
+from a strategy-supplied lift. OPE-17 returns :math:`C_\alpha`,
 :math:`H U_*`, :math:`H B \Pi^\mathsf{T}`, and either dense
 :math:`H B H^\mathsf{T}` or its diagonal.
 
@@ -243,9 +249,10 @@ setting. Both policies require a supplied-:math:`\Pi`-first OGI strategy.
        covariance-natural lift. Current 14-site production uses the
        absolute-prior-flux-weighted regional mean above.
      - Deliberate difference
-     - The first OPE-17 strategy is compatibility-oriented: it fixes
-       :math:`U_{\mathrm{bucket}}` first and derives :math:`\Pi_U`. The strategy
-       interface leaves room for a future :math:`\Pi`-first policy.
+     - The first OPE-17 strategy is compatibility-oriented: it uses
+       :math:`U_{\mathrm{bucket}}` internally to derive :math:`\Pi_U`. The
+       strategy interface itself is Pi-first, so later policies may supply a
+       physical restriction directly.
    * - Cross-source covariance, arbitrary reporting functionals :math:`Q`,
        :math:`B_\perp` products, coherent likelihood reduction, reconstruction,
        and covariance approximation

--- a/docs/usage/native_covariance.rst
+++ b/docs/usage/native_covariance.rst
@@ -1,0 +1,257 @@
+Native Covariance Projection
+============================
+
+The native covariance projection API prepares labelled covariance and
+observation product blocks for reducing a gridded scaling state. It keeps basis
+geometry, native covariance, and retained-state semantics separate, and never
+constructs a dense native-grid covariance matrix. This is the low-level OPE-17
+boundary: it is not connected to RHIME input preparation or likelihoods, and
+its product blocks are not the complete coherent-reduction artifact planned by
+OPE-18.
+
+Component overview
+------------------
+
+The classes have the following distinct roles.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 28 72
+
+   * - Component
+     - Responsibility
+   * - ``BasisOperator``
+     - Owns basis geometry and retained-state labels. For a single source,
+       ``basis_matrix`` is the bucket prolongation :math:`U_{\mathrm{bucket}}`.
+       A gathered multisource matrix is a spatial template that the projection
+       code expands onto an explicit native source dimension. In both cases,
+       the transpose does not define the retained restriction :math:`\Pi`.
+   * - ``InvertibleNativeCovarianceAction``
+     - Structural interface for applying :math:`B` and solving systems in
+       :math:`B` without constructing a dense native covariance matrix.
+   * - ``SeparableExponentialCovariance``
+     - Concrete latitude/longitude covariance action. Optional class labels
+       set cross-class covariance to zero; this alone does not assert
+       probabilistic independence outside a joint Gaussian model.
+   * - ``IndependentSourceCovariance``
+     - Composes ordered, source-specific spatial covariances into a
+       block-diagonal native covariance. Its blocks currently must be
+       ``SeparableExponentialCovariance`` instances. Covariance application
+       and solves use the common action interface; only multisource basis
+       expansion needs a separate source-aware path.
+   * - ``RetainedProjectionStrategy``
+     - Policy interface that chooses a compatible restriction :math:`\Pi` and
+       covariance-natural prolongation :math:`U_*`.
+   * - ``PreserveBucketProlongation``
+     - Current structural implementation of the strategy interface. It fixes
+       :math:`U_* = U_{\mathrm{bucket}}` and derives the compatible
+       :math:`\Pi_U`.
+   * - ``RetainedProjection``
+     - Frozen value dataclass returned by a strategy. It carries
+       :math:`(\Pi, U_*)` and the strategy identifier; it is not a protocol,
+       and its contained xarray objects remain mutable.
+   * - ``project_native_covariance``
+     - Validates and combines :math:`H`, :math:`B`, basis geometry, and a
+       projection strategy.
+   * - ``NativeCovarianceProducts``
+     - Frozen result and serialization dataclass containing the labelled
+       product blocks. Its contained xarray objects and provenance mapping
+       remain mutable.
+
+The data flow is:
+
+.. code-block:: text
+
+   BasisOperator ──> U_bucket ─┐
+                              ├─> RetainedProjectionStrategy
+   covariance action ──> B ───┘              │
+                                             v
+                              RetainedProjection(Pi, U_*)
+                                             │
+   native sensitivity H ─────────────────────┤
+   covariance action B ──────────────────────┤
+                                             v
+                              project_native_covariance
+                                             │
+                                             v
+                              NativeCovarianceProducts
+
+``FluxWeightedBasis`` is a data-preparation wrapper that pairs an operator
+with a flux field for sensitivity projection and flux reconstruction. It does
+not define :math:`\Pi`, apply native covariance, or own covariance transforms.
+By the time this API is called, :math:`H` already contains footprint times
+prior flux, so both the native and retained states are multiplicative
+scalings.
+
+Projection and centring
+-----------------------
+
+Let the native scaling state have mean :math:`m` and covariance :math:`B`:
+
+.. math::
+
+   \operatorname{E}[x] = m,
+   \qquad
+   \operatorname{Cov}(x) = B,
+   \qquad
+   \delta x = x - m.
+
+For a retained restriction :math:`\Pi`, define
+
+.. math::
+
+   \alpha = \Pi x,
+   \qquad
+   \delta\alpha = \alpha - \Pi m = \Pi\,\delta x,
+   \qquad
+   C_\alpha = \Pi B \Pi^\mathsf{T}.
+
+The covariance-natural prolongation associated with that restriction is
+
+.. math::
+
+   U_* = B \Pi^\mathsf{T} C_\alpha^{-1}.
+
+The full affine lift is therefore
+
+.. math::
+
+   \widehat{x}(\alpha)
+   = m + U_*\delta\alpha
+   = m + U_*(\alpha - \Pi m),
+
+not the uncentred expression :math:`U_*\alpha`. For a joint Gaussian model
+this lift is :math:`\operatorname{E}[x\mid\alpha]`. Without Gaussianity it is
+the linear-Bayes lift determined by the first two moments.
+
+In general, :math:`U_*`, :math:`U_{\mathrm{bucket}}`, and
+:math:`\Pi^\mathsf{T}` are different operators. The initial strategy preserves
+the established bucket-scaling interpretation by choosing
+
+.. math::
+
+   \Pi_U =
+   \left(U_{\mathrm{bucket}}^\mathsf{T} B^{-1}
+   U_{\mathrm{bucket}}\right)^{-1}
+   U_{\mathrm{bucket}}^\mathsf{T} B^{-1}.
+
+This gives :math:`\Pi_U U_{\mathrm{bucket}} = I` and
+:math:`U_* = U_{\mathrm{bucket}}`. OPE-17 returns :math:`C_\alpha`,
+:math:`H U_*`, :math:`H B \Pi^\mathsf{T}`, and either dense
+:math:`H B H^\mathsf{T}` or its diagonal.
+
+What OPE-17 does not construct
+------------------------------
+
+The exact Gaussian reduction also needs
+
+.. math::
+
+   B_\perp
+   = B - U_* C_\alpha U_*^\mathsf{T},
+
+and the centred conditional observation model
+
+.. math::
+
+   y \mid \alpha \sim \mathcal N\!\left(
+   Hm + H U_*(\alpha - \Pi m),
+   R + H B_\perp H^\mathsf{T}
+   \right).
+
+OPE-18 owns that solve-based transformation, unresolved covariance, and the
+single coherent artifact that binds prior, forward, residual, reconstruction,
+and state-treatment information. The OPE-17 product blocks are inputs to that
+work; they must not be described or persisted as though they were already the
+complete artifact. Arbitrary reporting-function products :math:`Q`,
+low-rank-plus-diagonal numerical views, and likelihood integration are also
+outside this API.
+
+Identity and serialization
+--------------------------
+
+``source_content_identity`` binds the shared :math:`B/H/\Pi/U_*` source
+content independently of the requested dense or diagonal observation product.
+``observation_covariance_view`` records that selector, and ``view_identity``
+is derived from it and the source identity. These values bind provenance and
+shared metadata; they are not load-time integrity checksums. Deserialization
+does not rehash product values to detect numeric tampering. The later
+coherent-reduction artifact can reference the OPE-17 source identity, but
+needs its own identity for the additional prior, affine-forward, residual,
+and reconstruction content.
+
+Memory and execution boundary
+-----------------------------
+
+The structured covariance action stores axis factors rather than dense native
+:math:`B`, but this API is otherwise eager. It materializes the native
+sensitivity, bucket prolongation, restriction/prolongation, reduced products,
+and requested observation product. For native size :math:`N`, retained size
+:math:`d`, and observation count :math:`M`, important dense storage includes
+:math:`M N` for :math:`H`, :math:`N d` for each native-by-retained array,
+:math:`d^2` for retained products, and either :math:`M^2` for dense
+:math:`H B H^\mathsf{T}` or :math:`M` for its diagonal.
+
+``observation_batch_size`` is an eager execution setting, not an xarray or
+Dask chunk size. Each batch applies :math:`B` to a group of columns from
+:math:`H^\mathsf{T}`, limiting the temporary :math:`N`-by-batch working set.
+Dense batches still fill a preallocated complete quadratic observation
+covariance. Changing the batch size changes execution only, not the scientific
+inputs or requested numerical form.
+
+Correspondence with ``verification-games``
+-------------------------------------------
+
+OPE-17 deliberately ports only the reusable lower-level prototype boundary.
+The recent 14-site production runs define retained coefficients with a
+source-blocked, absolute-prior-flux-weighted mean. For source :math:`s`, region
+:math:`r`, and native cell :math:`i`, let
+
+.. math::
+
+   q_{si} = \bar F^{\mathrm{UOB\,BASE}}_{si} A_i,
+   \qquad
+   \Pi_{(s,r),(s',i)} =
+   \mathbf 1[s=s']\,\mathbf 1[i\in r]\,
+   \frac{|q_{si}|}{\sum_{j\in r}|q_{sj}|}.
+
+Thus each row is nonnegative, sums to one, and averages native scaling factors
+within exactly one source and one active region. This physical restriction is
+chosen independently of :math:`B`; the covariance then determines
+:math:`C_\alpha` and :math:`U_*`. The prototype also supports a distinct
+signed-flux-total policy, but that is not the current 14-site production
+setting. Both policies require a supplied-:math:`\Pi`-first OGI strategy.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 31 21 48
+
+   * - Prototype capability
+     - OPE-17 status
+     - Correspondence
+   * - Separable exponential covariance action, optional class blocking, and
+       batched :math:`\Pi B\Pi^\mathsf{T}`,
+       :math:`H B\Pi^\mathsf{T}`, and :math:`H B H^\mathsf{T}` products
+     - Faithful port
+     - Re-expressed as labelled xarray actions and product objects; OPE-17 also
+       supports ordered independent-source blocks.
+   * - Choose a physical restriction :math:`\Pi` first, then derive its
+       covariance-natural lift. Current 14-site production uses the
+       absolute-prior-flux-weighted regional mean above.
+     - Deliberate difference
+     - The first OPE-17 strategy is compatibility-oriented: it fixes
+       :math:`U_{\mathrm{bucket}}` first and derives :math:`\Pi_U`. The strategy
+       interface leaves room for a future :math:`\Pi`-first policy.
+   * - Cross-source covariance, arbitrary reporting functionals :math:`Q`,
+       :math:`B_\perp` products, coherent likelihood reduction, reconstruction,
+       and covariance approximation
+     - Not ported
+     - These remain prototype or downstream OPE-18 work and must not be inferred
+       from the presence of OPE-17 product blocks.
+
+API reference
+-------------
+
+See :mod:`openghg_inversions.native_covariance`,
+:mod:`openghg_inversions.source_covariance`, and
+:mod:`openghg_inversions.basis.covariance_products` for the public interfaces.

--- a/docs/usage/native_covariance.rst
+++ b/docs/usage/native_covariance.rst
@@ -23,9 +23,10 @@ The classes have the following distinct roles.
    * - ``BasisOperator``
      - Owns basis geometry and retained-state labels. For a single source,
        ``basis_matrix`` is the bucket prolongation :math:`U_{\mathrm{bucket}}`.
-       A gathered multisource matrix is a spatial template that the projection
-       code expands onto an explicit native source dimension. In both cases,
-       the transpose does not define the retained restriction :math:`\Pi`.
+       A gathered multisource matrix is a spatial template; the basis-side
+       ``native_prolongation`` adapter expands it onto a canonical explicit
+       native source dimension. In both cases, the transpose does not define
+       the retained restriction :math:`\Pi`.
    * - ``InvertibleNativeCovarianceAction``
      - Structural interface for applying :math:`B` and solving systems in
        :math:`B` without constructing a dense native covariance matrix.
@@ -54,9 +55,9 @@ The classes have the following distinct roles.
      - Validates and combines :math:`H`, :math:`B`, basis geometry, and a
        projection strategy.
    * - ``NativeCovarianceProducts``
-     - Frozen result and serialization dataclass containing the labelled
-       product blocks. Its contained xarray objects and provenance mapping
-       remain mutable.
+     - Frozen in-memory result dataclass containing the labelled product
+       blocks. Its contained xarray objects remain mutable. Durable identity,
+       schema design, and persistence are deferred to OPE-40.
 
 The data flow is:
 
@@ -167,26 +168,26 @@ complete artifact. Arbitrary reporting-function products :math:`Q`,
 low-rank-plus-diagonal numerical views, and likelihood integration are also
 outside this API.
 
-Identity and serialization
---------------------------
+Units and persistence boundary
+------------------------------
 
-``source_content_identity`` binds the shared :math:`B/H/\Pi/U_*` source
-content independently of the requested dense or diagonal observation product.
-``observation_covariance_view`` records that selector, and ``view_identity``
-is derived from it and the source identity. These values bind provenance and
-shared metadata; they are not load-time integrity checksums. Deserialization
-does not rehash product values to detect numeric tampering. The later
-coherent-reduction artifact can reference the OPE-17 source identity, but
-needs its own identity for the additional prior, affine-forward, residual,
-and reconstruction content.
+Native and retained scaling perturbations are dimensionless. Accordingly,
+:math:`\Pi`, :math:`U_*`, and :math:`C_\alpha` carry units ``1``;
+:math:`H U_*` and :math:`H B\Pi^\mathsf{T}` inherit the sensitivity units;
+and :math:`H B H^\mathsf{T}` (including its diagonal view) carries their
+square. This low-level result is in-memory only. OPE-40 owns durable identities,
+typed coordinate persistence, schema compatibility, and DataTree/NetCDF I/O.
 
 Memory and execution boundary
 -----------------------------
 
 The structured covariance action stores axis factors rather than dense native
-:math:`B`, but this API is otherwise eager. It materializes the native
-sensitivity, bucket prolongation, restriction/prolongation, reduced products,
-and requested observation product. For native size :math:`N`, retained size
+:math:`B`, but the numerical product kernel is otherwise eager. The upstream
+pipeline must materialize the related sensitivity and canonical basis
+prolongation together before calling it; lazy inputs are rejected rather than
+computed implicitly. Custom restrictions may remain sparse or Dask-backed and
+are densified only in explicit retained-state right-hand-side blocks. For
+native size :math:`N`, retained size
 :math:`d`, and observation count :math:`M`, important dense storage includes
 :math:`M N` for :math:`H`, :math:`N d` for each native-by-retained array,
 :math:`d^2` for retained products, and either :math:`M^2` for dense
@@ -195,6 +196,7 @@ and requested observation product. For native size :math:`N`, retained size
 ``observation_batch_size`` is an eager execution setting, not an xarray or
 Dask chunk size. Each batch applies :math:`B` to a group of columns from
 :math:`H^\mathsf{T}`, limiting the temporary :math:`N`-by-batch working set.
+The same setting bounds explicit custom-restriction right-hand-side blocks.
 Dense batches still fill a preallocated complete quadratic observation
 covariance. Changing the batch size changes execution only, not the scientific
 inputs or requested numerical form.

--- a/docs/usage/rhime.rst
+++ b/docs/usage/rhime.rst
@@ -740,6 +740,10 @@ than 100,000 cells require a structured covariance representation, such as a
 Kronecker product, whose projected products can be evaluated without realizing
 the full native covariance.
 
+The low-level :doc:`native_covariance` API supplies this structured native
+covariance action and its covariance-compatible projected product blocks. It
+is a preparation interface and is not yet connected to the RHIME likelihood.
+
 This component does **not** perform the native-to-reduced uncertainty
 transformation or remove state coordinates. That work must transform the prior
 uncertainty, forward operator, and aggregation error together. The coherent

--- a/docs/usage/usage.rst
+++ b/docs/usage/usage.rst
@@ -10,3 +10,4 @@ Using OpenGHG Inversions
    grouped_basis_layout
    rhime
    concrete_rhime_model
+   native_covariance

--- a/openghg_inversions/_labelled_matrices.py
+++ b/openghg_inversions/_labelled_matrices.py
@@ -9,14 +9,14 @@ renamed deterministically to avoid collisions.
 
 from __future__ import annotations
 
-from collections.abc import Hashable
+from collections.abc import Hashable, Iterable
 
 import numpy as np
 import pandas as pd
 import xarray as xr
 
 
-def matrix_column_dim(row_dim: str, occupied: tuple[Hashable, ...]) -> str:
+def matrix_column_dim(row_dim: str, occupied: Iterable[Hashable]) -> str:
     """Return a deterministic unoccupied column dimension for ``row_dim``."""
     candidate = f"{row_dim}_cov"
     suffix = 2
@@ -63,11 +63,17 @@ def renamed_column_coordinates(
         renamed = index.rename(renamed_levels)
         coordinates = xr.Coordinates.from_pandas_multiindex(renamed, column_dim)
         result.update({str(name): coordinate for name, coordinate in coordinates.items()})
+        result[column_dim].attrs = array.coords[row_dim].attrs
+        for raw_name, renamed_name in zip(index.names, renamed_levels, strict=True):
+            if raw_name is not None and raw_name in array.coords:
+                result[renamed_name].attrs = array.coords[raw_name].attrs
     else:
         result[column_dim] = xr.DataArray(
-            index.to_numpy(copy=False),
-            dims=column_dim,
-            attrs=array.coords[row_dim].attrs,
+            xr.IndexVariable(
+                column_dim,
+                index.rename(column_dim),
+                attrs=array.coords[row_dim].attrs,
+            )
         )
 
     for raw_name, coordinate in array.coords.items():

--- a/openghg_inversions/_labelled_matrices.py
+++ b/openghg_inversions/_labelled_matrices.py
@@ -1,0 +1,176 @@
+"""Shared labelled square-matrix axis construction and diagnostics.
+
+Numerical kernels use distinct row and column dimensions so xarray never
+contracts a square matrix along both axes accidentally.  Column axes retain
+the row axis's typed :class:`pandas.Index` or :class:`pandas.MultiIndex`;
+MultiIndex level names and one-dimensional auxiliary-coordinate names are
+renamed deterministically to avoid collisions.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Hashable
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+
+def matrix_column_dim(row_dim: str, occupied: tuple[Hashable, ...]) -> str:
+    """Return a deterministic unoccupied column dimension for ``row_dim``."""
+    candidate = f"{row_dim}_cov"
+    suffix = 2
+    while candidate in occupied:
+        candidate = f"{row_dim}_cov_{suffix}"
+        suffix += 1
+    return candidate
+
+
+def renamed_column_coordinates(
+    array: xr.DataArray,
+    *,
+    row_dim: str,
+    column_dim: str,
+) -> dict[str, xr.DataArray]:
+    """Return typed column-axis coordinates copied from a labelled row axis.
+
+    Args:
+        array: Array containing the source row axis.
+        row_dim: Dimension whose index and auxiliary coordinates are copied.
+        column_dim: Distinct destination dimension.
+
+    Returns:
+        Coordinates for ``column_dim``. MultiIndex levels and auxiliary
+        coordinates are renamed with a ``_cov`` suffix when necessary.
+    """
+    index = array.get_index(row_dim)
+    result: dict[str, xr.DataArray] = {}
+    reserved = {str(name) for name in (*array.dims, *array.coords)} | {column_dim}
+    index_level_names: set[str] = set()
+    if isinstance(index, pd.MultiIndex):
+        renamed_levels: list[str] = []
+        for position, raw_name in enumerate(index.names):
+            base = f"{raw_name}_cov" if raw_name is not None else f"{column_dim}_level_{position}"
+            candidate = base
+            suffix = 2
+            while candidate in reserved or candidate in renamed_levels:
+                candidate = f"{base}_{suffix}"
+                suffix += 1
+            renamed_levels.append(candidate)
+            reserved.add(candidate)
+            if raw_name is not None:
+                index_level_names.add(str(raw_name))
+        renamed = index.rename(renamed_levels)
+        coordinates = xr.Coordinates.from_pandas_multiindex(renamed, column_dim)
+        result.update({str(name): coordinate for name, coordinate in coordinates.items()})
+    else:
+        result[column_dim] = xr.DataArray(
+            index.to_numpy(copy=False),
+            dims=column_dim,
+            attrs=array.coords[row_dim].attrs,
+        )
+
+    for raw_name, coordinate in array.coords.items():
+        name = str(raw_name)
+        if name == row_dim or name in index_level_names or tuple(coordinate.dims) != (row_dim,):
+            continue
+        base = f"{name}_cov"
+        candidate = base
+        suffix = 2
+        while candidate in reserved or candidate in result:
+            candidate = f"{base}_{suffix}"
+            suffix += 1
+        reserved.add(candidate)
+        result[candidate] = xr.DataArray(
+            coordinate.data,
+            dims=column_dim,
+            attrs=coordinate.attrs,
+        )
+    return result
+
+
+def to_column_axis(
+    array: xr.DataArray,
+    *,
+    row_dim: str,
+    column_dim: str,
+    leading_dims: tuple[str, ...],
+) -> xr.DataArray:
+    """Rename one labelled row axis to a typed, collision-safe column axis."""
+    ordered = array.transpose(*leading_dims, row_dim)
+    coords = {
+        str(name): coordinate
+        for name, coordinate in ordered.coords.items()
+        if set(coordinate.dims).issubset(leading_dims)
+    }
+    coords.update(renamed_column_coordinates(ordered, row_dim=row_dim, column_dim=column_dim))
+    return xr.DataArray(
+        ordered.data,
+        dims=(*leading_dims, column_dim),
+        coords=coords,
+        name=ordered.name,
+        attrs=ordered.attrs,
+    )
+
+
+def with_square_matrix_diagnostics(
+    array: xr.DataArray,
+    *,
+    mathematical_name: str,
+    require_positive_definite: bool = False,
+    maximum_eigen_diagnostic_size: int = 512,
+) -> xr.DataArray:
+    """Validate a labelled square matrix once and attach numerical diagnostics.
+
+    Args:
+        array: Eager two-dimensional square matrix with distinct dimensions.
+        mathematical_name: Mathematical label stored in attributes and errors.
+        require_positive_definite: Whether to reject non-positive or
+            numerically rank-deficient matrices.
+        maximum_eigen_diagnostic_size: Largest matrix for which a full
+            eigendecomposition is performed when positivity is not required.
+
+    Returns:
+        ``array`` with symmetry and optional eigenvalue diagnostics attached.
+
+    Raises:
+        ValueError: If the layout is not square, values are complex or
+            non-finite, symmetry fails, or requested positive definiteness
+            fails.
+    """
+    if array.ndim != 2 or array.dims[0] == array.dims[1] or array.shape[0] != array.shape[1]:
+        raise ValueError(f"{mathematical_name} must be a square matrix on distinct labelled axes")
+    raw_values = np.asarray(array.values)
+    if np.iscomplexobj(raw_values) or not np.all(np.isfinite(raw_values)):
+        raise ValueError(f"{mathematical_name} must contain only finite real values")
+    values = np.asarray(raw_values, dtype=np.float64)
+    asymmetry = float(np.max(np.abs(values - values.T))) if values.size else 0.0
+    scale = max(1.0, float(np.max(np.abs(values))) if values.size else 1.0)
+    tolerance = 1e-10
+    if asymmetry > tolerance * scale:
+        raise ValueError(f"{mathematical_name} is not symmetric within tolerance {tolerance:g}")
+
+    attrs: dict[str, object] = {
+        **array.attrs,
+        "mathematical_name": mathematical_name,
+        "symmetry_absolute_error": asymmetry,
+        "diagnostic_tolerance": tolerance,
+    }
+    should_diagnose_eigenvalues = (
+        require_positive_definite or values.shape[0] <= maximum_eigen_diagnostic_size
+    )
+    if should_diagnose_eigenvalues:
+        eigenvalues = np.linalg.eigvalsh((values + values.T) * 0.5)
+        minimum = float(eigenvalues[0]) if eigenvalues.size else 0.0
+        maximum = float(eigenvalues[-1]) if eigenvalues.size else 0.0
+        if require_positive_definite and (
+            not eigenvalues.size or maximum <= 0.0 or minimum <= 1e-12 * maximum
+        ):
+            raise ValueError(f"{mathematical_name} must be positive definite and full rank")
+        attrs.update(minimum_eigenvalue=minimum, psd_diagnostic="full_eigendecomposition")
+    else:
+        attrs.update(
+            minimum_eigenvalue=np.nan,
+            psd_diagnostic=f"skipped_full_eigendecomposition_above_{maximum_eigen_diagnostic_size}",
+        )
+    return array.assign_attrs(attrs)

--- a/openghg_inversions/basis/__init__.py
+++ b/openghg_inversions/basis/__init__.py
@@ -1,4 +1,20 @@
-"""Functions for creating basis functions and applying them to sensitivity matrices."""
+"""Basis construction, projection, and retained covariance-product interfaces.
+
+The package provides basis-generation functions, flux-weighted preparation
+wrappers, prior-width projection helpers, and the public OPE-17 retained
+covariance-product API. Basis operators own grid/state geometry: their bucket
+matrix is a prolongation from retained scalings to the native grid, not an
+automatic retained restriction. ``FluxWeightedBasis`` pairs that geometry with
+flux for sensitivity projection and reconstruction; it does not own native
+covariance transforms.
+
+Native covariance actions live in :mod:`openghg_inversions.native_covariance`
+and :mod:`openghg_inversions.source_covariance`. The interfaces re-exported
+here choose a compatible restriction/prolongation pair and prepare labelled
+product blocks. They are a low-level input to later coherent reduction and do
+not themselves construct the centred reduced likelihood, unresolved
+covariance, or a complete coherent-reduction artifact.
+"""
 
 from ._functions import (
     basis_weights_from_fp_all,
@@ -27,6 +43,13 @@ from .prior_uncertainty import (
     calibrate_basis_prior_stdev,
     project_basis_prior_stdev,
 )
+from .covariance_products import (
+    NativeCovarianceProducts,
+    PreserveBucketProlongation,
+    RetainedProjection,
+    RetainedProjectionStrategy,
+    project_native_covariance,
+)
 
 __all__ = [
     "basis_functions_wrapper",
@@ -40,9 +63,14 @@ __all__ = [
     "load_intem_outer_regions",
     "MEAN_TOTAL_TARGET_STATISTIC",
     "MEDIAN_RELATIVE_TARGET_STATISTIC",
+    "NativeCovarianceProducts",
+    "PreserveBucketProlongation",
+    "RetainedProjection",
+    "RetainedProjectionStrategy",
     "make_basis_functions",
     "paired_abs_response_weights",
     "project_basis_prior_stdev",
+    "project_native_covariance",
     "quadtree_basis_from_weights",
     "quadtree_basis_function",
     "quadtreebasisfunction",

--- a/openghg_inversions/basis/covariance_products.py
+++ b/openghg_inversions/basis/covariance_products.py
@@ -8,9 +8,13 @@ they are materialized once and reused by all retained-state RHS blocks.
 
 For native covariance ``B`` and retained restriction ``Pi``, the kernel returns
 ``C_alpha = Pi B Pi.T``, ``H U_*``, ``H B Pi.T``, and ``H B H.T`` (or its
-diagonal). The default strategy preserves bucket prolongation by deriving
-``Pi_U = (U.T B^-1 U)^-1 U.T B^-1``. Durable artifact identity and persistence
-are intentionally deferred to the artifact-I/O layer.
+diagonal). Strategies return authoritative ``Pi``; the kernel derives
+``B Pi.T``, ``C_alpha``, and ``U_* = B Pi.T C_alpha^-1``. The default strategy
+preserves bucket prolongation by deriving
+``Pi_U = (U.T B^-1 U)^-1 U.T B^-1``. The kernel trusts the covariance action's
+real self-adjoint positive-definite semantics and compatible inverse rather
+than globally certifying a matrix-free operator. Durable artifact identity and
+persistence are intentionally deferred to the artifact-I/O layer.
 """
 
 from __future__ import annotations
@@ -38,22 +42,21 @@ MAX_DENSE_EIGEN_DIAGNOSTIC_SIZE = 512
 
 @dataclass(frozen=True, slots=True)
 class RetainedProjection:
-    """A labelled restriction/prolongation pair selected by one strategy.
+    """A labelled retained restriction selected by one strategy.
 
     Attributes:
-        restriction: ``Pi`` with dimensions ``(state_dim, *native_dims)``.
-        prolongation: Covariance-natural ``U_*`` with dimensions
-            ``(*native_dims, state_dim)``.
+        restriction: Dimensionless ``Pi`` with dimensions
+            ``(state_dim, *native_dims)``. The frozen dataclass does not freeze
+            this mutable DataArray.
         strategy: Stable identifier for the scientific projection choice.
     """
 
     restriction: xr.DataArray
-    prolongation: xr.DataArray
     strategy: str
 
 
 class RetainedProjectionStrategy(Protocol):
-    """Extension seam for choosing retained coefficients and their lift."""
+    """Extension seam for choosing authoritative retained coefficients."""
 
     def projection(
         self,
@@ -63,7 +66,20 @@ class RetainedProjectionStrategy(Protocol):
         native_dims: tuple[str, ...],
         state_dim: str,
     ) -> RetainedProjection:
-        """Return a compatible labelled restriction and prolongation."""
+        """Return the authoritative labelled retained restriction ``Pi``.
+
+        Args:
+            covariance: Labelled native covariance action.
+            basis_prolongation: Dimensionless basis ``U`` with dimensions
+                ``(*native_dims, state_dim)``.
+            native_dims: Ordered native covariance dimensions.
+            state_dim: Retained-state dimension.
+
+        Returns:
+            A dimensionless restriction with dimensions
+            ``(state_dim, *native_dims)``. The kernel derives ``B Pi.T``,
+            ``C_alpha``, and ``U_*`` from it.
+        """
         ...
 
 
@@ -95,7 +111,7 @@ class PreserveBucketProlongation:
             state_dim: Retained-state dimension.
 
         Returns:
-            The coherent ``(Pi_U, U)`` pair and algebraically known products.
+            The authoritative bucket-compatible restriction ``Pi_U``.
 
         Raises:
             ValueError: If ``U`` is invalid or lacks full column rank.
@@ -162,19 +178,40 @@ class PreserveBucketProlongation:
             strategy=self.name,
             units="1",
         )
-        prolongation = prolongation.rename("prolongation").assign_attrs(
-            mathematical_name="U_bucket", strategy=self.name, units="1"
-        )
         return RetainedProjection(
             restriction=restriction,
-            prolongation=prolongation,
             strategy=self.name,
         )
 
 
 @dataclass(frozen=True, slots=True)
 class NativeCovarianceProducts:
-    """Labelled in-memory product blocks induced by one coherent projection."""
+    """Labelled in-memory product blocks induced by one retained restriction.
+
+    Attributes:
+        restriction: Dimensionless ``Pi`` with dimensions
+            ``(state_dim, *native_dims)``.
+        prolongation: Derived dimensionless covariance-natural ``U_*`` with
+            dimensions ``(*native_dims, state_dim)``.
+        state_covariance: Positive-definite dimensionless ``C_alpha`` with
+            distinct typed row/column state dimensions.
+        effective_observation_operator: ``H U_*`` with dimensions
+            ``(observation_dim, state_dim)`` and sensitivity units.
+        observation_state_cross_covariance: ``H B Pi.T`` with dimensions
+            ``(observation_dim, state_column_dim)`` and sensitivity units.
+        native_observation_covariance: Dense positive-semidefinite (and
+            possibly singular) ``H B H.T`` on distinct typed observation axes,
+            or its nonnegative observation-axis diagonal. Units are squared
+            sensitivity units.
+        strategy: Identifier of the strategy that selected ``Pi``.
+        observation_covariance_view: Whether the observation covariance field
+            contains the dense matrix or its diagonal.
+
+    Notes:
+        Freezing the dataclass prevents field reassignment, but the contained
+        DataArrays remain mutable. Product attributes are construction-time
+        snapshots, not live views of input attribute mappings.
+    """
 
     restriction: xr.DataArray
     prolongation: xr.DataArray
@@ -209,13 +246,19 @@ def project_native_covariance(
         observation_covariance: Return dense ``H B H.T`` or its diagonal.
         observation_batch_size: Positive integral number of covariance
             right-hand sides per eager block.
-        strategy: Projection choice; defaults to bucket preservation.
+        strategy: Authoritative restriction choice; defaults to the
+            bucket-preserving restriction.
 
     Returns:
         Frozen in-memory labelled product value object. Scaling covariance,
         restriction, and prolongation have units ``"1"``. Products linear in
         ``H`` inherit its units; observation covariance uses squared ``H``
         units when supplied.
+
+        The kernel trusts the covariance action's declared self-adjoint
+        positive-definite semantics; it does not globally certify a
+        matrix-free ``B``. Runtime checks diagnose only the requested products
+        and covariance-action outputs encountered here.
 
     Raises:
         TypeError: If ``observation_batch_size`` is not an integral non-Boolean.
@@ -256,9 +299,7 @@ def project_native_covariance(
         state_dim=state_dim,
     )
     occupied_names = {
-        str(name)
-        for array in (sensitivity, projection.restriction, projection.prolongation)
-        for name in (*array.dims, *array.coords)
+        str(name) for array in (sensitivity, projection.restriction) for name in (*array.dims, *array.coords)
     }
     state_column_dim = matrix_column_dim(state_dim, occupied_names)
     b_pi_t = _apply_restriction_blocks(
@@ -282,8 +323,8 @@ def project_native_covariance(
         mathematical_name="C_alpha",
         require_positive_definite=True,
     )
-    _validate_projection_invariant(
-        projection,
+    prolongation = _derive_covariance_natural_prolongation(
+        projection.restriction,
         state_covariance,
         b_pi_t,
         native_dims=native_dims,
@@ -292,7 +333,7 @@ def project_native_covariance(
     )
     h_units = sensitivity.attrs.get("units")
     linear_units = {"units": h_units} if h_units is not None else {}
-    effective_operator = xr.dot(sensitivity, projection.prolongation, dim=list(native_dims)).transpose(
+    effective_operator = xr.dot(sensitivity, prolongation, dim=list(native_dims)).transpose(
         observation_dim, state_dim
     )
     effective_operator = effective_operator.rename("effective_observation_operator").assign_attrs(
@@ -314,7 +355,7 @@ def project_native_covariance(
     )
     return NativeCovarianceProducts(
         restriction=projection.restriction,
-        prolongation=projection.prolongation,
+        prolongation=prolongation,
         state_covariance=state_covariance,
         effective_observation_operator=effective_operator,
         observation_state_cross_covariance=cross_covariance,
@@ -344,7 +385,13 @@ def _apply_restriction_blocks(
             leading_dims=native_dims,
         )
         rhs = _materialize_dense_preserving_coordinates(rhs)
-        blocks.append(covariance.apply(rhs))
+        blocks.append(
+            _validated_covariance_apply(
+                covariance,
+                rhs,
+                context="B Pi.T",
+            )
+        )
     return xr.concat(blocks, dim=column_dim).transpose(*native_dims, column_dim)
 
 
@@ -365,6 +412,41 @@ def _restriction_product_blocks(
         )
         blocks.append(xr.dot(rows, b_pi_t, dim=list(native_dims)))
     return xr.concat(blocks, dim=state_dim).transpose(state_dim, column_dim)
+
+
+def _validated_covariance_apply(
+    covariance: InvertibleNativeCovarianceAction,
+    rhs: xr.DataArray,
+    *,
+    context: str,
+) -> xr.DataArray:
+    """Apply ``B`` and reject invalid action output.
+
+    Args:
+        covariance: Native covariance action.
+        rhs: Labelled right-hand sides.
+        context: Product name included in validation errors.
+
+    Returns:
+        The labelled finite-real action result.
+
+    Raises:
+        ValueError: If the result is not a DataArray or contains complex or
+            non-finite values.
+    """
+    result = covariance.apply(rhs)
+    if not isinstance(result, xr.DataArray):
+        raise ValueError(
+            f"covariance.apply action-contract violation while computing {context}: "
+            "expected an xarray.DataArray"
+        )
+    values = np.asarray(result.values)
+    if np.iscomplexobj(values) or not np.all(np.isfinite(values)):
+        raise ValueError(
+            f"covariance.apply action-contract violation while computing {context}: "
+            "output must contain only finite real values"
+        )
+    return result
 
 
 def _observation_covariance(
@@ -398,7 +480,11 @@ def _observation_covariance(
             column_dim=column_dim,
             leading_dims=native_dims,
         )
-        b_rhs = covariance.apply(rhs)
+        b_rhs = _validated_covariance_apply(
+            covariance,
+            rhs,
+            context="H B H.T",
+        )
         if output == "dense":
             block = xr.dot(sensitivity, b_rhs, dim=list(native_dims)).transpose(observation_dim, column_dim)
             values[:, start:stop] = np.asarray(block.values)
@@ -412,7 +498,7 @@ def _observation_covariance(
             )
             diagonal_error_bounds[start:stop] = contraction_error_factor * np.maximum(
                 contraction_magnitudes,
-                1.0,
+                0.0,
             )
     units = sensitivity.attrs.get("units")
     unit_attrs = {"units": f"({units})^2"} if units is not None else {}
@@ -478,59 +564,25 @@ def _validated_projection(
     expected = {state_dim, *native_dims}
     if set(restriction.dims) != expected or len(restriction.dims) != len(expected):
         raise ValueError("Projection strategy restriction has invalid labelled dimensions")
-    prolongation = _validated_prolongation(
-        projection.prolongation, native_dims=native_dims, state_dim=state_dim
-    ).assign_attrs({**projection.prolongation.attrs, "units": "1"})
-    for role, array in (("restriction", restriction), ("prolongation", prolongation)):
-        _validate_exact_native_coordinates(array, native_reference, native_dims=native_dims, role=role)
-    if state_dim not in restriction.coords or state_dim not in prolongation.coords:
-        raise ValueError("Projection strategy restriction and prolongation require state labels")
-    if not restriction.get_index(state_dim).equals(prolongation.get_index(state_dim)):
-        raise ValueError("Projection strategy restriction/prolongation state labels differ")
-    _require_compatible_axis_coordinates(
+    _validate_exact_native_coordinates(
         restriction,
-        prolongation,
-        dim=state_dim,
-        role="retained-state",
+        native_reference,
+        native_dims=native_dims,
+        role="restriction",
     )
-    for role, array in (("restriction", restriction), ("prolongation", prolongation)):
-        _require_reference_native_coordinates(
-            array,
-            native_reference,
-            native_dims=native_dims,
-            role=role,
-        )
+    if state_dim not in restriction.coords:
+        raise ValueError("Projection strategy restriction requires state labels")
+    _require_reference_native_coordinates(
+        restriction,
+        native_reference,
+        native_dims=native_dims,
+        role="restriction",
+    )
     restriction = _materialize_dense_preserving_coordinates(restriction)
     restriction_values = np.asarray(restriction.values)
     if np.iscomplexobj(restriction_values) or not np.all(np.isfinite(restriction_values)):
         raise ValueError("Projection strategy restriction must contain only finite real values")
-    return replace(projection, restriction=restriction, prolongation=prolongation)
-
-
-def _require_compatible_axis_coordinates(
-    left: xr.DataArray,
-    right: xr.DataArray,
-    *,
-    dim: str,
-    role: str,
-) -> None:
-    """Require identical semantic coordinates attached to one shared axis."""
-    left_coords = {
-        str(name): coordinate
-        for name, coordinate in left.coords.items()
-        if dim in coordinate.dims and str(name) != dim
-    }
-    right_coords = {
-        str(name): coordinate
-        for name, coordinate in right.coords.items()
-        if dim in coordinate.dims and str(name) != dim
-    }
-    if set(left_coords) != set(right_coords):
-        raise ValueError(f"Projection {role} auxiliary coordinate names differ between Pi and U")
-    for name, coordinate in left_coords.items():
-        other = right_coords[name]
-        if coordinate.dims != other.dims or not coordinate.equals(other):
-            raise ValueError(f"Projection {role} auxiliary coordinate {name!r} differs between Pi and U")
+    return replace(projection, restriction=restriction)
 
 
 def _require_reference_native_coordinates(
@@ -572,29 +624,69 @@ def _validate_exact_native_coordinates(
             )
 
 
-def _validate_projection_invariant(
-    projection: RetainedProjection,
+def _derive_covariance_natural_prolongation(
+    restriction: xr.DataArray,
     state_covariance: xr.DataArray,
     b_pi_t: xr.DataArray,
     *,
     native_dims: tuple[str, ...],
     state_dim: str,
     state_column_dim: str,
-) -> None:
-    """Require ``B Pi.T = U_* C_alpha`` for a custom strategy."""
-    right = xr.dot(projection.prolongation, state_covariance, dim=state_dim).transpose(
-        *native_dims, state_column_dim
+) -> xr.DataArray:
+    """Derive labelled ``U_* = B Pi.T C_alpha^-1`` from authoritative ``Pi``.
+
+    The result has dimensions ``(*native_dims, state_dim)`` and preserves
+    native coordinates from ``B Pi.T`` and state coordinates from ``Pi``.
+
+    Args:
+        restriction: Authoritative labelled ``Pi``.
+        state_covariance: Positive-definite ``C_alpha``.
+        b_pi_t: Labelled ``B Pi.T``.
+        native_dims: Ordered native covariance dimensions.
+        state_dim: Retained-state row dimension.
+        state_column_dim: Distinct retained-state column dimension.
+
+    Returns:
+        The dimensionless covariance-natural prolongation ``U_*``.
+
+    Raises:
+        ValueError: If ``C_alpha`` cannot be factored as positive definite.
+    """
+    covariance_values = np.asarray(state_covariance.values, dtype=np.float64)
+    try:
+        factor = cho_factor(covariance_values, lower=True, check_finite=True)
+        b_pi_values = np.asarray(b_pi_t.transpose(*native_dims, state_column_dim).values)
+        native_shape = tuple(b_pi_t.sizes[dim] for dim in native_dims)
+        solved = cho_solve(
+            factor,
+            b_pi_values.reshape((-1, b_pi_t.sizes[state_column_dim])).T,
+            check_finite=True,
+        ).T.reshape((*native_shape, restriction.sizes[state_dim]))
+    except np.linalg.LinAlgError as exc:
+        raise ValueError("C_alpha must be positive definite to derive U_*") from exc
+    coords = {
+        str(name): coordinate
+        for name, coordinate in b_pi_t.coords.items()
+        if set(coordinate.dims).issubset(native_dims)
+    }
+    coords.update(
+        {
+            str(name): coordinate
+            for name, coordinate in restriction.coords.items()
+            if set(coordinate.dims).issubset({state_dim})
+        }
     )
-    left_values = np.asarray(b_pi_t.values, dtype=np.float64)
-    right_values = np.asarray(right.values, dtype=np.float64)
-    scale = max(
-        float(np.max(np.abs(left_values))) if left_values.size else 0.0,
-        float(np.max(np.abs(right_values))) if right_values.size else 0.0,
-        np.finfo(np.float64).tiny,
+    return xr.DataArray(
+        solved,
+        dims=(*native_dims, state_dim),
+        coords=coords,
+        attrs={
+            "mathematical_name": "U_*",
+            "definition": "B Pi.T C_alpha^-1",
+            "units": "1",
+        },
+        name="prolongation",
     )
-    error = float(np.max(np.abs(left_values - right_values))) if left_values.size else 0.0
-    if error > 1e-9 * scale + 10.0 * np.finfo(np.float64).tiny:
-        raise ValueError("Projection strategy is incoherent: expected B Pi.T = U_* C_alpha")
 
 
 def _validated_prolongation(

--- a/openghg_inversions/basis/covariance_products.py
+++ b/openghg_inversions/basis/covariance_products.py
@@ -31,7 +31,6 @@ from openghg_inversions._labelled_matrices import (
     to_column_axis,
     with_square_matrix_diagnostics,
 )
-from openghg_inversions.array_ops import to_dense
 from openghg_inversions.native_covariance import InvertibleNativeCovarianceAction
 
 MAX_DENSE_EIGEN_DIAGNOSTIC_SIZE = 512
@@ -46,22 +45,11 @@ class RetainedProjection:
         prolongation: Covariance-natural ``U_*`` with dimensions
             ``(*native_dims, state_dim)``.
         strategy: Stable identifier for the scientific projection choice.
-        state_covariance: Optional cached ``C_alpha``. The kernel independently
-            recomputes and validates caches supplied by external strategies.
-        covariance_restriction_transpose: Optional cached ``B Pi.T``. External
-            cached values are independently recomputed and validated.
     """
 
     restriction: xr.DataArray
     prolongation: xr.DataArray
     strategy: str
-    state_covariance: xr.DataArray | None = None
-    covariance_restriction_transpose: xr.DataArray | None = None
-
-
-@dataclass(frozen=True, slots=True)
-class _PreserveBucketProjection(RetainedProjection):
-    """Private built-in projection with independently derived trusted products."""
 
 
 class RetainedProjectionStrategy(Protocol):
@@ -132,6 +120,14 @@ class PreserveBucketProlongation:
         _require_symmetric(gram_values, "U.T B^-1 U")
         try:
             factor = cho_factor(gram_values, lower=True, check_finite=True)
+            cholesky_diagonal = np.diag(factor[0])
+            largest_pivot = float(np.max(np.abs(cholesky_diagonal)))
+            if (
+                not cholesky_diagonal.size
+                or largest_pivot <= 0.0
+                or float(np.min(np.abs(cholesky_diagonal))) <= 1e-6 * largest_pivot
+            ):
+                raise np.linalg.LinAlgError("numerically rank-deficient Gram matrix")
             covariance_values = cho_solve(factor, np.eye(gram_values.shape[0]), check_finite=False)
         except np.linalg.LinAlgError as exc:
             raise ValueError(
@@ -157,11 +153,6 @@ class PreserveBucketProlongation:
                 column_dim=state_column_dim,
             )
         )
-        state_covariance = with_square_matrix_diagnostics(
-            state_covariance,
-            mathematical_name="C_alpha",
-            require_positive_definite=True,
-        )
         restriction = xr.dot(state_covariance, precision_prolongation, dim=state_column_dim).transpose(
             state_dim, *native_dims
         )
@@ -174,15 +165,10 @@ class PreserveBucketProlongation:
         prolongation = prolongation.rename("prolongation").assign_attrs(
             mathematical_name="U_bucket", strategy=self.name, units="1"
         )
-        b_pi_t = xr.dot(prolongation, state_covariance, dim=state_dim).transpose(
-            *native_dims, state_column_dim
-        )
-        return _PreserveBucketProjection(
+        return RetainedProjection(
             restriction=restriction,
             prolongation=prolongation,
             strategy=self.name,
-            state_covariance=state_covariance,
-            covariance_restriction_transpose=b_pi_t,
         )
 
 
@@ -275,62 +261,35 @@ def project_native_covariance(
         for name in (*array.dims, *array.coords)
     }
     state_column_dim = matrix_column_dim(state_dim, occupied_names)
-    trusted_projection = (
-        _reaxis_builtin_projection(
-            projection,
-            native_dims=native_dims,
-            state_dim=state_dim,
-            state_column_dim=state_column_dim,
-        )
-        if type(projection_strategy) is PreserveBucketProlongation
-        and isinstance(projection, _PreserveBucketProjection)
-        else None
+    b_pi_t = _apply_restriction_blocks(
+        covariance,
+        projection.restriction,
+        native_dims=native_dims,
+        state_dim=state_dim,
+        column_dim=state_column_dim,
+        rhs_block_size=batch_size,
     )
-    if trusted_projection is None:
-        b_pi_t = _apply_restriction_blocks(
-            covariance,
-            projection.restriction,
-            native_dims=native_dims,
-            state_dim=state_dim,
-            column_dim=state_column_dim,
-            rhs_block_size=batch_size,
-        )
-    else:
-        assert trusted_projection.covariance_restriction_transpose is not None
-        b_pi_t = trusted_projection.covariance_restriction_transpose
-
-    if trusted_projection is None:
-        state_covariance = _restriction_product_blocks(
-            projection.restriction,
-            b_pi_t,
-            native_dims=native_dims,
-            state_dim=state_dim,
-            column_dim=state_column_dim,
-            rhs_block_size=batch_size,
-        )
-        state_covariance = with_square_matrix_diagnostics(
-            state_covariance.rename("state_covariance").assign_attrs(units="1"),
-            mathematical_name="C_alpha",
-            require_positive_definite=True,
-        )
-        _validate_external_cached_products(
-            projection,
-            computed_b_pi_t=b_pi_t,
-            computed_state_covariance=state_covariance,
-        )
-    else:
-        assert trusted_projection.state_covariance is not None
-        state_covariance = trusted_projection.state_covariance.rename("state_covariance")
-
-    if trusted_projection is None:
-        _validate_projection_invariant(
-            projection,
-            state_covariance,
-            b_pi_t,
-            native_dims=native_dims,
-            state_dim=state_dim,
-            state_column_dim=state_column_dim,
-        )
+    state_covariance = _restriction_product_blocks(
+        projection.restriction,
+        b_pi_t,
+        native_dims=native_dims,
+        state_dim=state_dim,
+        column_dim=state_column_dim,
+        rhs_block_size=batch_size,
+    )
+    state_covariance = with_square_matrix_diagnostics(
+        state_covariance.rename("state_covariance").assign_attrs(units="1"),
+        mathematical_name="C_alpha",
+        require_positive_definite=True,
+    )
+    _validate_projection_invariant(
+        projection,
+        state_covariance,
+        b_pi_t,
+        native_dims=native_dims,
+        state_dim=state_dim,
+        state_column_dim=state_column_dim,
+    )
     h_units = sensitivity.attrs.get("units")
     linear_units = {"units": h_units} if h_units is not None else {}
     effective_operator = xr.dot(sensitivity, projection.prolongation, dim=list(native_dims)).transpose(
@@ -427,6 +386,10 @@ def _observation_covariance(
         (count, count) if output == "dense" else count,
         dtype=np.result_type(sensitivity.dtype, np.float64),
     )
+    diagonal_error_bounds = np.empty(count, dtype=np.float64) if output == "diagonal" else None
+    native_size = int(np.prod([sensitivity.sizes[dim] for dim in native_dims]))
+    machine_epsilon = np.finfo(np.dtype(values.dtype)).eps
+    contraction_error_factor = 8.0 * native_size * machine_epsilon
     for start in range(0, count, batch_size):
         stop = min(start + batch_size, count)
         rhs = to_column_axis(
@@ -440,7 +403,17 @@ def _observation_covariance(
             block = xr.dot(sensitivity, b_rhs, dim=list(native_dims)).transpose(observation_dim, column_dim)
             values[:, start:stop] = np.asarray(block.values)
         else:
-            values[start:stop] = np.asarray((rhs * b_rhs).sum(dim=list(native_dims)).values)
+            terms = rhs * b_rhs
+            values[start:stop] = np.asarray(terms.sum(dim=list(native_dims)).values)
+            assert diagonal_error_bounds is not None
+            contraction_magnitudes = np.asarray(
+                abs(terms).sum(dim=list(native_dims)).values,
+                dtype=np.float64,
+            )
+            diagonal_error_bounds[start:stop] = contraction_error_factor * np.maximum(
+                contraction_magnitudes,
+                1.0,
+            )
     units = sensitivity.attrs.get("units")
     unit_attrs = {"units": f"({units})^2"} if units is not None else {}
     row_coords = {
@@ -466,10 +439,12 @@ def _observation_covariance(
         )
     if not np.all(np.isfinite(values)):
         raise ValueError("diag(H B H.T) must contain only finite real values")
-    diagonal_scale = max(1.0, float(np.max(np.abs(values))) if values.size else 1.0)
-    diagonal_tolerance = 1e-10 * diagonal_scale
-    if np.any(values < -diagonal_tolerance):
+    assert diagonal_error_bounds is not None
+    if not np.all(np.isfinite(diagonal_error_bounds)):
+        raise ValueError("diag(H B H.T) numerical error bounds must be finite")
+    if np.any(values < -diagonal_error_bounds):
         raise ValueError("diag(H B H.T) contains materially negative covariance values")
+    values = np.where(values < 0.0, 0.0, values)
     result = xr.DataArray(
         values,
         dims=observation_dim,
@@ -478,8 +453,9 @@ def _observation_covariance(
             **unit_attrs,
             "mathematical_name": "diag(H B H.T)",
             "minimum_diagonal": float(np.min(values)),
-            "diagonal_nonnegative": bool(np.all(values >= -diagonal_tolerance)),
-            "diagnostic_tolerance": diagonal_tolerance,
+            "diagonal_nonnegative": True,
+            "maximum_contraction_error_bound": float(np.max(diagonal_error_bounds)),
+            "diagnostic_tolerance": "per_observation_contraction_error_bound",
         },
         name="native_observation_covariance",
     )
@@ -524,98 +500,11 @@ def _validated_projection(
             native_dims=native_dims,
             role=role,
         )
-    if not isinstance(projection, _PreserveBucketProjection):
-        restriction = _materialize_dense_preserving_coordinates(restriction)
-        restriction_values = np.asarray(restriction.values)
-        if np.iscomplexobj(restriction_values) or not np.all(np.isfinite(restriction_values)):
-            raise ValueError("Projection strategy restriction must contain only finite real values")
+    restriction = _materialize_dense_preserving_coordinates(restriction)
+    restriction_values = np.asarray(restriction.values)
+    if np.iscomplexobj(restriction_values) or not np.all(np.isfinite(restriction_values)):
+        raise ValueError("Projection strategy restriction must contain only finite real values")
     return replace(projection, restriction=restriction, prolongation=prolongation)
-
-
-def _reaxis_builtin_projection(
-    projection: _PreserveBucketProjection,
-    *,
-    native_dims: tuple[str, ...],
-    state_dim: str,
-    state_column_dim: str,
-) -> _PreserveBucketProjection:
-    """Rebuild trusted built-in product columns on the globally safe axis."""
-    assert projection.state_covariance is not None
-    assert projection.covariance_restriction_transpose is not None
-    old_column_dim = next(dim for dim in projection.state_covariance.dims if dim != state_dim)
-    if old_column_dim == state_column_dim:
-        return projection
-    state_covariance = xr.DataArray(
-        projection.state_covariance.data,
-        dims=(state_dim, state_column_dim),
-        coords={
-            str(name): coordinate
-            for name, coordinate in projection.state_covariance.coords.items()
-            if set(coordinate.dims).issubset({state_dim})
-        },
-        attrs=projection.state_covariance.attrs,
-        name=projection.state_covariance.name,
-    ).assign_coords(
-        renamed_column_coordinates(
-            projection.prolongation,
-            row_dim=state_dim,
-            column_dim=state_column_dim,
-        )
-    )
-    b_pi_t = xr.DataArray(
-        projection.covariance_restriction_transpose.data,
-        dims=(*native_dims, state_column_dim),
-        coords={
-            str(name): coordinate
-            for name, coordinate in projection.covariance_restriction_transpose.coords.items()
-            if set(coordinate.dims).issubset(native_dims)
-        },
-        attrs=projection.covariance_restriction_transpose.attrs,
-        name=projection.covariance_restriction_transpose.name,
-    ).assign_coords(
-        renamed_column_coordinates(
-            projection.prolongation,
-            row_dim=state_dim,
-            column_dim=state_column_dim,
-        )
-    )
-    return replace(
-        projection,
-        state_covariance=state_covariance,
-        covariance_restriction_transpose=b_pi_t,
-    )
-
-
-def _validate_external_cached_products(
-    projection: RetainedProjection,
-    *,
-    computed_b_pi_t: xr.DataArray,
-    computed_state_covariance: xr.DataArray,
-) -> None:
-    """Independently validate optional products supplied by external strategies."""
-    candidates = (
-        (
-            "covariance_restriction_transpose",
-            projection.covariance_restriction_transpose,
-            computed_b_pi_t,
-        ),
-        ("state_covariance", projection.state_covariance, computed_state_covariance),
-    )
-    for name, cached, computed in candidates:
-        if cached is None:
-            continue
-        cached_values = np.asarray(to_dense(cached).compute().values)
-        computed_values = np.asarray(computed.values)
-        if (
-            cached_values.shape != computed_values.shape
-            or np.iscomplexobj(cached_values)
-            or not np.all(np.isfinite(cached_values))
-            or not np.allclose(cached_values, computed_values, rtol=1e-10, atol=1e-12)
-        ):
-            raise ValueError(
-                f"Projection strategy supplied inconsistent cached {name}; "
-                "it does not match the independently computed covariance product"
-            )
 
 
 def _require_compatible_axis_coordinates(

--- a/openghg_inversions/basis/covariance_products.py
+++ b/openghg_inversions/basis/covariance_products.py
@@ -1,77 +1,40 @@
-"""Coherent native-covariance products for retained bucket scaling states.
+"""Labelled in-memory native-covariance products for retained scaling states.
 
-OpenGHG Inversions constructs a native observation operator ``H`` from
-footprint times prior flux, so the native vector ``x`` and retained vector
-``alpha = Pi x`` are multiplicative scalings. Their covariance algebra applies
-to the centred perturbations ``x - m`` and ``alpha - Pi m``. The existing
-:attr:`~openghg_inversions.basis.operators.BasisOperator.basis_matrix` supplies
-the single-source bucket prolongation ``U_bucket`` (native by retained), or the
-gathered spatial template expanded to source-native ``U_bucket`` here. It is
-not ``Pi.T``.
+This module is an eager numerical kernel. Callers supply a canonical, eager
+native sensitivity ``H`` and basis prolongation ``U``; basis operators own any
+source expansion and the pipeline owns materialization. Custom restrictions
+may remain sparse or Dask-backed: they are materialized only as explicit
+retained-state right-hand-side blocks immediately before covariance actions.
 
-This module's initial strategy preserves that established coefficient meaning.
-For native covariance ``B`` it derives the compatible restriction
-
-``Pi_U = (U.T B^-1 U)^-1 U.T B^-1``.
-
-Consequently ``Pi_U U = I``, ``C_alpha = Pi_U B Pi_U.T`` and the
-covariance-weighted prolongation
-``U_* = B Pi_U.T C_alpha^-1`` is exactly ``U_bucket``.  The retained
-observation operator is therefore ``H_alpha = H U_bucket``, matching the
-current bucket sensitivity.  The centred residual
-``r = (x - m) - U_bucket (alpha - Pi_U m)`` satisfies
-``Cov(r, alpha) = 0``. Under a joint Gaussian model this also gives the affine
-conditional mean ``m + U_bucket (alpha - Pi_U m)``.
-
-The public strategy protocol deliberately keeps ``Pi`` separate from basis
-geometry so a future strategy can instead define physical retained
-functionals and derive its covariance-weighted prolongation.  This foundation
-computes labelled ``C_alpha``, ``H B Pi.T``, and ``H B H.T`` (or its diagonal)
-without constructing dense native ``B``. Operations eagerly materialize
-``U``, ``H``, and the requested product matrices; dense ``H B H.T`` therefore
-uses quadratic observation-space storage. Constructing unresolved covariance
-and the coherent reduced likelihood belongs to OPE-18.
-
-The components have deliberately separate roles:
-
-1. :class:`~openghg_inversions.basis.operators.BasisOperator` supplies the
-   bucket geometry ``U_bucket``.
-2. :class:`~openghg_inversions.native_covariance.InvertibleNativeCovarianceAction`
-   supplies labelled applications of ``B`` and ``B^-1``; its protocol is
-   imported rather than redefined here.
-3. :class:`RetainedProjectionStrategy` chooses a coherent ``(Pi, U_*)`` pair
-   and returns it as the :class:`RetainedProjection` value object.
-   :class:`PreserveBucketProlongation` is the initial concrete structural
-   implementation of that strategy protocol.
-4. :func:`project_native_covariance` combines those inputs into the frozen,
-   serializable :class:`NativeCovarianceProducts` dataclass. Its contained
-   xarray objects remain mutable.
-
-Projected artifacts carry a source identity derived from covariance
-configuration, projection strategy, and labelled ``Pi``, ``U``, and ``H``
-inputs, plus a view identity derived from that source identity and the requested
-dense/diagonal representation. These identities bind artifact metadata; they
-are not checksums of computed output values. Observation batching fills one
-preallocated eager result but does not reduce final dense quadratic storage.
+For native covariance ``B`` and retained restriction ``Pi``, the kernel returns
+``C_alpha = Pi B Pi.T``, ``H U_*``, ``H B Pi.T``, and ``H B H.T`` (or its
+diagonal). The default strategy preserves bucket prolongation by deriving
+``Pi_U = (U.T B^-1 U)^-1 U.T B^-1``. Durable artifact identity and persistence
+are intentionally deferred to the artifact-I/O layer.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field, replace
-import hashlib
-import json
-from typing import Any, Hashable, Literal, Protocol, cast
+from dataclasses import dataclass, replace
+from numbers import Integral
+from typing import Literal, Protocol
 
 import numpy as np
+import pandas as pd
 from scipy.linalg import cho_factor, cho_solve
 import xarray as xr
+from xarray.namedarray.pycompat import is_chunked_array
 
-from openghg_inversions.basis.operators import BasisOperator
+from openghg_inversions._labelled_matrices import (
+    matrix_column_dim,
+    renamed_column_coordinates,
+    to_column_axis,
+    with_square_matrix_diagnostics,
+)
+from openghg_inversions.array_ops import to_dense
 from openghg_inversions.native_covariance import InvertibleNativeCovarianceAction
 
 MAX_DENSE_EIGEN_DIAGNOSTIC_SIZE = 512
-_PRODUCT_COORDINATE_NAMESPACES_ATTR = "openghg_inversions:product_coordinate_namespaces"
-_PRODUCT_MULTIINDEX_DIMS_ATTR = "openghg_inversions:product_multiindex_dims"
 
 
 @dataclass(frozen=True, slots=True)
@@ -79,28 +42,25 @@ class RetainedProjection:
     """A labelled restriction/prolongation pair selected by one strategy.
 
     Attributes:
-        restriction: ``Pi`` with dimensions ``(state_dim, *native_dims)``;
-            retained coefficients satisfy ``alpha = Pi x``.
-        prolongation: Covariance-compatible ``U_*`` with dimensions
-            ``(*native_dims, state_dim)`` and ``x_hat = U_* alpha`` in centred
-            coordinates.
+        restriction: ``Pi`` with dimensions ``(state_dim, *native_dims)``.
+        prolongation: Covariance-natural ``U_*`` with dimensions
+            ``(*native_dims, state_dim)``.
         strategy: Stable identifier for the scientific projection choice.
+        state_covariance: Optional already-derived ``C_alpha``. Strategies may
+            provide this to avoid recomputing known algebraic identities.
+        covariance_restriction_transpose: Optional already-derived
+            ``B Pi.T`` on a typed column state axis.
     """
 
     restriction: xr.DataArray
     prolongation: xr.DataArray
     strategy: str
+    state_covariance: xr.DataArray | None = None
+    covariance_restriction_transpose: xr.DataArray | None = None
 
 
 class RetainedProjectionStrategy(Protocol):
-    """Extension seam for choosing retained coefficients and their lift.
-
-    Implementations must return a full-rank ``Pi`` and the covariance-natural
-    ``U_* = B Pi.T (Pi B Pi.T)^-1``. This invariant is what makes the returned
-    residual uncorrelated with the retained coefficients. Both arrays must use
-    native labels exactly matching the covariance grid in the same order, and
-    their retained-state labels must agree.
-    """
+    """Extension seam for choosing retained coefficients and their lift."""
 
     def projection(
         self,
@@ -110,50 +70,13 @@ class RetainedProjectionStrategy(Protocol):
         native_dims: tuple[str, ...],
         state_dim: str,
     ) -> RetainedProjection:
-        """Return a compatible labelled restriction and prolongation.
-
-        Args:
-            covariance: Invertible labelled action for the native covariance
-                ``B``.
-            basis_prolongation: Candidate bucket prolongation with dimensions
-                ``(*native_dims, state_dim)``.
-            native_dims: Ordered dimensions of the native state.
-            state_dim: Name of the retained-state dimension.
-
-        Returns:
-            A labelled :class:`RetainedProjection` whose restriction is
-            full-rank and whose prolongation satisfies
-            ``B Pi.T = U_* (Pi B Pi.T)``.
-
-        Raises:
-            ValueError: If the supplied arrays are invalid or a coherent,
-                full-rank projection cannot be constructed.
-        """
-        ...
-
-
-class _Digest(Protocol):
-    """Minimal hashlib digest surface used by identity helpers."""
-
-    def update(self, data: bytes, /) -> None:
-        """Add bytes to the digest."""
+        """Return a compatible labelled restriction and prolongation."""
         ...
 
 
 @dataclass(frozen=True, slots=True)
 class PreserveBucketProlongation:
-    """Derive ``Pi_U`` so covariance-weighted prolongation equals ``U_bucket``.
-
-    This class is a concrete structural implementation of
-    :class:`RetainedProjectionStrategy`. :class:`RetainedProjection` is the
-    value object returned by :meth:`projection`, not the protocol being
-    implemented.
-
-    Attributes:
-        name: Stable strategy identifier stored with projected products.
-
-    ``B`` must be positive definite and ``U_bucket`` must have full column rank.
-    """
+    """Derive ``Pi_U`` so covariance-weighted prolongation equals ``U_bucket``."""
 
     name: str = "preserve_bucket_prolongation"
 
@@ -173,117 +96,91 @@ class PreserveBucketProlongation:
         """Construct the prior-precision-compatible restriction.
 
         Args:
-            covariance: Invertible labelled action for the native covariance ``B``.
-            basis_prolongation: Current bucket prolongation ``U_bucket``.
+            covariance: Invertible labelled action for native covariance ``B``.
+            basis_prolongation: Eager canonical bucket prolongation ``U``.
             native_dims: Ordered native dimensions.
             state_dim: Retained-state dimension.
 
         Returns:
-            A :class:`RetainedProjection` containing the labelled pair
-            ``(Pi_U, U_bucket)``.
+            The coherent ``(Pi_U, U)`` pair and algebraically known products.
 
         Raises:
-            ValueError: If the prolongation is invalid or has redundant columns.
+            ValueError: If ``U`` is invalid or lacks full column rank.
         """
         prolongation = _validated_prolongation(
             basis_prolongation, native_dims=native_dims, state_dim=state_dim
         )
-        state_column_dim = _matrix_column_dim(state_dim, prolongation.dims)
-        precision_prolongation = _to_plain_column_axis(
+        state_column_dim = matrix_column_dim(state_dim, prolongation.dims)
+        precision_prolongation = to_column_axis(
             covariance.solve(prolongation),
             row_dim=state_dim,
             column_dim=state_column_dim,
             leading_dims=native_dims,
         )
-        gram = xr.dot(
-            prolongation,
-            precision_prolongation,
-            dim=list(native_dims),
-        ).transpose(state_dim, state_column_dim)
+        gram = xr.dot(prolongation, precision_prolongation, dim=list(native_dims)).transpose(
+            state_dim, state_column_dim
+        )
         gram_values = np.asarray(gram.values, dtype=np.float64)
-        _validate_symmetric(gram_values, "U.T B^-1 U")
-        eigenvalues = np.linalg.eigvalsh((gram_values + gram_values.T) * 0.5)
-        largest_eigenvalue = float(eigenvalues[-1]) if eigenvalues.size else 0.0
-        if (
-            not eigenvalues.size
-            or largest_eigenvalue <= 0.0
-            or float(eigenvalues[0]) <= 1e-12 * largest_eigenvalue
-        ):
-            raise ValueError(
-                "The bucket prolongation contains redundant or numerically unsupported retained states; "
-                "U.T B^-1 U must be positive definite and full rank"
-            )
+        _require_symmetric(gram_values, "U.T B^-1 U")
         try:
             factor = cho_factor(gram_values, lower=True, check_finite=True)
+            covariance_values = cho_solve(factor, np.eye(gram_values.shape[0]), check_finite=False)
         except np.linalg.LinAlgError as exc:
             raise ValueError(
-                "The bucket prolongation contains redundant or unsupported retained states; "
+                "The bucket prolongation contains redundant retained states; "
                 "U.T B^-1 U must be positive definite"
             ) from exc
-        covariance_values = cho_solve(factor, np.eye(gram_values.shape[0]), check_finite=False)
-        covariance_coords: dict[str, xr.DataArray] = {
-            state_dim: prolongation.coords[state_dim],
-        }
-        for name, coordinate in prolongation.coords.items():
-            if name != state_dim and tuple(coordinate.dims) == (state_dim,):
-                covariance_coords[str(name)] = coordinate
-        covariance_coords.update(
-            _column_coordinates(prolongation, row_dim=state_dim, column_dim=state_column_dim)
-        )
         state_covariance = xr.DataArray(
             covariance_values,
             dims=(state_dim, state_column_dim),
-            coords=covariance_coords,
+            attrs={"units": "1"},
         )
-        restriction = xr.dot(
+        state_index = prolongation.get_index(state_dim)
+        if isinstance(state_index, pd.MultiIndex):
+            state_covariance = state_covariance.assign_coords(
+                xr.Coordinates.from_pandas_multiindex(state_index, state_dim)
+            )
+        else:
+            state_covariance = state_covariance.assign_coords({state_dim: prolongation.coords[state_dim]})
+        state_covariance = state_covariance.assign_coords(
+            renamed_column_coordinates(
+                prolongation,
+                row_dim=state_dim,
+                column_dim=state_column_dim,
+            )
+        )
+        state_covariance = with_square_matrix_diagnostics(
             state_covariance,
-            precision_prolongation,
-            dim=state_column_dim,
-        ).transpose(state_dim, *native_dims)
+            mathematical_name="C_alpha",
+            require_positive_definite=True,
+        )
+        restriction = xr.dot(state_covariance, precision_prolongation, dim=state_column_dim).transpose(
+            state_dim, *native_dims
+        )
         restriction = restriction.rename("restriction").assign_attrs(
             mathematical_name="Pi_U",
             definition="(U.T B^-1 U)^-1 U.T B^-1",
             strategy=self.name,
+            units="1",
         )
         prolongation = prolongation.rename("prolongation").assign_attrs(
-            mathematical_name="U_bucket",
-            strategy=self.name,
+            mathematical_name="U_bucket", strategy=self.name, units="1"
+        )
+        b_pi_t = xr.dot(prolongation, state_covariance, dim=state_dim).transpose(
+            *native_dims, state_column_dim
         )
         return RetainedProjection(
             restriction=restriction,
             prolongation=prolongation,
             strategy=self.name,
+            state_covariance=state_covariance,
+            covariance_restriction_transpose=b_pi_t,
         )
 
 
 @dataclass(frozen=True, slots=True)
 class NativeCovarianceProducts:
-    """Labelled product blocks induced by one coherent ``(B, H, Pi, U)`` set.
-
-    Attributes:
-        restriction: Retained restriction ``Pi`` with dimensions retained by native.
-        prolongation: Covariance-compatible ``U_*`` with dimensions native by retained.
-        state_covariance: ``C_alpha = Pi B Pi.T``.
-        effective_observation_operator: ``H_alpha = H U_*``.
-        observation_state_cross_covariance: ``H B Pi.T``.
-        native_observation_covariance: Dense ``H B H.T`` with a collision-safe
-            observation column dimension, or its labelled observation diagonal.
-        strategy: Stable retained-projection strategy name.
-        source_content_identity: SHA-256 identity of the projection strategy,
-            covariance configuration or fallback representation, and labelled
-            ``Pi/U/H`` values, dimensions, and coordinates. It is independent
-            of the dense or diagonal numerical view.
-        view_identity: SHA-256 identity derived from the source identity and
-            requested observation-covariance view.
-        observation_covariance_view: Numerical view represented by
-            ``native_observation_covariance``.
-        covariance_configuration_digest: Digest declaring the covariance
-            configuration required to reproduce the source artifact. The
-            configuration content itself is stored separately in a DataTree
-            child.
-        covariance_configuration: Reproducible serialized kernel/source configuration.
-        basis_provenance: Stable basis implementation and dimension metadata.
-    """
+    """Labelled in-memory product blocks induced by one coherent projection."""
 
     restriction: xr.DataArray
     prolongation: xr.DataArray
@@ -292,585 +189,68 @@ class NativeCovarianceProducts:
     observation_state_cross_covariance: xr.DataArray
     native_observation_covariance: xr.DataArray
     strategy: str
-    source_content_identity: str
-    view_identity: str
     observation_covariance_view: Literal["dense", "diagonal"]
-    covariance_configuration_digest: str = ""
-    covariance_configuration: xr.Dataset | None = None
-    basis_provenance: dict[str, str] = field(default_factory=dict)
-
-    schema = "openghg_inversions.native_covariance_products"
-    schema_version = 2
-
-    def to_dataset(self) -> xr.Dataset:
-        """Serialize labelled product blocks and their source/view identities.
-
-        Returns:
-            A dataset containing every product array plus schema, strategy,
-            source/view identities, and basis-provenance metadata. Native
-            covariance configuration is intentionally excluded because it
-            occupies a separate child node in :meth:`to_datatree`.
-
-            The identities bind declared source and view metadata across the
-            artifact. They are not integrity checksums of the numerical output
-            variables, whose values are deliberately not re-hashed here.
-        """
-        configuration_digest = self._validated_configuration_digest()
-        arrays, coordinate_namespaces = _namespace_product_coordinates(
-            {
-                "restriction": self.restriction,
-                "prolongation": self.prolongation,
-                "state_covariance": self.state_covariance,
-                "effective_observation_operator": self.effective_observation_operator,
-                "observation_state_cross_covariance": self.observation_state_cross_covariance,
-                "native_observation_covariance": self.native_observation_covariance,
-            }
-        )
-        dataset = xr.Dataset(
-            arrays,
-            attrs={
-                "schema": self.schema,
-                "schema_version": self.schema_version,
-                "strategy": self.strategy,
-                "source_content_identity": self.source_content_identity,
-                "view_identity": self.view_identity,
-                "observation_covariance_view": self.observation_covariance_view,
-                "covariance_configuration_digest": configuration_digest,
-                "basis_provenance": json.dumps(self.basis_provenance, sort_keys=True),
-                _PRODUCT_COORDINATE_NAMESPACES_ATTR: json.dumps(
-                    coordinate_namespaces,
-                    sort_keys=True,
-                ),
-            },
-        )
-        multiindex_dims = sorted(
-            str(dim)
-            for dim, index in dataset.indexes.items()
-            if dim in dataset.dims and getattr(index, "nlevels", 1) > 1
-        )
-        dataset.attrs[_PRODUCT_MULTIINDEX_DIMS_ATTR] = json.dumps(multiindex_dims)
-        return dataset
-
-    def to_datatree(self) -> xr.DataTree:
-        """Serialize products and reproducible covariance configuration.
-
-        Returns:
-            A tree whose root contains :meth:`to_dataset` output and whose
-            optional ``covariance_configuration`` child preserves the native
-            covariance constructor data, source binding, and content digest.
-        """
-        from openghg_inversions.serialization import reset_serialisation_multiindexes
-
-        tree = xr.DataTree(reset_serialisation_multiindexes(self.to_dataset()))
-        if self.covariance_configuration is None and self.covariance_configuration_digest:
-            raise ValueError(
-                "Cannot serialize covariance products as a DataTree without the declared "
-                "covariance configuration content"
-            )
-        if self.covariance_configuration is not None:
-            configuration_digest = self._validated_configuration_digest()
-            tree["covariance_configuration"] = xr.DataTree(
-                _encode_configuration_dataset(
-                    self.covariance_configuration,
-                    source_content_identity=self.source_content_identity,
-                    configuration_digest=configuration_digest,
-                )
-            )
-        return tree
-
-    def _validated_configuration_digest(self) -> str:
-        """Return the declared digest after checking any attached configuration."""
-        if self.covariance_configuration is None:
-            return self.covariance_configuration_digest
-        actual_digest = _configuration_digest(self.covariance_configuration)
-        if self.covariance_configuration_digest and self.covariance_configuration_digest != actual_digest:
-            raise ValueError("Attached covariance configuration does not match its declared digest")
-        return actual_digest
-
-    @classmethod
-    def from_dataset(cls, dataset: xr.Dataset) -> NativeCovarianceProducts:
-        """Restore and validate :meth:`to_dataset` output.
-
-        Args:
-            dataset: Versioned product-block dataset.
-
-        Returns:
-            Restored frozen product dataclass. Its contained arrays remain
-            mutable.
-
-        Raises:
-            ValueError: If the schema version, required variables, shared
-                source/view identity, projection strategy, numerical view, or
-                JSON-encoded basis provenance is invalid. Numerical variable
-                values are not checksummed by this metadata validation.
-        """
-        if dataset.attrs.get("schema") != cls.schema:
-            raise ValueError(f"Expected product schema {cls.schema!r}")
-        if dataset.attrs.get("schema_version") != cls.schema_version:
-            raise ValueError(f"Unsupported product schema version {dataset.attrs.get('schema_version')!r}")
-        required = (
-            "restriction",
-            "prolongation",
-            "state_covariance",
-            "effective_observation_operator",
-            "observation_state_cross_covariance",
-            "native_observation_covariance",
-        )
-        missing = [name for name in required if name not in dataset]
-        if missing:
-            raise ValueError(f"Serialized covariance products are missing variables {missing}")
-        source_content_identity = _validated_identity(
-            dataset.attrs.get("source_content_identity"),
-            name="source content identity",
-        )
-        view_identity = _validated_identity(
-            dataset.attrs.get("view_identity"),
-            name="view identity",
-        )
-        observation_covariance_view = dataset.attrs.get("observation_covariance_view")
-        if observation_covariance_view not in {"dense", "diagonal"}:
-            raise ValueError("Serialized covariance products have an invalid numerical view")
-        expected_view_identity = _view_identity(
-            source_content_identity,
-            cast(Literal["dense", "diagonal"], observation_covariance_view),
-        )
-        if view_identity != expected_view_identity:
-            raise ValueError("Serialized covariance products have an invalid derived view identity")
-        configuration_digest = dataset.attrs.get("covariance_configuration_digest")
-        if configuration_digest != "":
-            _validated_identity(
-                configuration_digest,
-                name="covariance configuration digest",
-            )
-        strategy = str(dataset.attrs.get("strategy", ""))
-        if not strategy:
-            raise ValueError("Serialized covariance products are missing strategy metadata")
-        for name in required:
-            if dataset[name].attrs.get("source_content_identity") != source_content_identity:
-                raise ValueError(f"Serialized product {name!r} does not share the root source identity")
-            if dataset[name].attrs.get("view_identity") != view_identity:
-                raise ValueError(f"Serialized product {name!r} does not share the root view identity")
-            if dataset[name].attrs.get("projection_strategy") != strategy:
-                raise ValueError(f"Serialized product {name!r} does not share the root projection strategy")
-        coordinate_namespaces = _decode_product_coordinate_namespaces(
-            dataset.attrs.get(_PRODUCT_COORDINATE_NAMESPACES_ATTR)
-        )
-        if set(coordinate_namespaces) != set(required):
-            raise ValueError("Serialized covariance products have invalid coordinate namespace owners")
-        for owner, mapping in coordinate_namespaces.items():
-            prefix = f"__product__{owner}__"
-            if any(not encoded.startswith(prefix) for encoded in mapping):
-                raise ValueError(
-                    f"Serialized covariance product {owner!r} has invalid coordinate namespace names"
-                )
-        encoded_coordinate_names = {
-            coordinate for mapping in coordinate_namespaces.values() for coordinate in mapping
-        }
-        arrays: dict[str, xr.DataArray] = {}
-        for name in required:
-            mapping = coordinate_namespaces.get(name, {})
-            foreign_coordinates = [
-                coordinate
-                for coordinate in encoded_coordinate_names - mapping.keys()
-                if coordinate in dataset[name].coords
-            ]
-            array = dataset[name].drop_vars(foreign_coordinates)
-            arrays[name] = _restore_product_coordinates(array, mapping)
-        basis_provenance = _decode_basis_provenance(dataset.attrs.get("basis_provenance"))
-        _validate_serialized_product_arrays(
-            arrays,
-            observation_covariance_view=cast(Literal["dense", "diagonal"], observation_covariance_view),
-            basis_provenance=basis_provenance,
-            declared_multiindex_dims=_decode_product_multiindex_dims(
-                dataset.attrs.get(_PRODUCT_MULTIINDEX_DIMS_ATTR)
-            ),
-        )
-        return cls(
-            restriction=arrays["restriction"],
-            prolongation=arrays["prolongation"],
-            state_covariance=arrays["state_covariance"],
-            effective_observation_operator=arrays["effective_observation_operator"],
-            observation_state_cross_covariance=arrays["observation_state_cross_covariance"],
-            native_observation_covariance=arrays["native_observation_covariance"],
-            strategy=strategy,
-            source_content_identity=source_content_identity,
-            view_identity=view_identity,
-            observation_covariance_view=cast(Literal["dense", "diagonal"], observation_covariance_view),
-            covariance_configuration_digest=str(configuration_digest),
-            basis_provenance=basis_provenance,
-        )
-
-    @classmethod
-    def from_datatree(cls, tree: xr.DataTree) -> NativeCovarianceProducts:
-        """Restore products and covariance configuration from a data tree.
-
-        Args:
-            tree: Tree produced by :meth:`to_datatree`.
-
-        Returns:
-            Restored frozen product dataclass, including covariance
-            configuration when the child node is present. Its contained
-            arrays and mappings remain mutable.
-
-        Raises:
-            ValueError: If the root product schema, source/view identities,
-                strategy, MultiIndex metadata, or the covariance
-                configuration's source binding or content digest is invalid.
-        """
-        from openghg_inversions.serialization import (
-            MULTIINDEX_DIMS_ATTR,
-            restore_serialisation_multiindexes,
-        )
-
-        root_dataset = tree.to_dataset(inherit=False)
-        if MULTIINDEX_DIMS_ATTR in root_dataset.attrs:
-            root_dataset = restore_serialisation_multiindexes(root_dataset, strict=True)
-        products = cls.from_dataset(root_dataset)
-        if "covariance_configuration" not in tree:
-            if root_dataset.attrs.get("covariance_configuration_digest"):
-                raise ValueError("Serialized covariance products are missing covariance configuration")
-            return products
-        configuration_digest = _validated_identity(
-            root_dataset.attrs.get("covariance_configuration_digest"),
-            name="covariance configuration digest",
-        )
-        return replace(
-            products,
-            covariance_configuration=_decode_configuration_dataset(
-                cast(xr.DataTree, tree["covariance_configuration"]).to_dataset(inherit=False),
-                expected_source_content_identity=products.source_content_identity,
-                expected_configuration_digest=configuration_digest,
-            ),
-        )
-
-
-def _namespace_product_coordinates(
-    arrays: dict[str, xr.DataArray],
-) -> tuple[dict[str, xr.DataArray], dict[str, dict[str, str]]]:
-    """Namespace auxiliary coordinates so independent axes cannot collide in a dataset."""
-    canonical_multiindexes: dict[str, Any] = {}
-    normalized: dict[str, xr.DataArray] = {}
-    for variable_name, original in arrays.items():
-        array = original
-        for dim, index in tuple(array.indexes.items()):
-            dim = str(dim)
-            if dim not in array.dims or getattr(index, "nlevels", 1) <= 1:
-                continue
-            canonical = canonical_multiindexes.setdefault(dim, index)
-            if not index.equals(canonical) or tuple(index.names) != tuple(canonical.names):
-                raise ValueError(f"Product arrays carry inconsistent MultiIndex labels for {dim!r}")
-            if index is canonical:
-                continue
-            index_coordinate_names = [dim, *(str(name) for name in index.names)]
-            array = array.drop_indexes(index_coordinate_names).drop_vars(index_coordinate_names)
-            array = array.assign_coords(xr.Coordinates.from_pandas_multiindex(canonical, dim))
-        normalized[variable_name] = array
-    arrays = normalized
-
-    occupied = {str(name) for array in arrays.values() for name in (*array.dims, *array.coords)}
-    usages: dict[str, dict[tuple[str, ...], tuple[bool, bool, int]]] = {}
-    for array in arrays.values():
-        has_multiindex = any(
-            dim in array.dims and getattr(index, "nlevels", 1) > 1 for dim, index in array.indexes.items()
-        )
-        for coordinate_name in (str(name) for name in array.coords):
-            if coordinate_name in array.dims:
-                continue
-            coordinate_dims = tuple(str(dim) for dim in array.coords[coordinate_name].dims)
-            previous = usages.setdefault(coordinate_name, {}).get(
-                coordinate_dims,
-                (False, False, 0),
-            )
-            usages[coordinate_name][coordinate_dims] = (
-                previous[0] or coordinate_name in array.xindexes,
-                previous[1] or has_multiindex,
-                previous[2] + 1,
-            )
-    canonical_signatures = {
-        name: max(signatures, key=lambda dims: signatures[dims]) for name, signatures in usages.items()
-    }
-
-    encoded: dict[str, xr.DataArray] = {}
-    namespaces: dict[str, dict[str, str]] = {}
-    for variable_name, array in arrays.items():
-        rename: dict[str, str] = {}
-        for coordinate_name in (str(name) for name in array.coords):
-            if coordinate_name in array.dims:
-                continue
-            coordinate_dims = tuple(str(dim) for dim in array.coords[coordinate_name].dims)
-            if coordinate_name in array.xindexes or coordinate_dims == canonical_signatures[coordinate_name]:
-                continue
-            candidate = f"__product__{variable_name}__{coordinate_name}"
-            suffix = 2
-            while candidate in occupied:
-                candidate = f"__product__{variable_name}__{coordinate_name}_{suffix}"
-                suffix += 1
-            occupied.add(candidate)
-            rename[coordinate_name] = candidate
-        encoded[variable_name] = array.rename(rename) if rename else array
-        namespaces[variable_name] = {encoded_name: original for original, encoded_name in rename.items()}
-    return encoded, namespaces
-
-
-def _decode_product_coordinate_namespaces(value: object) -> dict[str, dict[str, str]]:
-    """Decode and validate reversible per-product coordinate namespaces."""
-    if not isinstance(value, str):
-        raise ValueError("Serialized covariance products are missing coordinate namespace metadata")
-    try:
-        decoded = json.loads(value)
-    except json.JSONDecodeError as error:
-        raise ValueError(
-            "Serialized covariance products have invalid coordinate namespace metadata"
-        ) from error
-    if not isinstance(decoded, dict):
-        raise ValueError("Serialized covariance products have invalid coordinate namespace metadata")
-    result: dict[str, dict[str, str]] = {}
-    for variable_name, mapping in decoded.items():
-        if (
-            not isinstance(variable_name, str)
-            or not isinstance(mapping, dict)
-            or any(
-                not isinstance(encoded, str) or not isinstance(original, str)
-                for encoded, original in mapping.items()
-            )
-        ):
-            raise ValueError("Serialized covariance products have invalid coordinate namespace metadata")
-        result[variable_name] = mapping
-    return result
-
-
-def _restore_product_coordinates(array: xr.DataArray, mapping: dict[str, str]) -> xr.DataArray:
-    """Restore one product array's original auxiliary coordinate names."""
-    missing = [name for name in mapping if name not in array.coords]
-    if missing:
-        raise ValueError(f"Serialized product is missing namespaced coordinates {missing}")
-    if len(set(mapping.values())) != len(mapping):
-        raise ValueError("Serialized product coordinate namespace metadata is not one-to-one")
-    return array.rename(mapping) if mapping else array
-
-
-def _decode_product_multiindex_dims(value: object) -> tuple[str, ...]:
-    """Decode dimensions declared to require restored MultiIndex semantics."""
-    if not isinstance(value, str):
-        raise ValueError("Serialized covariance products are missing MultiIndex declarations")
-    try:
-        decoded = json.loads(value)
-    except json.JSONDecodeError as error:
-        raise ValueError("Serialized covariance products have invalid MultiIndex declarations") from error
-    if not isinstance(decoded, list) or any(not isinstance(dim, str) for dim in decoded):
-        raise ValueError("Serialized covariance products have invalid MultiIndex declarations")
-    return tuple(decoded)
-
-
-def _validate_serialized_product_arrays(
-    arrays: dict[str, xr.DataArray],
-    *,
-    observation_covariance_view: Literal["dense", "diagonal"],
-    basis_provenance: dict[str, str],
-    declared_multiindex_dims: tuple[str, ...],
-) -> None:
-    """Validate dimensional, label, view, and restored-index invariants."""
-    state_dim = basis_provenance.get("state_dim", "")
-    if not state_dim:
-        raise ValueError("Serialized covariance products are missing retained-state provenance")
-    restriction = arrays["restriction"]
-    prolongation = arrays["prolongation"]
-    if not restriction.dims or restriction.dims[0] != state_dim:
-        raise ValueError("Serialized restriction has invalid retained-state dimensions")
-    native_dims = tuple(str(dim) for dim in restriction.dims[1:])
-    if not native_dims or prolongation.dims != (*native_dims, state_dim):
-        raise ValueError("Serialized restriction/prolongation dimensions are inconsistent")
-    if restriction.sizes[state_dim] != prolongation.sizes[state_dim]:
-        raise ValueError("Serialized restriction/prolongation retained-state sizes differ")
-
-    state_covariance = arrays["state_covariance"]
-    if state_covariance.ndim != 2 or state_covariance.dims[0] != state_dim:
-        raise ValueError("Serialized state covariance has invalid matrix dimensions")
-    state_column_dim = str(state_covariance.dims[1])
-    expected_state_column_dim = _matrix_column_dim(state_dim, restriction.dims)
-    if state_column_dim != expected_state_column_dim:
-        raise ValueError("Serialized state covariance has an invalid column dimension name")
-    state_size = restriction.sizes[state_dim]
-    if state_covariance.shape != (state_size, state_size):
-        raise ValueError("Serialized state covariance shape does not match retained state")
-
-    effective = arrays["effective_observation_operator"]
-    cross = arrays["observation_state_cross_covariance"]
-    if effective.ndim != 2 or effective.dims[1] != state_dim:
-        raise ValueError("Serialized effective observation operator has invalid dimensions")
-    observation_dim = str(effective.dims[0])
-    if cross.dims != (observation_dim, state_column_dim) or cross.shape != (
-        effective.sizes[observation_dim],
-        state_size,
-    ):
-        raise ValueError("Serialized observation/state products have inconsistent dimensions")
-
-    observation_covariance = arrays["native_observation_covariance"]
-    observation_size = effective.sizes[observation_dim]
-    expected_shape = (observation_size, observation_size)
-    if observation_covariance_view == "diagonal":
-        if observation_covariance.dims != (observation_dim,) or observation_covariance.shape != (
-            observation_size,
-        ):
-            raise ValueError("Serialized diagonal observation covariance has invalid dimensions")
-    elif (
-        observation_covariance.ndim != 2
-        or observation_covariance.dims[0] != observation_dim
-        or (observation_covariance.shape != expected_shape)
-    ):
-        raise ValueError("Serialized dense observation covariance has invalid dimensions")
-
-    for name, array in arrays.items():
-        values = np.asarray(array.values)
-        if np.iscomplexobj(values) or not np.all(np.isfinite(values)):
-            raise ValueError(f"Serialized product {name!r} must contain only finite real values")
-
-    for dim in declared_multiindex_dims:
-        owners = [array for array in arrays.values() if dim in array.dims]
-        if not owners or any(
-            (index := array.indexes.get(dim)) is None or getattr(index, "nlevels", 1) <= 1 for array in owners
-        ):
-            raise ValueError(f"Serialized covariance products did not restore MultiIndex dimension {dim!r}")
-
-    _require_matching_coordinate(restriction, prolongation, state_dim, "retained state")
-    _require_matching_coordinate(restriction, state_covariance, state_dim, "retained state")
-    _require_column_coordinates(
-        restriction,
-        state_covariance,
-        row_dim=state_dim,
-        column_dim=state_column_dim,
-        role="retained-state column",
-    )
-    _require_matching_coordinate(state_covariance, cross, state_column_dim, "retained-state column")
-    _require_column_coordinates(
-        restriction,
-        cross,
-        row_dim=state_dim,
-        column_dim=state_column_dim,
-        role="retained-state cross-covariance column",
-    )
-    _require_matching_coordinate(effective, cross, observation_dim, "observation")
-    _require_matching_coordinate(effective, observation_covariance, observation_dim, "observation")
-    if observation_covariance_view == "dense":
-        observation_column_dim = str(observation_covariance.dims[1])
-        if observation_column_dim != _matrix_column_dim(
-            observation_dim,
-            (observation_dim, *native_dims),
-        ):
-            raise ValueError("Serialized dense observation covariance has an invalid column dimension name")
-        _require_column_coordinates(
-            effective,
-            observation_covariance,
-            row_dim=observation_dim,
-            column_dim=observation_column_dim,
-            role="observation-covariance column",
-        )
-
-
-def _require_matching_coordinate(
-    left: xr.DataArray,
-    right: xr.DataArray,
-    dim: str,
-    role: str,
-) -> None:
-    """Require two arrays to carry identical labels on a shared dimension."""
-    if dim not in left.coords or dim not in right.coords:
-        raise ValueError(f"Serialized {role} products are missing coordinate {dim!r}")
-    if not np.array_equal(left.coords[dim].values, right.coords[dim].values):
-        raise ValueError(f"Serialized {role} product labels are inconsistent")
-
-
-def _require_column_coordinates(
-    row_array: xr.DataArray,
-    column_array: xr.DataArray,
-    *,
-    row_dim: str,
-    column_dim: str,
-    role: str,
-) -> None:
-    """Require serialized matrix columns to mirror all row-axis coordinates."""
-    expected = _column_coordinates(row_array, row_dim=row_dim, column_dim=column_dim)
-    for name, coordinate in expected.items():
-        if name not in column_array.coords:
-            raise ValueError(f"Serialized {role} product is missing coordinate {name!r}")
-        if not np.array_equal(column_array.coords[name].values, coordinate.values):
-            raise ValueError(f"Serialized {role} product labels are inconsistent")
 
 
 def project_native_covariance(
     *,
     covariance: InvertibleNativeCovarianceAction,
-    basis_operator: BasisOperator,
+    basis_prolongation: xr.DataArray,
+    state_dim: str,
     native_sensitivity: xr.DataArray,
     observation_dim: str,
     observation_covariance: Literal["dense", "diagonal"] = "dense",
     observation_batch_size: int = 64,
     strategy: RetainedProjectionStrategy | None = None,
 ) -> NativeCovarianceProducts:
-    """Compute coherent labelled native-covariance product blocks.
+    """Compute coherent labelled native-covariance products eagerly.
 
     Args:
         covariance: Labelled native covariance action with a compatible solve.
-        basis_operator: Basis whose matrix supplies the initial bucket prolongation.
-        native_sensitivity: Native ``H`` containing footprint times prior flux,
-            with dimensions ``(observation_dim, *native_dims)`` in any order.
-        observation_dim: Name of the observation dimension in ``native_sensitivity``.
-        observation_covariance: Return dense ``H B H.T`` or only its diagonal.
-        observation_batch_size: Positive number of observation right-hand sides
-            applied to ``B`` in each eager batch. This is independent of Dask
-            array chunking: each batch fills a slice of one preallocated result.
-            Dense ``H B H.T`` is still fully materialized.
-        strategy: Retained projection choice. The default preserves bucket scalings.
+        basis_prolongation: Canonical eager ``U`` from the basis-side native
+            expansion boundary.
+        state_dim: Retained-state dimension shared by ``U`` and ``Pi``.
+        native_sensitivity: Canonical eager native sensitivity ``H``.
+        observation_dim: Observation dimension in ``H``.
+        observation_covariance: Return dense ``H B H.T`` or its diagonal.
+        observation_batch_size: Positive integral number of covariance
+            right-hand sides per eager block.
+        strategy: Projection choice; defaults to bucket preservation.
 
     Returns:
-        Frozen product dataclass whose arrays carry a shared source identity
-        and a view identity derived from the requested dense/diagonal
-        representation. These identities bind metadata and are not checksums
-        of computed output values. Its contained arrays remain mutable. Inputs
-        and products are eagerly materialized; dense observation covariance
-        has quadratic observation-space storage. Full PSD eigendiagnostics are
-        skipped above 512 rows to avoid adding cubic observation-space work.
-        Input attrs/units are not propagated: product attrs are replaced by
-        mathematical diagnostics because this API does not implement unit
-        algebra.
+        Frozen in-memory labelled product value object. Scaling covariance,
+        restriction, and prolongation have units ``"1"``. Products linear in
+        ``H`` inherit its units; observation covariance uses squared ``H``
+        units when supplied.
 
     Raises:
-        ValueError: If labels, dimensions, values, or options are invalid.
+        TypeError: If ``observation_batch_size`` is not an integral non-Boolean.
+        ValueError: If arrays are lazy, labels or dimensions disagree, values
+            are invalid, or an option is unsupported.
     """
     native_dims = tuple(covariance.native_dims)
-    state_dim = basis_operator.meta.state_dim
     if len({*native_dims, state_dim, observation_dim}) != len(native_dims) + 2:
         raise ValueError("Native, retained-state, and observation dimension names must be distinct")
-    basis_grid_dims = tuple(basis_operator.meta.grid_dims)
-    if basis_grid_dims != native_dims and not (
-        len(native_dims) == len(basis_grid_dims) + 1 and native_dims[1:] == basis_grid_dims
-    ):
-        raise ValueError(
-            "Basis grid dimensions must equal the covariance spatial dimensions; "
-            f"{basis_operator.meta.grid_dims!r} is incompatible with {native_dims!r}"
-        )
-    sensitivity = _validated_sensitivity(
-        native_sensitivity,
-        native_dims=native_dims,
-        observation_dim=observation_dim,
-        covariance=covariance,
-    )
+    if isinstance(observation_batch_size, bool) or not isinstance(observation_batch_size, Integral):
+        raise TypeError("observation_batch_size must be an integral non-Boolean value")
     batch_size = int(observation_batch_size)
     if batch_size <= 0:
         raise ValueError("observation_batch_size must be positive")
     if observation_covariance not in {"dense", "diagonal"}:
         raise ValueError("observation_covariance must be 'dense' or 'diagonal'")
 
-    basis_prolongation = _native_basis_prolongation(
-        basis_operator,
-        sensitivity,
+    sensitivity = _validated_sensitivity(
+        native_sensitivity,
         native_dims=native_dims,
-        state_dim=state_dim,
+        observation_dim=observation_dim,
     )
-    projection_strategy = strategy if strategy is not None else PreserveBucketProlongation()
-    projection = projection_strategy.projection(
+    prolongation = _validated_prolongation(basis_prolongation, native_dims=native_dims, state_dim=state_dim)
+    _validate_exact_native_coordinates(
+        prolongation, sensitivity, native_dims=native_dims, role="prolongation"
+    )
+    projection = (strategy or PreserveBucketProlongation()).projection(
         covariance,
-        basis_prolongation,
+        prolongation,
         native_dims=native_dims,
         state_dim=state_dim,
     )
@@ -880,61 +260,59 @@ def project_native_covariance(
         native_dims=native_dims,
         state_dim=state_dim,
     )
-    state_column_dim = _matrix_column_dim(state_dim, projection.restriction.dims)
-    state_column_coordinates = _column_coordinates(
-        projection.restriction,
-        row_dim=state_dim,
-        column_dim=state_column_dim,
-    )
-    sensitivity = _namespace_axis_coordinate_collisions(
-        sensitivity,
-        axis_dim=observation_dim,
-        occupied={str(name) for name in projection.prolongation.coords} | set(state_column_coordinates),
-    )
-    restriction_transpose = _to_plain_column_axis(
-        projection.restriction,
-        row_dim=state_dim,
-        column_dim=state_column_dim,
-        leading_dims=native_dims,
-    )
-    b_restriction_transpose = covariance.apply(restriction_transpose)
+    state_column_dim = matrix_column_dim(state_dim, projection.restriction.dims)
+    if projection.covariance_restriction_transpose is None:
+        b_pi_t = _apply_restriction_blocks(
+            covariance,
+            projection.restriction,
+            native_dims=native_dims,
+            state_dim=state_dim,
+            column_dim=state_column_dim,
+            rhs_block_size=batch_size,
+        )
+    else:
+        b_pi_t = projection.covariance_restriction_transpose
 
-    state_covariance = xr.dot(
-        projection.restriction,
-        b_restriction_transpose,
-        dim=list(native_dims),
-    ).transpose(state_dim, state_column_dim)
-    _validate_positive_definite(np.asarray(state_covariance.values), "C_alpha")
-    state_covariance = _with_matrix_diagnostics(
-        state_covariance.rename("state_covariance"), mathematical_name="C_alpha"
-    )
-    _validate_projection_invariant(
-        projection,
-        state_covariance,
-        b_restriction_transpose,
-        native_dims=native_dims,
-        state_dim=state_dim,
-        state_column_dim=state_column_dim,
-    )
+    if projection.state_covariance is None:
+        state_covariance = _restriction_product_blocks(
+            projection.restriction,
+            b_pi_t,
+            native_dims=native_dims,
+            state_dim=state_dim,
+            column_dim=state_column_dim,
+            rhs_block_size=batch_size,
+        )
+        state_covariance = with_square_matrix_diagnostics(
+            state_covariance.rename("state_covariance").assign_attrs(units="1"),
+            mathematical_name="C_alpha",
+            require_positive_definite=True,
+        )
+    else:
+        state_covariance = projection.state_covariance.rename("state_covariance")
 
-    effective_operator = xr.dot(
-        sensitivity,
-        projection.prolongation,
-        dim=list(native_dims),
-    ).transpose(observation_dim, state_dim)
+    if projection.state_covariance is None or projection.covariance_restriction_transpose is None:
+        _validate_projection_invariant(
+            projection,
+            state_covariance,
+            b_pi_t,
+            native_dims=native_dims,
+            state_dim=state_dim,
+            state_column_dim=state_column_dim,
+        )
+    h_units = sensitivity.attrs.get("units")
+    linear_units = {"units": h_units} if h_units is not None else {}
+    effective_operator = xr.dot(sensitivity, projection.prolongation, dim=list(native_dims)).transpose(
+        observation_dim, state_dim
+    )
     effective_operator = effective_operator.rename("effective_observation_operator").assign_attrs(
-        mathematical_name="H_alpha",
-        definition="H U_*",
+        mathematical_name="H_alpha", definition="H U_*", **linear_units
     )
-    cross_covariance = xr.dot(
-        sensitivity,
-        b_restriction_transpose,
-        dim=list(native_dims),
-    ).transpose(observation_dim, state_column_dim)
+    cross_covariance = xr.dot(sensitivity, b_pi_t, dim=list(native_dims)).transpose(
+        observation_dim, state_column_dim
+    )
     cross_covariance = cross_covariance.rename("observation_state_cross_covariance").assign_attrs(
-        mathematical_name="H B Pi.T"
+        mathematical_name="H B Pi.T", **linear_units
     )
-
     native_observation_covariance = _observation_covariance(
         covariance,
         sensitivity,
@@ -943,40 +321,6 @@ def project_native_covariance(
         output=observation_covariance,
         batch_size=batch_size,
     )
-    source_content_identity = _source_content_identity(
-        covariance,
-        projection.restriction,
-        projection.prolongation,
-        sensitivity,
-        strategy=projection.strategy,
-    )
-    view_identity = _view_identity(source_content_identity, observation_covariance)
-    covariance_to_dataset = getattr(covariance, "to_dataset", None)
-    covariance_configuration = (
-        cast(xr.Dataset, covariance_to_dataset()).copy(deep=True) if callable(covariance_to_dataset) else None
-    )
-    basis_provenance = {
-        "operator_type": f"{type(basis_operator).__module__}.{type(basis_operator).__qualname__}",
-        "operator_kind": str(getattr(basis_operator, "kind", "unknown")),
-        "grid_dims": repr(tuple(basis_operator.meta.grid_dims)),
-        "state_dim": state_dim,
-    }
-    shared_attrs = {
-        "projection_strategy": projection.strategy,
-        "source_content_identity": source_content_identity,
-        "view_identity": view_identity,
-    }
-    arrays = (
-        projection.restriction,
-        projection.prolongation,
-        state_covariance,
-        effective_operator,
-        cross_covariance,
-        native_observation_covariance,
-    )
-    for array in arrays:
-        array.attrs.update(shared_attrs)
-
     return NativeCovarianceProducts(
         restriction=projection.restriction,
         prolongation=projection.prolongation,
@@ -985,15 +329,49 @@ def project_native_covariance(
         observation_state_cross_covariance=cross_covariance,
         native_observation_covariance=native_observation_covariance,
         strategy=projection.strategy,
-        source_content_identity=source_content_identity,
-        view_identity=view_identity,
         observation_covariance_view=observation_covariance,
-        covariance_configuration_digest=(
-            _configuration_digest(covariance_configuration) if covariance_configuration is not None else ""
-        ),
-        covariance_configuration=covariance_configuration,
-        basis_provenance=basis_provenance,
     )
+
+
+def _apply_restriction_blocks(
+    covariance: InvertibleNativeCovarianceAction,
+    restriction: xr.DataArray,
+    *,
+    native_dims: tuple[str, ...],
+    state_dim: str,
+    column_dim: str,
+    rhs_block_size: int,
+) -> xr.DataArray:
+    """Apply covariance to explicit dense retained-state RHS blocks."""
+    blocks: list[xr.DataArray] = []
+    for start in range(0, restriction.sizes[state_dim], rhs_block_size):
+        sliced = restriction.isel({state_dim: slice(start, start + rhs_block_size)})
+        rhs = to_column_axis(
+            sliced,
+            row_dim=state_dim,
+            column_dim=column_dim,
+            leading_dims=native_dims,
+        )
+        rhs = to_dense(rhs).compute()
+        blocks.append(covariance.apply(rhs))
+    return xr.concat(blocks, dim=column_dim).transpose(*native_dims, column_dim)
+
+
+def _restriction_product_blocks(
+    restriction: xr.DataArray,
+    b_pi_t: xr.DataArray,
+    *,
+    native_dims: tuple[str, ...],
+    state_dim: str,
+    column_dim: str,
+    rhs_block_size: int,
+) -> xr.DataArray:
+    """Form ``Pi B Pi.T`` while materializing explicit restriction row blocks."""
+    blocks: list[xr.DataArray] = []
+    for start in range(0, restriction.sizes[state_dim], rhs_block_size):
+        rows = to_dense(restriction.isel({state_dim: slice(start, start + rhs_block_size)})).compute()
+        blocks.append(xr.dot(rows, b_pi_t, dim=list(native_dims)))
+    return xr.concat(blocks, dim=state_dim).transpose(state_dim, column_dim)
 
 
 def _observation_covariance(
@@ -1005,91 +383,64 @@ def _observation_covariance(
     output: Literal["dense", "diagonal"],
     batch_size: int,
 ) -> xr.DataArray:
-    """Compute ``H B H.T`` in eager observation right-hand-side batches.
-
-    Batching limits the size of the temporary native-space ``B H.T`` block;
-    it is not Dask chunking. The result is allocated once and filled by
-    observation-column batch. Dense output therefore still materializes the
-    complete quadratic observation covariance, while diagonal output
-    materializes only its labelled diagonal.
-
-    Args:
-        covariance: Labelled action implementing multiplication by ``B``.
-        sensitivity: Eager native sensitivity ``H`` with observation followed
-            by native dimensions.
-        native_dims: Ordered native dimensions contracted in the products.
-        observation_dim: Name of the observation row dimension.
-        output: Whether to return the dense covariance or only its diagonal.
-        batch_size: Positive number of observation columns processed per
-            covariance application.
-
-    Returns:
-        Labelled dense ``H B H.T`` with dimensions ``(observation_dim,
-        collision-safe column dimension)``, or ``diag(H B H.T)`` with dimension
-        ``(observation_dim,)``. Observation-axis coordinates are preserved.
-
-    Raises:
-        ValueError: If covariance labels are incompatible or a dense result
-            fails the symmetry diagnostic.
-    """
-    observation_column_dim = _matrix_column_dim(observation_dim, sensitivity.dims)
-    observation_count = sensitivity.sizes[observation_dim]
-    result_values = np.empty(
-        (observation_count, observation_count) if output == "dense" else observation_count,
+    """Compute ``H B H.T`` in eager observation RHS blocks."""
+    column_dim = matrix_column_dim(observation_dim, sensitivity.dims)
+    count = sensitivity.sizes[observation_dim]
+    values = np.empty(
+        (count, count) if output == "dense" else count,
         dtype=np.result_type(sensitivity.dtype, np.float64),
     )
-    for start in range(0, sensitivity.sizes[observation_dim], batch_size):
-        stop = min(start + batch_size, sensitivity.sizes[observation_dim])
-        rhs = _to_plain_column_axis(
+    for start in range(0, count, batch_size):
+        stop = min(start + batch_size, count)
+        rhs = to_column_axis(
             sensitivity.isel({observation_dim: slice(start, stop)}),
             row_dim=observation_dim,
-            column_dim=observation_column_dim,
+            column_dim=column_dim,
             leading_dims=native_dims,
         )
         b_rhs = covariance.apply(rhs)
         if output == "dense":
-            block = xr.dot(sensitivity, b_rhs, dim=list(native_dims)).transpose(
-                observation_dim, observation_column_dim
-            )
-            result_values[:, start:stop] = np.asarray(block.values)
+            block = xr.dot(sensitivity, b_rhs, dim=list(native_dims)).transpose(observation_dim, column_dim)
+            values[:, start:stop] = np.asarray(block.values)
         else:
-            block = (rhs * b_rhs).sum(dim=list(native_dims))
-            result_values[start:stop] = np.asarray(block.values)
+            values[start:stop] = np.asarray((rhs * b_rhs).sum(dim=list(native_dims)).values)
+    units = sensitivity.attrs.get("units")
+    unit_attrs = {"units": f"({units})^2"} if units is not None else {}
+    row_coords = {
+        str(name): coordinate
+        for name, coordinate in sensitivity.coords.items()
+        if set(coordinate.dims).issubset({observation_dim})
+    }
     if output == "dense":
-        coords = {
-            str(name): coordinate
-            for name, coordinate in sensitivity.coords.items()
-            if set(coordinate.dims).issubset({observation_dim})
-        }
-        coords.update(
-            _column_coordinates(
-                sensitivity,
-                row_dim=observation_dim,
-                column_dim=observation_column_dim,
-            )
+        result = xr.DataArray(
+            values,
+            dims=(observation_dim, column_dim),
+            coords={
+                **row_coords,
+                **renamed_column_coordinates(sensitivity, row_dim=observation_dim, column_dim=column_dim),
+            },
+            attrs=unit_attrs,
+            name="native_observation_covariance",
         )
-        combined = xr.DataArray(
-            result_values,
-            dims=(observation_dim, observation_column_dim),
-            coords=coords,
+        return with_square_matrix_diagnostics(
+            result,
+            mathematical_name="H B H.T",
+            maximum_eigen_diagnostic_size=MAX_DENSE_EIGEN_DIAGNOSTIC_SIZE,
         )
-        combined = _with_matrix_diagnostics(
-            combined.rename("native_observation_covariance"), mathematical_name="H B H.T"
-        )
-    else:
-        coords = {
-            str(name): coordinate
-            for name, coordinate in sensitivity.coords.items()
-            if set(coordinate.dims).issubset({observation_dim})
-        }
-        combined = xr.DataArray(result_values, dims=observation_dim, coords=coords)
-        combined = combined.rename("native_observation_covariance").assign_attrs(
-            mathematical_name="diag(H B H.T)",
-            minimum_diagonal=float(combined.min().item()),
-            diagonal_nonnegative=bool((combined >= -1e-10).all().item()),
-            diagnostic_tolerance=1e-10,
-        )
-    return combined
+    result = xr.DataArray(
+        values,
+        dims=observation_dim,
+        coords=row_coords,
+        attrs={
+            **unit_attrs,
+            "mathematical_name": "diag(H B H.T)",
+            "minimum_diagonal": float(np.min(values)),
+            "diagonal_nonnegative": bool(np.all(values >= -1e-10)),
+            "diagnostic_tolerance": 1e-10,
+        },
+        name="native_observation_covariance",
+    )
+    return result
 
 
 def _validated_projection(
@@ -1099,54 +450,23 @@ def _validated_projection(
     native_dims: tuple[str, ...],
     state_dim: str,
 ) -> RetainedProjection:
-    """Validate custom strategy labels before any labelled contractions.
-
-    Args:
-        projection: Restriction/prolongation pair returned by a strategy.
-        native_reference: Validated sensitivity carrying canonical native
-            coordinates.
-        native_dims: Ordered native dimensions.
-        state_dim: Retained-state dimension.
-
-    Returns:
-        A projection with eager arrays in canonical dimension order.
-
-    Raises:
-        ValueError: If either array has invalid dimensions, values, or labels.
-            Native coordinates must exactly equal the reference coordinates;
-            xarray reordering or intersection is never used here.
-    """
-    restriction = projection.restriction
+    """Validate strategy labels without materializing a custom restriction."""
     if not isinstance(projection.strategy, str) or not projection.strategy:
         raise ValueError("Projection strategy must return a non-empty strategy identifier")
-    expected_restriction_dims = {state_dim, *native_dims}
-    if set(restriction.dims) != expected_restriction_dims or len(restriction.dims) != len(
-        expected_restriction_dims
-    ):
-        raise ValueError("Projection strategy restriction has invalid labelled dimensions")
-    restriction = _densify(restriction).transpose(state_dim, *native_dims)
-    restriction_values = np.asarray(restriction.values)
-    if np.iscomplexobj(restriction_values) or not np.all(np.isfinite(restriction_values)):
-        raise ValueError("Projection strategy restriction must contain only finite real values")
-
-    prolongation = _validated_prolongation(
-        projection.prolongation,
-        native_dims=native_dims,
-        state_dim=state_dim,
+    restriction = projection.restriction.transpose(state_dim, *native_dims).assign_attrs(
+        {**projection.restriction.attrs, "units": "1"}
     )
+    expected = {state_dim, *native_dims}
+    if set(restriction.dims) != expected or len(restriction.dims) != len(expected):
+        raise ValueError("Projection strategy restriction has invalid labelled dimensions")
+    prolongation = _validated_prolongation(
+        projection.prolongation, native_dims=native_dims, state_dim=state_dim
+    ).assign_attrs({**projection.prolongation.attrs, "units": "1"})
     for role, array in (("restriction", restriction), ("prolongation", prolongation)):
-        _validate_exact_native_coordinates(
-            array,
-            native_reference,
-            native_dims=native_dims,
-            role=role,
-        )
+        _validate_exact_native_coordinates(array, native_reference, native_dims=native_dims, role=role)
     if state_dim not in restriction.coords or state_dim not in prolongation.coords:
         raise ValueError("Projection strategy restriction and prolongation require state labels")
-    if not np.array_equal(
-        restriction.coords[state_dim].values,
-        prolongation.coords[state_dim].values,
-    ):
+    if not restriction.get_index(state_dim).equals(prolongation.get_index(state_dim)):
         raise ValueError("Projection strategy restriction/prolongation state labels differ")
     return replace(projection, restriction=restriction, prolongation=prolongation)
 
@@ -1158,187 +478,39 @@ def _validate_exact_native_coordinates(
     native_dims: tuple[str, ...],
     role: str,
 ) -> None:
-    """Require exact native labels before product alignment or contraction.
-
-    Args:
-        array: Strategy-produced restriction or prolongation.
-        reference: Validated array carrying canonical native coordinates.
-        native_dims: Ordered native dimensions to compare.
-        role: Array role used in validation errors.
-
-    Raises:
-        ValueError: If a native coordinate is absent, reordered, or different.
-    """
+    """Require exact ordered native indexes before labelled contractions."""
     for dim in native_dims:
         if dim not in array.coords:
-            raise ValueError(f"Projection strategy {role} is missing native coordinate {dim!r}")
-        actual = np.asarray(array.coords[dim].values)
-        expected = np.asarray(reference.coords[dim].values)
-        if actual.shape != expected.shape or not np.array_equal(actual, expected):
+            raise ValueError(f"Projection {role} is missing native coordinate {dim!r}")
+        if not array.get_index(dim).equals(reference.get_index(dim)):
             raise ValueError(
-                f"Projection strategy {role} native coordinate {dim!r} must exactly match "
-                "the covariance grid in the same order"
+                f"Projection {role} native coordinate {dim!r} must exactly match the covariance grid"
             )
 
 
 def _validate_projection_invariant(
     projection: RetainedProjection,
     state_covariance: xr.DataArray,
-    b_restriction_transpose: xr.DataArray,
+    b_pi_t: xr.DataArray,
     *,
     native_dims: tuple[str, ...],
     state_dim: str,
     state_column_dim: str,
 ) -> None:
-    """Require a strategy to return its covariance-natural prolongation.
-
-    Args:
-        projection: Restriction/prolongation pair returned by the strategy.
-        state_covariance: Labelled ``C_alpha = Pi B Pi.T``.
-        b_restriction_transpose: Labelled ``B Pi.T``.
-        native_dims: Ordered native dimensions.
-        state_dim: Retained-state row dimension.
-        state_column_dim: Collision-safe retained-state column dimension.
-
-    Raises:
-        ValueError: If dimensions, state labels, or values are invalid, or if
-            ``B Pi.T`` and ``U_* C_alpha`` disagree beyond tolerance.
-    """
-    prolongation = projection.prolongation
-    u_c = xr.dot(prolongation, state_covariance, dim=state_dim).transpose(*native_dims, state_column_dim)
-    left = np.asarray(b_restriction_transpose.values, dtype=np.float64)
-    right = np.asarray(u_c.values, dtype=np.float64)
+    """Require ``B Pi.T = U_* C_alpha`` for a custom strategy."""
+    right = xr.dot(projection.prolongation, state_covariance, dim=state_dim).transpose(
+        *native_dims, state_column_dim
+    )
+    left_values = np.asarray(b_pi_t.values, dtype=np.float64)
+    right_values = np.asarray(right.values, dtype=np.float64)
     scale = max(
-        float(np.max(np.abs(left))) if left.size else 0.0,
-        float(np.max(np.abs(right))) if right.size else 0.0,
+        float(np.max(np.abs(left_values))) if left_values.size else 0.0,
+        float(np.max(np.abs(right_values))) if right_values.size else 0.0,
         np.finfo(np.float64).tiny,
     )
-    absolute_error = float(np.max(np.abs(left - right))) if left.size else 0.0
-    if absolute_error > 1e-9 * scale + 10.0 * np.finfo(np.float64).tiny:
+    error = float(np.max(np.abs(left_values - right_values))) if left_values.size else 0.0
+    if error > 1e-9 * scale + 10.0 * np.finfo(np.float64).tiny:
         raise ValueError("Projection strategy is incoherent: expected B Pi.T = U_* C_alpha")
-
-
-def _native_basis_prolongation(
-    basis_operator: BasisOperator,
-    sensitivity: xr.DataArray,
-    *,
-    native_dims: tuple[str, ...],
-    state_dim: str,
-) -> xr.DataArray:
-    """Return ``U_bucket`` on the full native space, including source blocks.
-
-    A single-source basis already spans every native dimension. For a gathered
-    multisource basis, the operator carries source identity on the ragged state
-    coordinate rather than as a matrix dimension. This helper expands it onto
-    the covariance action's explicit leading source dimension, setting all
-    cross-source state columns to zero while retaining canonical state order.
-
-    Args:
-        basis_operator: Spatial basis supplying the bucket matrix and metadata.
-        sensitivity: Native sensitivity whose leading source coordinate defines
-            source ordering for multisource inputs.
-        native_dims: Ordered native covariance dimensions.
-        state_dim: Retained-state dimension of the basis matrix.
-
-    Returns:
-        Eager ``U_bucket`` spanning ``(*native_dims, state_dim)``.
-
-    Raises:
-        ValueError: If a multisource basis lacks source labels or names a source
-            absent from the native sensitivity.
-    """
-    basis_grid_dims = tuple(basis_operator.meta.grid_dims)
-    basis_matrix = _densify(basis_operator.basis_matrix)
-    if native_dims == basis_grid_dims:
-        return basis_matrix
-
-    native_source_dim = native_dims[0]
-    basis_source_dim = getattr(basis_operator, "source_dim", None)
-    if not isinstance(basis_source_dim, str) or basis_source_dim not in basis_matrix.coords:
-        raise ValueError(
-            "A covariance with a leading native source dimension requires a gathered "
-            "multisource basis carrying source labels on its state coordinate"
-        )
-    state_sources = np.asarray(basis_matrix.coords[basis_source_dim].values)
-    native_sources = np.asarray(sensitivity.coords[native_source_dim].values)
-    missing = [label for label in state_sources if label not in set(native_sources.tolist())]
-    if missing:
-        raise ValueError(f"Basis state sources are absent from native sensitivity: {missing!r}")
-    base = basis_matrix.transpose(*basis_grid_dims, state_dim)
-    values = np.asarray(base.values)
-    source_mask = native_sources[:, np.newaxis] == state_sources[np.newaxis, :]
-    expanded = values[np.newaxis, ...] * source_mask.reshape(
-        (native_sources.size, *([1] * len(basis_grid_dims)), state_sources.size)
-    )
-    coords: dict[str, xr.DataArray] = {
-        native_source_dim: sensitivity.coords[native_source_dim],
-        **{dim: base.coords[dim] for dim in basis_grid_dims},
-        state_dim: base.coords[state_dim],
-    }
-    for name, coordinate in base.coords.items():
-        if name not in coords and set(coordinate.dims).issubset({state_dim}):
-            coords[str(name)] = coordinate
-    return xr.DataArray(
-        expanded,
-        dims=(*native_dims, state_dim),
-        coords=coords,
-        name="prolongation",
-        attrs={**basis_matrix.attrs, "mathematical_name": "U_bucket"},
-    )
-
-
-def _to_plain_column_axis(
-    array: xr.DataArray,
-    *,
-    row_dim: str,
-    column_dim: str,
-    leading_dims: tuple[str, ...],
-) -> xr.DataArray:
-    """Replace a rich row axis by a collision-safe plain column axis.
-
-    Args:
-        array: Labelled array containing the row and leading dimensions.
-        row_dim: Existing row dimension, possibly backed by a MultiIndex.
-        column_dim: New collision-safe plain dimension name.
-        leading_dims: Dimensions to retain before the new column dimension.
-
-    Returns:
-        An array sharing the input data and attributes, with row coordinates
-        copied onto the new plain column axis.
-    """
-    ordered = array.transpose(*leading_dims, row_dim)
-    coords = {dim: ordered.coords[dim] for dim in leading_dims}
-    coords.update(_column_coordinates(ordered, row_dim=row_dim, column_dim=column_dim))
-    return xr.DataArray(
-        ordered.data,
-        dims=(*leading_dims, column_dim),
-        coords=coords,
-        name=ordered.name,
-        attrs=ordered.attrs,
-    )
-
-
-def _namespace_axis_coordinate_collisions(
-    array: xr.DataArray,
-    *,
-    axis_dim: str,
-    occupied: set[str],
-) -> xr.DataArray:
-    """Give colliding auxiliary/index-level names a stable axis prefix."""
-    rename: dict[str, str] = {}
-    reserved = occupied | {str(name) for name in array.coords} | {str(dim) for dim in array.dims}
-    for name, coordinate in array.coords.items():
-        name = str(name)
-        if name == axis_dim or axis_dim not in coordinate.dims or name not in occupied:
-            continue
-        candidate = f"{axis_dim}_{name}"
-        suffix = 2
-        while candidate in reserved:
-            candidate = f"{axis_dim}_{name}_{suffix}"
-            suffix += 1
-        reserved.add(candidate)
-        rename[name] = candidate
-    return array.rename(rename) if rename else array
 
 
 def _validated_prolongation(
@@ -1347,31 +519,21 @@ def _validated_prolongation(
     native_dims: tuple[str, ...],
     state_dim: str,
 ) -> xr.DataArray:
-    """Materialize and validate a labelled native-by-retained prolongation.
-
-    Args:
-        prolongation: Candidate ``U_*`` or ``U_bucket`` array.
-        native_dims: Ordered native dimensions required on the array.
-        state_dim: Required retained-state dimension.
-
-    Returns:
-        A finite, eager array ordered as ``(*native_dims, state_dim)``.
-
-    Raises:
-        ValueError: If dimensions are missing or duplicated, values are not
-            finite, or a retained-state column is empty.
-    """
-    expected_dims = set((*native_dims, state_dim))
-    if set(prolongation.dims) != expected_dims or len(prolongation.dims) != len(expected_dims):
+    """Validate an eager labelled native-by-retained prolongation."""
+    expected = {*native_dims, state_dim}
+    if set(prolongation.dims) != expected or len(prolongation.dims) != len(expected):
         raise ValueError(
-            "prolongation must have exactly the native grid and retained-state dimensions; "
-            f"got {prolongation.dims!r}"
+            f"prolongation must have exactly native and retained-state dimensions; got {prolongation.dims!r}"
         )
-    result = _densify(prolongation).transpose(*native_dims, state_dim)
-    raw_values = np.asarray(result.values)
-    if np.iscomplexobj(raw_values) or not np.all(np.isfinite(raw_values)):
+    if is_chunked_array(prolongation.data):
+        raise ValueError(
+            "basis_prolongation is lazy; materialize canonical U explicitly at the upstream "
+            "pipeline boundary before calling project_native_covariance"
+        )
+    result = to_dense(prolongation).transpose(*native_dims, state_dim)
+    values = np.asarray(result.values)
+    if np.iscomplexobj(values) or not np.all(np.isfinite(values)):
         raise ValueError("prolongation must contain only finite real values")
-    values = np.asarray(raw_values, dtype=np.float64)
     if result.sizes[state_dim] == 0 or np.any(np.all(values == 0.0, axis=tuple(range(len(native_dims))))):
         raise ValueError("prolongation contains an empty retained state")
     return result
@@ -1382,509 +544,35 @@ def _validated_sensitivity(
     *,
     native_dims: tuple[str, ...],
     observation_dim: str,
-    covariance: InvertibleNativeCovarianceAction,
 ) -> xr.DataArray:
-    """Materialize and validate the labelled native sensitivity ``H``.
-
-    Args:
-        sensitivity: Candidate observation-by-native sensitivity array.
-        native_dims: Ordered native dimensions required on the array.
-        observation_dim: Required observation dimension.
-        covariance: Covariance action used to validate native grid labels.
-
-    Returns:
-        A finite, eager array ordered as ``(observation_dim, *native_dims)``.
-
-    Raises:
-        ValueError: If dimensions or observation labels are invalid, the array
-            is empty or non-finite, or covariance grid labels do not match.
-    """
-    expected_dims = set((*native_dims, observation_dim))
-    if set(sensitivity.dims) != expected_dims or len(sensitivity.dims) != len(expected_dims):
+    """Validate canonical eager sensitivity without a disposable B apply."""
+    expected = {*native_dims, observation_dim}
+    if set(sensitivity.dims) != expected or len(sensitivity.dims) != len(expected):
         raise ValueError(
-            "native_sensitivity must have exactly one observation dimension and the native grid "
-            f"dimensions; got {sensitivity.dims!r}"
+            "native_sensitivity must have exactly observation and native dimensions; "
+            f"got {sensitivity.dims!r}"
         )
     if observation_dim not in sensitivity.coords:
         raise ValueError(f"native_sensitivity is missing observation coordinate {observation_dim!r}")
-    result = _densify(sensitivity).transpose(observation_dim, *native_dims)
+    if is_chunked_array(sensitivity.data):
+        raise ValueError(
+            "native_sensitivity is lazy; materialize canonical H explicitly at the upstream "
+            "pipeline boundary before calling project_native_covariance"
+        )
+    result = to_dense(sensitivity).transpose(observation_dim, *native_dims)
     if result.sizes[observation_dim] == 0:
         raise ValueError("native_sensitivity must contain at least one observation")
     values = np.asarray(result.values)
     if np.iscomplexobj(values) or not np.all(np.isfinite(values)):
         raise ValueError("native_sensitivity must contain only finite real values")
-    # Applying B to one labelled column performs the covariance-grid label validation.
-    covariance.apply(result.isel({observation_dim: slice(0, 1)}))
     return result
 
 
-def _densify(array: xr.DataArray) -> xr.DataArray:
-    """Eagerly materialize an array and convert sparse storage to NumPy."""
-    materialized = array.compute()
-    data = materialized.data
-    if hasattr(data, "todense"):
-        data = data.todense()
-    return materialized.copy(data=np.asarray(data))
-
-
-def _matrix_column_dim(primary_dim: str, occupied_dims: tuple[Hashable, ...]) -> str:
-    """Return an unoccupied column-dimension name derived from a row name."""
-    candidate = f"{primary_dim}_cov"
-    index = 2
-    while candidate in occupied_dims:
-        candidate = f"{primary_dim}_cov_{index}"
-        index += 1
-    return candidate
-
-
-def _column_coordinate(coordinate: xr.DataArray, column_dim: str) -> xr.DataArray:
-    """Copy row labels onto a plain column coordinate.
-
-    Tuple-valued labels are encoded as compact JSON strings so xarray does not
-    reinterpret them as a two-dimensional coordinate.
-
-    Args:
-        coordinate: One-dimensional row coordinate to copy.
-        column_dim: Destination column dimension.
-
-    Returns:
-        A plain one-dimensional column coordinate preserving attributes.
-    """
-    source_values = list(coordinate.values)
-    if any(isinstance(value, tuple) for value in source_values):
-        values = np.asarray(
-            [
-                json.dumps(
-                    list(value),
-                    separators=(",", ":"),
-                    default=_json_label_default,
-                )
-                for value in source_values
-            ],
-            dtype=str,
-        )
-    else:
-        values = np.asarray(source_values)
-    return xr.DataArray(values, dims=column_dim, attrs=coordinate.attrs)
-
-
-def _json_label_default(value: object) -> str:
-    """Encode a rich tuple-label scalar as a stable string.
-
-    NumPy scalars are first converted to their Python equivalent. Datetime-like
-    objects use ``isoformat()``, while other objects use ``str()``.
-
-    Args:
-        value: Non-JSON-native coordinate-label value.
-
-    Returns:
-        Stable string suitable for a JSON tuple token.
-    """
-    if isinstance(value, np.generic):
-        value = value.item()
-    isoformat = getattr(value, "isoformat", None)
-    if callable(isoformat):
-        return str(isoformat())
-    return str(value)
-
-
-def _column_coordinates(
-    array: xr.DataArray,
-    *,
-    row_dim: str,
-    column_dim: str,
-) -> dict[str, xr.DataArray]:
-    """Build a plain column index and copies of row-axis metadata.
-
-    Args:
-        array: Source array containing the row coordinate and auxiliary labels.
-        row_dim: Row dimension whose coordinates are copied.
-        column_dim: Collision-safe column dimension receiving the copies.
-
-    Returns:
-        Coordinates for the new column axis. Auxiliary coordinate names gain a
-        ``_cov`` suffix, with numeric suffixes added to avoid collisions.
-    """
-    result = {column_dim: _column_coordinate(array.coords[row_dim], column_dim)}
-    for name, coordinate in array.coords.items():
-        if name == row_dim or tuple(coordinate.dims) != (row_dim,):
-            continue
-        column_name = f"{name}_cov"
-        suffix = 2
-        while column_name in array.coords or column_name in result:
-            column_name = f"{name}_cov_{suffix}"
-            suffix += 1
-        result[column_name] = xr.DataArray(
-            np.asarray(coordinate.values),
-            dims=column_dim,
-            attrs=coordinate.attrs,
-        )
-    return result
-
-
-def _validate_symmetric(values: np.ndarray, name: str, *, tolerance: float = 1e-10) -> None:
-    """Validate matrix symmetry relative to its largest absolute value.
-
-    Args:
-        values: Matrix values to validate.
-        name: Mathematical name used in an error message.
-        tolerance: Relative symmetry tolerance, with unit absolute scale floor.
-
-    Raises:
-        ValueError: If the maximum asymmetry exceeds the scaled tolerance.
-    """
+def _require_symmetric(values: np.ndarray, name: str, tolerance: float = 1e-10) -> None:
+    """Require a square numeric array to be symmetric within tolerance."""
+    if values.ndim != 2 or values.shape[0] != values.shape[1]:
+        raise ValueError(f"{name} must be square")
     asymmetry = float(np.max(np.abs(values - values.T))) if values.size else 0.0
     scale = max(1.0, float(np.max(np.abs(values))) if values.size else 1.0)
     if asymmetry > tolerance * scale:
         raise ValueError(f"{name} is not symmetric within tolerance {tolerance:g}")
-
-
-def _validate_positive_definite(values: np.ndarray, name: str) -> None:
-    """Reject singular or numerically redundant covariance coordinates.
-
-    Args:
-        values: Symmetric covariance matrix to validate.
-        name: Mathematical name used in an error message.
-
-    Raises:
-        ValueError: If the matrix is asymmetric, empty, non-positive, or has a
-            smallest eigenvalue no larger than ``1e-12`` times the largest.
-    """
-    _validate_symmetric(values, name)
-    eigenvalues = np.linalg.eigvalsh((values + values.T) * 0.5)
-    largest = float(eigenvalues[-1]) if eigenvalues.size else 0.0
-    if not eigenvalues.size or largest <= 0.0 or float(eigenvalues[0]) <= 1e-12 * largest:
-        raise ValueError(f"{name} must be positive definite and full rank")
-
-
-def _with_matrix_diagnostics(array: xr.DataArray, *, mathematical_name: str) -> xr.DataArray:
-    """Attach symmetry and bounded-cost PSD diagnostics to a dense matrix.
-
-    Args:
-        array: Dense square labelled matrix.
-        mathematical_name: Mathematical label stored in the result attributes.
-
-    Returns:
-        The array with diagnostic attributes. Full eigenvalue diagnostics are
-        skipped when the matrix exceeds :data:`MAX_DENSE_EIGEN_DIAGNOSTIC_SIZE`.
-
-    Raises:
-        ValueError: If the matrix is not symmetric within tolerance.
-    """
-    raw_values = np.asarray(array.values)
-    if np.iscomplexobj(raw_values):
-        raise ValueError(f"{mathematical_name} must contain real values")
-    values = np.asarray(raw_values, dtype=np.float64)
-    _validate_symmetric(values, mathematical_name)
-    attrs: dict[str, object] = {
-        "mathematical_name": mathematical_name,
-        "symmetry_absolute_error": float(np.max(np.abs(values - values.T))) if values.size else 0.0,
-        "diagnostic_tolerance": 1e-10,
-    }
-    if values.shape[0] <= MAX_DENSE_EIGEN_DIAGNOSTIC_SIZE:
-        eigenvalues = np.linalg.eigvalsh((values + values.T) * 0.5)
-        attrs.update(
-            minimum_eigenvalue=float(eigenvalues.min()) if eigenvalues.size else 0.0,
-            psd_diagnostic="full_eigendecomposition",
-        )
-    else:
-        attrs.update(
-            minimum_eigenvalue=np.nan,
-            psd_diagnostic=(f"skipped_full_eigendecomposition_above_{MAX_DENSE_EIGEN_DIAGNOSTIC_SIZE}"),
-        )
-    return array.assign_attrs(attrs)
-
-
-def _encode_configuration_dataset(
-    dataset: xr.Dataset,
-    *,
-    source_content_identity: str,
-    configuration_digest: str,
-) -> xr.Dataset:
-    """Namespace configuration dimensions before DataTree persistence.
-
-    Args:
-        dataset: Native covariance configuration to encode.
-        source_content_identity: Identity of the source content whose
-            covariance configuration this dataset describes.
-        configuration_digest: Digest of the decoded configuration content.
-
-    Returns:
-        A copy whose dimensions have a ``covariance_configuration__`` prefix.
-        The reversible original-to-encoded mapping is stored in the
-        ``openghg_inversions:configuration_dims`` attribute so parent DataTree
-        dimensions cannot absorb the child dimensions. The child also carries
-        the source identity so configurations from different artifacts cannot
-        be mixed silently.
-    """
-    rename = {str(dim): f"covariance_configuration__{dim}" for dim in dataset.dims}
-    encoded = dataset.rename(rename).copy()
-    encoded.attrs = dict(encoded.attrs)
-    encoded.attrs["openghg_inversions:configuration_dims"] = json.dumps(rename, sort_keys=True)
-    encoded.attrs["openghg_inversions:source_content_identity"] = source_content_identity
-    encoded.attrs["openghg_inversions:configuration_digest"] = configuration_digest
-    return encoded
-
-
-def _decode_configuration_dataset(
-    dataset: xr.Dataset,
-    *,
-    expected_source_content_identity: str,
-    expected_configuration_digest: str,
-) -> xr.Dataset:
-    """Restore namespaced configuration dimensions after persistence.
-
-    Args:
-        dataset: Encoded covariance configuration child dataset.
-        expected_source_content_identity: Source identity declared by the root
-            product dataset.
-        expected_configuration_digest: Configuration digest declared by the
-            root product dataset.
-
-    Returns:
-        A dataset with original dimension names and encoding metadata removed.
-
-    Raises:
-        ValueError: If the source binding or dimension mapping metadata is
-            absent or invalid.
-    """
-    child_source_identity = dataset.attrs.get("openghg_inversions:source_content_identity")
-    if child_source_identity != expected_source_content_identity:
-        raise ValueError("Serialized covariance configuration does not share the root source identity")
-    child_configuration_digest = dataset.attrs.get("openghg_inversions:configuration_digest")
-    if child_configuration_digest != expected_configuration_digest:
-        raise ValueError("Serialized covariance configuration does not share the root digest")
-    encoded_dims = dataset.attrs.get("openghg_inversions:configuration_dims")
-    if not isinstance(encoded_dims, str):
-        raise ValueError("Serialized covariance configuration is missing dimension metadata")
-    rename = json.loads(encoded_dims)
-    if not isinstance(rename, dict):
-        raise ValueError("Serialized covariance configuration dimension metadata is invalid")
-    restored = dataset.rename({str(encoded): str(original) for original, encoded in rename.items()})
-    restored.attrs = dict(restored.attrs)
-    del restored.attrs["openghg_inversions:configuration_dims"]
-    del restored.attrs["openghg_inversions:source_content_identity"]
-    del restored.attrs["openghg_inversions:configuration_digest"]
-    if _configuration_digest(restored) != expected_configuration_digest:
-        raise ValueError("Serialized covariance configuration content does not match its digest")
-    return restored
-
-
-def _configuration_digest(dataset: xr.Dataset) -> str:
-    """Hash decoded covariance configuration content into a stable digest.
-
-    Args:
-        dataset: Configuration in its decoded, original-dimension form.
-
-    Returns:
-        Lowercase hexadecimal SHA-256 digest stable across supported NetCDF
-        scalar and string coercions.
-    """
-    digest = hashlib.sha256()
-    digest.update(b"openghg_inversions.native_covariance_products.configuration.v1\0")
-    digest.update(_canonical_json(dataset.attrs).encode("utf-8"))
-    for name in sorted(str(name) for name in dataset.coords):
-        _update_configuration_array_digest(digest, dataset.coords[name])
-    for name in sorted(str(name) for name in dataset.data_vars):
-        _update_configuration_array_digest(digest, dataset[name])
-    return digest.hexdigest()
-
-
-def _update_configuration_array_digest(digest: _Digest, array: xr.DataArray) -> None:
-    """Hash one configuration array across NetCDF scalar/string coercions.
-
-    Args:
-        digest: Digest receiving canonical array metadata and values.
-        array: Configuration coordinate or data variable to hash.
-    """
-    digest.update(str(array.name).encode("utf-8"))
-    digest.update(_canonical_json(tuple(str(dim) for dim in array.dims)).encode("utf-8"))
-    digest.update(_canonical_json(array.attrs).encode("utf-8"))
-    values = np.ascontiguousarray(array.values)
-    digest.update(_canonical_json(values.shape).encode("utf-8"))
-    if values.dtype.hasobject or values.dtype.kind in {"U", "S"}:
-        digest.update(_canonical_json(values.tolist()).encode("utf-8"))
-    else:
-        digest.update(values.dtype.str.encode("ascii"))
-        digest.update(values.view(np.uint8).tobytes())
-
-
-def _canonical_json(value: object) -> str:
-    """Encode serialization-compatible metadata with normalized scalar types.
-
-    Args:
-        value: Metadata value accepted by JSON or
-            :func:`_canonical_json_default`.
-
-    Returns:
-        Compact, key-sorted JSON text.
-    """
-    return json.dumps(
-        value,
-        sort_keys=True,
-        separators=(",", ":"),
-        default=_canonical_json_default,
-    )
-
-
-def _canonical_json_default(value: object) -> object:
-    """Normalize NumPy, byte, array, and datetime-like values for JSON.
-
-    Args:
-        value: Value rejected by the standard JSON encoder.
-
-    Returns:
-        A JSON-native scalar, list, or string.
-
-    Raises:
-        TypeError: If the value has no supported canonical representation.
-    """
-    if isinstance(value, np.generic):
-        return value.item()
-    if isinstance(value, np.ndarray):
-        return value.tolist()
-    if isinstance(value, bytes):
-        return value.decode("utf-8")
-    isoformat = getattr(value, "isoformat", None)
-    if callable(isoformat):
-        return isoformat()
-    raise TypeError(f"Cannot encode {type(value).__name__} in a configuration digest")
-
-
-def _source_content_identity(
-    covariance: InvertibleNativeCovarianceAction,
-    *arrays: xr.DataArray,
-    strategy: str,
-) -> str:
-    """Hash shared scientific inputs and configuration into a stable identity.
-
-    Execution batching is deliberately excluded, because changing
-    ``observation_batch_size`` does not change the requested scientific
-    product. The dense/diagonal numerical view and computed product values are
-    also excluded. This identity binds source content, not stored-byte
-    integrity, and therefore does not detect numerical output tampering. A
-    covariance with ``to_dataset()`` contributes its configuration metadata,
-    coordinates, and variables; the custom-action fallback is stable only when
-    that object's ``repr`` is stable.
-
-    Args:
-        covariance: Native covariance action, preferably with serializable
-            constructor configuration.
-        *arrays: Labelled restriction, prolongation, and sensitivity arrays;
-            their values, dimensions, and all coordinates are hashed.
-        strategy: Stable retained-projection strategy name.
-
-    Returns:
-        Lowercase hexadecimal SHA-256 digest.
-    """
-    digest = hashlib.sha256()
-    digest.update(strategy.encode("utf-8"))
-    to_dataset = getattr(covariance, "to_dataset", None)
-    if callable(to_dataset):
-        covariance_dataset = cast(xr.Dataset, to_dataset())
-        digest.update(repr(sorted(covariance_dataset.attrs.items())).encode("utf-8"))
-        for name in sorted(str(name) for name in covariance_dataset.coords):
-            _update_array_digest(digest, covariance_dataset.coords[name])
-        for name in sorted(str(name) for name in covariance_dataset.data_vars):
-            _update_array_digest(digest, covariance_dataset[name])
-    else:
-        covariance_type = f"{type(covariance).__module__}.{type(covariance).__qualname__}"
-        digest.update(covariance_type.encode("utf-8"))
-        digest.update(repr(covariance).encode("utf-8"))
-    for array in arrays:
-        _update_array_digest(digest, array)
-    return digest.hexdigest()
-
-
-def _view_identity(
-    source_content_identity: str,
-    observation_covariance_view: Literal["dense", "diagonal"],
-) -> str:
-    """Derive a numerical-view identity from source content and view kind.
-
-    Args:
-        source_content_identity: Identity shared by all numerical views of the
-            same ``B/H/Pi/U`` source.
-        observation_covariance_view: Requested dense or diagonal view.
-
-    Returns:
-        Lowercase hexadecimal SHA-256 digest for this derived view.
-    """
-    digest = hashlib.sha256()
-    digest.update(b"openghg_inversions.native_covariance_products.view.v1\0")
-    digest.update(source_content_identity.encode("ascii"))
-    digest.update(b"\0")
-    digest.update(observation_covariance_view.encode("ascii"))
-    return digest.hexdigest()
-
-
-def _validated_identity(value: object, *, name: str) -> str:
-    """Validate a lowercase hexadecimal SHA-256 identity.
-
-    Args:
-        value: Serialized identity candidate.
-        name: Human-readable identity name used in an error.
-
-    Returns:
-        The validated identity string.
-
-    Raises:
-        ValueError: If the value is not a 64-character lowercase hex digest.
-    """
-    if (
-        not isinstance(value, str)
-        or len(value) != 64
-        or any(character not in "0123456789abcdef" for character in value)
-    ):
-        raise ValueError(f"Serialized covariance products have an invalid {name}")
-    return value
-
-
-def _decode_basis_provenance(value: object) -> dict[str, str]:
-    """Decode and validate the serialized string-to-string provenance map.
-
-    Args:
-        value: JSON text from root dataset metadata.
-
-    Returns:
-        Decoded provenance mapping.
-
-    Raises:
-        ValueError: If the value is not valid JSON encoding an object with
-            string keys and string values.
-    """
-    if not isinstance(value, str):
-        raise ValueError("Serialized covariance products have invalid basis provenance JSON")
-    try:
-        decoded = json.loads(value)
-    except json.JSONDecodeError as exc:
-        raise ValueError("Serialized covariance products have invalid basis provenance JSON") from exc
-    if not isinstance(decoded, dict) or any(
-        not isinstance(key, str) or not isinstance(item, str) for key, item in decoded.items()
-    ):
-        raise ValueError("Serialized covariance products basis provenance must be a string mapping")
-    return decoded
-
-
-def _update_array_digest(digest: _Digest, array: xr.DataArray) -> None:
-    """Update a content digest with array data, dimensions, and coordinates."""
-    digest.update(str(array.name).encode("utf-8"))
-    digest.update(repr(tuple(array.dims)).encode("utf-8"))
-    values = np.ascontiguousarray(array.values)
-    digest.update(values.dtype.str.encode("ascii"))
-    digest.update(repr(values.shape).encode("ascii"))
-    if values.dtype.hasobject or values.dtype.kind in {"U", "S"}:
-        digest.update(repr(values.tolist()).encode("utf-8"))
-    else:
-        digest.update(values.view(np.uint8).tobytes())
-    for name in sorted(str(name) for name in array.coords):
-        coordinate = array.coords[name]
-        labels = np.asarray(coordinate.values)
-        digest.update(name.encode("utf-8"))
-        digest.update(repr(tuple(coordinate.dims)).encode("utf-8"))
-        digest.update(labels.dtype.str.encode("ascii"))
-        digest.update(repr(labels.shape).encode("ascii"))
-        if labels.dtype.hasobject or labels.dtype.kind in {"U", "S"}:
-            digest.update(repr(labels.tolist()).encode("utf-8"))
-        else:
-            digest.update(np.ascontiguousarray(labels).view(np.uint8).tobytes())

--- a/openghg_inversions/basis/covariance_products.py
+++ b/openghg_inversions/basis/covariance_products.py
@@ -3,8 +3,8 @@
 This module is an eager numerical kernel. Callers supply a canonical, eager
 native sensitivity ``H`` and basis prolongation ``U``; basis operators own any
 source expansion and the pipeline owns materialization. Custom restrictions
-may remain sparse or Dask-backed: they are materialized only as explicit
-retained-state right-hand-side blocks immediately before covariance actions.
+may remain sparse or Dask-backed until the named projection boundary, where
+they are materialized once and reused by all retained-state RHS blocks.
 
 For native covariance ``B`` and retained restriction ``Pi``, the kernel returns
 ``C_alpha = Pi B Pi.T``, ``H U_*``, ``H B Pi.T``, and ``H B H.T`` (or its
@@ -46,10 +46,10 @@ class RetainedProjection:
         prolongation: Covariance-natural ``U_*`` with dimensions
             ``(*native_dims, state_dim)``.
         strategy: Stable identifier for the scientific projection choice.
-        state_covariance: Optional already-derived ``C_alpha``. Strategies may
-            provide this to avoid recomputing known algebraic identities.
-        covariance_restriction_transpose: Optional already-derived
-            ``B Pi.T`` on a typed column state axis.
+        state_covariance: Optional cached ``C_alpha``. The kernel independently
+            recomputes and validates caches supplied by external strategies.
+        covariance_restriction_transpose: Optional cached ``B Pi.T``. External
+            cached values are independently recomputed and validated.
     """
 
     restriction: xr.DataArray
@@ -57,6 +57,11 @@ class RetainedProjection:
     strategy: str
     state_covariance: xr.DataArray | None = None
     covariance_restriction_transpose: xr.DataArray | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _PreserveBucketProjection(RetainedProjection):
+    """Private built-in projection with independently derived trusted products."""
 
 
 class RetainedProjectionStrategy(Protocol):
@@ -110,7 +115,10 @@ class PreserveBucketProlongation:
         prolongation = _validated_prolongation(
             basis_prolongation, native_dims=native_dims, state_dim=state_dim
         )
-        state_column_dim = matrix_column_dim(state_dim, prolongation.dims)
+        state_column_dim = matrix_column_dim(
+            state_dim,
+            {str(name) for name in (*prolongation.dims, *prolongation.coords)},
+        )
         precision_prolongation = to_column_axis(
             covariance.solve(prolongation),
             row_dim=state_dim,
@@ -169,7 +177,7 @@ class PreserveBucketProlongation:
         b_pi_t = xr.dot(prolongation, state_covariance, dim=state_dim).transpose(
             *native_dims, state_column_dim
         )
-        return RetainedProjection(
+        return _PreserveBucketProjection(
             restriction=restriction,
             prolongation=prolongation,
             strategy=self.name,
@@ -248,7 +256,8 @@ def project_native_covariance(
     _validate_exact_native_coordinates(
         prolongation, sensitivity, native_dims=native_dims, role="prolongation"
     )
-    projection = (strategy or PreserveBucketProlongation()).projection(
+    projection_strategy = strategy if strategy is not None else PreserveBucketProlongation()
+    projection = projection_strategy.projection(
         covariance,
         prolongation,
         native_dims=native_dims,
@@ -260,8 +269,24 @@ def project_native_covariance(
         native_dims=native_dims,
         state_dim=state_dim,
     )
-    state_column_dim = matrix_column_dim(state_dim, projection.restriction.dims)
-    if projection.covariance_restriction_transpose is None:
+    occupied_names = {
+        str(name)
+        for array in (sensitivity, projection.restriction, projection.prolongation)
+        for name in (*array.dims, *array.coords)
+    }
+    state_column_dim = matrix_column_dim(state_dim, occupied_names)
+    trusted_projection = (
+        _reaxis_builtin_projection(
+            projection,
+            native_dims=native_dims,
+            state_dim=state_dim,
+            state_column_dim=state_column_dim,
+        )
+        if type(projection_strategy) is PreserveBucketProlongation
+        and isinstance(projection, _PreserveBucketProjection)
+        else None
+    )
+    if trusted_projection is None:
         b_pi_t = _apply_restriction_blocks(
             covariance,
             projection.restriction,
@@ -271,9 +296,10 @@ def project_native_covariance(
             rhs_block_size=batch_size,
         )
     else:
-        b_pi_t = projection.covariance_restriction_transpose
+        assert trusted_projection.covariance_restriction_transpose is not None
+        b_pi_t = trusted_projection.covariance_restriction_transpose
 
-    if projection.state_covariance is None:
+    if trusted_projection is None:
         state_covariance = _restriction_product_blocks(
             projection.restriction,
             b_pi_t,
@@ -287,10 +313,16 @@ def project_native_covariance(
             mathematical_name="C_alpha",
             require_positive_definite=True,
         )
+        _validate_external_cached_products(
+            projection,
+            computed_b_pi_t=b_pi_t,
+            computed_state_covariance=state_covariance,
+        )
     else:
-        state_covariance = projection.state_covariance.rename("state_covariance")
+        assert trusted_projection.state_covariance is not None
+        state_covariance = trusted_projection.state_covariance.rename("state_covariance")
 
-    if projection.state_covariance is None or projection.covariance_restriction_transpose is None:
+    if trusted_projection is None:
         _validate_projection_invariant(
             projection,
             state_covariance,
@@ -352,7 +384,7 @@ def _apply_restriction_blocks(
             column_dim=column_dim,
             leading_dims=native_dims,
         )
-        rhs = to_dense(rhs).compute()
+        rhs = _materialize_dense_preserving_coordinates(rhs)
         blocks.append(covariance.apply(rhs))
     return xr.concat(blocks, dim=column_dim).transpose(*native_dims, column_dim)
 
@@ -369,7 +401,9 @@ def _restriction_product_blocks(
     """Form ``Pi B Pi.T`` while materializing explicit restriction row blocks."""
     blocks: list[xr.DataArray] = []
     for start in range(0, restriction.sizes[state_dim], rhs_block_size):
-        rows = to_dense(restriction.isel({state_dim: slice(start, start + rhs_block_size)})).compute()
+        rows = _materialize_dense_preserving_coordinates(
+            restriction.isel({state_dim: slice(start, start + rhs_block_size)})
+        )
         blocks.append(xr.dot(rows, b_pi_t, dim=list(native_dims)))
     return xr.concat(blocks, dim=state_dim).transpose(state_dim, column_dim)
 
@@ -384,7 +418,10 @@ def _observation_covariance(
     batch_size: int,
 ) -> xr.DataArray:
     """Compute ``H B H.T`` in eager observation RHS blocks."""
-    column_dim = matrix_column_dim(observation_dim, sensitivity.dims)
+    column_dim = matrix_column_dim(
+        observation_dim,
+        {str(name) for name in (*sensitivity.dims, *sensitivity.coords)},
+    )
     count = sensitivity.sizes[observation_dim]
     values = np.empty(
         (count, count) if output == "dense" else count,
@@ -427,6 +464,12 @@ def _observation_covariance(
             mathematical_name="H B H.T",
             maximum_eigen_diagnostic_size=MAX_DENSE_EIGEN_DIAGNOSTIC_SIZE,
         )
+    if not np.all(np.isfinite(values)):
+        raise ValueError("diag(H B H.T) must contain only finite real values")
+    diagonal_scale = max(1.0, float(np.max(np.abs(values))) if values.size else 1.0)
+    diagonal_tolerance = 1e-10 * diagonal_scale
+    if np.any(values < -diagonal_tolerance):
+        raise ValueError("diag(H B H.T) contains materially negative covariance values")
     result = xr.DataArray(
         values,
         dims=observation_dim,
@@ -435,8 +478,8 @@ def _observation_covariance(
             **unit_attrs,
             "mathematical_name": "diag(H B H.T)",
             "minimum_diagonal": float(np.min(values)),
-            "diagonal_nonnegative": bool(np.all(values >= -1e-10)),
-            "diagnostic_tolerance": 1e-10,
+            "diagonal_nonnegative": bool(np.all(values >= -diagonal_tolerance)),
+            "diagnostic_tolerance": diagonal_tolerance,
         },
         name="native_observation_covariance",
     )
@@ -450,7 +493,7 @@ def _validated_projection(
     native_dims: tuple[str, ...],
     state_dim: str,
 ) -> RetainedProjection:
-    """Validate strategy labels without materializing a custom restriction."""
+    """Validate labels and materialize a custom restriction exactly once."""
     if not isinstance(projection.strategy, str) or not projection.strategy:
         raise ValueError("Projection strategy must return a non-empty strategy identifier")
     restriction = projection.restriction.transpose(state_dim, *native_dims).assign_attrs(
@@ -468,7 +511,159 @@ def _validated_projection(
         raise ValueError("Projection strategy restriction and prolongation require state labels")
     if not restriction.get_index(state_dim).equals(prolongation.get_index(state_dim)):
         raise ValueError("Projection strategy restriction/prolongation state labels differ")
+    _require_compatible_axis_coordinates(
+        restriction,
+        prolongation,
+        dim=state_dim,
+        role="retained-state",
+    )
+    for role, array in (("restriction", restriction), ("prolongation", prolongation)):
+        _require_reference_native_coordinates(
+            array,
+            native_reference,
+            native_dims=native_dims,
+            role=role,
+        )
+    if not isinstance(projection, _PreserveBucketProjection):
+        restriction = _materialize_dense_preserving_coordinates(restriction)
+        restriction_values = np.asarray(restriction.values)
+        if np.iscomplexobj(restriction_values) or not np.all(np.isfinite(restriction_values)):
+            raise ValueError("Projection strategy restriction must contain only finite real values")
     return replace(projection, restriction=restriction, prolongation=prolongation)
+
+
+def _reaxis_builtin_projection(
+    projection: _PreserveBucketProjection,
+    *,
+    native_dims: tuple[str, ...],
+    state_dim: str,
+    state_column_dim: str,
+) -> _PreserveBucketProjection:
+    """Rebuild trusted built-in product columns on the globally safe axis."""
+    assert projection.state_covariance is not None
+    assert projection.covariance_restriction_transpose is not None
+    old_column_dim = next(dim for dim in projection.state_covariance.dims if dim != state_dim)
+    if old_column_dim == state_column_dim:
+        return projection
+    state_covariance = xr.DataArray(
+        projection.state_covariance.data,
+        dims=(state_dim, state_column_dim),
+        coords={
+            str(name): coordinate
+            for name, coordinate in projection.state_covariance.coords.items()
+            if set(coordinate.dims).issubset({state_dim})
+        },
+        attrs=projection.state_covariance.attrs,
+        name=projection.state_covariance.name,
+    ).assign_coords(
+        renamed_column_coordinates(
+            projection.prolongation,
+            row_dim=state_dim,
+            column_dim=state_column_dim,
+        )
+    )
+    b_pi_t = xr.DataArray(
+        projection.covariance_restriction_transpose.data,
+        dims=(*native_dims, state_column_dim),
+        coords={
+            str(name): coordinate
+            for name, coordinate in projection.covariance_restriction_transpose.coords.items()
+            if set(coordinate.dims).issubset(native_dims)
+        },
+        attrs=projection.covariance_restriction_transpose.attrs,
+        name=projection.covariance_restriction_transpose.name,
+    ).assign_coords(
+        renamed_column_coordinates(
+            projection.prolongation,
+            row_dim=state_dim,
+            column_dim=state_column_dim,
+        )
+    )
+    return replace(
+        projection,
+        state_covariance=state_covariance,
+        covariance_restriction_transpose=b_pi_t,
+    )
+
+
+def _validate_external_cached_products(
+    projection: RetainedProjection,
+    *,
+    computed_b_pi_t: xr.DataArray,
+    computed_state_covariance: xr.DataArray,
+) -> None:
+    """Independently validate optional products supplied by external strategies."""
+    candidates = (
+        (
+            "covariance_restriction_transpose",
+            projection.covariance_restriction_transpose,
+            computed_b_pi_t,
+        ),
+        ("state_covariance", projection.state_covariance, computed_state_covariance),
+    )
+    for name, cached, computed in candidates:
+        if cached is None:
+            continue
+        cached_values = np.asarray(to_dense(cached).compute().values)
+        computed_values = np.asarray(computed.values)
+        if (
+            cached_values.shape != computed_values.shape
+            or np.iscomplexobj(cached_values)
+            or not np.all(np.isfinite(cached_values))
+            or not np.allclose(cached_values, computed_values, rtol=1e-10, atol=1e-12)
+        ):
+            raise ValueError(
+                f"Projection strategy supplied inconsistent cached {name}; "
+                "it does not match the independently computed covariance product"
+            )
+
+
+def _require_compatible_axis_coordinates(
+    left: xr.DataArray,
+    right: xr.DataArray,
+    *,
+    dim: str,
+    role: str,
+) -> None:
+    """Require identical semantic coordinates attached to one shared axis."""
+    left_coords = {
+        str(name): coordinate
+        for name, coordinate in left.coords.items()
+        if dim in coordinate.dims and str(name) != dim
+    }
+    right_coords = {
+        str(name): coordinate
+        for name, coordinate in right.coords.items()
+        if dim in coordinate.dims and str(name) != dim
+    }
+    if set(left_coords) != set(right_coords):
+        raise ValueError(f"Projection {role} auxiliary coordinate names differ between Pi and U")
+    for name, coordinate in left_coords.items():
+        other = right_coords[name]
+        if coordinate.dims != other.dims or not coordinate.equals(other):
+            raise ValueError(f"Projection {role} auxiliary coordinate {name!r} differs between Pi and U")
+
+
+def _require_reference_native_coordinates(
+    array: xr.DataArray,
+    reference: xr.DataArray,
+    *,
+    native_dims: tuple[str, ...],
+    role: str,
+) -> None:
+    """Require all reference native-only and scalar coordinates on a projection array."""
+    native_set = set(native_dims)
+    expected = {
+        str(name): coordinate
+        for name, coordinate in reference.coords.items()
+        if set(coordinate.dims).issubset(native_set)
+    }
+    for name, coordinate in expected.items():
+        if name not in array.coords:
+            raise ValueError(f"Projection {role} is missing compatible native coordinate {name!r}")
+        actual = array.coords[name]
+        if actual.dims != coordinate.dims or not actual.equals(coordinate):
+            raise ValueError(f"Projection {role} native coordinate {name!r} is incompatible")
 
 
 def _validate_exact_native_coordinates(
@@ -530,7 +725,7 @@ def _validated_prolongation(
             "basis_prolongation is lazy; materialize canonical U explicitly at the upstream "
             "pipeline boundary before calling project_native_covariance"
         )
-    result = to_dense(prolongation).transpose(*native_dims, state_dim)
+    result = _materialize_dense_preserving_coordinates(prolongation).transpose(*native_dims, state_dim)
     values = np.asarray(result.values)
     if np.iscomplexobj(values) or not np.all(np.isfinite(values)):
         raise ValueError("prolongation must contain only finite real values")
@@ -559,7 +754,7 @@ def _validated_sensitivity(
             "native_sensitivity is lazy; materialize canonical H explicitly at the upstream "
             "pipeline boundary before calling project_native_covariance"
         )
-    result = to_dense(sensitivity).transpose(observation_dim, *native_dims)
+    result = _materialize_dense_preserving_coordinates(sensitivity).transpose(observation_dim, *native_dims)
     if result.sizes[observation_dim] == 0:
         raise ValueError("native_sensitivity must contain at least one observation")
     values = np.asarray(result.values)
@@ -576,3 +771,12 @@ def _require_symmetric(values: np.ndarray, name: str, tolerance: float = 1e-10) 
     scale = max(1.0, float(np.max(np.abs(values))) if values.size else 1.0)
     if asymmetry > tolerance * scale:
         raise ValueError(f"{name} is not symmetric within tolerance {tolerance:g}")
+
+
+def _materialize_dense_preserving_coordinates(array: xr.DataArray) -> xr.DataArray:
+    """Materialize dense payloads without reconstructing typed xarray indexes."""
+    materialized = array.compute()
+    data = materialized.data
+    if hasattr(data, "todense"):
+        data = data.todense()
+    return materialized.copy(data=np.asarray(data))

--- a/openghg_inversions/basis/covariance_products.py
+++ b/openghg_inversions/basis/covariance_products.py
@@ -1,0 +1,1890 @@
+"""Coherent native-covariance products for retained bucket scaling states.
+
+OpenGHG Inversions constructs a native observation operator ``H`` from
+footprint times prior flux, so the native vector ``x`` and retained vector
+``alpha = Pi x`` are multiplicative scalings. Their covariance algebra applies
+to the centred perturbations ``x - m`` and ``alpha - Pi m``. The existing
+:attr:`~openghg_inversions.basis.operators.BasisOperator.basis_matrix` supplies
+the single-source bucket prolongation ``U_bucket`` (native by retained), or the
+gathered spatial template expanded to source-native ``U_bucket`` here. It is
+not ``Pi.T``.
+
+This module's initial strategy preserves that established coefficient meaning.
+For native covariance ``B`` it derives the compatible restriction
+
+``Pi_U = (U.T B^-1 U)^-1 U.T B^-1``.
+
+Consequently ``Pi_U U = I``, ``C_alpha = Pi_U B Pi_U.T`` and the
+covariance-weighted prolongation
+``U_* = B Pi_U.T C_alpha^-1`` is exactly ``U_bucket``.  The retained
+observation operator is therefore ``H_alpha = H U_bucket``, matching the
+current bucket sensitivity.  The centred residual
+``r = (x - m) - U_bucket (alpha - Pi_U m)`` satisfies
+``Cov(r, alpha) = 0``. Under a joint Gaussian model this also gives the affine
+conditional mean ``m + U_bucket (alpha - Pi_U m)``.
+
+The public strategy protocol deliberately keeps ``Pi`` separate from basis
+geometry so a future strategy can instead define physical retained
+functionals and derive its covariance-weighted prolongation.  This foundation
+computes labelled ``C_alpha``, ``H B Pi.T``, and ``H B H.T`` (or its diagonal)
+without constructing dense native ``B``. Operations eagerly materialize
+``U``, ``H``, and the requested product matrices; dense ``H B H.T`` therefore
+uses quadratic observation-space storage. Constructing unresolved covariance
+and the coherent reduced likelihood belongs to OPE-18.
+
+The components have deliberately separate roles:
+
+1. :class:`~openghg_inversions.basis.operators.BasisOperator` supplies the
+   bucket geometry ``U_bucket``.
+2. :class:`~openghg_inversions.native_covariance.InvertibleNativeCovarianceAction`
+   supplies labelled applications of ``B`` and ``B^-1``; its protocol is
+   imported rather than redefined here.
+3. :class:`RetainedProjectionStrategy` chooses a coherent ``(Pi, U_*)`` pair
+   and returns it as the :class:`RetainedProjection` value object.
+   :class:`PreserveBucketProlongation` is the initial concrete structural
+   implementation of that strategy protocol.
+4. :func:`project_native_covariance` combines those inputs into the frozen,
+   serializable :class:`NativeCovarianceProducts` dataclass. Its contained
+   xarray objects remain mutable.
+
+Projected artifacts carry a source identity derived from covariance
+configuration, projection strategy, and labelled ``Pi``, ``U``, and ``H``
+inputs, plus a view identity derived from that source identity and the requested
+dense/diagonal representation. These identities bind artifact metadata; they
+are not checksums of computed output values. Observation batching fills one
+preallocated eager result but does not reduce final dense quadratic storage.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+import hashlib
+import json
+from typing import Any, Hashable, Literal, Protocol, cast
+
+import numpy as np
+from scipy.linalg import cho_factor, cho_solve
+import xarray as xr
+
+from openghg_inversions.basis.operators import BasisOperator
+from openghg_inversions.native_covariance import InvertibleNativeCovarianceAction
+
+MAX_DENSE_EIGEN_DIAGNOSTIC_SIZE = 512
+_PRODUCT_COORDINATE_NAMESPACES_ATTR = "openghg_inversions:product_coordinate_namespaces"
+_PRODUCT_MULTIINDEX_DIMS_ATTR = "openghg_inversions:product_multiindex_dims"
+
+
+@dataclass(frozen=True, slots=True)
+class RetainedProjection:
+    """A labelled restriction/prolongation pair selected by one strategy.
+
+    Attributes:
+        restriction: ``Pi`` with dimensions ``(state_dim, *native_dims)``;
+            retained coefficients satisfy ``alpha = Pi x``.
+        prolongation: Covariance-compatible ``U_*`` with dimensions
+            ``(*native_dims, state_dim)`` and ``x_hat = U_* alpha`` in centred
+            coordinates.
+        strategy: Stable identifier for the scientific projection choice.
+    """
+
+    restriction: xr.DataArray
+    prolongation: xr.DataArray
+    strategy: str
+
+
+class RetainedProjectionStrategy(Protocol):
+    """Extension seam for choosing retained coefficients and their lift.
+
+    Implementations must return a full-rank ``Pi`` and the covariance-natural
+    ``U_* = B Pi.T (Pi B Pi.T)^-1``. This invariant is what makes the returned
+    residual uncorrelated with the retained coefficients. Both arrays must use
+    native labels exactly matching the covariance grid in the same order, and
+    their retained-state labels must agree.
+    """
+
+    def projection(
+        self,
+        covariance: InvertibleNativeCovarianceAction,
+        basis_prolongation: xr.DataArray,
+        *,
+        native_dims: tuple[str, ...],
+        state_dim: str,
+    ) -> RetainedProjection:
+        """Return a compatible labelled restriction and prolongation.
+
+        Args:
+            covariance: Invertible labelled action for the native covariance
+                ``B``.
+            basis_prolongation: Candidate bucket prolongation with dimensions
+                ``(*native_dims, state_dim)``.
+            native_dims: Ordered dimensions of the native state.
+            state_dim: Name of the retained-state dimension.
+
+        Returns:
+            A labelled :class:`RetainedProjection` whose restriction is
+            full-rank and whose prolongation satisfies
+            ``B Pi.T = U_* (Pi B Pi.T)``.
+
+        Raises:
+            ValueError: If the supplied arrays are invalid or a coherent,
+                full-rank projection cannot be constructed.
+        """
+        ...
+
+
+class _Digest(Protocol):
+    """Minimal hashlib digest surface used by identity helpers."""
+
+    def update(self, data: bytes, /) -> None:
+        """Add bytes to the digest."""
+        ...
+
+
+@dataclass(frozen=True, slots=True)
+class PreserveBucketProlongation:
+    """Derive ``Pi_U`` so covariance-weighted prolongation equals ``U_bucket``.
+
+    This class is a concrete structural implementation of
+    :class:`RetainedProjectionStrategy`. :class:`RetainedProjection` is the
+    value object returned by :meth:`projection`, not the protocol being
+    implemented.
+
+    Attributes:
+        name: Stable strategy identifier stored with projected products.
+
+    ``B`` must be positive definite and ``U_bucket`` must have full column rank.
+    """
+
+    name: str = "preserve_bucket_prolongation"
+
+    def __post_init__(self) -> None:
+        """Require a stable non-empty strategy identifier."""
+        if not isinstance(self.name, str) or not self.name:
+            raise ValueError("Projection strategy name must be a non-empty string")
+
+    def projection(
+        self,
+        covariance: InvertibleNativeCovarianceAction,
+        basis_prolongation: xr.DataArray,
+        *,
+        native_dims: tuple[str, ...],
+        state_dim: str,
+    ) -> RetainedProjection:
+        """Construct the prior-precision-compatible restriction.
+
+        Args:
+            covariance: Invertible labelled action for the native covariance ``B``.
+            basis_prolongation: Current bucket prolongation ``U_bucket``.
+            native_dims: Ordered native dimensions.
+            state_dim: Retained-state dimension.
+
+        Returns:
+            A :class:`RetainedProjection` containing the labelled pair
+            ``(Pi_U, U_bucket)``.
+
+        Raises:
+            ValueError: If the prolongation is invalid or has redundant columns.
+        """
+        prolongation = _validated_prolongation(
+            basis_prolongation, native_dims=native_dims, state_dim=state_dim
+        )
+        state_column_dim = _matrix_column_dim(state_dim, prolongation.dims)
+        precision_prolongation = _to_plain_column_axis(
+            covariance.solve(prolongation),
+            row_dim=state_dim,
+            column_dim=state_column_dim,
+            leading_dims=native_dims,
+        )
+        gram = xr.dot(
+            prolongation,
+            precision_prolongation,
+            dim=list(native_dims),
+        ).transpose(state_dim, state_column_dim)
+        gram_values = np.asarray(gram.values, dtype=np.float64)
+        _validate_symmetric(gram_values, "U.T B^-1 U")
+        eigenvalues = np.linalg.eigvalsh((gram_values + gram_values.T) * 0.5)
+        largest_eigenvalue = float(eigenvalues[-1]) if eigenvalues.size else 0.0
+        if (
+            not eigenvalues.size
+            or largest_eigenvalue <= 0.0
+            or float(eigenvalues[0]) <= 1e-12 * largest_eigenvalue
+        ):
+            raise ValueError(
+                "The bucket prolongation contains redundant or numerically unsupported retained states; "
+                "U.T B^-1 U must be positive definite and full rank"
+            )
+        try:
+            factor = cho_factor(gram_values, lower=True, check_finite=True)
+        except np.linalg.LinAlgError as exc:
+            raise ValueError(
+                "The bucket prolongation contains redundant or unsupported retained states; "
+                "U.T B^-1 U must be positive definite"
+            ) from exc
+        covariance_values = cho_solve(factor, np.eye(gram_values.shape[0]), check_finite=False)
+        covariance_coords: dict[str, xr.DataArray] = {
+            state_dim: prolongation.coords[state_dim],
+        }
+        for name, coordinate in prolongation.coords.items():
+            if name != state_dim and tuple(coordinate.dims) == (state_dim,):
+                covariance_coords[str(name)] = coordinate
+        covariance_coords.update(
+            _column_coordinates(prolongation, row_dim=state_dim, column_dim=state_column_dim)
+        )
+        state_covariance = xr.DataArray(
+            covariance_values,
+            dims=(state_dim, state_column_dim),
+            coords=covariance_coords,
+        )
+        restriction = xr.dot(
+            state_covariance,
+            precision_prolongation,
+            dim=state_column_dim,
+        ).transpose(state_dim, *native_dims)
+        restriction = restriction.rename("restriction").assign_attrs(
+            mathematical_name="Pi_U",
+            definition="(U.T B^-1 U)^-1 U.T B^-1",
+            strategy=self.name,
+        )
+        prolongation = prolongation.rename("prolongation").assign_attrs(
+            mathematical_name="U_bucket",
+            strategy=self.name,
+        )
+        return RetainedProjection(
+            restriction=restriction,
+            prolongation=prolongation,
+            strategy=self.name,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class NativeCovarianceProducts:
+    """Labelled product blocks induced by one coherent ``(B, H, Pi, U)`` set.
+
+    Attributes:
+        restriction: Retained restriction ``Pi`` with dimensions retained by native.
+        prolongation: Covariance-compatible ``U_*`` with dimensions native by retained.
+        state_covariance: ``C_alpha = Pi B Pi.T``.
+        effective_observation_operator: ``H_alpha = H U_*``.
+        observation_state_cross_covariance: ``H B Pi.T``.
+        native_observation_covariance: Dense ``H B H.T`` with a collision-safe
+            observation column dimension, or its labelled observation diagonal.
+        strategy: Stable retained-projection strategy name.
+        source_content_identity: SHA-256 identity of the projection strategy,
+            covariance configuration or fallback representation, and labelled
+            ``Pi/U/H`` values, dimensions, and coordinates. It is independent
+            of the dense or diagonal numerical view.
+        view_identity: SHA-256 identity derived from the source identity and
+            requested observation-covariance view.
+        observation_covariance_view: Numerical view represented by
+            ``native_observation_covariance``.
+        covariance_configuration_digest: Digest declaring the covariance
+            configuration required to reproduce the source artifact. The
+            configuration content itself is stored separately in a DataTree
+            child.
+        covariance_configuration: Reproducible serialized kernel/source configuration.
+        basis_provenance: Stable basis implementation and dimension metadata.
+    """
+
+    restriction: xr.DataArray
+    prolongation: xr.DataArray
+    state_covariance: xr.DataArray
+    effective_observation_operator: xr.DataArray
+    observation_state_cross_covariance: xr.DataArray
+    native_observation_covariance: xr.DataArray
+    strategy: str
+    source_content_identity: str
+    view_identity: str
+    observation_covariance_view: Literal["dense", "diagonal"]
+    covariance_configuration_digest: str = ""
+    covariance_configuration: xr.Dataset | None = None
+    basis_provenance: dict[str, str] = field(default_factory=dict)
+
+    schema = "openghg_inversions.native_covariance_products"
+    schema_version = 2
+
+    def to_dataset(self) -> xr.Dataset:
+        """Serialize labelled product blocks and their source/view identities.
+
+        Returns:
+            A dataset containing every product array plus schema, strategy,
+            source/view identities, and basis-provenance metadata. Native
+            covariance configuration is intentionally excluded because it
+            occupies a separate child node in :meth:`to_datatree`.
+
+            The identities bind declared source and view metadata across the
+            artifact. They are not integrity checksums of the numerical output
+            variables, whose values are deliberately not re-hashed here.
+        """
+        configuration_digest = self._validated_configuration_digest()
+        arrays, coordinate_namespaces = _namespace_product_coordinates(
+            {
+                "restriction": self.restriction,
+                "prolongation": self.prolongation,
+                "state_covariance": self.state_covariance,
+                "effective_observation_operator": self.effective_observation_operator,
+                "observation_state_cross_covariance": self.observation_state_cross_covariance,
+                "native_observation_covariance": self.native_observation_covariance,
+            }
+        )
+        dataset = xr.Dataset(
+            arrays,
+            attrs={
+                "schema": self.schema,
+                "schema_version": self.schema_version,
+                "strategy": self.strategy,
+                "source_content_identity": self.source_content_identity,
+                "view_identity": self.view_identity,
+                "observation_covariance_view": self.observation_covariance_view,
+                "covariance_configuration_digest": configuration_digest,
+                "basis_provenance": json.dumps(self.basis_provenance, sort_keys=True),
+                _PRODUCT_COORDINATE_NAMESPACES_ATTR: json.dumps(
+                    coordinate_namespaces,
+                    sort_keys=True,
+                ),
+            },
+        )
+        multiindex_dims = sorted(
+            str(dim)
+            for dim, index in dataset.indexes.items()
+            if dim in dataset.dims and getattr(index, "nlevels", 1) > 1
+        )
+        dataset.attrs[_PRODUCT_MULTIINDEX_DIMS_ATTR] = json.dumps(multiindex_dims)
+        return dataset
+
+    def to_datatree(self) -> xr.DataTree:
+        """Serialize products and reproducible covariance configuration.
+
+        Returns:
+            A tree whose root contains :meth:`to_dataset` output and whose
+            optional ``covariance_configuration`` child preserves the native
+            covariance constructor data, source binding, and content digest.
+        """
+        from openghg_inversions.serialization import reset_serialisation_multiindexes
+
+        tree = xr.DataTree(reset_serialisation_multiindexes(self.to_dataset()))
+        if self.covariance_configuration is None and self.covariance_configuration_digest:
+            raise ValueError(
+                "Cannot serialize covariance products as a DataTree without the declared "
+                "covariance configuration content"
+            )
+        if self.covariance_configuration is not None:
+            configuration_digest = self._validated_configuration_digest()
+            tree["covariance_configuration"] = xr.DataTree(
+                _encode_configuration_dataset(
+                    self.covariance_configuration,
+                    source_content_identity=self.source_content_identity,
+                    configuration_digest=configuration_digest,
+                )
+            )
+        return tree
+
+    def _validated_configuration_digest(self) -> str:
+        """Return the declared digest after checking any attached configuration."""
+        if self.covariance_configuration is None:
+            return self.covariance_configuration_digest
+        actual_digest = _configuration_digest(self.covariance_configuration)
+        if self.covariance_configuration_digest and self.covariance_configuration_digest != actual_digest:
+            raise ValueError("Attached covariance configuration does not match its declared digest")
+        return actual_digest
+
+    @classmethod
+    def from_dataset(cls, dataset: xr.Dataset) -> NativeCovarianceProducts:
+        """Restore and validate :meth:`to_dataset` output.
+
+        Args:
+            dataset: Versioned product-block dataset.
+
+        Returns:
+            Restored frozen product dataclass. Its contained arrays remain
+            mutable.
+
+        Raises:
+            ValueError: If the schema version, required variables, shared
+                source/view identity, projection strategy, numerical view, or
+                JSON-encoded basis provenance is invalid. Numerical variable
+                values are not checksummed by this metadata validation.
+        """
+        if dataset.attrs.get("schema") != cls.schema:
+            raise ValueError(f"Expected product schema {cls.schema!r}")
+        if dataset.attrs.get("schema_version") != cls.schema_version:
+            raise ValueError(f"Unsupported product schema version {dataset.attrs.get('schema_version')!r}")
+        required = (
+            "restriction",
+            "prolongation",
+            "state_covariance",
+            "effective_observation_operator",
+            "observation_state_cross_covariance",
+            "native_observation_covariance",
+        )
+        missing = [name for name in required if name not in dataset]
+        if missing:
+            raise ValueError(f"Serialized covariance products are missing variables {missing}")
+        source_content_identity = _validated_identity(
+            dataset.attrs.get("source_content_identity"),
+            name="source content identity",
+        )
+        view_identity = _validated_identity(
+            dataset.attrs.get("view_identity"),
+            name="view identity",
+        )
+        observation_covariance_view = dataset.attrs.get("observation_covariance_view")
+        if observation_covariance_view not in {"dense", "diagonal"}:
+            raise ValueError("Serialized covariance products have an invalid numerical view")
+        expected_view_identity = _view_identity(
+            source_content_identity,
+            cast(Literal["dense", "diagonal"], observation_covariance_view),
+        )
+        if view_identity != expected_view_identity:
+            raise ValueError("Serialized covariance products have an invalid derived view identity")
+        configuration_digest = dataset.attrs.get("covariance_configuration_digest")
+        if configuration_digest != "":
+            _validated_identity(
+                configuration_digest,
+                name="covariance configuration digest",
+            )
+        strategy = str(dataset.attrs.get("strategy", ""))
+        if not strategy:
+            raise ValueError("Serialized covariance products are missing strategy metadata")
+        for name in required:
+            if dataset[name].attrs.get("source_content_identity") != source_content_identity:
+                raise ValueError(f"Serialized product {name!r} does not share the root source identity")
+            if dataset[name].attrs.get("view_identity") != view_identity:
+                raise ValueError(f"Serialized product {name!r} does not share the root view identity")
+            if dataset[name].attrs.get("projection_strategy") != strategy:
+                raise ValueError(f"Serialized product {name!r} does not share the root projection strategy")
+        coordinate_namespaces = _decode_product_coordinate_namespaces(
+            dataset.attrs.get(_PRODUCT_COORDINATE_NAMESPACES_ATTR)
+        )
+        if set(coordinate_namespaces) != set(required):
+            raise ValueError("Serialized covariance products have invalid coordinate namespace owners")
+        for owner, mapping in coordinate_namespaces.items():
+            prefix = f"__product__{owner}__"
+            if any(not encoded.startswith(prefix) for encoded in mapping):
+                raise ValueError(
+                    f"Serialized covariance product {owner!r} has invalid coordinate namespace names"
+                )
+        encoded_coordinate_names = {
+            coordinate for mapping in coordinate_namespaces.values() for coordinate in mapping
+        }
+        arrays: dict[str, xr.DataArray] = {}
+        for name in required:
+            mapping = coordinate_namespaces.get(name, {})
+            foreign_coordinates = [
+                coordinate
+                for coordinate in encoded_coordinate_names - mapping.keys()
+                if coordinate in dataset[name].coords
+            ]
+            array = dataset[name].drop_vars(foreign_coordinates)
+            arrays[name] = _restore_product_coordinates(array, mapping)
+        basis_provenance = _decode_basis_provenance(dataset.attrs.get("basis_provenance"))
+        _validate_serialized_product_arrays(
+            arrays,
+            observation_covariance_view=cast(Literal["dense", "diagonal"], observation_covariance_view),
+            basis_provenance=basis_provenance,
+            declared_multiindex_dims=_decode_product_multiindex_dims(
+                dataset.attrs.get(_PRODUCT_MULTIINDEX_DIMS_ATTR)
+            ),
+        )
+        return cls(
+            restriction=arrays["restriction"],
+            prolongation=arrays["prolongation"],
+            state_covariance=arrays["state_covariance"],
+            effective_observation_operator=arrays["effective_observation_operator"],
+            observation_state_cross_covariance=arrays["observation_state_cross_covariance"],
+            native_observation_covariance=arrays["native_observation_covariance"],
+            strategy=strategy,
+            source_content_identity=source_content_identity,
+            view_identity=view_identity,
+            observation_covariance_view=cast(Literal["dense", "diagonal"], observation_covariance_view),
+            covariance_configuration_digest=str(configuration_digest),
+            basis_provenance=basis_provenance,
+        )
+
+    @classmethod
+    def from_datatree(cls, tree: xr.DataTree) -> NativeCovarianceProducts:
+        """Restore products and covariance configuration from a data tree.
+
+        Args:
+            tree: Tree produced by :meth:`to_datatree`.
+
+        Returns:
+            Restored frozen product dataclass, including covariance
+            configuration when the child node is present. Its contained
+            arrays and mappings remain mutable.
+
+        Raises:
+            ValueError: If the root product schema, source/view identities,
+                strategy, MultiIndex metadata, or the covariance
+                configuration's source binding or content digest is invalid.
+        """
+        from openghg_inversions.serialization import (
+            MULTIINDEX_DIMS_ATTR,
+            restore_serialisation_multiindexes,
+        )
+
+        root_dataset = tree.to_dataset(inherit=False)
+        if MULTIINDEX_DIMS_ATTR in root_dataset.attrs:
+            root_dataset = restore_serialisation_multiindexes(root_dataset, strict=True)
+        products = cls.from_dataset(root_dataset)
+        if "covariance_configuration" not in tree:
+            if root_dataset.attrs.get("covariance_configuration_digest"):
+                raise ValueError("Serialized covariance products are missing covariance configuration")
+            return products
+        configuration_digest = _validated_identity(
+            root_dataset.attrs.get("covariance_configuration_digest"),
+            name="covariance configuration digest",
+        )
+        return replace(
+            products,
+            covariance_configuration=_decode_configuration_dataset(
+                cast(xr.DataTree, tree["covariance_configuration"]).to_dataset(inherit=False),
+                expected_source_content_identity=products.source_content_identity,
+                expected_configuration_digest=configuration_digest,
+            ),
+        )
+
+
+def _namespace_product_coordinates(
+    arrays: dict[str, xr.DataArray],
+) -> tuple[dict[str, xr.DataArray], dict[str, dict[str, str]]]:
+    """Namespace auxiliary coordinates so independent axes cannot collide in a dataset."""
+    canonical_multiindexes: dict[str, Any] = {}
+    normalized: dict[str, xr.DataArray] = {}
+    for variable_name, original in arrays.items():
+        array = original
+        for dim, index in tuple(array.indexes.items()):
+            dim = str(dim)
+            if dim not in array.dims or getattr(index, "nlevels", 1) <= 1:
+                continue
+            canonical = canonical_multiindexes.setdefault(dim, index)
+            if not index.equals(canonical) or tuple(index.names) != tuple(canonical.names):
+                raise ValueError(f"Product arrays carry inconsistent MultiIndex labels for {dim!r}")
+            if index is canonical:
+                continue
+            index_coordinate_names = [dim, *(str(name) for name in index.names)]
+            array = array.drop_indexes(index_coordinate_names).drop_vars(index_coordinate_names)
+            array = array.assign_coords(xr.Coordinates.from_pandas_multiindex(canonical, dim))
+        normalized[variable_name] = array
+    arrays = normalized
+
+    occupied = {str(name) for array in arrays.values() for name in (*array.dims, *array.coords)}
+    usages: dict[str, dict[tuple[str, ...], tuple[bool, bool, int]]] = {}
+    for array in arrays.values():
+        has_multiindex = any(
+            dim in array.dims and getattr(index, "nlevels", 1) > 1 for dim, index in array.indexes.items()
+        )
+        for coordinate_name in (str(name) for name in array.coords):
+            if coordinate_name in array.dims:
+                continue
+            coordinate_dims = tuple(str(dim) for dim in array.coords[coordinate_name].dims)
+            previous = usages.setdefault(coordinate_name, {}).get(
+                coordinate_dims,
+                (False, False, 0),
+            )
+            usages[coordinate_name][coordinate_dims] = (
+                previous[0] or coordinate_name in array.xindexes,
+                previous[1] or has_multiindex,
+                previous[2] + 1,
+            )
+    canonical_signatures = {
+        name: max(signatures, key=lambda dims: signatures[dims]) for name, signatures in usages.items()
+    }
+
+    encoded: dict[str, xr.DataArray] = {}
+    namespaces: dict[str, dict[str, str]] = {}
+    for variable_name, array in arrays.items():
+        rename: dict[str, str] = {}
+        for coordinate_name in (str(name) for name in array.coords):
+            if coordinate_name in array.dims:
+                continue
+            coordinate_dims = tuple(str(dim) for dim in array.coords[coordinate_name].dims)
+            if coordinate_name in array.xindexes or coordinate_dims == canonical_signatures[coordinate_name]:
+                continue
+            candidate = f"__product__{variable_name}__{coordinate_name}"
+            suffix = 2
+            while candidate in occupied:
+                candidate = f"__product__{variable_name}__{coordinate_name}_{suffix}"
+                suffix += 1
+            occupied.add(candidate)
+            rename[coordinate_name] = candidate
+        encoded[variable_name] = array.rename(rename) if rename else array
+        namespaces[variable_name] = {encoded_name: original for original, encoded_name in rename.items()}
+    return encoded, namespaces
+
+
+def _decode_product_coordinate_namespaces(value: object) -> dict[str, dict[str, str]]:
+    """Decode and validate reversible per-product coordinate namespaces."""
+    if not isinstance(value, str):
+        raise ValueError("Serialized covariance products are missing coordinate namespace metadata")
+    try:
+        decoded = json.loads(value)
+    except json.JSONDecodeError as error:
+        raise ValueError(
+            "Serialized covariance products have invalid coordinate namespace metadata"
+        ) from error
+    if not isinstance(decoded, dict):
+        raise ValueError("Serialized covariance products have invalid coordinate namespace metadata")
+    result: dict[str, dict[str, str]] = {}
+    for variable_name, mapping in decoded.items():
+        if (
+            not isinstance(variable_name, str)
+            or not isinstance(mapping, dict)
+            or any(
+                not isinstance(encoded, str) or not isinstance(original, str)
+                for encoded, original in mapping.items()
+            )
+        ):
+            raise ValueError("Serialized covariance products have invalid coordinate namespace metadata")
+        result[variable_name] = mapping
+    return result
+
+
+def _restore_product_coordinates(array: xr.DataArray, mapping: dict[str, str]) -> xr.DataArray:
+    """Restore one product array's original auxiliary coordinate names."""
+    missing = [name for name in mapping if name not in array.coords]
+    if missing:
+        raise ValueError(f"Serialized product is missing namespaced coordinates {missing}")
+    if len(set(mapping.values())) != len(mapping):
+        raise ValueError("Serialized product coordinate namespace metadata is not one-to-one")
+    return array.rename(mapping) if mapping else array
+
+
+def _decode_product_multiindex_dims(value: object) -> tuple[str, ...]:
+    """Decode dimensions declared to require restored MultiIndex semantics."""
+    if not isinstance(value, str):
+        raise ValueError("Serialized covariance products are missing MultiIndex declarations")
+    try:
+        decoded = json.loads(value)
+    except json.JSONDecodeError as error:
+        raise ValueError("Serialized covariance products have invalid MultiIndex declarations") from error
+    if not isinstance(decoded, list) or any(not isinstance(dim, str) for dim in decoded):
+        raise ValueError("Serialized covariance products have invalid MultiIndex declarations")
+    return tuple(decoded)
+
+
+def _validate_serialized_product_arrays(
+    arrays: dict[str, xr.DataArray],
+    *,
+    observation_covariance_view: Literal["dense", "diagonal"],
+    basis_provenance: dict[str, str],
+    declared_multiindex_dims: tuple[str, ...],
+) -> None:
+    """Validate dimensional, label, view, and restored-index invariants."""
+    state_dim = basis_provenance.get("state_dim", "")
+    if not state_dim:
+        raise ValueError("Serialized covariance products are missing retained-state provenance")
+    restriction = arrays["restriction"]
+    prolongation = arrays["prolongation"]
+    if not restriction.dims or restriction.dims[0] != state_dim:
+        raise ValueError("Serialized restriction has invalid retained-state dimensions")
+    native_dims = tuple(str(dim) for dim in restriction.dims[1:])
+    if not native_dims or prolongation.dims != (*native_dims, state_dim):
+        raise ValueError("Serialized restriction/prolongation dimensions are inconsistent")
+    if restriction.sizes[state_dim] != prolongation.sizes[state_dim]:
+        raise ValueError("Serialized restriction/prolongation retained-state sizes differ")
+
+    state_covariance = arrays["state_covariance"]
+    if state_covariance.ndim != 2 or state_covariance.dims[0] != state_dim:
+        raise ValueError("Serialized state covariance has invalid matrix dimensions")
+    state_column_dim = str(state_covariance.dims[1])
+    expected_state_column_dim = _matrix_column_dim(state_dim, restriction.dims)
+    if state_column_dim != expected_state_column_dim:
+        raise ValueError("Serialized state covariance has an invalid column dimension name")
+    state_size = restriction.sizes[state_dim]
+    if state_covariance.shape != (state_size, state_size):
+        raise ValueError("Serialized state covariance shape does not match retained state")
+
+    effective = arrays["effective_observation_operator"]
+    cross = arrays["observation_state_cross_covariance"]
+    if effective.ndim != 2 or effective.dims[1] != state_dim:
+        raise ValueError("Serialized effective observation operator has invalid dimensions")
+    observation_dim = str(effective.dims[0])
+    if cross.dims != (observation_dim, state_column_dim) or cross.shape != (
+        effective.sizes[observation_dim],
+        state_size,
+    ):
+        raise ValueError("Serialized observation/state products have inconsistent dimensions")
+
+    observation_covariance = arrays["native_observation_covariance"]
+    observation_size = effective.sizes[observation_dim]
+    expected_shape = (observation_size, observation_size)
+    if observation_covariance_view == "diagonal":
+        if observation_covariance.dims != (observation_dim,) or observation_covariance.shape != (
+            observation_size,
+        ):
+            raise ValueError("Serialized diagonal observation covariance has invalid dimensions")
+    elif (
+        observation_covariance.ndim != 2
+        or observation_covariance.dims[0] != observation_dim
+        or (observation_covariance.shape != expected_shape)
+    ):
+        raise ValueError("Serialized dense observation covariance has invalid dimensions")
+
+    for name, array in arrays.items():
+        values = np.asarray(array.values)
+        if np.iscomplexobj(values) or not np.all(np.isfinite(values)):
+            raise ValueError(f"Serialized product {name!r} must contain only finite real values")
+
+    for dim in declared_multiindex_dims:
+        owners = [array for array in arrays.values() if dim in array.dims]
+        if not owners or any(
+            (index := array.indexes.get(dim)) is None or getattr(index, "nlevels", 1) <= 1 for array in owners
+        ):
+            raise ValueError(f"Serialized covariance products did not restore MultiIndex dimension {dim!r}")
+
+    _require_matching_coordinate(restriction, prolongation, state_dim, "retained state")
+    _require_matching_coordinate(restriction, state_covariance, state_dim, "retained state")
+    _require_column_coordinates(
+        restriction,
+        state_covariance,
+        row_dim=state_dim,
+        column_dim=state_column_dim,
+        role="retained-state column",
+    )
+    _require_matching_coordinate(state_covariance, cross, state_column_dim, "retained-state column")
+    _require_column_coordinates(
+        restriction,
+        cross,
+        row_dim=state_dim,
+        column_dim=state_column_dim,
+        role="retained-state cross-covariance column",
+    )
+    _require_matching_coordinate(effective, cross, observation_dim, "observation")
+    _require_matching_coordinate(effective, observation_covariance, observation_dim, "observation")
+    if observation_covariance_view == "dense":
+        observation_column_dim = str(observation_covariance.dims[1])
+        if observation_column_dim != _matrix_column_dim(
+            observation_dim,
+            (observation_dim, *native_dims),
+        ):
+            raise ValueError("Serialized dense observation covariance has an invalid column dimension name")
+        _require_column_coordinates(
+            effective,
+            observation_covariance,
+            row_dim=observation_dim,
+            column_dim=observation_column_dim,
+            role="observation-covariance column",
+        )
+
+
+def _require_matching_coordinate(
+    left: xr.DataArray,
+    right: xr.DataArray,
+    dim: str,
+    role: str,
+) -> None:
+    """Require two arrays to carry identical labels on a shared dimension."""
+    if dim not in left.coords or dim not in right.coords:
+        raise ValueError(f"Serialized {role} products are missing coordinate {dim!r}")
+    if not np.array_equal(left.coords[dim].values, right.coords[dim].values):
+        raise ValueError(f"Serialized {role} product labels are inconsistent")
+
+
+def _require_column_coordinates(
+    row_array: xr.DataArray,
+    column_array: xr.DataArray,
+    *,
+    row_dim: str,
+    column_dim: str,
+    role: str,
+) -> None:
+    """Require serialized matrix columns to mirror all row-axis coordinates."""
+    expected = _column_coordinates(row_array, row_dim=row_dim, column_dim=column_dim)
+    for name, coordinate in expected.items():
+        if name not in column_array.coords:
+            raise ValueError(f"Serialized {role} product is missing coordinate {name!r}")
+        if not np.array_equal(column_array.coords[name].values, coordinate.values):
+            raise ValueError(f"Serialized {role} product labels are inconsistent")
+
+
+def project_native_covariance(
+    *,
+    covariance: InvertibleNativeCovarianceAction,
+    basis_operator: BasisOperator,
+    native_sensitivity: xr.DataArray,
+    observation_dim: str,
+    observation_covariance: Literal["dense", "diagonal"] = "dense",
+    observation_batch_size: int = 64,
+    strategy: RetainedProjectionStrategy | None = None,
+) -> NativeCovarianceProducts:
+    """Compute coherent labelled native-covariance product blocks.
+
+    Args:
+        covariance: Labelled native covariance action with a compatible solve.
+        basis_operator: Basis whose matrix supplies the initial bucket prolongation.
+        native_sensitivity: Native ``H`` containing footprint times prior flux,
+            with dimensions ``(observation_dim, *native_dims)`` in any order.
+        observation_dim: Name of the observation dimension in ``native_sensitivity``.
+        observation_covariance: Return dense ``H B H.T`` or only its diagonal.
+        observation_batch_size: Positive number of observation right-hand sides
+            applied to ``B`` in each eager batch. This is independent of Dask
+            array chunking: each batch fills a slice of one preallocated result.
+            Dense ``H B H.T`` is still fully materialized.
+        strategy: Retained projection choice. The default preserves bucket scalings.
+
+    Returns:
+        Frozen product dataclass whose arrays carry a shared source identity
+        and a view identity derived from the requested dense/diagonal
+        representation. These identities bind metadata and are not checksums
+        of computed output values. Its contained arrays remain mutable. Inputs
+        and products are eagerly materialized; dense observation covariance
+        has quadratic observation-space storage. Full PSD eigendiagnostics are
+        skipped above 512 rows to avoid adding cubic observation-space work.
+        Input attrs/units are not propagated: product attrs are replaced by
+        mathematical diagnostics because this API does not implement unit
+        algebra.
+
+    Raises:
+        ValueError: If labels, dimensions, values, or options are invalid.
+    """
+    native_dims = tuple(covariance.native_dims)
+    state_dim = basis_operator.meta.state_dim
+    if len({*native_dims, state_dim, observation_dim}) != len(native_dims) + 2:
+        raise ValueError("Native, retained-state, and observation dimension names must be distinct")
+    basis_grid_dims = tuple(basis_operator.meta.grid_dims)
+    if basis_grid_dims != native_dims and not (
+        len(native_dims) == len(basis_grid_dims) + 1 and native_dims[1:] == basis_grid_dims
+    ):
+        raise ValueError(
+            "Basis grid dimensions must equal the covariance spatial dimensions; "
+            f"{basis_operator.meta.grid_dims!r} is incompatible with {native_dims!r}"
+        )
+    sensitivity = _validated_sensitivity(
+        native_sensitivity,
+        native_dims=native_dims,
+        observation_dim=observation_dim,
+        covariance=covariance,
+    )
+    batch_size = int(observation_batch_size)
+    if batch_size <= 0:
+        raise ValueError("observation_batch_size must be positive")
+    if observation_covariance not in {"dense", "diagonal"}:
+        raise ValueError("observation_covariance must be 'dense' or 'diagonal'")
+
+    basis_prolongation = _native_basis_prolongation(
+        basis_operator,
+        sensitivity,
+        native_dims=native_dims,
+        state_dim=state_dim,
+    )
+    projection_strategy = strategy if strategy is not None else PreserveBucketProlongation()
+    projection = projection_strategy.projection(
+        covariance,
+        basis_prolongation,
+        native_dims=native_dims,
+        state_dim=state_dim,
+    )
+    projection = _validated_projection(
+        projection,
+        native_reference=sensitivity,
+        native_dims=native_dims,
+        state_dim=state_dim,
+    )
+    state_column_dim = _matrix_column_dim(state_dim, projection.restriction.dims)
+    state_column_coordinates = _column_coordinates(
+        projection.restriction,
+        row_dim=state_dim,
+        column_dim=state_column_dim,
+    )
+    sensitivity = _namespace_axis_coordinate_collisions(
+        sensitivity,
+        axis_dim=observation_dim,
+        occupied={str(name) for name in projection.prolongation.coords} | set(state_column_coordinates),
+    )
+    restriction_transpose = _to_plain_column_axis(
+        projection.restriction,
+        row_dim=state_dim,
+        column_dim=state_column_dim,
+        leading_dims=native_dims,
+    )
+    b_restriction_transpose = covariance.apply(restriction_transpose)
+
+    state_covariance = xr.dot(
+        projection.restriction,
+        b_restriction_transpose,
+        dim=list(native_dims),
+    ).transpose(state_dim, state_column_dim)
+    _validate_positive_definite(np.asarray(state_covariance.values), "C_alpha")
+    state_covariance = _with_matrix_diagnostics(
+        state_covariance.rename("state_covariance"), mathematical_name="C_alpha"
+    )
+    _validate_projection_invariant(
+        projection,
+        state_covariance,
+        b_restriction_transpose,
+        native_dims=native_dims,
+        state_dim=state_dim,
+        state_column_dim=state_column_dim,
+    )
+
+    effective_operator = xr.dot(
+        sensitivity,
+        projection.prolongation,
+        dim=list(native_dims),
+    ).transpose(observation_dim, state_dim)
+    effective_operator = effective_operator.rename("effective_observation_operator").assign_attrs(
+        mathematical_name="H_alpha",
+        definition="H U_*",
+    )
+    cross_covariance = xr.dot(
+        sensitivity,
+        b_restriction_transpose,
+        dim=list(native_dims),
+    ).transpose(observation_dim, state_column_dim)
+    cross_covariance = cross_covariance.rename("observation_state_cross_covariance").assign_attrs(
+        mathematical_name="H B Pi.T"
+    )
+
+    native_observation_covariance = _observation_covariance(
+        covariance,
+        sensitivity,
+        native_dims=native_dims,
+        observation_dim=observation_dim,
+        output=observation_covariance,
+        batch_size=batch_size,
+    )
+    source_content_identity = _source_content_identity(
+        covariance,
+        projection.restriction,
+        projection.prolongation,
+        sensitivity,
+        strategy=projection.strategy,
+    )
+    view_identity = _view_identity(source_content_identity, observation_covariance)
+    covariance_to_dataset = getattr(covariance, "to_dataset", None)
+    covariance_configuration = (
+        cast(xr.Dataset, covariance_to_dataset()).copy(deep=True) if callable(covariance_to_dataset) else None
+    )
+    basis_provenance = {
+        "operator_type": f"{type(basis_operator).__module__}.{type(basis_operator).__qualname__}",
+        "operator_kind": str(getattr(basis_operator, "kind", "unknown")),
+        "grid_dims": repr(tuple(basis_operator.meta.grid_dims)),
+        "state_dim": state_dim,
+    }
+    shared_attrs = {
+        "projection_strategy": projection.strategy,
+        "source_content_identity": source_content_identity,
+        "view_identity": view_identity,
+    }
+    arrays = (
+        projection.restriction,
+        projection.prolongation,
+        state_covariance,
+        effective_operator,
+        cross_covariance,
+        native_observation_covariance,
+    )
+    for array in arrays:
+        array.attrs.update(shared_attrs)
+
+    return NativeCovarianceProducts(
+        restriction=projection.restriction,
+        prolongation=projection.prolongation,
+        state_covariance=state_covariance,
+        effective_observation_operator=effective_operator,
+        observation_state_cross_covariance=cross_covariance,
+        native_observation_covariance=native_observation_covariance,
+        strategy=projection.strategy,
+        source_content_identity=source_content_identity,
+        view_identity=view_identity,
+        observation_covariance_view=observation_covariance,
+        covariance_configuration_digest=(
+            _configuration_digest(covariance_configuration) if covariance_configuration is not None else ""
+        ),
+        covariance_configuration=covariance_configuration,
+        basis_provenance=basis_provenance,
+    )
+
+
+def _observation_covariance(
+    covariance: InvertibleNativeCovarianceAction,
+    sensitivity: xr.DataArray,
+    *,
+    native_dims: tuple[str, ...],
+    observation_dim: str,
+    output: Literal["dense", "diagonal"],
+    batch_size: int,
+) -> xr.DataArray:
+    """Compute ``H B H.T`` in eager observation right-hand-side batches.
+
+    Batching limits the size of the temporary native-space ``B H.T`` block;
+    it is not Dask chunking. The result is allocated once and filled by
+    observation-column batch. Dense output therefore still materializes the
+    complete quadratic observation covariance, while diagonal output
+    materializes only its labelled diagonal.
+
+    Args:
+        covariance: Labelled action implementing multiplication by ``B``.
+        sensitivity: Eager native sensitivity ``H`` with observation followed
+            by native dimensions.
+        native_dims: Ordered native dimensions contracted in the products.
+        observation_dim: Name of the observation row dimension.
+        output: Whether to return the dense covariance or only its diagonal.
+        batch_size: Positive number of observation columns processed per
+            covariance application.
+
+    Returns:
+        Labelled dense ``H B H.T`` with dimensions ``(observation_dim,
+        collision-safe column dimension)``, or ``diag(H B H.T)`` with dimension
+        ``(observation_dim,)``. Observation-axis coordinates are preserved.
+
+    Raises:
+        ValueError: If covariance labels are incompatible or a dense result
+            fails the symmetry diagnostic.
+    """
+    observation_column_dim = _matrix_column_dim(observation_dim, sensitivity.dims)
+    observation_count = sensitivity.sizes[observation_dim]
+    result_values = np.empty(
+        (observation_count, observation_count) if output == "dense" else observation_count,
+        dtype=np.result_type(sensitivity.dtype, np.float64),
+    )
+    for start in range(0, sensitivity.sizes[observation_dim], batch_size):
+        stop = min(start + batch_size, sensitivity.sizes[observation_dim])
+        rhs = _to_plain_column_axis(
+            sensitivity.isel({observation_dim: slice(start, stop)}),
+            row_dim=observation_dim,
+            column_dim=observation_column_dim,
+            leading_dims=native_dims,
+        )
+        b_rhs = covariance.apply(rhs)
+        if output == "dense":
+            block = xr.dot(sensitivity, b_rhs, dim=list(native_dims)).transpose(
+                observation_dim, observation_column_dim
+            )
+            result_values[:, start:stop] = np.asarray(block.values)
+        else:
+            block = (rhs * b_rhs).sum(dim=list(native_dims))
+            result_values[start:stop] = np.asarray(block.values)
+    if output == "dense":
+        coords = {
+            str(name): coordinate
+            for name, coordinate in sensitivity.coords.items()
+            if set(coordinate.dims).issubset({observation_dim})
+        }
+        coords.update(
+            _column_coordinates(
+                sensitivity,
+                row_dim=observation_dim,
+                column_dim=observation_column_dim,
+            )
+        )
+        combined = xr.DataArray(
+            result_values,
+            dims=(observation_dim, observation_column_dim),
+            coords=coords,
+        )
+        combined = _with_matrix_diagnostics(
+            combined.rename("native_observation_covariance"), mathematical_name="H B H.T"
+        )
+    else:
+        coords = {
+            str(name): coordinate
+            for name, coordinate in sensitivity.coords.items()
+            if set(coordinate.dims).issubset({observation_dim})
+        }
+        combined = xr.DataArray(result_values, dims=observation_dim, coords=coords)
+        combined = combined.rename("native_observation_covariance").assign_attrs(
+            mathematical_name="diag(H B H.T)",
+            minimum_diagonal=float(combined.min().item()),
+            diagonal_nonnegative=bool((combined >= -1e-10).all().item()),
+            diagnostic_tolerance=1e-10,
+        )
+    return combined
+
+
+def _validated_projection(
+    projection: RetainedProjection,
+    *,
+    native_reference: xr.DataArray,
+    native_dims: tuple[str, ...],
+    state_dim: str,
+) -> RetainedProjection:
+    """Validate custom strategy labels before any labelled contractions.
+
+    Args:
+        projection: Restriction/prolongation pair returned by a strategy.
+        native_reference: Validated sensitivity carrying canonical native
+            coordinates.
+        native_dims: Ordered native dimensions.
+        state_dim: Retained-state dimension.
+
+    Returns:
+        A projection with eager arrays in canonical dimension order.
+
+    Raises:
+        ValueError: If either array has invalid dimensions, values, or labels.
+            Native coordinates must exactly equal the reference coordinates;
+            xarray reordering or intersection is never used here.
+    """
+    restriction = projection.restriction
+    if not isinstance(projection.strategy, str) or not projection.strategy:
+        raise ValueError("Projection strategy must return a non-empty strategy identifier")
+    expected_restriction_dims = {state_dim, *native_dims}
+    if set(restriction.dims) != expected_restriction_dims or len(restriction.dims) != len(
+        expected_restriction_dims
+    ):
+        raise ValueError("Projection strategy restriction has invalid labelled dimensions")
+    restriction = _densify(restriction).transpose(state_dim, *native_dims)
+    restriction_values = np.asarray(restriction.values)
+    if np.iscomplexobj(restriction_values) or not np.all(np.isfinite(restriction_values)):
+        raise ValueError("Projection strategy restriction must contain only finite real values")
+
+    prolongation = _validated_prolongation(
+        projection.prolongation,
+        native_dims=native_dims,
+        state_dim=state_dim,
+    )
+    for role, array in (("restriction", restriction), ("prolongation", prolongation)):
+        _validate_exact_native_coordinates(
+            array,
+            native_reference,
+            native_dims=native_dims,
+            role=role,
+        )
+    if state_dim not in restriction.coords or state_dim not in prolongation.coords:
+        raise ValueError("Projection strategy restriction and prolongation require state labels")
+    if not np.array_equal(
+        restriction.coords[state_dim].values,
+        prolongation.coords[state_dim].values,
+    ):
+        raise ValueError("Projection strategy restriction/prolongation state labels differ")
+    return replace(projection, restriction=restriction, prolongation=prolongation)
+
+
+def _validate_exact_native_coordinates(
+    array: xr.DataArray,
+    reference: xr.DataArray,
+    *,
+    native_dims: tuple[str, ...],
+    role: str,
+) -> None:
+    """Require exact native labels before product alignment or contraction.
+
+    Args:
+        array: Strategy-produced restriction or prolongation.
+        reference: Validated array carrying canonical native coordinates.
+        native_dims: Ordered native dimensions to compare.
+        role: Array role used in validation errors.
+
+    Raises:
+        ValueError: If a native coordinate is absent, reordered, or different.
+    """
+    for dim in native_dims:
+        if dim not in array.coords:
+            raise ValueError(f"Projection strategy {role} is missing native coordinate {dim!r}")
+        actual = np.asarray(array.coords[dim].values)
+        expected = np.asarray(reference.coords[dim].values)
+        if actual.shape != expected.shape or not np.array_equal(actual, expected):
+            raise ValueError(
+                f"Projection strategy {role} native coordinate {dim!r} must exactly match "
+                "the covariance grid in the same order"
+            )
+
+
+def _validate_projection_invariant(
+    projection: RetainedProjection,
+    state_covariance: xr.DataArray,
+    b_restriction_transpose: xr.DataArray,
+    *,
+    native_dims: tuple[str, ...],
+    state_dim: str,
+    state_column_dim: str,
+) -> None:
+    """Require a strategy to return its covariance-natural prolongation.
+
+    Args:
+        projection: Restriction/prolongation pair returned by the strategy.
+        state_covariance: Labelled ``C_alpha = Pi B Pi.T``.
+        b_restriction_transpose: Labelled ``B Pi.T``.
+        native_dims: Ordered native dimensions.
+        state_dim: Retained-state row dimension.
+        state_column_dim: Collision-safe retained-state column dimension.
+
+    Raises:
+        ValueError: If dimensions, state labels, or values are invalid, or if
+            ``B Pi.T`` and ``U_* C_alpha`` disagree beyond tolerance.
+    """
+    prolongation = projection.prolongation
+    u_c = xr.dot(prolongation, state_covariance, dim=state_dim).transpose(*native_dims, state_column_dim)
+    left = np.asarray(b_restriction_transpose.values, dtype=np.float64)
+    right = np.asarray(u_c.values, dtype=np.float64)
+    scale = max(
+        float(np.max(np.abs(left))) if left.size else 0.0,
+        float(np.max(np.abs(right))) if right.size else 0.0,
+        np.finfo(np.float64).tiny,
+    )
+    absolute_error = float(np.max(np.abs(left - right))) if left.size else 0.0
+    if absolute_error > 1e-9 * scale + 10.0 * np.finfo(np.float64).tiny:
+        raise ValueError("Projection strategy is incoherent: expected B Pi.T = U_* C_alpha")
+
+
+def _native_basis_prolongation(
+    basis_operator: BasisOperator,
+    sensitivity: xr.DataArray,
+    *,
+    native_dims: tuple[str, ...],
+    state_dim: str,
+) -> xr.DataArray:
+    """Return ``U_bucket`` on the full native space, including source blocks.
+
+    A single-source basis already spans every native dimension. For a gathered
+    multisource basis, the operator carries source identity on the ragged state
+    coordinate rather than as a matrix dimension. This helper expands it onto
+    the covariance action's explicit leading source dimension, setting all
+    cross-source state columns to zero while retaining canonical state order.
+
+    Args:
+        basis_operator: Spatial basis supplying the bucket matrix and metadata.
+        sensitivity: Native sensitivity whose leading source coordinate defines
+            source ordering for multisource inputs.
+        native_dims: Ordered native covariance dimensions.
+        state_dim: Retained-state dimension of the basis matrix.
+
+    Returns:
+        Eager ``U_bucket`` spanning ``(*native_dims, state_dim)``.
+
+    Raises:
+        ValueError: If a multisource basis lacks source labels or names a source
+            absent from the native sensitivity.
+    """
+    basis_grid_dims = tuple(basis_operator.meta.grid_dims)
+    basis_matrix = _densify(basis_operator.basis_matrix)
+    if native_dims == basis_grid_dims:
+        return basis_matrix
+
+    native_source_dim = native_dims[0]
+    basis_source_dim = getattr(basis_operator, "source_dim", None)
+    if not isinstance(basis_source_dim, str) or basis_source_dim not in basis_matrix.coords:
+        raise ValueError(
+            "A covariance with a leading native source dimension requires a gathered "
+            "multisource basis carrying source labels on its state coordinate"
+        )
+    state_sources = np.asarray(basis_matrix.coords[basis_source_dim].values)
+    native_sources = np.asarray(sensitivity.coords[native_source_dim].values)
+    missing = [label for label in state_sources if label not in set(native_sources.tolist())]
+    if missing:
+        raise ValueError(f"Basis state sources are absent from native sensitivity: {missing!r}")
+    base = basis_matrix.transpose(*basis_grid_dims, state_dim)
+    values = np.asarray(base.values)
+    source_mask = native_sources[:, np.newaxis] == state_sources[np.newaxis, :]
+    expanded = values[np.newaxis, ...] * source_mask.reshape(
+        (native_sources.size, *([1] * len(basis_grid_dims)), state_sources.size)
+    )
+    coords: dict[str, xr.DataArray] = {
+        native_source_dim: sensitivity.coords[native_source_dim],
+        **{dim: base.coords[dim] for dim in basis_grid_dims},
+        state_dim: base.coords[state_dim],
+    }
+    for name, coordinate in base.coords.items():
+        if name not in coords and set(coordinate.dims).issubset({state_dim}):
+            coords[str(name)] = coordinate
+    return xr.DataArray(
+        expanded,
+        dims=(*native_dims, state_dim),
+        coords=coords,
+        name="prolongation",
+        attrs={**basis_matrix.attrs, "mathematical_name": "U_bucket"},
+    )
+
+
+def _to_plain_column_axis(
+    array: xr.DataArray,
+    *,
+    row_dim: str,
+    column_dim: str,
+    leading_dims: tuple[str, ...],
+) -> xr.DataArray:
+    """Replace a rich row axis by a collision-safe plain column axis.
+
+    Args:
+        array: Labelled array containing the row and leading dimensions.
+        row_dim: Existing row dimension, possibly backed by a MultiIndex.
+        column_dim: New collision-safe plain dimension name.
+        leading_dims: Dimensions to retain before the new column dimension.
+
+    Returns:
+        An array sharing the input data and attributes, with row coordinates
+        copied onto the new plain column axis.
+    """
+    ordered = array.transpose(*leading_dims, row_dim)
+    coords = {dim: ordered.coords[dim] for dim in leading_dims}
+    coords.update(_column_coordinates(ordered, row_dim=row_dim, column_dim=column_dim))
+    return xr.DataArray(
+        ordered.data,
+        dims=(*leading_dims, column_dim),
+        coords=coords,
+        name=ordered.name,
+        attrs=ordered.attrs,
+    )
+
+
+def _namespace_axis_coordinate_collisions(
+    array: xr.DataArray,
+    *,
+    axis_dim: str,
+    occupied: set[str],
+) -> xr.DataArray:
+    """Give colliding auxiliary/index-level names a stable axis prefix."""
+    rename: dict[str, str] = {}
+    reserved = occupied | {str(name) for name in array.coords} | {str(dim) for dim in array.dims}
+    for name, coordinate in array.coords.items():
+        name = str(name)
+        if name == axis_dim or axis_dim not in coordinate.dims or name not in occupied:
+            continue
+        candidate = f"{axis_dim}_{name}"
+        suffix = 2
+        while candidate in reserved:
+            candidate = f"{axis_dim}_{name}_{suffix}"
+            suffix += 1
+        reserved.add(candidate)
+        rename[name] = candidate
+    return array.rename(rename) if rename else array
+
+
+def _validated_prolongation(
+    prolongation: xr.DataArray,
+    *,
+    native_dims: tuple[str, ...],
+    state_dim: str,
+) -> xr.DataArray:
+    """Materialize and validate a labelled native-by-retained prolongation.
+
+    Args:
+        prolongation: Candidate ``U_*`` or ``U_bucket`` array.
+        native_dims: Ordered native dimensions required on the array.
+        state_dim: Required retained-state dimension.
+
+    Returns:
+        A finite, eager array ordered as ``(*native_dims, state_dim)``.
+
+    Raises:
+        ValueError: If dimensions are missing or duplicated, values are not
+            finite, or a retained-state column is empty.
+    """
+    expected_dims = set((*native_dims, state_dim))
+    if set(prolongation.dims) != expected_dims or len(prolongation.dims) != len(expected_dims):
+        raise ValueError(
+            "prolongation must have exactly the native grid and retained-state dimensions; "
+            f"got {prolongation.dims!r}"
+        )
+    result = _densify(prolongation).transpose(*native_dims, state_dim)
+    raw_values = np.asarray(result.values)
+    if np.iscomplexobj(raw_values) or not np.all(np.isfinite(raw_values)):
+        raise ValueError("prolongation must contain only finite real values")
+    values = np.asarray(raw_values, dtype=np.float64)
+    if result.sizes[state_dim] == 0 or np.any(np.all(values == 0.0, axis=tuple(range(len(native_dims))))):
+        raise ValueError("prolongation contains an empty retained state")
+    return result
+
+
+def _validated_sensitivity(
+    sensitivity: xr.DataArray,
+    *,
+    native_dims: tuple[str, ...],
+    observation_dim: str,
+    covariance: InvertibleNativeCovarianceAction,
+) -> xr.DataArray:
+    """Materialize and validate the labelled native sensitivity ``H``.
+
+    Args:
+        sensitivity: Candidate observation-by-native sensitivity array.
+        native_dims: Ordered native dimensions required on the array.
+        observation_dim: Required observation dimension.
+        covariance: Covariance action used to validate native grid labels.
+
+    Returns:
+        A finite, eager array ordered as ``(observation_dim, *native_dims)``.
+
+    Raises:
+        ValueError: If dimensions or observation labels are invalid, the array
+            is empty or non-finite, or covariance grid labels do not match.
+    """
+    expected_dims = set((*native_dims, observation_dim))
+    if set(sensitivity.dims) != expected_dims or len(sensitivity.dims) != len(expected_dims):
+        raise ValueError(
+            "native_sensitivity must have exactly one observation dimension and the native grid "
+            f"dimensions; got {sensitivity.dims!r}"
+        )
+    if observation_dim not in sensitivity.coords:
+        raise ValueError(f"native_sensitivity is missing observation coordinate {observation_dim!r}")
+    result = _densify(sensitivity).transpose(observation_dim, *native_dims)
+    if result.sizes[observation_dim] == 0:
+        raise ValueError("native_sensitivity must contain at least one observation")
+    values = np.asarray(result.values)
+    if np.iscomplexobj(values) or not np.all(np.isfinite(values)):
+        raise ValueError("native_sensitivity must contain only finite real values")
+    # Applying B to one labelled column performs the covariance-grid label validation.
+    covariance.apply(result.isel({observation_dim: slice(0, 1)}))
+    return result
+
+
+def _densify(array: xr.DataArray) -> xr.DataArray:
+    """Eagerly materialize an array and convert sparse storage to NumPy."""
+    materialized = array.compute()
+    data = materialized.data
+    if hasattr(data, "todense"):
+        data = data.todense()
+    return materialized.copy(data=np.asarray(data))
+
+
+def _matrix_column_dim(primary_dim: str, occupied_dims: tuple[Hashable, ...]) -> str:
+    """Return an unoccupied column-dimension name derived from a row name."""
+    candidate = f"{primary_dim}_cov"
+    index = 2
+    while candidate in occupied_dims:
+        candidate = f"{primary_dim}_cov_{index}"
+        index += 1
+    return candidate
+
+
+def _column_coordinate(coordinate: xr.DataArray, column_dim: str) -> xr.DataArray:
+    """Copy row labels onto a plain column coordinate.
+
+    Tuple-valued labels are encoded as compact JSON strings so xarray does not
+    reinterpret them as a two-dimensional coordinate.
+
+    Args:
+        coordinate: One-dimensional row coordinate to copy.
+        column_dim: Destination column dimension.
+
+    Returns:
+        A plain one-dimensional column coordinate preserving attributes.
+    """
+    source_values = list(coordinate.values)
+    if any(isinstance(value, tuple) for value in source_values):
+        values = np.asarray(
+            [
+                json.dumps(
+                    list(value),
+                    separators=(",", ":"),
+                    default=_json_label_default,
+                )
+                for value in source_values
+            ],
+            dtype=str,
+        )
+    else:
+        values = np.asarray(source_values)
+    return xr.DataArray(values, dims=column_dim, attrs=coordinate.attrs)
+
+
+def _json_label_default(value: object) -> str:
+    """Encode a rich tuple-label scalar as a stable string.
+
+    NumPy scalars are first converted to their Python equivalent. Datetime-like
+    objects use ``isoformat()``, while other objects use ``str()``.
+
+    Args:
+        value: Non-JSON-native coordinate-label value.
+
+    Returns:
+        Stable string suitable for a JSON tuple token.
+    """
+    if isinstance(value, np.generic):
+        value = value.item()
+    isoformat = getattr(value, "isoformat", None)
+    if callable(isoformat):
+        return str(isoformat())
+    return str(value)
+
+
+def _column_coordinates(
+    array: xr.DataArray,
+    *,
+    row_dim: str,
+    column_dim: str,
+) -> dict[str, xr.DataArray]:
+    """Build a plain column index and copies of row-axis metadata.
+
+    Args:
+        array: Source array containing the row coordinate and auxiliary labels.
+        row_dim: Row dimension whose coordinates are copied.
+        column_dim: Collision-safe column dimension receiving the copies.
+
+    Returns:
+        Coordinates for the new column axis. Auxiliary coordinate names gain a
+        ``_cov`` suffix, with numeric suffixes added to avoid collisions.
+    """
+    result = {column_dim: _column_coordinate(array.coords[row_dim], column_dim)}
+    for name, coordinate in array.coords.items():
+        if name == row_dim or tuple(coordinate.dims) != (row_dim,):
+            continue
+        column_name = f"{name}_cov"
+        suffix = 2
+        while column_name in array.coords or column_name in result:
+            column_name = f"{name}_cov_{suffix}"
+            suffix += 1
+        result[column_name] = xr.DataArray(
+            np.asarray(coordinate.values),
+            dims=column_dim,
+            attrs=coordinate.attrs,
+        )
+    return result
+
+
+def _validate_symmetric(values: np.ndarray, name: str, *, tolerance: float = 1e-10) -> None:
+    """Validate matrix symmetry relative to its largest absolute value.
+
+    Args:
+        values: Matrix values to validate.
+        name: Mathematical name used in an error message.
+        tolerance: Relative symmetry tolerance, with unit absolute scale floor.
+
+    Raises:
+        ValueError: If the maximum asymmetry exceeds the scaled tolerance.
+    """
+    asymmetry = float(np.max(np.abs(values - values.T))) if values.size else 0.0
+    scale = max(1.0, float(np.max(np.abs(values))) if values.size else 1.0)
+    if asymmetry > tolerance * scale:
+        raise ValueError(f"{name} is not symmetric within tolerance {tolerance:g}")
+
+
+def _validate_positive_definite(values: np.ndarray, name: str) -> None:
+    """Reject singular or numerically redundant covariance coordinates.
+
+    Args:
+        values: Symmetric covariance matrix to validate.
+        name: Mathematical name used in an error message.
+
+    Raises:
+        ValueError: If the matrix is asymmetric, empty, non-positive, or has a
+            smallest eigenvalue no larger than ``1e-12`` times the largest.
+    """
+    _validate_symmetric(values, name)
+    eigenvalues = np.linalg.eigvalsh((values + values.T) * 0.5)
+    largest = float(eigenvalues[-1]) if eigenvalues.size else 0.0
+    if not eigenvalues.size or largest <= 0.0 or float(eigenvalues[0]) <= 1e-12 * largest:
+        raise ValueError(f"{name} must be positive definite and full rank")
+
+
+def _with_matrix_diagnostics(array: xr.DataArray, *, mathematical_name: str) -> xr.DataArray:
+    """Attach symmetry and bounded-cost PSD diagnostics to a dense matrix.
+
+    Args:
+        array: Dense square labelled matrix.
+        mathematical_name: Mathematical label stored in the result attributes.
+
+    Returns:
+        The array with diagnostic attributes. Full eigenvalue diagnostics are
+        skipped when the matrix exceeds :data:`MAX_DENSE_EIGEN_DIAGNOSTIC_SIZE`.
+
+    Raises:
+        ValueError: If the matrix is not symmetric within tolerance.
+    """
+    raw_values = np.asarray(array.values)
+    if np.iscomplexobj(raw_values):
+        raise ValueError(f"{mathematical_name} must contain real values")
+    values = np.asarray(raw_values, dtype=np.float64)
+    _validate_symmetric(values, mathematical_name)
+    attrs: dict[str, object] = {
+        "mathematical_name": mathematical_name,
+        "symmetry_absolute_error": float(np.max(np.abs(values - values.T))) if values.size else 0.0,
+        "diagnostic_tolerance": 1e-10,
+    }
+    if values.shape[0] <= MAX_DENSE_EIGEN_DIAGNOSTIC_SIZE:
+        eigenvalues = np.linalg.eigvalsh((values + values.T) * 0.5)
+        attrs.update(
+            minimum_eigenvalue=float(eigenvalues.min()) if eigenvalues.size else 0.0,
+            psd_diagnostic="full_eigendecomposition",
+        )
+    else:
+        attrs.update(
+            minimum_eigenvalue=np.nan,
+            psd_diagnostic=(f"skipped_full_eigendecomposition_above_{MAX_DENSE_EIGEN_DIAGNOSTIC_SIZE}"),
+        )
+    return array.assign_attrs(attrs)
+
+
+def _encode_configuration_dataset(
+    dataset: xr.Dataset,
+    *,
+    source_content_identity: str,
+    configuration_digest: str,
+) -> xr.Dataset:
+    """Namespace configuration dimensions before DataTree persistence.
+
+    Args:
+        dataset: Native covariance configuration to encode.
+        source_content_identity: Identity of the source content whose
+            covariance configuration this dataset describes.
+        configuration_digest: Digest of the decoded configuration content.
+
+    Returns:
+        A copy whose dimensions have a ``covariance_configuration__`` prefix.
+        The reversible original-to-encoded mapping is stored in the
+        ``openghg_inversions:configuration_dims`` attribute so parent DataTree
+        dimensions cannot absorb the child dimensions. The child also carries
+        the source identity so configurations from different artifacts cannot
+        be mixed silently.
+    """
+    rename = {str(dim): f"covariance_configuration__{dim}" for dim in dataset.dims}
+    encoded = dataset.rename(rename).copy()
+    encoded.attrs = dict(encoded.attrs)
+    encoded.attrs["openghg_inversions:configuration_dims"] = json.dumps(rename, sort_keys=True)
+    encoded.attrs["openghg_inversions:source_content_identity"] = source_content_identity
+    encoded.attrs["openghg_inversions:configuration_digest"] = configuration_digest
+    return encoded
+
+
+def _decode_configuration_dataset(
+    dataset: xr.Dataset,
+    *,
+    expected_source_content_identity: str,
+    expected_configuration_digest: str,
+) -> xr.Dataset:
+    """Restore namespaced configuration dimensions after persistence.
+
+    Args:
+        dataset: Encoded covariance configuration child dataset.
+        expected_source_content_identity: Source identity declared by the root
+            product dataset.
+        expected_configuration_digest: Configuration digest declared by the
+            root product dataset.
+
+    Returns:
+        A dataset with original dimension names and encoding metadata removed.
+
+    Raises:
+        ValueError: If the source binding or dimension mapping metadata is
+            absent or invalid.
+    """
+    child_source_identity = dataset.attrs.get("openghg_inversions:source_content_identity")
+    if child_source_identity != expected_source_content_identity:
+        raise ValueError("Serialized covariance configuration does not share the root source identity")
+    child_configuration_digest = dataset.attrs.get("openghg_inversions:configuration_digest")
+    if child_configuration_digest != expected_configuration_digest:
+        raise ValueError("Serialized covariance configuration does not share the root digest")
+    encoded_dims = dataset.attrs.get("openghg_inversions:configuration_dims")
+    if not isinstance(encoded_dims, str):
+        raise ValueError("Serialized covariance configuration is missing dimension metadata")
+    rename = json.loads(encoded_dims)
+    if not isinstance(rename, dict):
+        raise ValueError("Serialized covariance configuration dimension metadata is invalid")
+    restored = dataset.rename({str(encoded): str(original) for original, encoded in rename.items()})
+    restored.attrs = dict(restored.attrs)
+    del restored.attrs["openghg_inversions:configuration_dims"]
+    del restored.attrs["openghg_inversions:source_content_identity"]
+    del restored.attrs["openghg_inversions:configuration_digest"]
+    if _configuration_digest(restored) != expected_configuration_digest:
+        raise ValueError("Serialized covariance configuration content does not match its digest")
+    return restored
+
+
+def _configuration_digest(dataset: xr.Dataset) -> str:
+    """Hash decoded covariance configuration content into a stable digest.
+
+    Args:
+        dataset: Configuration in its decoded, original-dimension form.
+
+    Returns:
+        Lowercase hexadecimal SHA-256 digest stable across supported NetCDF
+        scalar and string coercions.
+    """
+    digest = hashlib.sha256()
+    digest.update(b"openghg_inversions.native_covariance_products.configuration.v1\0")
+    digest.update(_canonical_json(dataset.attrs).encode("utf-8"))
+    for name in sorted(str(name) for name in dataset.coords):
+        _update_configuration_array_digest(digest, dataset.coords[name])
+    for name in sorted(str(name) for name in dataset.data_vars):
+        _update_configuration_array_digest(digest, dataset[name])
+    return digest.hexdigest()
+
+
+def _update_configuration_array_digest(digest: _Digest, array: xr.DataArray) -> None:
+    """Hash one configuration array across NetCDF scalar/string coercions.
+
+    Args:
+        digest: Digest receiving canonical array metadata and values.
+        array: Configuration coordinate or data variable to hash.
+    """
+    digest.update(str(array.name).encode("utf-8"))
+    digest.update(_canonical_json(tuple(str(dim) for dim in array.dims)).encode("utf-8"))
+    digest.update(_canonical_json(array.attrs).encode("utf-8"))
+    values = np.ascontiguousarray(array.values)
+    digest.update(_canonical_json(values.shape).encode("utf-8"))
+    if values.dtype.hasobject or values.dtype.kind in {"U", "S"}:
+        digest.update(_canonical_json(values.tolist()).encode("utf-8"))
+    else:
+        digest.update(values.dtype.str.encode("ascii"))
+        digest.update(values.view(np.uint8).tobytes())
+
+
+def _canonical_json(value: object) -> str:
+    """Encode serialization-compatible metadata with normalized scalar types.
+
+    Args:
+        value: Metadata value accepted by JSON or
+            :func:`_canonical_json_default`.
+
+    Returns:
+        Compact, key-sorted JSON text.
+    """
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=_canonical_json_default,
+    )
+
+
+def _canonical_json_default(value: object) -> object:
+    """Normalize NumPy, byte, array, and datetime-like values for JSON.
+
+    Args:
+        value: Value rejected by the standard JSON encoder.
+
+    Returns:
+        A JSON-native scalar, list, or string.
+
+    Raises:
+        TypeError: If the value has no supported canonical representation.
+    """
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, bytes):
+        return value.decode("utf-8")
+    isoformat = getattr(value, "isoformat", None)
+    if callable(isoformat):
+        return isoformat()
+    raise TypeError(f"Cannot encode {type(value).__name__} in a configuration digest")
+
+
+def _source_content_identity(
+    covariance: InvertibleNativeCovarianceAction,
+    *arrays: xr.DataArray,
+    strategy: str,
+) -> str:
+    """Hash shared scientific inputs and configuration into a stable identity.
+
+    Execution batching is deliberately excluded, because changing
+    ``observation_batch_size`` does not change the requested scientific
+    product. The dense/diagonal numerical view and computed product values are
+    also excluded. This identity binds source content, not stored-byte
+    integrity, and therefore does not detect numerical output tampering. A
+    covariance with ``to_dataset()`` contributes its configuration metadata,
+    coordinates, and variables; the custom-action fallback is stable only when
+    that object's ``repr`` is stable.
+
+    Args:
+        covariance: Native covariance action, preferably with serializable
+            constructor configuration.
+        *arrays: Labelled restriction, prolongation, and sensitivity arrays;
+            their values, dimensions, and all coordinates are hashed.
+        strategy: Stable retained-projection strategy name.
+
+    Returns:
+        Lowercase hexadecimal SHA-256 digest.
+    """
+    digest = hashlib.sha256()
+    digest.update(strategy.encode("utf-8"))
+    to_dataset = getattr(covariance, "to_dataset", None)
+    if callable(to_dataset):
+        covariance_dataset = cast(xr.Dataset, to_dataset())
+        digest.update(repr(sorted(covariance_dataset.attrs.items())).encode("utf-8"))
+        for name in sorted(str(name) for name in covariance_dataset.coords):
+            _update_array_digest(digest, covariance_dataset.coords[name])
+        for name in sorted(str(name) for name in covariance_dataset.data_vars):
+            _update_array_digest(digest, covariance_dataset[name])
+    else:
+        covariance_type = f"{type(covariance).__module__}.{type(covariance).__qualname__}"
+        digest.update(covariance_type.encode("utf-8"))
+        digest.update(repr(covariance).encode("utf-8"))
+    for array in arrays:
+        _update_array_digest(digest, array)
+    return digest.hexdigest()
+
+
+def _view_identity(
+    source_content_identity: str,
+    observation_covariance_view: Literal["dense", "diagonal"],
+) -> str:
+    """Derive a numerical-view identity from source content and view kind.
+
+    Args:
+        source_content_identity: Identity shared by all numerical views of the
+            same ``B/H/Pi/U`` source.
+        observation_covariance_view: Requested dense or diagonal view.
+
+    Returns:
+        Lowercase hexadecimal SHA-256 digest for this derived view.
+    """
+    digest = hashlib.sha256()
+    digest.update(b"openghg_inversions.native_covariance_products.view.v1\0")
+    digest.update(source_content_identity.encode("ascii"))
+    digest.update(b"\0")
+    digest.update(observation_covariance_view.encode("ascii"))
+    return digest.hexdigest()
+
+
+def _validated_identity(value: object, *, name: str) -> str:
+    """Validate a lowercase hexadecimal SHA-256 identity.
+
+    Args:
+        value: Serialized identity candidate.
+        name: Human-readable identity name used in an error.
+
+    Returns:
+        The validated identity string.
+
+    Raises:
+        ValueError: If the value is not a 64-character lowercase hex digest.
+    """
+    if (
+        not isinstance(value, str)
+        or len(value) != 64
+        or any(character not in "0123456789abcdef" for character in value)
+    ):
+        raise ValueError(f"Serialized covariance products have an invalid {name}")
+    return value
+
+
+def _decode_basis_provenance(value: object) -> dict[str, str]:
+    """Decode and validate the serialized string-to-string provenance map.
+
+    Args:
+        value: JSON text from root dataset metadata.
+
+    Returns:
+        Decoded provenance mapping.
+
+    Raises:
+        ValueError: If the value is not valid JSON encoding an object with
+            string keys and string values.
+    """
+    if not isinstance(value, str):
+        raise ValueError("Serialized covariance products have invalid basis provenance JSON")
+    try:
+        decoded = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise ValueError("Serialized covariance products have invalid basis provenance JSON") from exc
+    if not isinstance(decoded, dict) or any(
+        not isinstance(key, str) or not isinstance(item, str) for key, item in decoded.items()
+    ):
+        raise ValueError("Serialized covariance products basis provenance must be a string mapping")
+    return decoded
+
+
+def _update_array_digest(digest: _Digest, array: xr.DataArray) -> None:
+    """Update a content digest with array data, dimensions, and coordinates."""
+    digest.update(str(array.name).encode("utf-8"))
+    digest.update(repr(tuple(array.dims)).encode("utf-8"))
+    values = np.ascontiguousarray(array.values)
+    digest.update(values.dtype.str.encode("ascii"))
+    digest.update(repr(values.shape).encode("ascii"))
+    if values.dtype.hasobject or values.dtype.kind in {"U", "S"}:
+        digest.update(repr(values.tolist()).encode("utf-8"))
+    else:
+        digest.update(values.view(np.uint8).tobytes())
+    for name in sorted(str(name) for name in array.coords):
+        coordinate = array.coords[name]
+        labels = np.asarray(coordinate.values)
+        digest.update(name.encode("utf-8"))
+        digest.update(repr(tuple(coordinate.dims)).encode("utf-8"))
+        digest.update(labels.dtype.str.encode("ascii"))
+        digest.update(repr(labels.shape).encode("ascii"))
+        if labels.dtype.hasobject or labels.dtype.kind in {"U", "S"}:
+            digest.update(repr(labels.tolist()).encode("utf-8"))
+        else:
+            digest.update(np.ascontiguousarray(labels).view(np.uint8).tobytes())

--- a/openghg_inversions/basis/operators.py
+++ b/openghg_inversions/basis/operators.py
@@ -1,52 +1,45 @@
-"""Basis operator classes
+"""Labelled basis geometry operators for retained scaling states.
 
-Design goals
-------------
-1) Separate the *partition/aggregation operator* (basis functions) from any *flux weighting*.
-   - The basis operator represents a linear map from a grid (lat/lon) to a reduced state space.
-   - Flux weighting (multiplying by flux on the grid, interpolation to maps, covariance transforms)
-     is handled by ``FluxWeightedBasis`` so that:
-       * sensitivity(fp_x_flux) does not require flux (since fp_x_flux is already precomputed),
-       * but flux-aware operations remain available when needed.
+A :class:`BasisOperator` separates bucket geometry from flux weighting and
+native covariance. For one source, :attr:`BasisOperator.basis_matrix` is the
+bucket prolongation ``U_bucket`` with native-grid rows and retained-state
+columns. A gathered multisource matrix is the spatial membership template from
+which projection code expands a source-native ``U_bucket``. Its transpose is
+not automatically the retained restriction ``Pi``.
 
-2) Canonical "state" dimension.
-   - Operators expose a single state dimension (default name: "state").
-   - In multisource/multisector cases with ragged per-source region counts, the state coordinate
-     becomes a ragged MultiIndex over (source, region_in_source). This avoids padding with zeros.
+``FluxWeightedBasis`` handles flux weighting for sensitivity projection and
+flux reconstruction. Native covariance actions, retained restrictions, and
+covariance product transforms instead belong to
+:mod:`openghg_inversions.native_covariance`,
+:mod:`openghg_inversions.source_covariance`, and
+:mod:`openghg_inversions.basis.covariance_products`.
 
-3) Minimal metadata (BasisMeta).
-   - We only need to know which dims to dot over (grid_dims) and the state_dim name.
-   - Source-labeled arrays are aligned against the state MultiIndex by concrete
-     subclasses rather than inferred from metadata.
+Operators expose one canonical state dimension, named ``"state"`` by default.
+Multisource operators represent ragged per-source region counts with a
+MultiIndex over source and region-within-source, avoiding padded state arrays.
+:class:`BasisMeta` records only the grid dimensions and state-dimension name;
+concrete operators perform any source-label alignment.
 
-4) Serialization via xarray.DataTree.
-   - BasisOperator.to_datatree() returns a self-describing DataTree with schema/kind/version attrs.
-   - BasisOperator.decode_datatree(dt) dispatches to the correct registered subclass based on dt.attrs["kind"].
-   - For multisource operators, the canonical serialized representation stores one source-labelled
-     `basis_flat` array. Readers retain compatibility with the earlier per-source child layout.
+Serialization uses self-describing :class:`xarray.DataTree` objects with
+schema, kind, and version metadata. Multisource operators store one
+source-labelled ``basis_flat`` array while readers retain compatibility with
+the earlier per-source child layout.
 
-How to use
-----------
-- Construct a basis operator:
-    op = BucketBasisOperator(basis_flat)                         # single-sector
-    op = MultiSourceBucketBasisOperator({"a": bf_a, "b": bf_b})   # ragged multisource
+Examples:
+    Construct operators, compute a sensitivity, and round-trip one operator::
 
-- Compute sensitivities:
-    H = op.sensitivity(fp_x_flux)
+        op = BucketBasisOperator(basis_flat)
+        multisource_op = MultiSourceBucketBasisOperator({"a": bf_a, "b": bf_b})
+        sensitivity = op.sensitivity(fp_x_flux)
+        restored = BasisOperator.decode_datatree(op.to_datatree())
 
-  where fp_x_flux is an xarray.DataArray with at least the grid dims (lat, lon), and typically time.
-  In multisource workflows, fp_x_flux often has a separate dimension "source".
-  The multisource operator aligns those labels against the "source" level of
-  the state MultiIndex.
+    ``fp_x_flux`` contains the configured grid dimensions and typically time.
+    In multisource workflows it may also have a ``source`` dimension, whose
+    labels the multisource operator aligns to the state MultiIndex.
 
-- Serialize/deserialize:
-    dt = op.to_datatree()
-    op2 = BasisOperator.decode_datatree(dt)
-
-Notes
------
-- Currently, basis operators cannot have a time dimension. If the input flat array has
-  a time dimension with more than one coordinate value, an error is raised.
+Note:
+    Basis geometry cannot currently vary through time. A singleton time
+    dimension is dropped; a longer time dimension raises :class:`ValueError`.
 """
 
 from __future__ import annotations
@@ -160,13 +153,12 @@ class BasisMeta:
 class BasisOperator(ABC):
     """Abstract basis operator.
 
-    Concrete subclasses must define:
-    - meta (grid dims + state dim)
-    - basis_matrix: one-hot/dummy matrix with dims (*grid_dims, state_dim)
-    - to_datatree / from_datatree
+    Concrete subclasses provide operator metadata, a bucket prolongation
+    ``U_bucket`` whose ordered dimensions are the grid dimensions followed by
+    the state dimension, and DataTree serialization methods.
 
-    The default sensitivity implementation assumes fp_x_flux has the grid dims and
-    any extra dims (e.g. time, source) are preserved.
+    The default sensitivity implementation requires ``fp_x_flux`` to contain
+    the grid dimensions and preserves extra dimensions such as time or source.
     """
 
     # stable kind string used for serialization dispatch
@@ -184,17 +176,21 @@ class BasisOperator(ABC):
     @property
     @abstractmethod
     def basis_matrix(self) -> xr.DataArray:
-        """Dummy matrix mapping grid -> state.
+        """Return the bucket prolongation ``U_bucket`` from state to grid.
 
-        Expected dims: (*grid_dims, state_dim)
-        (state_dim may be a MultiIndex coordinate)
+        Its ordered dimensions are the configured grid dimensions followed by
+        the state dimension, which may carry a MultiIndex coordinate.
+
+        Multiplying this matrix by a state vector reconstructs a native scaling
+        field. Although its transpose has the shape of a restriction, it is not
+        generally the covariance-compatible retained restriction ``Pi``.
         """
         raise NotImplementedError
 
     def sensitivity(self, fp_x_flux: xr.DataArray, fillna: bool = True) -> xr.DataArray:
         """Computes the sensitivity matrix ("H") by dotting over the grid.
 
-        This implements the common bucket-basis reduction:
+        This implements the common bucket-basis forward operator ``H U_bucket``:
 
         - `fp_x_flux` is a gridded quantity with dimensions that include
           `meta.grid_dims` (typically `lat` and `lon`) and usually a `time` dimension.
@@ -521,7 +517,11 @@ class BucketBasisOperator(BasisOperator):
 
     @property
     def basis_matrix(self) -> xr.DataArray:
-        """Basis matrix."""
+        """Return ``U_bucket``, mapping retained scalings to native scalings.
+
+        The dimensions are native grid by retained state. Its transpose is not
+        generally the compatible retained restriction ``Pi``.
+        """
         return self._basis_matrix
 
     @property
@@ -756,7 +756,13 @@ class MultiSourceBucketBasisOperator(BasisOperator):
 
     @property
     def basis_matrix(self) -> xr.DataArray:
-        """Basis matrix."""
+        """Return the gathered spatial template for multisource ``U_bucket``.
+
+        The dimensions are spatial grid by retained state; source identity is
+        carried by the ragged state coordinate. Projection code expands an
+        explicit source-native dimension and zeros cross-source columns. This
+        template's transpose is not the compatible retained restriction ``Pi``.
+        """
         return self._basis_matrix
 
     @property

--- a/openghg_inversions/basis/operators.py
+++ b/openghg_inversions/basis/operators.py
@@ -4,8 +4,9 @@ A :class:`BasisOperator` separates bucket geometry from flux weighting and
 native covariance. For one source, :attr:`BasisOperator.basis_matrix` is the
 bucket prolongation ``U_bucket`` with native-grid rows and retained-state
 columns. A gathered multisource matrix is the spatial membership template from
-which projection code expands a source-native ``U_bucket``. Its transpose is
-not automatically the retained restriction ``Pi``.
+which :meth:`BasisOperator.native_prolongation` expands a canonical
+source-native ``U_bucket``. Its transpose is not automatically the retained
+restriction ``Pi``.
 
 ``FluxWeightedBasis`` handles flux weighting for sensitivity projection and
 flux reconstruction. Native covariance actions, retained restrictions, and
@@ -226,6 +227,47 @@ class BasisOperator(ABC):
                 h = h.transpose(self.meta.state_dim, ...)
         return h
 
+    def native_prolongation(
+        self,
+        native_layout: xr.DataArray,
+        *,
+        native_dims: tuple[str, ...],
+    ) -> xr.DataArray:
+        """Return the bucket prolongation on a canonical labelled native grid.
+
+        This basis-side operation aligns geometry only. It preserves the
+        basis matrix's lazy or sparse storage and does not choose an execution
+        or covariance materialization policy.
+
+        Args:
+            native_layout: Array carrying the canonical native coordinates and
+                compatible auxiliary coordinates. It may contain additional
+                non-native dimensions.
+            native_dims: Ordered native dimensions required by the covariance
+                action.
+
+        Returns:
+            Potentially lazy ``U_bucket`` with dimensions
+            ``(*native_dims, meta.state_dim)``.
+
+        Raises:
+            ValueError: If this single-source basis does not span exactly the
+                requested native dimensions or their indexes do not match.
+        """
+        if native_dims != self.meta.grid_dims:
+            raise ValueError(
+                "A single-source basis requires native_dims to equal its grid dimensions; "
+                f"got {native_dims!r} and {self.meta.grid_dims!r}"
+            )
+        result = self.basis_matrix.transpose(*native_dims, self.meta.state_dim)
+        _require_exact_native_indexes(result, native_layout, native_dims=native_dims)
+        return _assign_compatible_native_coordinates(
+            result,
+            native_layout,
+            native_dims=native_dims,
+            protected_dims={self.meta.state_dim},
+        ).rename("prolongation")
+
     def interpolate(self, state: xr.DataArray, weights: xr.DataArray | None = None) -> xr.DataArray:
         """Interpolates/reconstructs a gridded field from a state vector.
 
@@ -350,6 +392,42 @@ def drop_singleton_time(da: xr.DataArray, *, name: str = "basis_flat") -> xr.Dat
 
     # Use squeeze to remove the dim (and drop the coordinate variable if it becomes scalar).
     return da.squeeze("time", drop=True)
+
+
+def _require_exact_native_indexes(
+    array: xr.DataArray,
+    native_layout: xr.DataArray,
+    *,
+    native_dims: tuple[str, ...],
+) -> None:
+    """Require exact ordered native indexes without implicit reindexing."""
+    for dim in native_dims:
+        if dim not in native_layout.dims or dim not in native_layout.coords:
+            raise ValueError(f"native_layout is missing native coordinate {dim!r}")
+        if dim not in array.dims or dim not in array.coords:
+            raise ValueError(f"basis prolongation is missing native coordinate {dim!r}")
+        if not array.get_index(dim).equals(native_layout.get_index(dim)):
+            raise ValueError(f"basis prolongation native coordinate {dim!r} must exactly match native_layout")
+
+
+def _assign_compatible_native_coordinates(
+    array: xr.DataArray,
+    native_layout: xr.DataArray,
+    *,
+    native_dims: tuple[str, ...],
+    protected_dims: set[str],
+) -> xr.DataArray:
+    """Attach layout coordinates defined only on native axes or scalars."""
+    native_dim_set = set(native_dims)
+    coordinates: dict[str, xr.DataArray] = {}
+    for raw_name, coordinate in native_layout.coords.items():
+        name = str(raw_name)
+        if name in protected_dims or not set(coordinate.dims).issubset(native_dim_set):
+            continue
+        if name in array.coords and name not in native_dim_set:
+            continue
+        coordinates[name] = coordinate
+    return array.assign_coords(coordinates)
 
 
 def _canonicalise_multisource_basis_grids(
@@ -759,9 +837,10 @@ class MultiSourceBucketBasisOperator(BasisOperator):
         """Return the gathered spatial template for multisource ``U_bucket``.
 
         The dimensions are spatial grid by retained state; source identity is
-        carried by the ragged state coordinate. Projection code expands an
-        explicit source-native dimension and zeros cross-source columns. This
-        template's transpose is not the compatible retained restriction ``Pi``.
+        carried by the ragged state coordinate. :meth:`native_prolongation`
+        expands an explicit source-native dimension and zeros cross-source
+        columns. This template's transpose is not the compatible retained
+        restriction ``Pi``.
         """
         return self._basis_matrix
 
@@ -774,6 +853,65 @@ class MultiSourceBucketBasisOperator(BasisOperator):
             ragged state MultiIndex.
         """
         return tuple(self.basis_flat)
+
+    def native_prolongation(
+        self,
+        native_layout: xr.DataArray,
+        *,
+        native_dims: tuple[str, ...],
+    ) -> xr.DataArray:
+        """Expand the gathered basis to a labelled source-native prolongation.
+
+        Args:
+            native_layout: Canonical native layout carrying an explicit source
+                dimension and native-compatible auxiliary coordinates.
+            native_dims: Ordered native dimensions. The first must be this
+                operator's source dimension and the remainder its grid dims.
+
+        Returns:
+            Potentially lazy ``U_bucket`` with zero cross-source columns and
+            dimensions ``(*native_dims, meta.state_dim)``.
+
+        Raises:
+            ValueError: If dimensions, source labels, or native indexes are
+                incompatible with this multisource basis.
+        """
+        if len(native_dims) != len(self.meta.grid_dims) + 1 or native_dims[1:] != self.meta.grid_dims:
+            raise ValueError(
+                "A multisource basis requires one native source dimension followed by its "
+                f"grid dimensions; got {native_dims!r}"
+            )
+        native_source_dim = native_dims[0]
+        base = self.basis_matrix.transpose(*self.meta.grid_dims, self.meta.state_dim)
+        _require_exact_native_indexes(base, native_layout, native_dims=self.meta.grid_dims)
+        if native_source_dim not in native_layout.coords:
+            raise ValueError(f"native_layout is missing source coordinate {native_source_dim!r}")
+        native_sources = native_layout.coords[native_source_dim]
+        expected_source_order = list(self.source_labels)
+        if native_sources.values.tolist() != expected_source_order:
+            raise ValueError(
+                "native_layout source coordinate must exactly match the basis source order; "
+                f"got {native_sources.values.tolist()!r}, expected {expected_source_order!r}"
+            )
+        # Use a positional state variable for broadcasting. Carrying the
+        # MultiIndex level coordinate itself into the comparison would add a
+        # second, equivalent ``state`` index and make xarray reject alignment.
+        state_sources = xr.DataArray(
+            np.asarray(base.coords[self.source_dim].values),
+            dims=self.meta.state_dim,
+        )
+        missing = set(state_sources.values.tolist()) - set(native_sources.values.tolist())
+        if missing:
+            raise ValueError(f"Basis state sources are absent from native_layout: {sorted(missing)!r}")
+        source_mask = native_sources == state_sources
+        result = (base * source_mask).transpose(*native_dims, self.meta.state_dim)
+        result = _assign_compatible_native_coordinates(
+            result,
+            native_layout,
+            native_dims=native_dims,
+            protected_dims={self.meta.state_dim, native_source_dim},
+        )
+        return result.rename("prolongation")
 
     def _stacked_basis_flat(self) -> xr.DataArray:
         """Stack source bases on a common labeled grid, retaining common attributes.

--- a/openghg_inversions/basis/operators.py
+++ b/openghg_inversions/basis/operators.py
@@ -883,6 +883,13 @@ class MultiSourceBucketBasisOperator(BasisOperator):
             )
         native_source_dim = native_dims[0]
         base = self.basis_matrix.transpose(*self.meta.grid_dims, self.meta.state_dim)
+        state_index = base.get_index(self.meta.state_dim)
+        state_level_names = {str(name) for name in getattr(state_index, "names", ()) if name is not None}
+        if native_source_dim in state_level_names:
+            raise ValueError(
+                f"Native source dimension {native_source_dim!r} collides with a retained-state "
+                "MultiIndex level; use distinct native and retained source dimension names"
+            )
         _require_exact_native_indexes(base, native_layout, native_dims=self.meta.grid_dims)
         if native_source_dim not in native_layout.coords:
             raise ValueError(f"native_layout is missing source coordinate {native_source_dim!r}")

--- a/openghg_inversions/native_covariance.py
+++ b/openghg_inversions/native_covariance.py
@@ -74,7 +74,14 @@ __all__ = [
 
 
 class NativeCovarianceAction(Protocol):
-    """Structural interface for a labelled native covariance action."""
+    """Structural interface for a labelled self-adjoint PSD covariance action.
+
+    Implementations represent a real, self-adjoint positive-semidefinite
+    operator ``B`` on the labelled native state. They must preserve RHS layout
+    and labels and return finite real values for finite real inputs. Consumers
+    may trust these semantic guarantees without globally materializing or
+    certifying the matrix-free operator.
+    """
 
     @property
     def native_dims(self) -> tuple[str, ...]:
@@ -100,7 +107,12 @@ class NativeCovarianceAction(Protocol):
 
 
 class InvertibleNativeCovarianceAction(NativeCovarianceAction, Protocol):
-    """Native covariance action that can also solve systems in ``B``."""
+    """Positive-definite native covariance action with a compatible inverse.
+
+    In addition to :class:`NativeCovarianceAction` semantics, ``B`` is positive
+    definite and :meth:`solve` implements the inverse compatible with
+    :meth:`apply` on the same labelled native state.
+    """
 
     def solve(self, rhs: xr.DataArray) -> xr.DataArray:
         """Return labelled ``B^-1 rhs`` while preserving the input layout.

--- a/tests/test_covariance_products.py
+++ b/tests/test_covariance_products.py
@@ -123,7 +123,6 @@ def test_preserve_bucket_strategy_derives_compatible_restriction() -> None:
     )
 
     assert projection.strategy == "preserve_bucket_prolongation"
-    assert projection.prolongation.dims == ("lat", "lon", "state")
     assert projection.restriction.dims == ("state", "lat", "lon")
     assert projection.restriction.state.values.tolist() == [0, 1]
     np.testing.assert_allclose(
@@ -137,11 +136,10 @@ def test_preserve_bucket_strategy_derives_compatible_restriction() -> None:
     )
 
 
-def test_retained_projection_public_contract_contains_only_pi_u_and_strategy() -> None:
-    """External projection results expose only restriction, prolongation, and strategy."""
+def test_retained_projection_public_contract_contains_only_pi_and_strategy() -> None:
+    """External projection results expose only restriction and strategy."""
     assert tuple(RetainedProjection.__dataclass_fields__) == (
         "restriction",
-        "prolongation",
         "strategy",
     )
 
@@ -384,21 +382,58 @@ def test_diagonal_observation_covariance_rejects_overflow() -> None:
             )
 
 
+@pytest.mark.parametrize("output", ["dense", "diagonal"])
+@pytest.mark.parametrize("invalid_output", ["complex", "nonfinite"])
+def test_covariance_products_reject_invalid_covariance_action_output(
+    monkeypatch: pytest.MonkeyPatch,
+    output: str,
+    invalid_output: str,
+) -> None:
+    """Dense and diagonal paths reject complex or non-finite B RHS before casting."""
+    covariance, basis_operator, h, _ = _problem()
+    original_apply = type(covariance).apply
+
+    def invalid_apply(self, rhs):
+        """Corrupt only observation covariance actions, leaving Pi derivation valid."""
+        rhs_dim = next(dim for dim in rhs.dims if dim not in covariance.native_dims)
+        if not str(rhs_dim).startswith("observation"):
+            return original_apply(self, rhs)
+        if invalid_output == "complex":
+            return rhs.astype(complex) * (1.0 + 1.0j)
+        return xr.full_like(rhs, np.nan)
+
+    monkeypatch.setattr(type(covariance), "apply", invalid_apply)
+
+    with pytest.raises(ValueError, match="finite real|complex|non-finite"):
+        _project(
+            covariance,
+            basis_operator,
+            h,
+            observation_covariance=output,
+        )
+
+
+@pytest.mark.parametrize(
+    "target_values",
+    [[1e20, -1.0, 1.0], [1e-20, -1e-20, 1e-20]],
+    ids=["unrelated-huge-positive", "small-scale-no-unit-floor"],
+)
 def test_diagonal_observation_covariance_uses_per_observation_negative_tolerance(
     monkeypatch: pytest.MonkeyPatch,
+    target_values: list[float],
 ) -> None:
-    """An unrelated huge positive variance cannot make negative one acceptable."""
+    """Negative tolerance is local, scale-invariant, and has no absolute unit floor."""
     covariance, basis_operator, h, _ = _problem()
     original_apply = type(covariance).apply
 
     def mixed_scale_apply(self, rhs):
-        """Return observation variances of approximately 1e20, -1, and 1."""
+        """Return the parameterized observation variances."""
         rhs_dim = next(dim for dim in rhs.dims if dim not in covariance.native_dims)
         if not str(rhs_dim).startswith("observation"):
             return original_apply(self, rhs)
         squared_norm = (rhs * rhs).sum(dim=list(covariance.native_dims))
         target = xr.DataArray(
-            [1e20, -1.0, 1.0],
+            target_values,
             dims=rhs_dim,
             coords={rhs_dim: rhs.coords[rhs_dim]},
         )
@@ -486,7 +521,6 @@ def test_lazy_custom_restriction_is_materialized_in_explicit_rhs_blocks() -> Non
             )
             return RetainedProjection(
                 valid.restriction.chunk({state_dim: 1}),
-                valid.prolongation,
                 "lazy_restriction",
             )
 
@@ -542,7 +576,7 @@ def test_single_chunk_lazy_restriction_is_materialized_once() -> None:
                 coords=valid.restriction.coords,
                 attrs=valid.restriction.attrs,
             )
-            return RetainedProjection(restriction, valid.prolongation, "single_chunk")
+            return RetainedProjection(restriction, "single_chunk")
 
     _project(
         covariance,
@@ -684,34 +718,6 @@ def test_each_dense_matrix_diagnostic_uses_one_eigendecomposition(
     assert "minimum_eigenvalue" in products.native_observation_covariance.attrs
 
 
-def test_projection_strategy_must_return_covariance_natural_prolongation() -> None:
-    """Custom strategies cannot return a Pi/U pair that violates B Pi.T = U C_alpha."""
-    covariance, basis_operator, h, _ = _problem()
-
-    class IncoherentStrategy:
-        """Perturb an otherwise compatible prolongation to violate the invariant."""
-
-        def projection(self, covariance, basis_prolongation, *, native_dims, state_dim):
-            """Return a deliberately incoherent restriction/prolongation pair."""
-            valid = PreserveBucketProlongation().projection(
-                covariance,
-                basis_prolongation,
-                native_dims=native_dims,
-                state_dim=state_dim,
-            )
-            return RetainedProjection(valid.restriction, 2.0 * valid.prolongation, "incoherent")
-
-    for sigma in (covariance.sigma, 1e-8):
-        scaled = SeparableExponentialCovariance(
-            covariance.latitude,
-            covariance.longitude,
-            sigma=sigma,
-            correlation_length=covariance.correlation_length,
-        )
-        with pytest.raises(ValueError, match="incoherent|B Pi"):
-            _project(scaled, basis_operator, h, strategy=IncoherentStrategy())
-
-
 def test_projection_strategy_protocol_accepts_structural_implementations() -> None:
     """A compatible strategy is accepted without inheriting from the public protocol."""
     covariance, basis_operator, h, _ = _problem()
@@ -727,17 +733,16 @@ def test_projection_strategy_protocol_accepts_structural_implementations() -> No
                 native_dims=native_dims,
                 state_dim=state_dim,
             )
-            return RetainedProjection(
-                projection.restriction,
-                projection.prolongation,
-                "delegating_strategy",
-            )
+            return RetainedProjection(projection.restriction, "delegating_strategy")
 
     strategy: RetainedProjectionStrategy = DelegatingStrategy()
 
+    expected = _project(covariance, basis_operator, h)
     products = _project(covariance, basis_operator, h, strategy=strategy)
 
     assert products.strategy == "delegating_strategy"
+    xr.testing.assert_allclose(products.prolongation, expected.prolongation)
+    xr.testing.assert_allclose(products.state_covariance, expected.state_covariance)
 
 
 def test_false_valued_structural_strategy_is_invoked() -> None:
@@ -762,7 +767,7 @@ def test_false_valued_structural_strategy_is_invoked() -> None:
                 native_dims=native_dims,
                 state_dim=state_dim,
             )
-            return RetainedProjection(valid.restriction, valid.prolongation, "false_valued")
+            return RetainedProjection(valid.restriction, "false_valued")
 
     products = _project(covariance, basis_operator, h, strategy=FalseValuedStrategy())
 
@@ -770,17 +775,13 @@ def test_false_valued_structural_strategy_is_invoked() -> None:
     assert products.strategy == "false_valued"
 
 
-@pytest.mark.parametrize("coordinate_role", ["state", "native"])
-def test_custom_projection_rejects_conflicting_semantic_auxiliary_coordinates(
-    coordinate_role: str,
-) -> None:
-    """Pi and U cannot attach contradictory state or native semantic metadata."""
+def test_custom_projection_rejects_conflicting_native_auxiliary_coordinates() -> None:
+    """Pi native semantic metadata must match the canonical native reference."""
     covariance, basis_operator, h, _ = _problem()
-    if coordinate_role == "native":
-        h = h.assign_coords(cell_area=(("lat", "lon"), np.arange(6).reshape(3, 2)))
+    h = h.assign_coords(cell_area=(("lat", "lon"), np.arange(6).reshape(3, 2)))
 
     class ConflictingAuxiliaryStrategy:
-        """Return a valid numerical pair with contradictory semantic coordinates."""
+        """Return valid Pi values with contradictory semantic coordinates."""
 
         def projection(self, covariance, basis_prolongation, *, native_dims, state_dim):
             """Relabel one semantic auxiliary without changing numerical values."""
@@ -790,15 +791,10 @@ def test_custom_projection_rejects_conflicting_semantic_auxiliary_coordinates(
                 native_dims=native_dims,
                 state_dim=state_dim,
             )
-            if coordinate_role == "state":
-                restriction = valid.restriction.assign_coords(group=(state_dim, ["a", "b"]))
-                prolongation = valid.prolongation.assign_coords(group=(state_dim, ["b", "a"]))
-            else:
-                restriction = valid.restriction.assign_coords(
-                    cell_area=(("lat", "lon"), np.arange(6).reshape(3, 2) + 1)
-                )
-                prolongation = valid.prolongation
-            return RetainedProjection(restriction, prolongation, "conflicting_auxiliary")
+            restriction = valid.restriction.assign_coords(
+                cell_area=(("lat", "lon"), np.arange(6).reshape(3, 2) + 1)
+            )
+            return RetainedProjection(restriction, "conflicting_auxiliary")
 
     with pytest.raises(ValueError, match="auxiliary|coordinate|group|cell_area"):
         _project(covariance, basis_operator, h, strategy=ConflictingAuxiliaryStrategy())
@@ -822,54 +818,46 @@ def test_projection_strategy_names_must_be_nonempty() -> None:
                 native_dims=native_dims,
                 state_dim=state_dim,
             )
-            return RetainedProjection(valid.restriction, valid.prolongation, "")
+            return RetainedProjection(valid.restriction, "")
 
     with pytest.raises(ValueError, match="non-empty"):
         _project(covariance, basis_operator, h, strategy=EmptyNameStrategy())
 
 
-@pytest.mark.parametrize("role", ["restriction", "prolongation"])
-def test_projection_strategy_rejects_complex_arrays(role: str) -> None:
-    """Projection products use real covariance algebra and reject complex strategy arrays."""
+def test_projection_strategy_rejects_complex_restriction() -> None:
+    """Projection strategies use real covariance algebra and reject complex Pi."""
     covariance, basis_operator, h, _ = _problem()
 
     class ComplexStrategy:
-        """Add an imaginary component to one otherwise valid projection array."""
+        """Add an imaginary component to an otherwise valid restriction."""
 
         def projection(self, covariance, basis_prolongation, *, native_dims, state_dim):
-            """Return a deliberately complex restriction or prolongation."""
+            """Return a deliberately complex restriction."""
             valid = PreserveBucketProlongation().projection(
                 covariance,
                 basis_prolongation,
                 native_dims=native_dims,
                 state_dim=state_dim,
             )
-            restriction = valid.restriction
-            prolongation = valid.prolongation
-            if role == "restriction":
-                restriction = restriction.astype(complex) + 1j
-            else:
-                prolongation = prolongation.astype(complex) + 1j
-            return RetainedProjection(restriction, prolongation, "complex")
+            restriction = valid.restriction.astype(complex) + 1j
+            return RetainedProjection(restriction, "complex")
 
     with pytest.raises(ValueError, match="finite real"):
         _project(covariance, basis_operator, h, strategy=ComplexStrategy())
 
 
-@pytest.mark.parametrize("role", ["restriction", "prolongation"])
 @pytest.mark.parametrize("coordinate_change", ["mismatch", "reordered", "empty-intersection"])
 def test_custom_projection_requires_exact_native_coordinates(
-    role: str,
     coordinate_change: str,
 ) -> None:
-    """Custom Pi and U native labels must match before product alignment or contraction."""
+    """Custom Pi native labels must match before product alignment or contraction."""
     covariance, basis_operator, h, _ = _problem()
 
     class RelabelledStrategy:
-        """Relabel one projection array to exercise strict native-coordinate checks."""
+        """Relabel Pi to exercise strict native-coordinate checks."""
 
         def projection(self, covariance, basis_prolongation, *, native_dims, state_dim):
-            """Return a coherent numeric pair with deliberately invalid latitude labels."""
+            """Return numeric Pi with deliberately invalid latitude labels."""
             valid = PreserveBucketProlongation().projection(
                 covariance,
                 basis_prolongation,
@@ -883,30 +871,24 @@ def test_custom_projection_requires_exact_native_coordinates(
                 invalid_latitude = latitude + 1000.0
             else:
                 invalid_latitude = latitude + 0.25
-            restriction = valid.restriction
-            prolongation = valid.prolongation
-            if role == "restriction":
-                restriction = restriction.assign_coords(lat=invalid_latitude)
-            else:
-                prolongation = prolongation.assign_coords(lat=invalid_latitude)
-            return RetainedProjection(restriction, prolongation, "relabeled")
+            restriction = valid.restriction.assign_coords(lat=invalid_latitude)
+            return RetainedProjection(restriction, "relabeled")
 
     with pytest.raises(ValueError, match=r"native coordinate 'lat'.*exactly match"):
         _project(covariance, basis_operator, h, strategy=RelabelledStrategy())
 
 
 def test_projection_strategy_must_return_full_rank_restriction() -> None:
-    """A formally compatible zero Pi/U pair is rejected because C_alpha is singular."""
+    """A zero authoritative Pi is rejected because derived C_alpha is singular."""
     covariance, basis_operator, h, _ = _problem()
 
     class SingularStrategy:
-        """Return a zero restriction and prolongation with the expected dimensions."""
+        """Return a zero restriction with the expected dimensions."""
 
         def projection(self, covariance, basis_prolongation, *, native_dims, state_dim):
             """Return a deliberately singular retained projection."""
             return RetainedProjection(
                 xr.zeros_like(basis_prolongation.transpose(state_dim, *native_dims)),
-                xr.zeros_like(basis_prolongation),
                 "singular",
             )
 

--- a/tests/test_covariance_products.py
+++ b/tests/test_covariance_products.py
@@ -137,6 +137,15 @@ def test_preserve_bucket_strategy_derives_compatible_restriction() -> None:
     )
 
 
+def test_retained_projection_public_contract_contains_only_pi_u_and_strategy() -> None:
+    """External projection results expose only restriction, prolongation, and strategy."""
+    assert tuple(RetainedProjection.__dataclass_fields__) == (
+        "restriction",
+        "prolongation",
+        "strategy",
+    )
+
+
 def test_products_match_dense_oracle_and_coherent_forward_model() -> None:
     """C_alpha, H_alpha, H B Pi.T, and H B H.T match dense coherent oracles."""
     covariance, basis_operator, h, dense_b = _problem()
@@ -255,11 +264,16 @@ def test_dense_batching_preallocates_instead_of_concatenating(
     """Dense observation batching avoids the former xr.concat block-assembly path."""
     covariance, basis_operator, h, _ = _problem()
 
-    def reject_concat(*args: object, **kwargs: object) -> None:
-        """Fail if the former all-block concatenation path is used."""
-        raise AssertionError(f"unexpected xr.concat call: {args!r}, {kwargs!r}")
+    original_concat = xr.concat
 
-    monkeypatch.setattr(xr, "concat", reject_concat)
+    def reject_observation_concat(*args: object, **kwargs: object):
+        """Allow state blocking but fail on former observation block assembly."""
+        dim = kwargs.get("dim")
+        if dim in {"observation", "observation_cov"}:
+            raise AssertionError(f"unexpected observation xr.concat call: {args!r}, {kwargs!r}")
+        return original_concat(*args, **kwargs)
+
+    monkeypatch.setattr(xr, "concat", reject_observation_concat)
 
     products = _project(
         covariance,
@@ -370,17 +384,27 @@ def test_diagonal_observation_covariance_rejects_overflow() -> None:
             )
 
 
-def test_diagonal_observation_covariance_rejects_materially_negative_values(
+def test_diagonal_observation_covariance_uses_per_observation_negative_tolerance(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The diagonal view rejects covariance actions producing negative variance."""
+    """An unrelated huge positive variance cannot make negative one acceptable."""
     covariance, basis_operator, h, _ = _problem()
+    original_apply = type(covariance).apply
 
-    def negative_apply(self, rhs):
-        """Return a deliberately non-positive covariance action."""
-        return -rhs
+    def mixed_scale_apply(self, rhs):
+        """Return observation variances of approximately 1e20, -1, and 1."""
+        rhs_dim = next(dim for dim in rhs.dims if dim not in covariance.native_dims)
+        if not str(rhs_dim).startswith("observation"):
+            return original_apply(self, rhs)
+        squared_norm = (rhs * rhs).sum(dim=list(covariance.native_dims))
+        target = xr.DataArray(
+            [1e20, -1.0, 1.0],
+            dims=rhs_dim,
+            coords={rhs_dim: rhs.coords[rhs_dim]},
+        )
+        return rhs * (target / squared_norm)
 
-    monkeypatch.setattr(type(covariance), "apply", negative_apply)
+    monkeypatch.setattr(type(covariance), "apply", mixed_scale_apply)
 
     with pytest.raises(ValueError, match="negative|nonnegative|diagonal"):
         _project(
@@ -389,6 +413,42 @@ def test_diagonal_observation_covariance_rejects_materially_negative_values(
             h,
             observation_covariance="diagonal",
         )
+
+
+def test_diagonal_observation_covariance_allows_tiny_local_roundoff(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tiny negative diagonal within its local numerical scale is tolerated."""
+    covariance, basis_operator, h, _ = _problem()
+    original_apply = type(covariance).apply
+
+    def roundoff_apply(self, rhs):
+        """Create one tiny negative through cancellation of order-one terms."""
+        rhs_dim = next(dim for dim in rhs.dims if dim not in covariance.native_dims)
+        if not str(rhs_dim).startswith("observation"):
+            return original_apply(self, rhs)
+        result = xr.zeros_like(rhs)
+        rhs_values = np.asarray(rhs.values)
+        result_values = np.asarray(result.values)
+        result_values[..., 0] = rhs_values[..., 0]
+        result_values[..., 2] = rhs_values[..., 2]
+        middle_rhs = rhs_values[..., 1].reshape(-1)
+        middle_result = result_values[..., 1].reshape(-1)
+        middle_result[0] = 1.0 / middle_rhs[0]
+        middle_result[1] = (-1.0 - 1e-14) / middle_rhs[1]
+        return result
+
+    monkeypatch.setattr(type(covariance), "apply", roundoff_apply)
+
+    products = _project(
+        covariance,
+        basis_operator,
+        h,
+        observation_covariance="diagonal",
+    )
+
+    assert products.native_observation_covariance.values[1] == 0.0
+    assert products.native_observation_covariance.attrs["diagonal_nonnegative"] is True
 
 
 def test_lazy_sensitivity_is_rejected_at_explicit_materialization_boundary() -> None:
@@ -583,7 +643,7 @@ def test_square_products_preserve_specialized_indexes_and_coordinate_attrs(
 def test_product_kernel_avoids_throwaway_covariance_application(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Covariance application occurs only for the two real observation RHS blocks."""
+    """Covariance applies only to one Pi block and two observation RHS blocks."""
     covariance, basis_operator, h, _ = _problem()
     original_apply = type(covariance).apply
     calls = 0
@@ -598,7 +658,7 @@ def test_product_kernel_avoids_throwaway_covariance_application(
 
     _project(covariance, basis_operator, h, observation_batch_size=2)
 
-    assert calls == 2
+    assert calls == 3
 
 
 def test_each_dense_matrix_diagnostic_uses_one_eigendecomposition(
@@ -708,77 +768,6 @@ def test_false_valued_structural_strategy_is_invoked() -> None:
 
     assert invoked
     assert products.strategy == "false_valued"
-
-
-def test_external_strategy_rejects_forged_cached_products() -> None:
-    """Untrusted zero C_alpha and B Pi.T cannot bypass products derived from Pi and B."""
-    covariance, basis_operator, h, _ = _problem()
-
-    class ForgedCacheStrategy:
-        """Return valid Pi/U alongside coherent-looking but zero cached products."""
-
-        def projection(self, covariance, basis_prolongation, *, native_dims, state_dim):
-            """Forge both optional cached products while retaining a valid Pi/U pair."""
-            valid = PreserveBucketProlongation().projection(
-                covariance,
-                basis_prolongation,
-                native_dims=native_dims,
-                state_dim=state_dim,
-            )
-            assert valid.state_covariance is not None
-            assert valid.covariance_restriction_transpose is not None
-            return RetainedProjection(
-                valid.restriction,
-                valid.prolongation,
-                "forged_cache",
-                state_covariance=xr.zeros_like(valid.state_covariance),
-                covariance_restriction_transpose=xr.zeros_like(valid.covariance_restriction_transpose),
-            )
-
-    with pytest.raises(ValueError, match="cached|C_alpha|B Pi|covariance"):
-        _project(covariance, basis_operator, h, strategy=ForgedCacheStrategy())
-
-
-@pytest.mark.parametrize("cache_mode", ["valid", "scaled-b-pi-t"])
-def test_external_strategy_cached_products_are_independently_validated(cache_mode: str) -> None:
-    """Valid external caches are accepted while a coherently scaled B Pi.T is rejected."""
-    covariance, basis_operator, h, _ = _problem()
-
-    class CachedStrategy:
-        """Return built-in Pi/U with externally supplied cached products."""
-
-        def projection(self, covariance, basis_prolongation, *, native_dims, state_dim):
-            """Supply either exact caches or a scaled covariance action cache."""
-            valid = PreserveBucketProlongation().projection(
-                covariance,
-                basis_prolongation,
-                native_dims=native_dims,
-                state_dim=state_dim,
-            )
-            assert valid.state_covariance is not None
-            assert valid.covariance_restriction_transpose is not None
-            b_pi_t = valid.covariance_restriction_transpose
-            if cache_mode == "scaled-b-pi-t":
-                b_pi_t = 2.0 * b_pi_t
-            return RetainedProjection(
-                valid.restriction,
-                valid.prolongation,
-                f"external_{cache_mode}",
-                state_covariance=valid.state_covariance,
-                covariance_restriction_transpose=b_pi_t,
-            )
-
-    if cache_mode == "scaled-b-pi-t":
-        with pytest.raises(ValueError, match="cached|B Pi|covariance"):
-            _project(covariance, basis_operator, h, strategy=CachedStrategy())
-    else:
-        expected = _project(covariance, basis_operator, h)
-        actual = _project(covariance, basis_operator, h, strategy=CachedStrategy())
-        xr.testing.assert_allclose(actual.state_covariance, expected.state_covariance)
-        xr.testing.assert_allclose(
-            actual.observation_state_cross_covariance,
-            expected.observation_state_cross_covariance,
-        )
 
 
 @pytest.mark.parametrize("coordinate_role", ["state", "native"])

--- a/tests/test_covariance_products.py
+++ b/tests/test_covariance_products.py
@@ -1,8 +1,4 @@
-"""Test covariance projection, identities, eager batching, labels, and persistence."""
-
-import json
-from pathlib import Path
-from typing import cast
+"""Test labelled covariance projection, eager batching, and numerical contracts."""
 
 import numpy as np
 import pandas as pd
@@ -16,7 +12,8 @@ from openghg_inversions.basis.covariance_products import (
     RetainedProjectionStrategy,
     project_native_covariance,
 )
-from openghg_inversions.basis.operators import BasisMeta, BucketBasisOperator
+from openghg_inversions.array_ops import to_dense
+from openghg_inversions.basis.operators import BucketBasisOperator
 from openghg_inversions.native_covariance import SeparableExponentialCovariance
 
 
@@ -94,9 +91,16 @@ def _project(
     **options,
 ) -> NativeCovarianceProducts:
     """Project the shared problem with its canonical observation dimension."""
+    basis_prolongation = to_dense(
+        basis_operator.native_prolongation(
+            native_sensitivity,
+            native_dims=covariance.native_dims,
+        )
+    ).compute()
     return project_native_covariance(
         covariance=covariance,
-        basis_operator=basis_operator,
+        basis_prolongation=basis_prolongation,
+        state_dim=basis_operator.meta.state_dim,
         native_sensitivity=native_sensitivity,
         observation_dim="observation",
         **options,
@@ -110,7 +114,7 @@ def test_preserve_bucket_strategy_derives_compatible_restriction() -> None:
 
     projection = PreserveBucketProlongation().projection(
         covariance,
-        basis_operator.basis_matrix,
+        to_dense(basis_operator.basis_matrix).compute(),
         native_dims=covariance.native_dims,
         state_dim="state",
     )
@@ -186,8 +190,8 @@ def test_covariance_natural_prolongation_is_the_bucket_prolongation() -> None:
     np.testing.assert_allclose(u_star, u, rtol=1e-11, atol=1e-11)
 
 
-def test_dense_and_diagonal_products_have_stable_source_and_derived_view_identities() -> None:
-    """Batching preserves identities while dense/diagonal views share only source identity."""
+def test_dense_and_diagonal_products_are_invariant_to_rhs_batching() -> None:
+    """RHS batching preserves dense products and the diagonal view."""
     covariance, basis_operator, h, _ = _problem()
 
     full_batch = _project(
@@ -230,10 +234,6 @@ def test_dense_and_diagonal_products_have_stable_source_and_derived_view_identit
         ),
     ):
         xr.testing.assert_allclose(batched, full)
-    assert single_observation_batches.source_content_identity == full_batch.source_content_identity
-    assert single_observation_batches.view_identity == full_batch.view_identity
-    assert diagonal.source_content_identity == full_batch.source_content_identity
-    assert diagonal.view_identity != full_batch.view_identity
     assert full_batch.observation_covariance_view == "dense"
     assert diagonal.observation_covariance_view == "diagonal"
     assert diagonal.native_observation_covariance.dims == ("observation",)
@@ -269,281 +269,198 @@ def test_dense_batching_preallocates_instead_of_concatenating(
     assert products.native_observation_covariance.shape == (3, 3)
 
 
-def test_products_round_trip_with_labels_and_identity() -> None:
-    """Dataset and DataTree round trips preserve blocks, labels, identities, and config."""
+def test_single_source_native_prolongation_preserves_native_auxiliary_coordinates() -> None:
+    """Canonical single-source U retains native-axis and scalar context coordinates."""
     covariance, basis_operator, h, _ = _problem()
+    native_layout = h.assign_coords(
+        cell_area=(("lat", "lon"), np.arange(6).reshape(3, 2)),
+        latitude_band=("lat", ["south", "middle", "north"]),
+        grid_mapping="latitude_longitude",
+    )
+
+    prolongation = basis_operator.native_prolongation(
+        native_layout,
+        native_dims=covariance.native_dims,
+    )
+
+    assert prolongation.dims == ("lat", "lon", "state")
+    xr.testing.assert_identical(prolongation.coords["cell_area"], native_layout.coords["cell_area"])
+    xr.testing.assert_identical(
+        prolongation.coords["latitude_band"],
+        native_layout.coords["latitude_band"],
+    )
+    assert prolongation.coords["grid_mapping"].item() == "latitude_longitude"
+
+
+@pytest.mark.parametrize(
+    "invalid_batch_size",
+    [True, "2", 1.9],
+    ids=["boolean", "string", "non-integral-float"],
+)
+def test_observation_batch_size_requires_integral_non_boolean(invalid_batch_size: object) -> None:
+    """The RHS block size rejects values that merely coerce to an integer."""
+    covariance, basis_operator, h, _ = _problem()
+
+    with pytest.raises((TypeError, ValueError), match="integer|integral|Boolean"):
+        _project(
+            covariance,
+            basis_operator,
+            h,
+            observation_batch_size=invalid_batch_size,
+        )
+
+
+def test_observation_batch_size_accepts_numpy_integral() -> None:
+    """NumPy integer scalars satisfy the public integral block-size contract."""
+    covariance, basis_operator, h, _ = _problem()
+
     products = _project(
         covariance,
         basis_operator,
         h,
-        observation_batch_size=2,
+        observation_batch_size=np.int64(2),
     )
 
-    restored = NativeCovarianceProducts.from_dataset(products.to_dataset())
-
-    xr.testing.assert_identical(restored.restriction, products.restriction)
-    xr.testing.assert_identical(restored.state_covariance, products.state_covariance)
-    xr.testing.assert_identical(
-        restored.effective_observation_operator, products.effective_observation_operator
-    )
-    xr.testing.assert_identical(
-        restored.observation_state_cross_covariance,
-        products.observation_state_cross_covariance,
-    )
-    xr.testing.assert_identical(
-        restored.native_observation_covariance, products.native_observation_covariance
-    )
-    assert restored.strategy == products.strategy
-    assert restored.source_content_identity == products.source_content_identity
-    assert restored.view_identity == products.view_identity
-    assert restored.observation_covariance_view == products.observation_covariance_view
-    assert restored.covariance_configuration_digest == products.covariance_configuration_digest
-    assert len(products.source_content_identity) == 64
-    assert len(products.view_identity) == 64
-    assert all(
-        array.attrs["source_content_identity"] == products.source_content_identity
-        and array.attrs["view_identity"] == products.view_identity
-        for array in (
-            products.restriction,
-            products.state_covariance,
-            products.effective_observation_operator,
-            products.observation_state_cross_covariance,
-            products.native_observation_covariance,
-        )
-    )
-
-    restored_tree = NativeCovarianceProducts.from_datatree(products.to_datatree())
-    assert restored_tree.covariance_configuration is not None
-    assert products.covariance_configuration is not None
-    xr.testing.assert_identical(
-        restored_tree.covariance_configuration,
-        products.covariance_configuration,
-    )
-    assert restored_tree.basis_provenance == products.basis_provenance
-    assert restored_tree.prolongation.attrs["source_content_identity"] == products.source_content_identity
+    assert products.native_observation_covariance.shape == (3, 3)
 
 
-def test_dataset_round_trip_cannot_silently_drop_covariance_configuration() -> None:
-    """A root-only restore preserves its config digest and refuses an incomplete tree."""
+def test_lazy_sensitivity_is_rejected_at_explicit_materialization_boundary() -> None:
+    """The eager kernel rejects Dask H instead of silently computing its full graph."""
     covariance, basis_operator, h, _ = _problem()
+    lazy_h = h.chunk({"observation": 1})
+    basis_prolongation = to_dense(
+        basis_operator.native_prolongation(h, native_dims=covariance.native_dims)
+    ).compute()
+
+    with pytest.raises(ValueError, match="upstream materialization|lazy|Dask"):
+        project_native_covariance(
+            covariance=covariance,
+            basis_prolongation=basis_prolongation,
+            state_dim="state",
+            native_sensitivity=lazy_h,
+            observation_dim="observation",
+        )
+
+
+def test_lazy_custom_restriction_is_materialized_in_explicit_rhs_blocks() -> None:
+    """Custom Dask Pi follows the explicit retained-state RHS block path."""
+    covariance, basis_operator, h, _ = _problem()
+
+    class LazyRestrictionStrategy:
+        """Return a valid numerical projection with a deliberately lazy restriction."""
+
+        def projection(self, covariance, basis_prolongation, *, native_dims, state_dim):
+            """Chunk the restriction to exercise the explicit eager boundary."""
+            valid = PreserveBucketProlongation().projection(
+                covariance,
+                basis_prolongation,
+                native_dims=native_dims,
+                state_dim=state_dim,
+            )
+            return RetainedProjection(
+                valid.restriction.chunk({state_dim: 1}),
+                valid.prolongation,
+                "lazy_restriction",
+            )
+
+    expected = _project(covariance, basis_operator, h)
+    actual = _project(
+        covariance,
+        basis_operator,
+        h,
+        strategy=LazyRestrictionStrategy(),
+        observation_batch_size=1,
+    )
+
+    xr.testing.assert_allclose(actual.state_covariance, expected.state_covariance)
+    xr.testing.assert_allclose(
+        actual.observation_state_cross_covariance,
+        expected.observation_state_cross_covariance,
+    )
+
+
+def test_product_units_follow_dimensionless_scaling_contract() -> None:
+    """State arrays are dimensionless while H products retain or square H units."""
+    covariance, basis_operator, h, _ = _problem()
+    products = _project(covariance, basis_operator, h.assign_attrs(units="ppt"))
+
+    for array in (
+        products.restriction,
+        products.prolongation,
+        products.state_covariance,
+    ):
+        assert array.attrs["units"] == "1"
+    assert products.effective_observation_operator.attrs["units"] == "ppt"
+    assert products.observation_state_cross_covariance.attrs["units"] == "ppt"
+    assert products.native_observation_covariance.attrs["units"] == "(ppt)^2"
+
+
+@pytest.mark.parametrize("multiindex", [False, True], ids=["index", "multiindex"])
+def test_square_products_preserve_typed_row_and_column_indexes(multiindex: bool) -> None:
+    """Square product axes carry symmetric typed Index or MultiIndex labels."""
+    covariance, basis_operator, h, _ = _problem()
+    if multiindex:
+        index = pd.MultiIndex.from_arrays(
+            [["MHD", "TAC", "RGL"], pd.to_datetime(["2020-01-01", "2020-01-02", "2020-01-03"])],
+            names=("site", "time"),
+        )
+        h = h.drop_indexes("observation").drop_vars("observation")
+        h = h.assign_coords(xr.Coordinates.from_pandas_multiindex(index, "observation"))
+    else:
+        index = pd.Index(["MHD", 7, ("RGL", 1)], dtype=object, name="observation")
+        h = h.assign_coords(observation=index)
+
+    matrix = _project(covariance, basis_operator, h).native_observation_covariance
+    row_index = matrix.indexes["observation"]
+    column_index = matrix.indexes["observation_cov"]
+
+    assert isinstance(column_index, type(row_index))
+    assert list(column_index) == list(row_index)
+    assert matrix.sel(observation=row_index[0], observation_cov=column_index[0]).ndim == 0
+
+
+def test_product_kernel_avoids_throwaway_covariance_application(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Covariance application occurs only for the two real observation RHS blocks."""
+    covariance, basis_operator, h, _ = _problem()
+    original_apply = type(covariance).apply
+    calls = 0
+
+    def counted_apply(self, rhs):
+        """Count each real covariance application before delegating."""
+        nonlocal calls
+        calls += 1
+        return original_apply(self, rhs)
+
+    monkeypatch.setattr(type(covariance), "apply", counted_apply)
+
+    _project(covariance, basis_operator, h, observation_batch_size=2)
+
+    assert calls == 2
+
+
+def test_each_dense_matrix_diagnostic_uses_one_eigendecomposition(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """State and observation covariance diagnostics each compute eigenvalues once."""
+    covariance, basis_operator, h, _ = _problem()
+    original_eigvalsh = np.linalg.eigvalsh
+    calls = 0
+
+    def counted_eigvalsh(matrix):
+        """Count symmetric eigensolver calls before delegating."""
+        nonlocal calls
+        calls += 1
+        return original_eigvalsh(matrix)
+
+    monkeypatch.setattr(np.linalg, "eigvalsh", counted_eigvalsh)
+
     products = _project(covariance, basis_operator, h)
 
-    restored = NativeCovarianceProducts.from_dataset(products.to_dataset())
-
-    assert restored.covariance_configuration is None
-    assert restored.covariance_configuration_digest == products.covariance_configuration_digest
-    with pytest.raises(ValueError, match="without.*covariance configuration content"):
-        restored.to_datatree()
-
-
-def test_source_content_identity_changes_with_covariance_configuration() -> None:
-    """Kernel amplitudes and class maps participate in the stable source identity."""
-    covariance, basis_operator, h, _ = _problem()
-    baseline = _project(covariance, basis_operator, h)
-    rescaled = _project(
-        SeparableExponentialCovariance(
-            covariance.latitude,
-            covariance.longitude,
-            sigma=2.0,
-            correlation_length=covariance.correlation_length,
-        ),
-        basis_operator,
-        h,
-    )
-    classes = xr.DataArray(
-        [[0, 1], [0, 1], [1, 1]],
-        dims=("lat", "lon"),
-        coords={"lat": covariance.latitude, "lon": covariance.longitude},
-    )
-    blocked = _project(
-        SeparableExponentialCovariance(
-            covariance.latitude,
-            covariance.longitude,
-            sigma=covariance.sigma,
-            correlation_length=covariance.correlation_length,
-            class_labels=classes,
-        ),
-        basis_operator,
-        h,
-    )
-
-    assert baseline.source_content_identity != rescaled.source_content_identity
-    assert baseline.source_content_identity != blocked.source_content_identity
-
-
-def test_product_deserialization_rejects_mixed_source_identity() -> None:
-    """A product variable whose source identity differs from the root is rejected."""
-    covariance, basis_operator, h, _ = _problem()
-    dataset = _project(covariance, basis_operator, h).to_dataset()
-    dataset["state_covariance"].attrs["source_content_identity"] = "0" * 64
-
-    with pytest.raises(ValueError, match="source identity"):
-        NativeCovarianceProducts.from_dataset(dataset)
-
-
-def test_product_deserialization_rejects_dense_matrix_declared_as_diagonal() -> None:
-    """View metadata cannot relabel a two-dimensional dense matrix as a diagonal."""
-    covariance, basis_operator, h, _ = _problem()
-    dense = _project(covariance, basis_operator, h, observation_covariance="dense")
-    diagonal = _project(covariance, basis_operator, h, observation_covariance="diagonal")
-    dataset = dense.to_dataset()
-    dataset.attrs["observation_covariance_view"] = "diagonal"
-    dataset.attrs["view_identity"] = diagonal.view_identity
-    for variable in dataset.data_vars.values():
-        variable.attrs["view_identity"] = diagonal.view_identity
-
-    with pytest.raises(ValueError, match="diagonal observation covariance.*dimensions"):
-        NativeCovarianceProducts.from_dataset(dataset)
-
-
-@pytest.mark.parametrize(
-    ("variable", "column_dim"),
-    [
-        ("state_covariance", "state_cov"),
-        ("native_observation_covariance", "observation_cov"),
-    ],
-)
-def test_product_deserialization_rejects_reordered_matrix_column_labels(
-    variable: str,
-    column_dim: str,
-) -> None:
-    """Matrix column labels must remain bound to their corresponding row labels."""
-    covariance, basis_operator, h, _ = _problem()
-    dataset = _project(covariance, basis_operator, h).to_dataset()
-    dataset = dataset.assign_coords({column_dim: dataset.coords[column_dim].values[::-1]})
-
-    with pytest.raises(ValueError, match="column.*labels are inconsistent"):
-        NativeCovarianceProducts.from_dataset(dataset)
-
-
-def test_product_deserialization_rejects_reordered_auxiliary_column_labels() -> None:
-    """Copied observation-column auxiliaries remain bound to their row labels."""
-    covariance, basis_operator, h, _ = _problem()
-    h = h.assign_coords(site=("observation", ["MHD", "TAC", "RGL"]))
-    dataset = _project(covariance, basis_operator, h).to_dataset()
-    dataset = dataset.assign_coords(site_cov=("observation_cov", dataset.coords["site_cov"].values[::-1]))
-
-    with pytest.raises(ValueError, match="column.*labels are inconsistent"):
-        NativeCovarianceProducts.from_dataset(dataset)
-
-
-def test_product_round_trip_allows_native_dimension_named_like_observation_column() -> None:
-    """Loader derives the same collision-safe observation column name as construction."""
-    covariance, _, h, _ = _problem()
-    longitude = covariance.longitude.rename({"lon": "observation_cov"})
-    renamed_covariance = SeparableExponentialCovariance(
-        covariance.latitude,
-        longitude,
-        sigma=covariance.sigma,
-        correlation_length=covariance.correlation_length,
-    )
-    basis = BucketBasisOperator(
-        xr.DataArray(
-            [[1, 1], [1, 2], [2, 2]],
-            dims=("lat", "observation_cov"),
-            coords={"lat": covariance.latitude, "observation_cov": longitude},
-        ),
-        meta=BasisMeta(grid_dims=("lat", "observation_cov"), state_dim="state"),
-    )
-    products = _project(
-        renamed_covariance,
-        basis,
-        h.rename({"lon": "observation_cov"}),
-    )
-
-    restored = NativeCovarianceProducts.from_dataset(products.to_dataset())
-
-    assert restored.native_observation_covariance.dims == (
-        "observation",
-        "observation_cov_2",
-    )
-
-
-@pytest.mark.parametrize("invalid_value", [np.nan, 1.0j])
-def test_product_deserialization_rejects_non_finite_or_complex_values(
-    invalid_value: complex,
-) -> None:
-    """Loaded numerical products retain the construction-time finite-real contract."""
-    covariance, basis_operator, h, _ = _problem()
-    dataset = _project(covariance, basis_operator, h).to_dataset()
-    dataset["effective_observation_operator"] = dataset["effective_observation_operator"].astype(
-        np.result_type(invalid_value)
-    )
-    dataset["effective_observation_operator"].values[0, 0] = invalid_value
-
-    with pytest.raises(ValueError, match="finite real"):
-        NativeCovarianceProducts.from_dataset(dataset)
-
-
-def test_product_deserialization_rejects_forged_coordinate_namespace_owner() -> None:
-    """Namespace metadata cannot claim coordinates for unknown product owners."""
-    covariance, basis_operator, h, _ = _problem()
-    dataset = _project(covariance, basis_operator, h).to_dataset()
-    namespaces = json.loads(dataset.attrs["openghg_inversions:product_coordinate_namespaces"])
-    namespaces["forged"] = {"observation": "removed"}
-    dataset.attrs["openghg_inversions:product_coordinate_namespaces"] = json.dumps(namespaces)
-
-    with pytest.raises(ValueError, match="namespace owners"):
-        NativeCovarianceProducts.from_dataset(dataset)
-
-
-@pytest.mark.parametrize(
-    "encoded_provenance",
-    [None, "not-json", "[]", '{"operator_type": 1}'],
-)
-def test_product_deserialization_validates_basis_provenance_shape(
-    encoded_provenance: object,
-) -> None:
-    """Basis provenance must be a JSON encoding of a string-to-string mapping."""
-    covariance, basis_operator, h, _ = _problem()
-    dataset = _project(covariance, basis_operator, h).to_dataset()
-    dataset.attrs["basis_provenance"] = encoded_provenance
-
-    with pytest.raises(ValueError, match="basis provenance"):
-        NativeCovarianceProducts.from_dataset(dataset)
-
-
-def test_product_identity_metadata_is_not_a_numerical_checksum() -> None:
-    """Identity metadata binds source/view declarations but does not checksum output values."""
-    covariance, basis_operator, h, _ = _problem()
-    dataset = _project(covariance, basis_operator, h).to_dataset()
-    dataset["state_covariance"].values[0, 0] += 1.0
-
-    restored = NativeCovarianceProducts.from_dataset(dataset)
-
-    assert restored.state_covariance.values[0, 0] == dataset["state_covariance"].values[0, 0]
-
-
-def test_datatree_rejects_covariance_configuration_from_another_source() -> None:
-    """A covariance configuration child cannot be mixed into another source artifact."""
-    covariance, basis_operator, h, _ = _problem()
-    baseline_tree = _project(covariance, basis_operator, h).to_datatree()
-    other_covariance = SeparableExponentialCovariance(
-        covariance.latitude,
-        covariance.longitude,
-        sigma=2.0,
-        correlation_length=covariance.correlation_length,
-    )
-    other_tree = _project(other_covariance, basis_operator, h).to_datatree()
-    baseline_tree["covariance_configuration"] = xr.DataTree(
-        cast(xr.DataTree, other_tree["covariance_configuration"]).to_dataset(inherit=False).copy(deep=True)
-    )
-
-    with pytest.raises(ValueError, match="configuration.*root source identity"):
-        NativeCovarianceProducts.from_datatree(baseline_tree)
-
-
-def test_datatree_rejects_tampered_covariance_configuration_content() -> None:
-    """Configuration content is recomputed and checked against its bound root digest."""
-    covariance, basis_operator, h, _ = _problem()
-    tree = _project(covariance, basis_operator, h).to_datatree()
-    child = cast(xr.DataTree, tree["covariance_configuration"]).to_dataset(inherit=False).copy(deep=True)
-    latitude_dim = "covariance_configuration__lat"
-    child = child.assign_coords({latitude_dim: child.coords[latitude_dim] + 0.25})
-    tree["covariance_configuration"] = xr.DataTree(child)
-
-    with pytest.raises(ValueError, match="configuration content.*digest"):
-        NativeCovarianceProducts.from_datatree(tree)
+    assert calls == 2
+    assert "minimum_eigenvalue" in products.state_covariance.attrs
+    assert "minimum_eigenvalue" in products.native_observation_covariance.attrs
 
 
 def test_projection_strategy_must_return_covariance_natural_prolongation() -> None:
@@ -603,7 +520,7 @@ def test_projection_strategy_protocol_accepts_structural_implementations() -> No
 
 
 def test_projection_strategy_names_must_be_nonempty() -> None:
-    """Empty built-in and custom identifiers are rejected before serialization."""
+    """Empty built-in and custom strategy identifiers are rejected."""
     covariance, basis_operator, h, _ = _problem()
 
     with pytest.raises(ValueError, match="non-empty"):
@@ -712,23 +629,6 @@ def test_projection_strategy_must_return_full_rank_restriction() -> None:
         _project(covariance, basis_operator, h, strategy=SingularStrategy())
 
 
-def test_source_content_identity_includes_auxiliary_semantic_coordinates() -> None:
-    """Relabelling an auxiliary observation coordinate changes the source identity."""
-    covariance, basis_operator, h, _ = _problem()
-    first = _project(
-        covariance,
-        basis_operator,
-        h.assign_coords(network=("observation", ["ICOS", "DECC", "DECC"])),
-    )
-    second = _project(
-        covariance,
-        basis_operator,
-        h.assign_coords(network=("observation", ["DECC", "DECC", "DECC"])),
-    )
-
-    assert first.source_content_identity != second.source_content_identity
-
-
 def test_redundant_bucket_states_are_rejected() -> None:
     """Linearly dependent retained coordinates fail instead of being pseudoinverted."""
     covariance, basis_operator, _, _ = _problem()
@@ -812,53 +712,4 @@ def test_class_blocked_products_match_dense_oracle() -> None:
         products.native_observation_covariance,
         h_matrix @ dense_b @ h_matrix.T,
         atol=2e-10,
-    )
-
-
-def test_datetime_multiindex_observation_labels_persist_on_both_matrix_axes(
-    tmp_path: Path,
-) -> None:
-    """Real Timestamp MultiIndex labels encode safely and persist through NetCDF."""
-    covariance, basis_operator, h, _ = _problem()
-    dates = pd.to_datetime(["2020-01-01", "2020-01-02", "2020-01-03"])
-    observation_index = pd.MultiIndex.from_arrays(
-        [["MHD", "TAC", "RGL"], dates],
-        names=("site", "date"),
-    )
-    h = h.drop_indexes("observation").drop_vars("observation")
-    h = h.assign_coords(xr.Coordinates.from_pandas_multiindex(observation_index, "observation"))
-
-    products = _project(covariance, basis_operator, h)
-
-    assert products.native_observation_covariance.coords["site"].values.tolist() == [
-        "MHD",
-        "TAC",
-        "RGL",
-    ]
-    assert products.native_observation_covariance.coords["site_cov"].values.tolist() == [
-        "MHD",
-        "TAC",
-        "RGL",
-    ]
-    np.testing.assert_array_equal(
-        products.native_observation_covariance.coords["date_cov"].values,
-        dates.values,
-    )
-    assert products.native_observation_covariance.coords["observation_cov"].values.tolist() == [
-        '["MHD","2020-01-01T00:00:00"]',
-        '["TAC","2020-01-02T00:00:00"]',
-        '["RGL","2020-01-03T00:00:00"]',
-    ]
-
-    path = tmp_path / "datetime-multiindex-products.nc"
-    products.to_datatree().to_netcdf(path, engine="h5netcdf")
-    with xr.open_datatree(path, engine="h5netcdf") as stored:
-        restored = NativeCovarianceProducts.from_datatree(stored.load())
-
-    restored_index = restored.native_observation_covariance.indexes["observation"]
-    assert isinstance(restored_index, pd.MultiIndex)
-    assert restored_index.equals(observation_index)
-    np.testing.assert_array_equal(
-        restored.native_observation_covariance.coords["observation_cov"].values,
-        products.native_observation_covariance.coords["observation_cov"].values,
     )

--- a/tests/test_covariance_products.py
+++ b/tests/test_covariance_products.py
@@ -4,6 +4,9 @@ import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
+from dask import delayed
+from dask import array as da
+from xarray.core.indexes import PandasIndex
 
 from openghg_inversions.basis.covariance_products import (
     NativeCovarianceProducts,
@@ -324,6 +327,70 @@ def test_observation_batch_size_accepts_numpy_integral() -> None:
     assert products.native_observation_covariance.shape == (3, 3)
 
 
+@pytest.mark.parametrize("collision", ["observation-dimension", "auxiliary-coordinate"])
+def test_state_column_name_avoids_observation_namespace_collisions(collision: str) -> None:
+    """The generated state column avoids observation dimensions and coordinates."""
+    covariance, basis_operator, h, _ = _problem()
+    observation_dim = "observation"
+    if collision == "observation-dimension":
+        h = h.rename(observation="state_cov")
+        observation_dim = "state_cov"
+    else:
+        h = h.assign_coords(state_cov=("observation", ["MHD", "TAC", "RGL"]))
+    prolongation = to_dense(
+        basis_operator.native_prolongation(h, native_dims=covariance.native_dims)
+    ).compute()
+
+    products = project_native_covariance(
+        covariance=covariance,
+        basis_prolongation=prolongation,
+        state_dim="state",
+        native_sensitivity=h,
+        observation_dim=observation_dim,
+    )
+
+    state_column_dim = products.observation_state_cross_covariance.dims[1]
+    assert state_column_dim != observation_dim
+    assert state_column_dim not in h.coords
+    assert products.observation_state_cross_covariance.shape == (3, 2)
+
+
+def test_diagonal_observation_covariance_rejects_overflow() -> None:
+    """The diagonal view rejects non-finite values produced by finite huge H."""
+    covariance, basis_operator, h, _ = _problem()
+    huge_h = xr.full_like(h, 1e308)
+
+    with np.errstate(over="ignore", invalid="ignore"):
+        with pytest.raises(ValueError, match="finite|non-finite"):
+            _project(
+                covariance,
+                basis_operator,
+                huge_h,
+                observation_covariance="diagonal",
+            )
+
+
+def test_diagonal_observation_covariance_rejects_materially_negative_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The diagonal view rejects covariance actions producing negative variance."""
+    covariance, basis_operator, h, _ = _problem()
+
+    def negative_apply(self, rhs):
+        """Return a deliberately non-positive covariance action."""
+        return -rhs
+
+    monkeypatch.setattr(type(covariance), "apply", negative_apply)
+
+    with pytest.raises(ValueError, match="negative|nonnegative|diagonal"):
+        _project(
+            covariance,
+            basis_operator,
+            h,
+            observation_covariance="diagonal",
+        )
+
+
 def test_lazy_sensitivity_is_rejected_at_explicit_materialization_boundary() -> None:
     """The eager kernel rejects Dask H instead of silently computing its full graph."""
     covariance, basis_operator, h, _ = _problem()
@@ -379,6 +446,55 @@ def test_lazy_custom_restriction_is_materialized_in_explicit_rhs_blocks() -> Non
     )
 
 
+def test_single_chunk_lazy_restriction_is_materialized_once() -> None:
+    """A full-state Dask Pi producer executes once despite state RHS blocking."""
+    covariance, basis_operator, h, _ = _problem()
+    executions = 0
+
+    class SingleChunkRestrictionStrategy:
+        """Wrap a valid restriction in one delayed full-state chunk."""
+
+        def projection(self, covariance, basis_prolongation, *, native_dims, state_dim):
+            """Return a delayed Pi whose producer records each execution."""
+            valid = PreserveBucketProlongation().projection(
+                covariance,
+                basis_prolongation,
+                native_dims=native_dims,
+                state_dim=state_dim,
+            )
+            values = np.asarray(valid.restriction.values)
+
+            @delayed
+            def produce_restriction() -> np.ndarray:
+                """Return the full restriction and record graph execution."""
+                nonlocal executions
+                executions += 1
+                return values
+
+            lazy_values = da.from_delayed(
+                produce_restriction(),
+                shape=values.shape,
+                dtype=values.dtype,
+            )
+            restriction = xr.DataArray(
+                lazy_values,
+                dims=valid.restriction.dims,
+                coords=valid.restriction.coords,
+                attrs=valid.restriction.attrs,
+            )
+            return RetainedProjection(restriction, valid.prolongation, "single_chunk")
+
+    _project(
+        covariance,
+        basis_operator,
+        h,
+        strategy=SingleChunkRestrictionStrategy(),
+        observation_batch_size=1,
+    )
+
+    assert executions == 1
+
+
 def test_product_units_follow_dimensionless_scaling_contract() -> None:
     """State arrays are dimensionless while H products retain or square H units."""
     covariance, basis_operator, h, _ = _problem()
@@ -406,6 +522,8 @@ def test_square_products_preserve_typed_row_and_column_indexes(multiindex: bool)
         )
         h = h.drop_indexes("observation").drop_vars("observation")
         h = h.assign_coords(xr.Coordinates.from_pandas_multiindex(index, "observation"))
+        h.coords["site"].attrs["semantic_role"] = "station"
+        h.coords["time"].attrs["semantic_role"] = "sample_time"
     else:
         index = pd.Index(["MHD", 7, ("RGL", 1)], dtype=object, name="observation")
         h = h.assign_coords(observation=index)
@@ -417,6 +535,49 @@ def test_square_products_preserve_typed_row_and_column_indexes(multiindex: bool)
     assert isinstance(column_index, type(row_index))
     assert list(column_index) == list(row_index)
     assert matrix.sel(observation=row_index[0], observation_cov=column_index[0]).ndim == 0
+    if multiindex:
+        assert matrix.coords["site"].attrs["semantic_role"] == "station"
+        assert matrix.coords["site_cov"].attrs["semantic_role"] == "station"
+        assert matrix.coords["time"].attrs["semantic_role"] == "sample_time"
+        assert matrix.coords["time_cov"].attrs["semantic_role"] == "sample_time"
+
+
+@pytest.mark.parametrize(
+    "index",
+    [
+        pytest.param(
+            pd.CategoricalIndex(
+                ["MHD", "TAC", "RGL"],
+                categories=["RGL", "TAC", "MHD"],
+                ordered=True,
+                name="observation",
+            ),
+            id="categorical",
+        ),
+        pytest.param(
+            pd.period_range("2020-01", periods=3, freq="M", name="observation"),
+            id="period",
+        ),
+        pytest.param(pd.RangeIndex(5, 8, name="observation"), id="range"),
+    ],
+)
+def test_square_products_preserve_specialized_indexes_and_coordinate_attrs(
+    index: pd.Index,
+) -> None:
+    """Square row/column axes preserve specialized indexes and coordinate attrs."""
+    covariance, basis_operator, h, _ = _problem()
+    h = h.drop_indexes("observation").drop_vars("observation")
+    h = h.assign_coords(xr.Coordinates.from_xindex(PandasIndex(index, "observation")))
+    h.coords["observation"].attrs["semantic_role"] = "measurement"
+
+    matrix = _project(covariance, basis_operator, h).native_observation_covariance
+
+    assert type(matrix.indexes["observation"]) is type(index)
+    assert type(matrix.indexes["observation_cov"]) is type(index)
+    assert matrix.indexes["observation"].equals(index)
+    assert matrix.indexes["observation_cov"].equals(index.rename("observation_cov"))
+    assert matrix.coords["observation"].attrs["semantic_role"] == "measurement"
+    assert matrix.coords["observation_cov"].attrs["semantic_role"] == "measurement"
 
 
 def test_product_kernel_avoids_throwaway_covariance_application(
@@ -517,6 +678,141 @@ def test_projection_strategy_protocol_accepts_structural_implementations() -> No
     products = _project(covariance, basis_operator, h, strategy=strategy)
 
     assert products.strategy == "delegating_strategy"
+
+
+def test_false_valued_structural_strategy_is_invoked() -> None:
+    """A valid strategy with false truth value does not trigger default fallback."""
+    covariance, basis_operator, h, _ = _problem()
+    invoked = False
+
+    class FalseValuedStrategy:
+        """Expose a false truth value while implementing the strategy protocol."""
+
+        def __bool__(self) -> bool:
+            """Return false without changing the object's strategy validity."""
+            return False
+
+        def projection(self, covariance, basis_prolongation, *, native_dims, state_dim):
+            """Delegate valid algebra and record that this strategy was selected."""
+            nonlocal invoked
+            invoked = True
+            valid = PreserveBucketProlongation().projection(
+                covariance,
+                basis_prolongation,
+                native_dims=native_dims,
+                state_dim=state_dim,
+            )
+            return RetainedProjection(valid.restriction, valid.prolongation, "false_valued")
+
+    products = _project(covariance, basis_operator, h, strategy=FalseValuedStrategy())
+
+    assert invoked
+    assert products.strategy == "false_valued"
+
+
+def test_external_strategy_rejects_forged_cached_products() -> None:
+    """Untrusted zero C_alpha and B Pi.T cannot bypass products derived from Pi and B."""
+    covariance, basis_operator, h, _ = _problem()
+
+    class ForgedCacheStrategy:
+        """Return valid Pi/U alongside coherent-looking but zero cached products."""
+
+        def projection(self, covariance, basis_prolongation, *, native_dims, state_dim):
+            """Forge both optional cached products while retaining a valid Pi/U pair."""
+            valid = PreserveBucketProlongation().projection(
+                covariance,
+                basis_prolongation,
+                native_dims=native_dims,
+                state_dim=state_dim,
+            )
+            assert valid.state_covariance is not None
+            assert valid.covariance_restriction_transpose is not None
+            return RetainedProjection(
+                valid.restriction,
+                valid.prolongation,
+                "forged_cache",
+                state_covariance=xr.zeros_like(valid.state_covariance),
+                covariance_restriction_transpose=xr.zeros_like(valid.covariance_restriction_transpose),
+            )
+
+    with pytest.raises(ValueError, match="cached|C_alpha|B Pi|covariance"):
+        _project(covariance, basis_operator, h, strategy=ForgedCacheStrategy())
+
+
+@pytest.mark.parametrize("cache_mode", ["valid", "scaled-b-pi-t"])
+def test_external_strategy_cached_products_are_independently_validated(cache_mode: str) -> None:
+    """Valid external caches are accepted while a coherently scaled B Pi.T is rejected."""
+    covariance, basis_operator, h, _ = _problem()
+
+    class CachedStrategy:
+        """Return built-in Pi/U with externally supplied cached products."""
+
+        def projection(self, covariance, basis_prolongation, *, native_dims, state_dim):
+            """Supply either exact caches or a scaled covariance action cache."""
+            valid = PreserveBucketProlongation().projection(
+                covariance,
+                basis_prolongation,
+                native_dims=native_dims,
+                state_dim=state_dim,
+            )
+            assert valid.state_covariance is not None
+            assert valid.covariance_restriction_transpose is not None
+            b_pi_t = valid.covariance_restriction_transpose
+            if cache_mode == "scaled-b-pi-t":
+                b_pi_t = 2.0 * b_pi_t
+            return RetainedProjection(
+                valid.restriction,
+                valid.prolongation,
+                f"external_{cache_mode}",
+                state_covariance=valid.state_covariance,
+                covariance_restriction_transpose=b_pi_t,
+            )
+
+    if cache_mode == "scaled-b-pi-t":
+        with pytest.raises(ValueError, match="cached|B Pi|covariance"):
+            _project(covariance, basis_operator, h, strategy=CachedStrategy())
+    else:
+        expected = _project(covariance, basis_operator, h)
+        actual = _project(covariance, basis_operator, h, strategy=CachedStrategy())
+        xr.testing.assert_allclose(actual.state_covariance, expected.state_covariance)
+        xr.testing.assert_allclose(
+            actual.observation_state_cross_covariance,
+            expected.observation_state_cross_covariance,
+        )
+
+
+@pytest.mark.parametrize("coordinate_role", ["state", "native"])
+def test_custom_projection_rejects_conflicting_semantic_auxiliary_coordinates(
+    coordinate_role: str,
+) -> None:
+    """Pi and U cannot attach contradictory state or native semantic metadata."""
+    covariance, basis_operator, h, _ = _problem()
+    if coordinate_role == "native":
+        h = h.assign_coords(cell_area=(("lat", "lon"), np.arange(6).reshape(3, 2)))
+
+    class ConflictingAuxiliaryStrategy:
+        """Return a valid numerical pair with contradictory semantic coordinates."""
+
+        def projection(self, covariance, basis_prolongation, *, native_dims, state_dim):
+            """Relabel one semantic auxiliary without changing numerical values."""
+            valid = PreserveBucketProlongation().projection(
+                covariance,
+                basis_prolongation,
+                native_dims=native_dims,
+                state_dim=state_dim,
+            )
+            if coordinate_role == "state":
+                restriction = valid.restriction.assign_coords(group=(state_dim, ["a", "b"]))
+                prolongation = valid.prolongation.assign_coords(group=(state_dim, ["b", "a"]))
+            else:
+                restriction = valid.restriction.assign_coords(
+                    cell_area=(("lat", "lon"), np.arange(6).reshape(3, 2) + 1)
+                )
+                prolongation = valid.prolongation
+            return RetainedProjection(restriction, prolongation, "conflicting_auxiliary")
+
+    with pytest.raises(ValueError, match="auxiliary|coordinate|group|cell_area"):
+        _project(covariance, basis_operator, h, strategy=ConflictingAuxiliaryStrategy())
 
 
 def test_projection_strategy_names_must_be_nonempty() -> None:

--- a/tests/test_covariance_products.py
+++ b/tests/test_covariance_products.py
@@ -1,0 +1,864 @@
+"""Test covariance projection, identities, eager batching, labels, and persistence."""
+
+import json
+from pathlib import Path
+from typing import cast
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+from openghg_inversions.basis.covariance_products import (
+    NativeCovarianceProducts,
+    PreserveBucketProlongation,
+    RetainedProjection,
+    RetainedProjectionStrategy,
+    project_native_covariance,
+)
+from openghg_inversions.basis.operators import BasisMeta, BucketBasisOperator
+from openghg_inversions.native_covariance import SeparableExponentialCovariance
+
+
+def _problem() -> tuple[
+    SeparableExponentialCovariance,
+    BucketBasisOperator,
+    xr.DataArray,
+    np.ndarray,
+]:
+    """Return a labelled small-grid problem and its dense native covariance."""
+    latitude = xr.DataArray(
+        [-1.0, 0.5, 2.0],
+        dims="lat",
+        coords={"lat": [-1.0, 0.5, 2.0]},
+        attrs={"units": "degrees_north"},
+    )
+    longitude = xr.DataArray(
+        [10.0, 11.0],
+        dims="lon",
+        coords={"lon": [10.0, 11.0]},
+        attrs={"units": "degrees_east"},
+    )
+    covariance = SeparableExponentialCovariance(
+        latitude=latitude,
+        longitude=longitude,
+        sigma=1.4,
+        correlation_length=0.9,
+    )
+    basis_flat = xr.DataArray(
+        [[1, 1], [1, 2], [2, 2]],
+        dims=("lat", "lon"),
+        coords={"lat": latitude, "lon": longitude},
+        name="basis_flat",
+    )
+    basis_operator = BucketBasisOperator(basis_flat, state_dim="state")
+    native_sensitivity = xr.DataArray(
+        np.array(
+            [
+                [[0.2, -0.1], [0.4, 0.7], [0.3, -0.2]],
+                [[-0.3, 0.8], [0.1, -0.4], [0.9, 0.5]],
+                [[0.6, 0.2], [-0.7, 0.3], [0.2, 0.1]],
+            ]
+        ),
+        dims=("observation", "lat", "lon"),
+        coords={
+            "observation": ["MHD-1", "TAC-1", "RGL-1"],
+            "lat": latitude,
+            "lon": longitude,
+        },
+        name="native_sensitivity",
+    )
+    k_lat = np.exp(-np.abs(latitude.values[:, np.newaxis] - latitude.values[np.newaxis, :]) / 0.9)
+    k_lon = np.exp(-np.abs(longitude.values[:, np.newaxis] - longitude.values[np.newaxis, :]) / 0.9)
+    dense_b = 1.4**2 * np.kron(k_lat, k_lon)
+    return covariance, basis_operator, native_sensitivity, dense_b
+
+
+def _dense_operators(
+    basis_operator: BucketBasisOperator,
+    dense_b: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return dense-oracle prolongation, restriction, and retained covariance."""
+    matrix = basis_operator.basis_matrix.transpose("lat", "lon", "state").compute()
+    u = np.asarray(matrix.data.todense()).reshape(6, 2)
+    precision_u = np.linalg.solve(dense_b, u)
+    c_alpha = np.linalg.inv(u.T @ precision_u)
+    restriction = c_alpha @ precision_u.T
+    return u, restriction, c_alpha
+
+
+def _project(
+    covariance: SeparableExponentialCovariance,
+    basis_operator: BucketBasisOperator,
+    native_sensitivity: xr.DataArray,
+    **options,
+) -> NativeCovarianceProducts:
+    """Project the shared problem with its canonical observation dimension."""
+    return project_native_covariance(
+        covariance=covariance,
+        basis_operator=basis_operator,
+        native_sensitivity=native_sensitivity,
+        observation_dim="observation",
+        **options,
+    )
+
+
+def test_preserve_bucket_strategy_derives_compatible_restriction() -> None:
+    """The derived restriction satisfies Pi_U U_bucket = identity with stable labels."""
+    covariance, basis_operator, _, dense_b = _problem()
+    u, expected_pi, _ = _dense_operators(basis_operator, dense_b)
+
+    projection = PreserveBucketProlongation().projection(
+        covariance,
+        basis_operator.basis_matrix,
+        native_dims=covariance.native_dims,
+        state_dim="state",
+    )
+
+    assert projection.strategy == "preserve_bucket_prolongation"
+    assert projection.prolongation.dims == ("lat", "lon", "state")
+    assert projection.restriction.dims == ("state", "lat", "lon")
+    assert projection.restriction.state.values.tolist() == [0, 1]
+    np.testing.assert_allclose(
+        projection.restriction.values.reshape(2, 6), expected_pi, rtol=1e-11, atol=1e-11
+    )
+    np.testing.assert_allclose(
+        projection.restriction.values.reshape(2, 6) @ u,
+        np.eye(2),
+        rtol=1e-11,
+        atol=1e-11,
+    )
+
+
+def test_products_match_dense_oracle_and_coherent_forward_model() -> None:
+    """C_alpha, H_alpha, H B Pi.T, and H B H.T match dense coherent oracles."""
+    covariance, basis_operator, h, dense_b = _problem()
+    u, expected_pi, expected_c_alpha = _dense_operators(basis_operator, dense_b)
+    h_matrix = h.values.reshape(3, 6)
+
+    products = _project(covariance, basis_operator, h)
+
+    expected_h_alpha = h_matrix @ u
+    expected_hb_pi_t = h_matrix @ dense_b @ expected_pi.T
+    expected_hbht = h_matrix @ dense_b @ h_matrix.T
+    np.testing.assert_allclose(products.state_covariance, expected_c_alpha, rtol=1e-11, atol=1e-11)
+    np.testing.assert_allclose(
+        products.effective_observation_operator, expected_h_alpha, rtol=1e-11, atol=1e-11
+    )
+    np.testing.assert_allclose(
+        products.observation_state_cross_covariance,
+        expected_hb_pi_t,
+        rtol=1e-11,
+        atol=1e-11,
+    )
+    np.testing.assert_allclose(products.native_observation_covariance, expected_hbht, rtol=1e-11, atol=1e-11)
+    np.testing.assert_allclose(
+        products.observation_state_cross_covariance,
+        expected_h_alpha @ expected_c_alpha,
+        rtol=1e-11,
+        atol=1e-11,
+    )
+    assert products.state_covariance.dims == ("state", "state_cov")
+    assert products.effective_observation_operator.dims == ("observation", "state")
+    assert products.observation_state_cross_covariance.dims == ("observation", "state_cov")
+    assert products.native_observation_covariance.dims == ("observation", "observation_cov")
+    assert products.native_observation_covariance.observation.values.tolist() == [
+        "MHD-1",
+        "TAC-1",
+        "RGL-1",
+    ]
+    assert products.native_observation_covariance.observation_cov.values.tolist() == [
+        "MHD-1",
+        "TAC-1",
+        "RGL-1",
+    ]
+
+
+def test_covariance_natural_prolongation_is_the_bucket_prolongation() -> None:
+    """The compatible Pi makes B Pi.T C_alpha^-1 exactly equal U_bucket."""
+    covariance, basis_operator, h, dense_b = _problem()
+    u, _, _ = _dense_operators(basis_operator, dense_b)
+    products = _project(covariance, basis_operator, h)
+    pi = products.restriction.values.reshape(2, 6)
+
+    u_star = dense_b @ pi.T @ np.linalg.inv(products.state_covariance.values)
+
+    np.testing.assert_allclose(u_star, u, rtol=1e-11, atol=1e-11)
+
+
+def test_dense_and_diagonal_products_have_stable_source_and_derived_view_identities() -> None:
+    """Batching preserves identities while dense/diagonal views share only source identity."""
+    covariance, basis_operator, h, _ = _problem()
+
+    full_batch = _project(
+        covariance,
+        basis_operator,
+        h,
+        observation_covariance="dense",
+        observation_batch_size=64,
+    )
+    single_observation_batches = _project(
+        covariance,
+        basis_operator,
+        h,
+        observation_covariance="dense",
+        observation_batch_size=1,
+    )
+    diagonal = _project(
+        covariance,
+        basis_operator,
+        h,
+        observation_covariance="diagonal",
+        observation_batch_size=2,
+    )
+
+    for batched, full in (
+        (single_observation_batches.restriction, full_batch.restriction),
+        (single_observation_batches.prolongation, full_batch.prolongation),
+        (single_observation_batches.state_covariance, full_batch.state_covariance),
+        (
+            single_observation_batches.effective_observation_operator,
+            full_batch.effective_observation_operator,
+        ),
+        (
+            single_observation_batches.observation_state_cross_covariance,
+            full_batch.observation_state_cross_covariance,
+        ),
+        (
+            single_observation_batches.native_observation_covariance,
+            full_batch.native_observation_covariance,
+        ),
+    ):
+        xr.testing.assert_allclose(batched, full)
+    assert single_observation_batches.source_content_identity == full_batch.source_content_identity
+    assert single_observation_batches.view_identity == full_batch.view_identity
+    assert diagonal.source_content_identity == full_batch.source_content_identity
+    assert diagonal.view_identity != full_batch.view_identity
+    assert full_batch.observation_covariance_view == "dense"
+    assert diagonal.observation_covariance_view == "diagonal"
+    assert diagonal.native_observation_covariance.dims == ("observation",)
+    expected_diagonal = xr.DataArray(
+        np.diag(full_batch.native_observation_covariance.values),
+        dims="observation",
+        coords={"observation": h.observation},
+        name="native_observation_covariance",
+    )
+    np.testing.assert_allclose(diagonal.native_observation_covariance, expected_diagonal)
+
+
+def test_dense_batching_preallocates_instead_of_concatenating(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Dense observation batching avoids the former xr.concat block-assembly path."""
+    covariance, basis_operator, h, _ = _problem()
+
+    def reject_concat(*args: object, **kwargs: object) -> None:
+        """Fail if the former all-block concatenation path is used."""
+        raise AssertionError(f"unexpected xr.concat call: {args!r}, {kwargs!r}")
+
+    monkeypatch.setattr(xr, "concat", reject_concat)
+
+    products = _project(
+        covariance,
+        basis_operator,
+        h,
+        observation_covariance="dense",
+        observation_batch_size=1,
+    )
+
+    assert products.native_observation_covariance.shape == (3, 3)
+
+
+def test_products_round_trip_with_labels_and_identity() -> None:
+    """Dataset and DataTree round trips preserve blocks, labels, identities, and config."""
+    covariance, basis_operator, h, _ = _problem()
+    products = _project(
+        covariance,
+        basis_operator,
+        h,
+        observation_batch_size=2,
+    )
+
+    restored = NativeCovarianceProducts.from_dataset(products.to_dataset())
+
+    xr.testing.assert_identical(restored.restriction, products.restriction)
+    xr.testing.assert_identical(restored.state_covariance, products.state_covariance)
+    xr.testing.assert_identical(
+        restored.effective_observation_operator, products.effective_observation_operator
+    )
+    xr.testing.assert_identical(
+        restored.observation_state_cross_covariance,
+        products.observation_state_cross_covariance,
+    )
+    xr.testing.assert_identical(
+        restored.native_observation_covariance, products.native_observation_covariance
+    )
+    assert restored.strategy == products.strategy
+    assert restored.source_content_identity == products.source_content_identity
+    assert restored.view_identity == products.view_identity
+    assert restored.observation_covariance_view == products.observation_covariance_view
+    assert restored.covariance_configuration_digest == products.covariance_configuration_digest
+    assert len(products.source_content_identity) == 64
+    assert len(products.view_identity) == 64
+    assert all(
+        array.attrs["source_content_identity"] == products.source_content_identity
+        and array.attrs["view_identity"] == products.view_identity
+        for array in (
+            products.restriction,
+            products.state_covariance,
+            products.effective_observation_operator,
+            products.observation_state_cross_covariance,
+            products.native_observation_covariance,
+        )
+    )
+
+    restored_tree = NativeCovarianceProducts.from_datatree(products.to_datatree())
+    assert restored_tree.covariance_configuration is not None
+    assert products.covariance_configuration is not None
+    xr.testing.assert_identical(
+        restored_tree.covariance_configuration,
+        products.covariance_configuration,
+    )
+    assert restored_tree.basis_provenance == products.basis_provenance
+    assert restored_tree.prolongation.attrs["source_content_identity"] == products.source_content_identity
+
+
+def test_dataset_round_trip_cannot_silently_drop_covariance_configuration() -> None:
+    """A root-only restore preserves its config digest and refuses an incomplete tree."""
+    covariance, basis_operator, h, _ = _problem()
+    products = _project(covariance, basis_operator, h)
+
+    restored = NativeCovarianceProducts.from_dataset(products.to_dataset())
+
+    assert restored.covariance_configuration is None
+    assert restored.covariance_configuration_digest == products.covariance_configuration_digest
+    with pytest.raises(ValueError, match="without.*covariance configuration content"):
+        restored.to_datatree()
+
+
+def test_source_content_identity_changes_with_covariance_configuration() -> None:
+    """Kernel amplitudes and class maps participate in the stable source identity."""
+    covariance, basis_operator, h, _ = _problem()
+    baseline = _project(covariance, basis_operator, h)
+    rescaled = _project(
+        SeparableExponentialCovariance(
+            covariance.latitude,
+            covariance.longitude,
+            sigma=2.0,
+            correlation_length=covariance.correlation_length,
+        ),
+        basis_operator,
+        h,
+    )
+    classes = xr.DataArray(
+        [[0, 1], [0, 1], [1, 1]],
+        dims=("lat", "lon"),
+        coords={"lat": covariance.latitude, "lon": covariance.longitude},
+    )
+    blocked = _project(
+        SeparableExponentialCovariance(
+            covariance.latitude,
+            covariance.longitude,
+            sigma=covariance.sigma,
+            correlation_length=covariance.correlation_length,
+            class_labels=classes,
+        ),
+        basis_operator,
+        h,
+    )
+
+    assert baseline.source_content_identity != rescaled.source_content_identity
+    assert baseline.source_content_identity != blocked.source_content_identity
+
+
+def test_product_deserialization_rejects_mixed_source_identity() -> None:
+    """A product variable whose source identity differs from the root is rejected."""
+    covariance, basis_operator, h, _ = _problem()
+    dataset = _project(covariance, basis_operator, h).to_dataset()
+    dataset["state_covariance"].attrs["source_content_identity"] = "0" * 64
+
+    with pytest.raises(ValueError, match="source identity"):
+        NativeCovarianceProducts.from_dataset(dataset)
+
+
+def test_product_deserialization_rejects_dense_matrix_declared_as_diagonal() -> None:
+    """View metadata cannot relabel a two-dimensional dense matrix as a diagonal."""
+    covariance, basis_operator, h, _ = _problem()
+    dense = _project(covariance, basis_operator, h, observation_covariance="dense")
+    diagonal = _project(covariance, basis_operator, h, observation_covariance="diagonal")
+    dataset = dense.to_dataset()
+    dataset.attrs["observation_covariance_view"] = "diagonal"
+    dataset.attrs["view_identity"] = diagonal.view_identity
+    for variable in dataset.data_vars.values():
+        variable.attrs["view_identity"] = diagonal.view_identity
+
+    with pytest.raises(ValueError, match="diagonal observation covariance.*dimensions"):
+        NativeCovarianceProducts.from_dataset(dataset)
+
+
+@pytest.mark.parametrize(
+    ("variable", "column_dim"),
+    [
+        ("state_covariance", "state_cov"),
+        ("native_observation_covariance", "observation_cov"),
+    ],
+)
+def test_product_deserialization_rejects_reordered_matrix_column_labels(
+    variable: str,
+    column_dim: str,
+) -> None:
+    """Matrix column labels must remain bound to their corresponding row labels."""
+    covariance, basis_operator, h, _ = _problem()
+    dataset = _project(covariance, basis_operator, h).to_dataset()
+    dataset = dataset.assign_coords({column_dim: dataset.coords[column_dim].values[::-1]})
+
+    with pytest.raises(ValueError, match="column.*labels are inconsistent"):
+        NativeCovarianceProducts.from_dataset(dataset)
+
+
+def test_product_deserialization_rejects_reordered_auxiliary_column_labels() -> None:
+    """Copied observation-column auxiliaries remain bound to their row labels."""
+    covariance, basis_operator, h, _ = _problem()
+    h = h.assign_coords(site=("observation", ["MHD", "TAC", "RGL"]))
+    dataset = _project(covariance, basis_operator, h).to_dataset()
+    dataset = dataset.assign_coords(site_cov=("observation_cov", dataset.coords["site_cov"].values[::-1]))
+
+    with pytest.raises(ValueError, match="column.*labels are inconsistent"):
+        NativeCovarianceProducts.from_dataset(dataset)
+
+
+def test_product_round_trip_allows_native_dimension_named_like_observation_column() -> None:
+    """Loader derives the same collision-safe observation column name as construction."""
+    covariance, _, h, _ = _problem()
+    longitude = covariance.longitude.rename({"lon": "observation_cov"})
+    renamed_covariance = SeparableExponentialCovariance(
+        covariance.latitude,
+        longitude,
+        sigma=covariance.sigma,
+        correlation_length=covariance.correlation_length,
+    )
+    basis = BucketBasisOperator(
+        xr.DataArray(
+            [[1, 1], [1, 2], [2, 2]],
+            dims=("lat", "observation_cov"),
+            coords={"lat": covariance.latitude, "observation_cov": longitude},
+        ),
+        meta=BasisMeta(grid_dims=("lat", "observation_cov"), state_dim="state"),
+    )
+    products = _project(
+        renamed_covariance,
+        basis,
+        h.rename({"lon": "observation_cov"}),
+    )
+
+    restored = NativeCovarianceProducts.from_dataset(products.to_dataset())
+
+    assert restored.native_observation_covariance.dims == (
+        "observation",
+        "observation_cov_2",
+    )
+
+
+@pytest.mark.parametrize("invalid_value", [np.nan, 1.0j])
+def test_product_deserialization_rejects_non_finite_or_complex_values(
+    invalid_value: complex,
+) -> None:
+    """Loaded numerical products retain the construction-time finite-real contract."""
+    covariance, basis_operator, h, _ = _problem()
+    dataset = _project(covariance, basis_operator, h).to_dataset()
+    dataset["effective_observation_operator"] = dataset["effective_observation_operator"].astype(
+        np.result_type(invalid_value)
+    )
+    dataset["effective_observation_operator"].values[0, 0] = invalid_value
+
+    with pytest.raises(ValueError, match="finite real"):
+        NativeCovarianceProducts.from_dataset(dataset)
+
+
+def test_product_deserialization_rejects_forged_coordinate_namespace_owner() -> None:
+    """Namespace metadata cannot claim coordinates for unknown product owners."""
+    covariance, basis_operator, h, _ = _problem()
+    dataset = _project(covariance, basis_operator, h).to_dataset()
+    namespaces = json.loads(dataset.attrs["openghg_inversions:product_coordinate_namespaces"])
+    namespaces["forged"] = {"observation": "removed"}
+    dataset.attrs["openghg_inversions:product_coordinate_namespaces"] = json.dumps(namespaces)
+
+    with pytest.raises(ValueError, match="namespace owners"):
+        NativeCovarianceProducts.from_dataset(dataset)
+
+
+@pytest.mark.parametrize(
+    "encoded_provenance",
+    [None, "not-json", "[]", '{"operator_type": 1}'],
+)
+def test_product_deserialization_validates_basis_provenance_shape(
+    encoded_provenance: object,
+) -> None:
+    """Basis provenance must be a JSON encoding of a string-to-string mapping."""
+    covariance, basis_operator, h, _ = _problem()
+    dataset = _project(covariance, basis_operator, h).to_dataset()
+    dataset.attrs["basis_provenance"] = encoded_provenance
+
+    with pytest.raises(ValueError, match="basis provenance"):
+        NativeCovarianceProducts.from_dataset(dataset)
+
+
+def test_product_identity_metadata_is_not_a_numerical_checksum() -> None:
+    """Identity metadata binds source/view declarations but does not checksum output values."""
+    covariance, basis_operator, h, _ = _problem()
+    dataset = _project(covariance, basis_operator, h).to_dataset()
+    dataset["state_covariance"].values[0, 0] += 1.0
+
+    restored = NativeCovarianceProducts.from_dataset(dataset)
+
+    assert restored.state_covariance.values[0, 0] == dataset["state_covariance"].values[0, 0]
+
+
+def test_datatree_rejects_covariance_configuration_from_another_source() -> None:
+    """A covariance configuration child cannot be mixed into another source artifact."""
+    covariance, basis_operator, h, _ = _problem()
+    baseline_tree = _project(covariance, basis_operator, h).to_datatree()
+    other_covariance = SeparableExponentialCovariance(
+        covariance.latitude,
+        covariance.longitude,
+        sigma=2.0,
+        correlation_length=covariance.correlation_length,
+    )
+    other_tree = _project(other_covariance, basis_operator, h).to_datatree()
+    baseline_tree["covariance_configuration"] = xr.DataTree(
+        cast(xr.DataTree, other_tree["covariance_configuration"]).to_dataset(inherit=False).copy(deep=True)
+    )
+
+    with pytest.raises(ValueError, match="configuration.*root source identity"):
+        NativeCovarianceProducts.from_datatree(baseline_tree)
+
+
+def test_datatree_rejects_tampered_covariance_configuration_content() -> None:
+    """Configuration content is recomputed and checked against its bound root digest."""
+    covariance, basis_operator, h, _ = _problem()
+    tree = _project(covariance, basis_operator, h).to_datatree()
+    child = cast(xr.DataTree, tree["covariance_configuration"]).to_dataset(inherit=False).copy(deep=True)
+    latitude_dim = "covariance_configuration__lat"
+    child = child.assign_coords({latitude_dim: child.coords[latitude_dim] + 0.25})
+    tree["covariance_configuration"] = xr.DataTree(child)
+
+    with pytest.raises(ValueError, match="configuration content.*digest"):
+        NativeCovarianceProducts.from_datatree(tree)
+
+
+def test_projection_strategy_must_return_covariance_natural_prolongation() -> None:
+    """Custom strategies cannot return a Pi/U pair that violates B Pi.T = U C_alpha."""
+    covariance, basis_operator, h, _ = _problem()
+
+    class IncoherentStrategy:
+        """Perturb an otherwise compatible prolongation to violate the invariant."""
+
+        def projection(self, covariance, basis_prolongation, *, native_dims, state_dim):
+            """Return a deliberately incoherent restriction/prolongation pair."""
+            valid = PreserveBucketProlongation().projection(
+                covariance,
+                basis_prolongation,
+                native_dims=native_dims,
+                state_dim=state_dim,
+            )
+            return RetainedProjection(valid.restriction, 2.0 * valid.prolongation, "incoherent")
+
+    for sigma in (covariance.sigma, 1e-8):
+        scaled = SeparableExponentialCovariance(
+            covariance.latitude,
+            covariance.longitude,
+            sigma=sigma,
+            correlation_length=covariance.correlation_length,
+        )
+        with pytest.raises(ValueError, match="incoherent|B Pi"):
+            _project(scaled, basis_operator, h, strategy=IncoherentStrategy())
+
+
+def test_projection_strategy_protocol_accepts_structural_implementations() -> None:
+    """A compatible strategy is accepted without inheriting from the public protocol."""
+    covariance, basis_operator, h, _ = _problem()
+
+    class DelegatingStrategy:
+        """Delegate projection construction while exposing a distinct strategy name."""
+
+        def projection(self, covariance, basis_prolongation, *, native_dims, state_dim):
+            """Return a coherent projection using the established bucket strategy."""
+            projection = PreserveBucketProlongation().projection(
+                covariance,
+                basis_prolongation,
+                native_dims=native_dims,
+                state_dim=state_dim,
+            )
+            return RetainedProjection(
+                projection.restriction,
+                projection.prolongation,
+                "delegating_strategy",
+            )
+
+    strategy: RetainedProjectionStrategy = DelegatingStrategy()
+
+    products = _project(covariance, basis_operator, h, strategy=strategy)
+
+    assert products.strategy == "delegating_strategy"
+
+
+def test_projection_strategy_names_must_be_nonempty() -> None:
+    """Empty built-in and custom identifiers are rejected before serialization."""
+    covariance, basis_operator, h, _ = _problem()
+
+    with pytest.raises(ValueError, match="non-empty"):
+        PreserveBucketProlongation(name="")
+
+    class EmptyNameStrategy:
+        """Delegate a valid projection but remove its stable identifier."""
+
+        def projection(self, covariance, basis_prolongation, *, native_dims, state_dim):
+            """Return a coherent projection with an invalid empty name."""
+            valid = PreserveBucketProlongation().projection(
+                covariance,
+                basis_prolongation,
+                native_dims=native_dims,
+                state_dim=state_dim,
+            )
+            return RetainedProjection(valid.restriction, valid.prolongation, "")
+
+    with pytest.raises(ValueError, match="non-empty"):
+        _project(covariance, basis_operator, h, strategy=EmptyNameStrategy())
+
+
+@pytest.mark.parametrize("role", ["restriction", "prolongation"])
+def test_projection_strategy_rejects_complex_arrays(role: str) -> None:
+    """Projection products use real covariance algebra and reject complex strategy arrays."""
+    covariance, basis_operator, h, _ = _problem()
+
+    class ComplexStrategy:
+        """Add an imaginary component to one otherwise valid projection array."""
+
+        def projection(self, covariance, basis_prolongation, *, native_dims, state_dim):
+            """Return a deliberately complex restriction or prolongation."""
+            valid = PreserveBucketProlongation().projection(
+                covariance,
+                basis_prolongation,
+                native_dims=native_dims,
+                state_dim=state_dim,
+            )
+            restriction = valid.restriction
+            prolongation = valid.prolongation
+            if role == "restriction":
+                restriction = restriction.astype(complex) + 1j
+            else:
+                prolongation = prolongation.astype(complex) + 1j
+            return RetainedProjection(restriction, prolongation, "complex")
+
+    with pytest.raises(ValueError, match="finite real"):
+        _project(covariance, basis_operator, h, strategy=ComplexStrategy())
+
+
+@pytest.mark.parametrize("role", ["restriction", "prolongation"])
+@pytest.mark.parametrize("coordinate_change", ["mismatch", "reordered", "empty-intersection"])
+def test_custom_projection_requires_exact_native_coordinates(
+    role: str,
+    coordinate_change: str,
+) -> None:
+    """Custom Pi and U native labels must match before product alignment or contraction."""
+    covariance, basis_operator, h, _ = _problem()
+
+    class RelabelledStrategy:
+        """Relabel one projection array to exercise strict native-coordinate checks."""
+
+        def projection(self, covariance, basis_prolongation, *, native_dims, state_dim):
+            """Return a coherent numeric pair with deliberately invalid latitude labels."""
+            valid = PreserveBucketProlongation().projection(
+                covariance,
+                basis_prolongation,
+                native_dims=native_dims,
+                state_dim=state_dim,
+            )
+            latitude = valid.restriction.coords["lat"].values
+            if coordinate_change == "reordered":
+                invalid_latitude = latitude[::-1]
+            elif coordinate_change == "empty-intersection":
+                invalid_latitude = latitude + 1000.0
+            else:
+                invalid_latitude = latitude + 0.25
+            restriction = valid.restriction
+            prolongation = valid.prolongation
+            if role == "restriction":
+                restriction = restriction.assign_coords(lat=invalid_latitude)
+            else:
+                prolongation = prolongation.assign_coords(lat=invalid_latitude)
+            return RetainedProjection(restriction, prolongation, "relabeled")
+
+    with pytest.raises(ValueError, match=r"native coordinate 'lat'.*exactly match"):
+        _project(covariance, basis_operator, h, strategy=RelabelledStrategy())
+
+
+def test_projection_strategy_must_return_full_rank_restriction() -> None:
+    """A formally compatible zero Pi/U pair is rejected because C_alpha is singular."""
+    covariance, basis_operator, h, _ = _problem()
+
+    class SingularStrategy:
+        """Return a zero restriction and prolongation with the expected dimensions."""
+
+        def projection(self, covariance, basis_prolongation, *, native_dims, state_dim):
+            """Return a deliberately singular retained projection."""
+            return RetainedProjection(
+                xr.zeros_like(basis_prolongation.transpose(state_dim, *native_dims)),
+                xr.zeros_like(basis_prolongation),
+                "singular",
+            )
+
+    with pytest.raises(ValueError, match="empty retained state|positive definite|full rank"):
+        _project(covariance, basis_operator, h, strategy=SingularStrategy())
+
+
+def test_source_content_identity_includes_auxiliary_semantic_coordinates() -> None:
+    """Relabelling an auxiliary observation coordinate changes the source identity."""
+    covariance, basis_operator, h, _ = _problem()
+    first = _project(
+        covariance,
+        basis_operator,
+        h.assign_coords(network=("observation", ["ICOS", "DECC", "DECC"])),
+    )
+    second = _project(
+        covariance,
+        basis_operator,
+        h.assign_coords(network=("observation", ["DECC", "DECC", "DECC"])),
+    )
+
+    assert first.source_content_identity != second.source_content_identity
+
+
+def test_redundant_bucket_states_are_rejected() -> None:
+    """Linearly dependent retained coordinates fail instead of being pseudoinverted."""
+    covariance, basis_operator, _, _ = _problem()
+    prolongation = basis_operator.basis_matrix.compute()
+    redundant = xr.concat(
+        [
+            prolongation.sel(state=0),
+            prolongation.sel(state=0),
+        ],
+        dim=xr.IndexVariable("state", ["west", "west-copy"]),
+    ).transpose("lat", "lon", "state")
+
+    with pytest.raises(ValueError, match="positive definite|redundant|rank"):
+        PreserveBucketProlongation().projection(
+            covariance,
+            redundant,
+            native_dims=covariance.native_dims,
+            state_dim="state",
+        )
+
+
+@pytest.mark.parametrize(
+    ("transform", "message"),
+    [
+        pytest.param(
+            lambda h: h.assign_coords(lon=h.lon[::-1]),
+            "coordinate|align|longitude|lon",
+            id="misordered-native-coordinate",
+        ),
+        pytest.param(
+            lambda h: h.where(h.observation != "TAC-1"),
+            "finite|NaN",
+            id="non-finite-sensitivity",
+        ),
+        pytest.param(
+            lambda h: h.astype(complex) + 1j,
+            "finite real",
+            id="complex-sensitivity",
+        ),
+    ],
+)
+def test_products_reject_invalid_native_sensitivity(transform, message: str) -> None:
+    """Product construction rejects misaligned or non-finite native sensitivity."""
+    covariance, basis_operator, h, _ = _problem()
+
+    with pytest.raises(ValueError, match=message):
+        _project(covariance, basis_operator, transform(h))
+
+
+def test_class_blocked_products_match_dense_oracle() -> None:
+    """The compatible restriction and all products remain coherent with class masks."""
+    covariance, basis_operator, h, dense_unblocked = _problem()
+    labels = xr.DataArray(
+        [["land", "sea"], ["land", "sea"], ["sea", "sea"]],
+        dims=("lat", "lon"),
+        coords={"lat": covariance.latitude, "lon": covariance.longitude},
+    )
+    covariance = SeparableExponentialCovariance(
+        covariance.latitude,
+        covariance.longitude,
+        sigma=covariance.sigma,
+        correlation_length=covariance.correlation_length,
+        class_labels=labels,
+    )
+    flat_labels = labels.values.reshape(-1)
+    dense_b = dense_unblocked * (flat_labels[:, None] == flat_labels[None, :])
+    u, expected_pi, expected_c = _dense_operators(basis_operator, dense_b)
+    h_matrix = h.values.reshape(3, 6)
+
+    products = _project(covariance, basis_operator, h)
+
+    np.testing.assert_allclose(products.restriction.values.reshape(2, 6), expected_pi, atol=2e-10)
+    np.testing.assert_allclose(products.state_covariance, expected_c, atol=2e-10)
+    np.testing.assert_allclose(products.effective_observation_operator, h_matrix @ u, atol=2e-10)
+    np.testing.assert_allclose(
+        products.observation_state_cross_covariance,
+        h_matrix @ dense_b @ expected_pi.T,
+        atol=2e-10,
+    )
+    np.testing.assert_allclose(
+        products.native_observation_covariance,
+        h_matrix @ dense_b @ h_matrix.T,
+        atol=2e-10,
+    )
+
+
+def test_datetime_multiindex_observation_labels_persist_on_both_matrix_axes(
+    tmp_path: Path,
+) -> None:
+    """Real Timestamp MultiIndex labels encode safely and persist through NetCDF."""
+    covariance, basis_operator, h, _ = _problem()
+    dates = pd.to_datetime(["2020-01-01", "2020-01-02", "2020-01-03"])
+    observation_index = pd.MultiIndex.from_arrays(
+        [["MHD", "TAC", "RGL"], dates],
+        names=("site", "date"),
+    )
+    h = h.drop_indexes("observation").drop_vars("observation")
+    h = h.assign_coords(xr.Coordinates.from_pandas_multiindex(observation_index, "observation"))
+
+    products = _project(covariance, basis_operator, h)
+
+    assert products.native_observation_covariance.coords["site"].values.tolist() == [
+        "MHD",
+        "TAC",
+        "RGL",
+    ]
+    assert products.native_observation_covariance.coords["site_cov"].values.tolist() == [
+        "MHD",
+        "TAC",
+        "RGL",
+    ]
+    np.testing.assert_array_equal(
+        products.native_observation_covariance.coords["date_cov"].values,
+        dates.values,
+    )
+    assert products.native_observation_covariance.coords["observation_cov"].values.tolist() == [
+        '["MHD","2020-01-01T00:00:00"]',
+        '["TAC","2020-01-02T00:00:00"]',
+        '["RGL","2020-01-03T00:00:00"]',
+    ]
+
+    path = tmp_path / "datetime-multiindex-products.nc"
+    products.to_datatree().to_netcdf(path, engine="h5netcdf")
+    with xr.open_datatree(path, engine="h5netcdf") as stored:
+        restored = NativeCovarianceProducts.from_datatree(stored.load())
+
+    restored_index = restored.native_observation_covariance.indexes["observation"]
+    assert isinstance(restored_index, pd.MultiIndex)
+    assert restored_index.equals(observation_index)
+    np.testing.assert_array_equal(
+        restored.native_observation_covariance.coords["observation_cov"].values,
+        products.native_observation_covariance.coords["observation_cov"].values,
+    )

--- a/tests/test_source_covariance.py
+++ b/tests/test_source_covariance.py
@@ -389,3 +389,20 @@ def test_multisource_native_prolongation_requires_canonical_source_order() -> No
 
     with pytest.raises(ValueError, match="source|coordinate|align|order"):
         basis.native_prolongation(reordered, native_dims=covariance.native_dims)
+
+
+def test_multisource_native_prolongation_rejects_source_dimension_level_collision() -> None:
+    """A native source dimension cannot reuse the gathered state source-level name."""
+    covariance, native_sensitivity = _problem()
+    colliding_covariance = IndependentSourceCovariance(
+        covariance.source_covariances,
+        source_dim="source",
+    )
+    colliding_sensitivity = native_sensitivity.rename(native_source="source")
+    basis = _basis(covariance)
+
+    with pytest.raises(ValueError, match="source.*dimension|MultiIndex|level|collision"):
+        basis.native_prolongation(
+            colliding_sensitivity,
+            native_dims=colliding_covariance.native_dims,
+        )

--- a/tests/test_source_covariance.py
+++ b/tests/test_source_covariance.py
@@ -1,12 +1,19 @@
 """Tests for ordered independent-source native covariance blocks."""
 
 from dataclasses import is_dataclass
+from pathlib import Path
 from typing import cast
 
 import numpy as np
+import pandas as pd
 import pytest
 import xarray as xr
 
+from openghg_inversions.basis.covariance_products import (
+    NativeCovarianceProducts,
+    project_native_covariance,
+)
+from openghg_inversions.basis.operators import MultiSourceBucketBasisOperator
 from openghg_inversions.native_covariance import SeparableExponentialCovariance
 from openghg_inversions.source_covariance import IndependentSourceCovariance
 
@@ -66,6 +73,28 @@ def _dense_block_diagonal(covariance: IndependentSourceCovariance) -> np.ndarray
         result[offset:stop, offset:stop] = block
         offset = stop
     return result
+
+
+def _basis(covariance: IndependentSourceCovariance) -> MultiSourceBucketBasisOperator:
+    """Construct the gathered bucket basis used only by Slice C product tests."""
+    component = covariance.source_covariances["z-source"]
+    latitude = component.latitude
+    longitude = component.longitude
+    return MultiSourceBucketBasisOperator(
+        {
+            "z-source": xr.DataArray(
+                [[1, 1], [2, 2]],
+                dims=("lat", "lon"),
+                coords={"lat": latitude, "lon": longitude},
+            ),
+            "a-source": xr.DataArray(
+                [[1, 1], [1, 1]],
+                dims=("lat", "lon"),
+                coords={"lat": latitude, "lon": longitude},
+            ),
+        },
+        state_dim="state",
+    )
 
 
 def test_independent_source_action_and_serialization_preserve_order() -> None:
@@ -277,3 +306,115 @@ def test_deserialization_rejects_contradictory_source_blocked_state() -> None:
 
     with pytest.raises(ValueError, match="contradicts"):
         IndependentSourceCovariance.from_dataset(dataset)
+
+
+def test_gathered_source_products_match_block_diagonal_dense_oracle() -> None:
+    """Ragged source states keep insertion order and zero cross-source covariance."""
+    covariance, native_sensitivity = _problem()
+    basis = _basis(covariance)
+    products = project_native_covariance(
+        covariance=covariance,
+        basis_operator=basis,
+        native_sensitivity=native_sensitivity,
+        observation_dim="observation",
+        observation_batch_size=1,
+    )
+    dense_b = _dense_block_diagonal(covariance)
+    h = native_sensitivity.values.reshape(3, 8)
+
+    base = basis.basis_matrix.transpose("lat", "lon", "state").compute()
+    base_values = np.asarray(base.data.todense())
+    state_sources = np.asarray(base.coords["source"].values)
+    u = np.zeros((2, 2, 2, base.sizes["state"]))
+    for source_index, source in enumerate(covariance.source_labels):
+        u[source_index] = base_values * (state_sources == source)[None, None, :]
+    u = u.reshape(8, base.sizes["state"])
+    c_alpha = np.linalg.inv(u.T @ np.linalg.solve(dense_b, u))
+    pi = c_alpha @ np.linalg.solve(dense_b, u).T
+
+    assert products.state_covariance.coords["source"].values.tolist() == [
+        "z-source",
+        "z-source",
+        "a-source",
+    ]
+    np.testing.assert_allclose(products.restriction.values.reshape(3, 8), pi, atol=1e-11)
+    np.testing.assert_allclose(products.state_covariance, c_alpha, atol=1e-11)
+    np.testing.assert_allclose(products.effective_observation_operator, h @ u, atol=1e-11)
+    np.testing.assert_allclose(
+        products.observation_state_cross_covariance,
+        h @ dense_b @ pi.T,
+        atol=1e-11,
+    )
+    np.testing.assert_allclose(products.native_observation_covariance, h @ dense_b @ h.T, atol=1e-11)
+    np.testing.assert_allclose(pi @ u, np.eye(3), atol=1e-11)
+
+
+def test_gathered_source_product_datatree_persists_multiindex(tmp_path: Path) -> None:
+    """Ragged state labels and covariance configuration survive NetCDF persistence."""
+    covariance, native_sensitivity = _problem()
+    observation_index = pd.MultiIndex.from_arrays(
+        [["observed-a", "observed-b", "observed-c"], [1, 2, 3]],
+        names=("source", "observation_id"),
+    )
+    native_sensitivity = native_sensitivity.drop_indexes("observation").drop_vars("observation")
+    native_sensitivity = native_sensitivity.assign_coords(
+        xr.Coordinates.from_pandas_multiindex(observation_index, "observation")
+    )
+    native_sensitivity = native_sensitivity.assign_coords(
+        source_cov=("observation", ["aux-a", "aux-b", "aux-c"])
+    )
+    products = project_native_covariance(
+        covariance=covariance,
+        basis_operator=_basis(covariance),
+        native_sensitivity=native_sensitivity,
+        observation_dim="observation",
+    )
+    path = tmp_path / "source-products.nc"
+
+    products.to_datatree().to_netcdf(path, engine="h5netcdf")
+    with xr.open_datatree(path, engine="h5netcdf") as stored:
+        restored = NativeCovarianceProducts.from_datatree(stored.load())
+
+    assert restored.state_covariance.coords["source"].values.tolist() == [
+        "z-source",
+        "z-source",
+        "a-source",
+    ]
+    assert restored.covariance_configuration is not None
+    assert products.covariance_configuration is not None
+    xr.testing.assert_identical(restored.covariance_configuration, products.covariance_configuration)
+    xr.testing.assert_allclose(restored.state_covariance, products.state_covariance)
+    np.testing.assert_array_equal(
+        restored.native_observation_covariance.coords["observation_source"],
+        native_sensitivity.coords["source"],
+    )
+    np.testing.assert_array_equal(
+        restored.native_observation_covariance.coords["observation_source_cov"],
+        native_sensitivity.coords["source_cov"],
+    )
+    assert restored.native_observation_covariance.indexes["observation"].names == [
+        "observation_source",
+        "observation_id",
+    ]
+
+
+def test_gathered_source_product_requires_multiindex_restoration_metadata() -> None:
+    """Expanded ragged-state coordinates cannot load silently as a plain index."""
+    from openghg_inversions.serialization import MULTIINDEX_DIMS_ATTR
+
+    covariance, native_sensitivity = _problem()
+    tree = project_native_covariance(
+        covariance=covariance,
+        basis_operator=_basis(covariance),
+        native_sensitivity=native_sensitivity,
+        observation_dim="observation",
+    ).to_datatree()
+    root = tree.to_dataset(inherit=False).copy(deep=True)
+    root.attrs.pop(MULTIINDEX_DIMS_ATTR)
+    malformed = xr.DataTree(root)
+    malformed["covariance_configuration"] = xr.DataTree(
+        cast(xr.DataTree, tree["covariance_configuration"]).to_dataset(inherit=False).copy(deep=True)
+    )
+
+    with pytest.raises(ValueError, match="restore MultiIndex"):
+        NativeCovarianceProducts.from_datatree(malformed)

--- a/tests/test_source_covariance.py
+++ b/tests/test_source_covariance.py
@@ -1,19 +1,15 @@
 """Tests for ordered independent-source native covariance blocks."""
 
 from dataclasses import is_dataclass
-from pathlib import Path
 from typing import cast
 
 import numpy as np
-import pandas as pd
 import pytest
 import xarray as xr
 
-from openghg_inversions.basis.covariance_products import (
-    NativeCovarianceProducts,
-    project_native_covariance,
-)
+from openghg_inversions.basis.covariance_products import project_native_covariance
 from openghg_inversions.basis.operators import MultiSourceBucketBasisOperator
+from openghg_inversions.array_ops import to_dense
 from openghg_inversions.native_covariance import SeparableExponentialCovariance
 from openghg_inversions.source_covariance import IndependentSourceCovariance
 
@@ -312,9 +308,16 @@ def test_gathered_source_products_match_block_diagonal_dense_oracle() -> None:
     """Ragged source states keep insertion order and zero cross-source covariance."""
     covariance, native_sensitivity = _problem()
     basis = _basis(covariance)
+    basis_prolongation = to_dense(
+        basis.native_prolongation(
+            native_sensitivity,
+            native_dims=covariance.native_dims,
+        )
+    ).compute()
     products = project_native_covariance(
         covariance=covariance,
-        basis_operator=basis,
+        basis_prolongation=basis_prolongation,
+        state_dim=basis.meta.state_dim,
         native_sensitivity=native_sensitivity,
         observation_dim="observation",
         observation_batch_size=1,
@@ -349,72 +352,40 @@ def test_gathered_source_products_match_block_diagonal_dense_oracle() -> None:
     np.testing.assert_allclose(pi @ u, np.eye(3), atol=1e-11)
 
 
-def test_gathered_source_product_datatree_persists_multiindex(tmp_path: Path) -> None:
-    """Ragged state labels and covariance configuration survive NetCDF persistence."""
+def test_multisource_native_prolongation_preserves_native_auxiliary_coordinates() -> None:
+    """Canonical gathered U retains source, spatial, state, and scalar metadata."""
     covariance, native_sensitivity = _problem()
-    observation_index = pd.MultiIndex.from_arrays(
-        [["observed-a", "observed-b", "observed-c"], [1, 2, 3]],
-        names=("source", "observation_id"),
+    basis = _basis(covariance)
+    native_layout = native_sensitivity.assign_coords(
+        inventory=("native_source", ["EDGAR", "GFAS"]),
+        cell_area=(
+            ("native_source", "lat", "lon"),
+            np.arange(8).reshape(2, 2, 2),
+        ),
+        grid_mapping="latitude_longitude",
     )
-    native_sensitivity = native_sensitivity.drop_indexes("observation").drop_vars("observation")
-    native_sensitivity = native_sensitivity.assign_coords(
-        xr.Coordinates.from_pandas_multiindex(observation_index, "observation")
-    )
-    native_sensitivity = native_sensitivity.assign_coords(
-        source_cov=("observation", ["aux-a", "aux-b", "aux-c"])
-    )
-    products = project_native_covariance(
-        covariance=covariance,
-        basis_operator=_basis(covariance),
-        native_sensitivity=native_sensitivity,
-        observation_dim="observation",
-    )
-    path = tmp_path / "source-products.nc"
 
-    products.to_datatree().to_netcdf(path, engine="h5netcdf")
-    with xr.open_datatree(path, engine="h5netcdf") as stored:
-        restored = NativeCovarianceProducts.from_datatree(stored.load())
+    prolongation = basis.native_prolongation(
+        native_layout,
+        native_dims=covariance.native_dims,
+    )
 
-    assert restored.state_covariance.coords["source"].values.tolist() == [
+    assert prolongation.dims == ("native_source", "lat", "lon", "state")
+    xr.testing.assert_identical(prolongation.coords["inventory"], native_layout.coords["inventory"])
+    xr.testing.assert_identical(prolongation.coords["cell_area"], native_layout.coords["cell_area"])
+    assert prolongation.coords["grid_mapping"].item() == "latitude_longitude"
+    assert prolongation.coords["source"].values.tolist() == [
         "z-source",
         "z-source",
         "a-source",
     ]
-    assert restored.covariance_configuration is not None
-    assert products.covariance_configuration is not None
-    xr.testing.assert_identical(restored.covariance_configuration, products.covariance_configuration)
-    xr.testing.assert_allclose(restored.state_covariance, products.state_covariance)
-    np.testing.assert_array_equal(
-        restored.native_observation_covariance.coords["observation_source"],
-        native_sensitivity.coords["source"],
-    )
-    np.testing.assert_array_equal(
-        restored.native_observation_covariance.coords["observation_source_cov"],
-        native_sensitivity.coords["source_cov"],
-    )
-    assert restored.native_observation_covariance.indexes["observation"].names == [
-        "observation_source",
-        "observation_id",
-    ]
 
 
-def test_gathered_source_product_requires_multiindex_restoration_metadata() -> None:
-    """Expanded ragged-state coordinates cannot load silently as a plain index."""
-    from openghg_inversions.serialization import MULTIINDEX_DIMS_ATTR
-
+def test_multisource_native_prolongation_requires_canonical_source_order() -> None:
+    """Canonical gathered U rejects a native layout with reordered source labels."""
     covariance, native_sensitivity = _problem()
-    tree = project_native_covariance(
-        covariance=covariance,
-        basis_operator=_basis(covariance),
-        native_sensitivity=native_sensitivity,
-        observation_dim="observation",
-    ).to_datatree()
-    root = tree.to_dataset(inherit=False).copy(deep=True)
-    root.attrs.pop(MULTIINDEX_DIMS_ATTR)
-    malformed = xr.DataTree(root)
-    malformed["covariance_configuration"] = xr.DataTree(
-        cast(xr.DataTree, tree["covariance_configuration"]).to_dataset(inherit=False).copy(deep=True)
-    )
+    basis = _basis(covariance)
+    reordered = native_sensitivity.isel(native_source=[1, 0])
 
-    with pytest.raises(ValueError, match="restore MultiIndex"):
-        NativeCovarianceProducts.from_datatree(malformed)
+    with pytest.raises(ValueError, match="source|coordinate|align|order"):
+        basis.native_prolongation(reordered, native_dims=covariance.native_dims)


### PR DESCRIPTION
## Stack

1. [#581 — Slice A: no-class separable native covariance](https://github.com/openghg/openghg_inversions/pull/581)
2. [#582 — Slice B: class/source covariance and serialization](https://github.com/openghg/openghg_inversions/pull/582)
3. **This PR — Slice C:** retained projection and covariance-product artifacts

Base: `codex/ope-32-b-class-source-covariance`. Review only the changes after #582.

## Summary of changes

- add the retained-projection strategy protocol and bucket-preserving covariance-compatible restriction
- compute labelled `C_alpha`, `H U_*`, `H B Pi.T`, and dense/diagonal `H B H.T` without constructing dense native `B`
- add source/view/configuration identities and DataTree/NetCDF persistence
- harden product loading against malformed shapes, labels, views, namespace metadata, complex/non-finite values, and missing MultiIndexes
- make observation/state coordinate namespaces collision-safe, including shared MultiIndex level names
- document `Pi`, `U_*`, `U_bucket`, centring, batching, persistence, and the downstream OPE-18 boundary
- add the integrated usage guide and CHANGELOG entry

This is Slice C of [OPE-32](https://linear.app/openghg-inversions/issue/OPE-32/split-ope-17-pr-578-into-a-stacked-pr-series), completing the stacked delivery of [OPE-17](https://linear.app/openghg-inversions/issue/OPE-17/foundation-labelled-native-covariance-actions-and-product-blocks). Together #581 → #582 → this PR supersede draft #578.

## Production evidence and review context

The mathematical and production discussion remains recorded on #578 and GitHub #528. Verification-games commit [b976de2](https://github.com/openghg/verification-games/commit/b976de23e11a77d1708fe89ae26acefd8d919705) exercised the public strategy seam at original revision `946db07` across all 361 retained states and 14 sites, with worst OGI/VG product relative Frobenius difference `5.44e-16`. It also established that supplied physical `Pi` is production-capable while the bucket-first default is not production-equivalent; the supplied-`Pi` concrete strategy remains follow-up OPE-31.

Restacked onto the #581/#582 borrowed-marker adoption with no Slice C ownership changes; the OPE-38 and OPE-17 changelog entries are both preserved. Independent code, correctness, architecture, and scientific-array reviews were run slice-by-slice. C follow-up review drove collision-safe MultiIndex construction/serialization, finite-real enforcement, strong row/column binding, namespace-owner validation, configuration digest strengthening, and complex-input rejection.

## Validation

- cumulative OPE-32 suite — 104 passed
- Ruff — passed
- Pyright covariance modules — 0 errors
- `git diff --check` — passed
- `tox -e docs` — passed with existing repository warnings
- borrowed-reference Pyright/Mypy probes — 4 passed
- final `tox -p --parallel-no-spinner` — current OpenGHG integration, borrowed types, and lint passed

## Checklist

- [ ] Closes a GitHub issue — tracked in Linear as OPE-32/OPE-17
- [x] Tests added and passing
- [x] Documentation and tutorials updated/added
- [x] Added an entry to `CHANGELOG.md`
- [x] No new requirements
