### PR TITLE
Add experimental borrowed array type markers

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -97,12 +97,32 @@ jobs:
       - name: Run lint
         run: tox -e lint
 
+  borrowed-types:
+    name: Verify borrowed-reference typing
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+          enable-cache: true
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install tox
+        run: uv tool install tox --with tox-uv
+      - name: Verify Pyright and Mypy diagnostics
+        run: tox -e borrowed-types
+
   # Stable job name for branch-protection required-check rules.
   # Use "CI Gate" as the required check name instead of brittle matrix-expanded names.
   ci-gate:
     name: CI Gate
     runs-on: ubuntu-latest
-    needs: [test, lint]
+    needs: [test, lint, borrowed-types]
     if: ${{ always() }}
     permissions: {}
     steps:
@@ -116,4 +136,8 @@ jobs:
             echo "Lint job failed, was cancelled, or was skipped (result: ${{ needs.lint.result }})."
             exit 1
           fi
-          echo "All tests and lint checks passed."
+          if [ "${{ needs.borrowed-types.result }}" != "success" ]; then
+            echo "Borrowed-reference typing failed, was cancelled, or was skipped (result: ${{ needs.borrowed-types.result }})."
+            exit 1
+          fi
+          echo "All tests, lint, and borrowed-reference typing checks passed."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ default full set:
 
 ```bash
 tox -e py310-openghgCur -- tests/test_array_ops.py
+tox -e borrowed-types
 tox -e lint
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ## Code changes
 
+- Added experimental static borrowed-reference markers for NumPy arrays and
+  xarray data arrays. The markers preserve runtime identity and lazy backing
+  while allowing Pyright and Mypy to diagnose selected in-place mutations;
+  they deliberately do not claim runtime immutability. [OPE-38](https://linear.app/openghg-inversions/issue/OPE-38/add-experimental-borrowed-numpyxarray-type-markers)
+
 - Separated basis-group constraints from the algorithms applied within each
   group. The constrained module now owns masks, target allocation, per-group
   dispatch, and global relabelling; partition geometry, steps, policies, and

--- a/docs/plans/numerical_data_ownership_and_execution_boundaries.md
+++ b/docs/plans/numerical_data_ownership_and_execution_boundaries.md
@@ -212,9 +212,29 @@ Python's standard type qualifiers cannot express a deeply read-only
 Use `Final` when non-rebinding is itself useful, not as evidence of array
 immutability. Prefer a narrow behavioral interface over returning a cache-
 sensitive array. Where returning an xarray object is useful, the borrowed-data
-contract, review, and focused tests are more honest than a misleading type
-annotation. A read-only protocol is worth considering only for a genuinely
-small project interface, not as a shadow type for all of xarray.
+contract, review, and focused tests remain the primary safeguards.
+
+`openghg_inversions.borrowed` provides an experimental, type-checker-only
+marker for the narrower case where returning the real NumPy or xarray object is
+useful but mutation through that reference is unsupported. `borrow(value)` is
+an identity operation at runtime: it does not wrap, copy, compute, persist, or
+make the value immutable. Its phantom return types make selected direct
+mutations fail static checking and retain the marker through some aliases.
+Callers can explicitly relinquish the marker by taking a deep copy. This is a
+static capability change, not a promise that a lazy backend has become an
+independent concrete buffer; the snapshot and execution distinctions below
+still apply.
+
+This marker strengthens communication but is not a sound ownership type.
+Existing aliases, untyped code, `Any`, casts, backend-specific accessors, and
+ordinary typed NumPy/xarray parameters can erase the marker. Mutating helper
+APIs such as NumPy's `out=` and operations whose upstream stubs erase
+subclasses can also bypass it. Some materializing operations can instead
+retain the marker conservatively. The module is checked within this repository
+but is not yet advertised as a package-wide PEP 561 typing contract. Keep the
+ordinary ownership docstring, do not use the marker as evidence of runtime
+immutability, and extend its shadow API only when a real borrowed return needs
+the additional coverage.
 
 ### Snapshot and export methods
 

--- a/docs/reference/openghg_inversions.borrowed.rst
+++ b/docs/reference/openghg_inversions.borrowed.rst
@@ -1,0 +1,7 @@
+openghg\_inversions.borrowed
+============================
+
+.. automodule:: openghg_inversions.borrowed
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/reference/openghg_inversions.rst
+++ b/docs/reference/openghg_inversions.rst
@@ -23,6 +23,7 @@ openghg\_inversions
    :maxdepth: 4
 
    openghg_inversions.array_ops
+   openghg_inversions.borrowed
    openghg_inversions.correlated_state
    openghg_inversions.convert
    openghg_inversions.filters

--- a/openghg_inversions/borrowed.py
+++ b/openghg_inversions/borrowed.py
@@ -1,0 +1,276 @@
+"""Experimental static markers for borrowed NumPy and xarray arrays.
+
+The :func:`borrow` helper is an identity function at runtime.  Its overloads
+cast supported arrays to phantom subclasses whose common mutation entry points
+are marked with PEP 702 ``deprecated`` diagnostics.  The diagnostic means
+"mutation is unsupported through this borrowed reference"; the underlying
+object is neither copied nor made read-only.
+
+This is an experimental module without a stability guarantee.  Its deliberately
+narrow public surface consists only of :class:`BorrowedNDArray`,
+:class:`BorrowedDataArray`, and :func:`borrow`.
+
+It deliberately provides a warning aid rather than an immutability claim.
+Static diagnostics can be bypassed by an untyped alias, ``cast``,
+``Any``, widening to an ordinary ``ndarray`` or ``DataArray`` parameter,
+mutating helper APIs (including NumPy ``out=``), NumPy functions whose stubs
+erase subclasses, or xarray escape hatches such as ``coords``, ``variables``,
+``data_vars``, ``attrs``, and ``loc``.
+Mutation through aliases created before :func:`borrow` is also invisible.  The
+``DataArray.data`` marker preserves arbitrary duck-array use through
+``__getattr__``, so slices of that data are currently typed as ``Any`` and are
+another false negative.  NumPy view-producing APIs are only protected when
+their existing annotations preserve ``Self``; not every NumPy operation does.
+Conversely, ``values`` or ``to_numpy`` may materialize an independent buffer
+from a lazy backend, but the experiment conservatively retains the borrowed
+marker because the backend is not represented in the ``DataArray`` type.  A
+deep ``DataArray.copy()`` relinquishes the marker as an explicit mutation-rights
+escape; for lazy and duck-array backends this says nothing about independent
+memory, graph isolation, or computation.
+
+PEP 702 diagnostics are checker configuration, not runtime warnings.  Pyright
+reports explicit calls through ``reportDeprecated``, but version 1.1.408 does
+not report assignment syntax that implicitly calls a deprecated
+``__setitem__``.  The mutation operands therefore also use ``Never`` to make
+direct assignments fail in both Pyright and Mypy.  Mypy recognizes the PEP 702
+annotations but requires the ``deprecated`` optional error code to be enabled.
+The project does not yet publish a package-wide PEP 561 ``py.typed`` marker;
+this experimental contract is enforced in the repository checker environment
+until its coverage and first production uses have been evaluated.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Literal, Protocol, cast, overload
+
+import numpy as np
+import xarray as xr
+
+if TYPE_CHECKING:
+    from typing_extensions import Never, deprecated
+else:
+    Never = Any
+
+    def deprecated(message: str, *, category: None = None) -> Any:
+        """Return a runtime no-op for a type-checker-only PEP 702 marker."""
+
+        def decorator(value: Any) -> Any:
+            return value
+
+        return decorator
+
+
+__all__ = ["BorrowedDataArray", "BorrowedNDArray", "borrow"]
+
+
+class _BorrowedArrayData(Protocol):
+    """Static facade for the arbitrary duck array returned by ``DataArray.data``.
+
+    Attribute access remains ``Any`` so that backend-specific observational
+    APIs stay usable.  Only direct indexed assignment is marked; aliases
+    returned by indexed reads are not tracked.
+    """
+
+    def __getitem__(self, key: Any) -> Any:
+        """Return an item or untracked alias from the underlying duck array."""
+        ...
+
+    @deprecated("Mutation through a borrowed array reference is unsupported", category=None)
+    def __setitem__(self, key: Any, mutation_requires_mutable_copy: Never) -> None:
+        """Mark direct indexed assignment as unsupported."""
+        ...
+
+    def __getattr__(self, name: str) -> Any:
+        """Preserve access to backend-specific observational attributes."""
+        ...
+
+
+class BorrowedNDArray(np.ndarray[Any, Any]):
+    """Type-only NumPy subtype marking common in-place operations.
+
+    Instances returned by :func:`borrow` are ordinary ``numpy.ndarray``
+    objects at runtime.  Do not construct this class or use it for runtime
+    ``isinstance`` checks.
+    """
+
+    __slots__ = ()
+
+    @deprecated("Mutation through a borrowed array reference is unsupported", category=None)
+    def __setitem__(  # type: ignore[override]
+        self, key: Any, mutation_requires_mutable_copy: Never
+    ) -> None:
+        """Mark indexed assignment as unsupported."""
+        super().__setitem__(key, mutation_requires_mutable_copy)
+
+    @deprecated("Mutation through a borrowed array reference is unsupported", category=None)
+    def fill(self, mutation_requires_mutable_copy: Never) -> None:  # type: ignore[override]
+        """Mark in-place filling as unsupported."""
+        super().fill(mutation_requires_mutable_copy)
+
+    @deprecated("Mutation through a borrowed array reference is unsupported", category=None)
+    def __iadd__(  # type: ignore[override,misc]
+        self, mutation_requires_mutable_copy: Never
+    ) -> BorrowedNDArray:
+        """Mark in-place addition as unsupported."""
+        return cast(BorrowedNDArray, super().__iadd__(mutation_requires_mutable_copy))
+
+    @deprecated("Mutation through a borrowed array reference is unsupported", category=None)
+    def partition(self, *args: Any, **kwargs: Any) -> None:
+        """Mark in-place partitioning as unsupported."""
+        super().partition(*args, **kwargs)
+
+    @deprecated("Mutation through a borrowed array reference is unsupported", category=None)
+    def put(self, *args: Any, **kwargs: Any) -> None:
+        """Mark indexed in-place insertion as unsupported."""
+        super().put(*args, **kwargs)
+
+    @deprecated("Mutation through a borrowed array reference is unsupported", category=None)
+    def resize(self, *args: Any, **kwargs: Any) -> None:
+        """Mark in-place resizing as unsupported."""
+        super().resize(*args, **kwargs)
+
+    @deprecated("Mutation through a borrowed array reference is unsupported", category=None)
+    def setfield(self, *args: Any, **kwargs: Any) -> None:
+        """Mark in-place field assignment as unsupported."""
+        super().setfield(*args, **kwargs)
+
+    @deprecated("Mutation through a borrowed array reference is unsupported", category=None)
+    def setflags(self, *args: Any, **kwargs: Any) -> None:
+        """Mark changes to array flags as unsupported."""
+        super().setflags(*args, **kwargs)
+
+    @deprecated("Mutation through a borrowed array reference is unsupported", category=None)
+    def sort(self, *args: Any, **kwargs: Any) -> None:
+        """Mark in-place sorting as unsupported."""
+        super().sort(*args, **kwargs)
+
+    def copy(self, order: Any = "C") -> np.ndarray[Any, Any]:  # type: ignore[override]
+        """Return a mutable independent NumPy array.
+
+        Args:
+            order: Memory-layout order passed to ``numpy.ndarray.copy``.
+
+        Returns:
+            An ordinary mutable NumPy array with independent storage.
+        """
+        return super().copy(order)
+
+
+class BorrowedDataArray(xr.DataArray):
+    """Type-only xarray ``DataArray`` subtype marking common mutations.
+
+    ``values`` and ``to_numpy`` return :class:`BorrowedNDArray` statically.
+    ``data`` returns a narrow duck-array facade that marks direct indexed
+    assignment without assuming a NumPy backend.
+    """
+
+    __slots__ = ()
+
+    @property
+    def data(self) -> _BorrowedArrayData:
+        """Return the exact borrowed NumPy, Dask, or other duck-array backend."""
+        return cast(_BorrowedArrayData, super().data)
+
+    @data.setter
+    @deprecated("Mutation through a borrowed array reference is unsupported", category=None)
+    def data(self, value: Never) -> None:
+        """Mark replacement of underlying duck-array data as unsupported."""
+        self.variable.data = value
+
+    @property  # type: ignore[override]
+    def values(self) -> BorrowedNDArray:
+        """Return NumPy values with a conservative borrowed static marker.
+
+        Xarray may compute or materialize the backend during conversion.
+        """
+        return cast(BorrowedNDArray, super().values)
+
+    @values.setter
+    @deprecated("Mutation through a borrowed array reference is unsupported", category=None)
+    def values(self, value: Never) -> None:
+        """Mark replacement of NumPy values as unsupported."""
+        self.variable.values = value
+
+    def to_numpy(self) -> BorrowedNDArray:
+        """Convert to NumPy while conservatively retaining the borrowed marker.
+
+        Conversion may compute or materialize the backend. Xarray does not
+        promise that the returned NumPy array is an independent copy.
+        """
+        return cast(BorrowedNDArray, super().to_numpy())
+
+    @deprecated("Mutation through a borrowed array reference is unsupported", category=None)
+    def __setitem__(  # type: ignore[override]
+        self, key: Any, mutation_requires_mutable_copy: Never
+    ) -> None:
+        """Mark indexed and coordinate assignment as unsupported."""
+        super().__setitem__(key, mutation_requires_mutable_copy)
+
+    @deprecated("Mutation through a borrowed array reference is unsupported", category=None)
+    def __delitem__(  # type: ignore[override]
+        self, mutation_requires_mutable_copy: Never
+    ) -> None:
+        """Mark coordinate deletion as unsupported."""
+        super().__delitem__(mutation_requires_mutable_copy)
+
+    @deprecated("Mutation through a borrowed array reference is unsupported", category=None)
+    def __iadd__(  # type: ignore[override,misc]
+        self, mutation_requires_mutable_copy: Never
+    ) -> BorrowedDataArray:
+        """Mark in-place addition as unsupported."""
+        return cast(BorrowedDataArray, super().__iadd__(mutation_requires_mutable_copy))
+
+    @overload  # type: ignore[override]
+    def copy(self, deep: Literal[True] = True, data: Any = None) -> xr.DataArray: ...
+
+    @overload
+    def copy(self, deep: Literal[False], data: Any = None) -> BorrowedDataArray: ...
+
+    @overload
+    def copy(self, deep: bool, data: Any = None) -> xr.DataArray | BorrowedDataArray: ...
+
+    def copy(  # type: ignore[override]
+        self, deep: bool = True, data: Any = None
+    ) -> xr.DataArray | BorrowedDataArray:
+        """Relinquish borrowing after a deep copy; retain it if shallow.
+
+        Args:
+            deep: Whether xarray should copy the wrapped data and coordinates.
+            data: Optional replacement data passed through to xarray.
+
+        Returns:
+            An ordinary mutable ``DataArray`` static type when ``deep`` is
+            true, otherwise another borrowed static reference.
+
+        Note:
+        A deep copy returns an ordinary mutable static type but does not promise
+        backend-independent memory or graph isolation for lazy or duck arrays.
+        """
+        return cast(xr.DataArray | BorrowedDataArray, super().copy(deep=deep, data=data))
+
+
+@overload
+def borrow(value: np.ndarray[Any, Any]) -> BorrowedNDArray: ...
+
+
+@overload
+def borrow(value: xr.DataArray) -> BorrowedDataArray: ...
+
+
+def borrow(value: np.ndarray[Any, Any] | xr.DataArray) -> BorrowedNDArray | BorrowedDataArray:
+    """Mark a NumPy or xarray array as borrowed for static checking.
+
+    Args:
+        value: NumPy array or xarray ``DataArray`` whose existing object
+            identity and lazy backend must be preserved.
+
+    Returns:
+        The exact input object with a borrowed static type.  No runtime type is
+        changed.
+
+    Note:
+        This function performs no copy, validation, runtime wrapping, or
+        write-protection.  PEP 702 diagnostics only affect supported static
+        type checkers.
+    """
+    return cast(BorrowedNDArray | BorrowedDataArray, value)

--- a/tests/test_borrowed.py
+++ b/tests/test_borrowed.py
@@ -1,0 +1,82 @@
+"""Runtime tests for experimental borrowed-array static markers."""
+
+import dask.array as da
+import numpy as np
+import xarray as xr
+
+from openghg_inversions.borrowed import BorrowedDataArray, BorrowedNDArray, borrow
+
+
+def test_borrow_numpy_preserves_runtime_identity() -> None:
+    """Borrowing a NumPy array adds only a static marker."""
+    array = np.arange(3)
+
+    borrowed: BorrowedNDArray = borrow(array)
+
+    assert borrowed is array
+    assert type(borrowed) is np.ndarray
+    borrowed[0] = 10  # type: ignore[assignment]
+    assert array[0] == 10
+
+
+def test_borrowed_numpy_copy_is_independent() -> None:
+    """Copying a borrowed NumPy array returns independent mutable data."""
+    array = np.arange(3)
+    borrowed: BorrowedNDArray = borrow(array)
+
+    mutable_copy = borrowed.copy()
+    mutable_copy[0] = 10
+
+    assert type(mutable_copy) is np.ndarray
+    assert not np.shares_memory(mutable_copy, array)
+    assert array[0] == 0
+
+
+def test_borrow_data_array_preserves_runtime_identity() -> None:
+    """Borrowing a DataArray preserves the object and its NumPy buffer."""
+    data = np.arange(3)
+    data_array = xr.DataArray(data, dims="x")
+
+    borrowed: BorrowedDataArray = borrow(data_array)
+
+    assert borrowed is data_array
+    assert type(borrowed) is xr.DataArray
+    assert borrowed.data is data
+
+
+def test_borrowed_data_array_copy_respects_xarray_depth() -> None:
+    """Shallow DataArray copies share data while deep copies are independent."""
+    data_array = xr.DataArray(np.arange(3), dims="x")
+    borrowed: BorrowedDataArray = borrow(data_array)
+
+    shallow_copy = borrowed.copy(deep=False)
+    deep_copy = borrowed.copy(deep=True)
+
+    assert shallow_copy.data is data_array.data
+    assert deep_copy.data is not data_array.data
+
+    deep_copy.data[0] = 10
+    assert data_array.data[0] == 0
+
+
+def test_borrow_dask_data_array_preserves_lazy_graph() -> None:
+    """Borrowing a Dask-backed DataArray neither copies nor rebuilds its graph."""
+    lazy_data = da.arange(6, chunks="auto")
+    data_array = xr.DataArray(lazy_data, dims="x")
+
+    borrowed: BorrowedDataArray = borrow(data_array)
+
+    assert borrowed is data_array
+    assert borrowed.data is lazy_data
+    assert borrowed.data.__dask_graph__() is lazy_data.__dask_graph__()
+
+
+def test_borrowed_dask_data_array_shallow_copy_preserves_graph() -> None:
+    """A shallow DataArray copy preserves the exact lazy backend and graph."""
+    lazy_data = da.arange(6, chunks="auto")
+    borrowed: BorrowedDataArray = borrow(xr.DataArray(lazy_data, dims="x"))
+
+    shallow_copy = borrowed.copy(deep=False)
+
+    assert shallow_copy.data is lazy_data
+    assert shallow_copy.data.__dask_graph__() is lazy_data.__dask_graph__()

--- a/tests/typing/borrowed_negative.py.txt
+++ b/tests/typing/borrowed_negative.py.txt
@@ -1,0 +1,22 @@
+"""Negative static-type probe for borrowed NumPy and xarray arrays."""
+
+import numpy as np
+import xarray as xr
+
+from openghg_inversions.borrowed import borrow
+
+
+borrowed_array = borrow(np.arange(3))
+borrowed_array[0] = 10  # expect-error: ndarray-item
+borrowed_array.fill(10)  # expect-error: ndarray-method
+borrowed_array.sort()  # expect-error: ndarray-deprecated-method
+
+borrowed_data_array = borrow(xr.DataArray(np.arange(3), dims="x"))
+borrowed_data_array[0] = 10  # expect-error: dataarray-item
+borrowed_data_array.values = np.arange(3)  # expect-error: dataarray-values
+borrowed_data_array.values[0] = 10  # expect-error: dataarray-values-item
+borrowed_data_array.data[0] = 10  # expect-error: dataarray-data-item
+borrowed_data_array.to_numpy()[0] = 10  # expect-error: dataarray-numpy-item
+
+shallow_copy = borrowed_data_array.copy(deep=False)
+shallow_copy[0] = 10  # expect-error: shallow-copy-item

--- a/tests/typing/borrowed_positive.py.txt
+++ b/tests/typing/borrowed_positive.py.txt
@@ -1,0 +1,43 @@
+"""Positive static-type probe for borrowed NumPy and xarray arrays."""
+
+from typing import Any
+
+import numpy as np
+import xarray as xr
+from typing_extensions import assert_type
+
+from openghg_inversions.borrowed import BorrowedDataArray, BorrowedNDArray, borrow
+
+
+array = np.arange(3)
+borrowed_array = borrow(array)
+assert_type(borrowed_array, BorrowedNDArray)
+assert_type(borrowed_array.copy(), np.ndarray[Any, Any])
+
+data_array = xr.DataArray(np.arange(3), dims="x")
+borrowed_data_array = borrow(data_array)
+assert_type(borrowed_data_array, BorrowedDataArray)
+assert_type(borrowed_data_array.values, BorrowedNDArray)
+assert_type(borrowed_data_array.to_numpy(), BorrowedNDArray)
+assert_type(borrowed_data_array.copy(deep=False), BorrowedDataArray)
+assert_type(borrowed_data_array.copy(deep=True), xr.DataArray)
+
+# Copies that own their buffers remain mutable to both checkers.
+mutable_array = borrowed_array.copy()
+mutable_array[0] = 10
+mutable_data_array = borrowed_data_array.copy(deep=True)
+mutable_data_array[0] = 10
+
+# Known static escapes are accepted deliberately and documented by the module.
+# An ordinary typed parameter widens away the phantom subtype.
+def mutate_array(value: np.ndarray[Any, Any]) -> None:
+    value[0] = 10
+
+
+def mutate_data_array(value: xr.DataArray) -> None:
+    value[0] = 10
+
+
+mutate_array(borrowed_array)
+mutate_data_array(borrowed_data_array)
+np.add(borrowed_array, 1, out=borrowed_array)

--- a/tests/typing/test_borrowed_typing.py
+++ b/tests/typing/test_borrowed_typing.py
@@ -1,0 +1,146 @@
+"""Static-checker regression tests for borrowed NumPy and xarray arrays."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).parents[2]
+POSITIVE_PROBE = Path(__file__).with_name("borrowed_positive.py.txt")
+NEGATIVE_PROBE = Path(__file__).with_name("borrowed_negative.py.txt")
+EXPECTED_MARKERS = {
+    "ndarray-item": re.compile(r"Never|never|incompatible type", re.IGNORECASE),
+    "ndarray-method": re.compile(r"deprecated|Never|incompatible type", re.IGNORECASE),
+    "ndarray-deprecated-method": re.compile(r"deprecated", re.IGNORECASE),
+    "dataarray-item": re.compile(r"Never|never|incompatible type", re.IGNORECASE),
+    "dataarray-values": re.compile(r"Never|never|incompatible type|read-only", re.IGNORECASE),
+    "dataarray-values-item": re.compile(r"Never|never|incompatible type", re.IGNORECASE),
+    "dataarray-data-item": re.compile(r"Never|never|incompatible type", re.IGNORECASE),
+    "dataarray-numpy-item": re.compile(r"Never|never|incompatible type", re.IGNORECASE),
+    "shallow-copy-item": re.compile(r"Never|never|incompatible type", re.IGNORECASE),
+}
+CheckerResult = tuple[int, dict[int, list[str]], str]
+CheckerRunner = Callable[[Path], CheckerResult]
+
+
+def _materialize_probe(source: Path, destination: Path) -> dict[int, str]:
+    """Copy a non-Python probe to a temporary module and return error markers."""
+    text = source.read_text(encoding="utf-8")
+    destination.write_text(text, encoding="utf-8")
+    return {
+        line_number: line.rsplit("# expect-error: ", 1)[1].strip()
+        for line_number, line in enumerate(text.splitlines(), start=1)
+        if "# expect-error: " in line
+    }
+
+
+def _checker_path(name: str) -> str:
+    """Return an installed checker executable or skip outside the dev environment."""
+    environment_executable = Path(sys.executable).with_name(name)
+    if environment_executable.is_file():
+        return str(environment_executable)
+    pytest.skip(f"{name} is not installed in the active environment")
+
+
+def _run(command: list[str]) -> subprocess.CompletedProcess[str]:
+    """Run a static checker from the repository root with captured diagnostics."""
+    return subprocess.run(
+        command,
+        cwd=PROJECT_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _pyright_diagnostics(probe: Path) -> tuple[int, dict[int, list[str]], str]:
+    """Run Pyright and group error messages by one-based source line."""
+    config = probe.with_name("pyrightconfig.json")
+    config.write_text(
+        json.dumps(
+            {
+                "include": [str(probe)],
+                "extraPaths": [str(PROJECT_ROOT)],
+                "reportDeprecated": "error",
+            }
+        ),
+        encoding="utf-8",
+    )
+    result = _run(
+        [
+            _checker_path("pyright"),
+            "--outputjson",
+            "--project",
+            str(config),
+            "--pythonpath",
+            sys.executable,
+            str(probe),
+        ]
+    )
+    report = json.loads(result.stdout)
+    diagnostics: dict[int, list[str]] = {}
+    for diagnostic in report.get("generalDiagnostics", []):
+        if diagnostic.get("severity") != "error":
+            continue
+        line = diagnostic["range"]["start"]["line"] + 1
+        diagnostics.setdefault(line, []).append(diagnostic["message"])
+    return result.returncode, diagnostics, result.stdout + result.stderr
+
+
+def _mypy_diagnostics(probe: Path) -> tuple[int, dict[int, list[str]], str]:
+    """Run Mypy and group error messages by one-based source line."""
+    result = _run(
+        [
+            _checker_path("mypy"),
+            "--no-incremental",
+            "--cache-dir=/dev/null",
+            "--no-error-summary",
+            "--no-pretty",
+            "--show-error-codes",
+            "--enable-error-code=deprecated",
+            str(probe),
+        ]
+    )
+    diagnostic_pattern = re.compile(rf"^{re.escape(str(probe))}:(\d+): error: (.*)$")
+    diagnostics: dict[int, list[str]] = {}
+    for output_line in result.stdout.splitlines():
+        match = diagnostic_pattern.match(output_line)
+        if match:
+            diagnostics.setdefault(int(match.group(1)), []).append(match.group(2))
+    return result.returncode, diagnostics, result.stdout + result.stderr
+
+
+@pytest.mark.parametrize("runner", [_pyright_diagnostics, _mypy_diagnostics], ids=["pyright", "mypy"])
+def test_borrowed_positive_type_probe(runner: CheckerRunner, tmp_path: Path) -> None:
+    """Both checkers accept reads and mutation of explicitly owned copies."""
+    probe = tmp_path / "borrowed_positive.py"
+    _materialize_probe(POSITIVE_PROBE, probe)
+
+    returncode, diagnostics, output = runner(probe)
+
+    assert returncode == 0, output
+    assert diagnostics == {}, output
+
+
+@pytest.mark.parametrize("runner", [_pyright_diagnostics, _mypy_diagnostics], ids=["pyright", "mypy"])
+def test_borrowed_negative_type_probe(runner: CheckerRunner, tmp_path: Path) -> None:
+    """Both checkers reject each marked mutation through a borrowed reference."""
+    probe = tmp_path / "borrowed_negative.py"
+    markers = _materialize_probe(NEGATIVE_PROBE, probe)
+
+    returncode, diagnostics, output = runner(probe)
+
+    assert returncode != 0, output
+    assert set(diagnostics) == set(markers), output
+    for line, marker in markers.items():
+        messages = "\n".join(diagnostics[line])
+        assert EXPECTED_MARKERS[marker].search(messages), (
+            f"unexpected diagnostic for {marker!r} on line {line}:\n{messages}\n\n{output}"
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ requires =
 isolated_build = True
 env_list =
     py310-openghgCur
+    borrowed-types
     lint
 
 [testenv]
@@ -38,6 +39,15 @@ deps =
     mypy
 commands =
     mypy {posargs:openghg_inversions}
+
+[testenv:borrowed-types]
+description = "Verify experimental borrowed-reference diagnostics with Pyright and Mypy."
+deps =
+    pytest
+    pyright==1.1.408
+    mypy==1.19.1
+commands =
+    pytest {posargs:tests/typing/test_borrowed_typing.py}
 
 [testenv:docs-strict]
 #skip_install = True


### PR DESCRIPTION
* **Summary of changes**

Adds an experimental, runtime-identity `borrow()` marker for NumPy arrays and xarray `DataArray` objects.

- The returned phantom types diagnose selected direct in-place mutations in Pyright and Mypy without wrapping, copying, computing, persisting, or changing Dask graphs.
- Deep copies explicitly relinquish the static marker; shallow xarray copies retain it.
- The module documents known false negatives, including existing aliases, typed upcasts, `Any`, xarray escape hatches, NumPy `out=`, and upstream stubs that erase subclasses.
- A dedicated tox/CI environment pins both checkers and verifies positive and negative diagnostic probes.
- The numerical ownership note and API reference explain how this aid complements—rather than replaces—the borrowed-data docstring contract.

This deliberately does **not** add a package-wide `py.typed` marker. That would advertise every inline annotation in `openghg_inversions` as a PEP 561 contract; this experiment remains enforced inside the repository until it has real production adoption and a stable coverage surface.

This is intended as a precursor to the #581–#583 stack: after this lands, #581 can annotate borrowed latitude/longitude returns and #582 can annotate class labels. #583's public result fields should remain a separate ownership-policy decision.

Tracks [OPE-38](https://linear.app/openghg-inversions/issue/OPE-38/add-experimental-borrowed-numpyxarray-type-markers).

* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx — not applicable; tracked in Linear as OPE-38
- [x] Tests added and passing
- [x] Documentation and tutorials updated/added
- [x] Added an entry to the `CHANGELOG.md` file
- [x] No new runtime requirements

**Verification**

- `tox -p --parallel-no-spinner`
  - current OpenGHG integration: passed (1,113 passed, 10 skipped, 6 xfailed in the initial full run; the corrected rerun passed)
  - borrowed Pyright/Mypy diagnostics: passed
  - Ruff: passed
- Focused runtime and checker suite: 10 passed
- Sphinx docs build: passed (existing missing `_static` warning only)
