### PR TITLE
Add explicit legacy fixedbasis compatibility route

### DIFF
--- a/docs/usage/getting_started.rst
+++ b/docs/usage/getting_started.rst
@@ -139,6 +139,12 @@ Method 2: ini file
   ``openghg-inversions run-rhime`` and the RHIME config vocabulary.
   Unsupported fixedbasis-only options now raise targeted errors instead of
   being passed through to ``inferpymc``.
+- Existing INI workflows that temporarily require the historical
+  ``fixedbasisMCMC`` / ``inferpymc_postprocessouts`` product can add
+  ``--legacy-fixedbasis``. This explicit opt-in keeps legacy parameter names;
+  it does not translate them or fall back to RHIME. A missing output format or
+  ``hbmcmc`` / ``hbmcmc_postprocessing`` selects the historical product, while
+  ``output_format="legacy"`` continues to select the modern adapter.
 - A sample ``.ini`` script is at the bottom of this document.
 
 Method 3: as a job on Blue Pebble
@@ -148,6 +154,10 @@ Method 3: as a job on Blue Pebble
   SLURM <https://www.acrc.bris.ac.uk/protected/hpc-docs/job_types/serial.html>`__
   using ``sbatch``.
 - This file will specify:
+
+  - the same ``run_hbmcmc.py`` command as above; add
+    ``--legacy-fixedbasis`` after the script path only when the submitted job
+    must reproduce the historical fixedbasis product;
 
   - the name of the job
   - resources required (number of nodes, number of tasks per node,

--- a/docs/usage/rhime.rst
+++ b/docs/usage/rhime.rst
@@ -847,8 +847,13 @@ compatibility output formats, but new workflows should save and load DataTree
 files. It translates legacy option names to the modern ``run_rhime`` API and
 uses the legacy filename convention. New scripts and new configs should use
 ``openghg-inversions run-rhime`` or ``run_rhime(...)`` directly.
-This compatibility route no longer preserves the exact historical
-``fixedbasisMCMC`` / ``inferpymc`` passthrough behaviour. Use release ``0.6`` or
-earlier if you need the old fixedbasis implementation.
+For temporary reproduction of historical products, pass
+``--legacy-fixedbasis`` to ``run_hbmcmc.py``. This explicit opt-in sends the
+untranslated INI parameters to ``fixedbasisMCMC``; a missing output format or
+the old ``hbmcmc`` / ``hbmcmc_postprocessing`` names select the historical
+``inferpymc_postprocessouts`` product and filename. An explicit
+``output_format="legacy"`` still selects the modern legacy-format adapter.
+The command prints a prominent warning, raises on unsupported options, and
+does not fall back to RHIME if the legacy run fails.
 Direct ``fixedbasisMCMC(...)`` calls are a temporary legacy Python path, not a
 wrapper around ``run_rhime(...)``.

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -25,6 +25,7 @@ object stores and for the paths to object stores to already be set in
 the users OpenGHG config file (default location: ~/.openghg/openghg.conf).
 """
 
+import inspect
 import logging
 import time
 import warnings
@@ -48,6 +49,9 @@ from openghg_inversions.models.priors import lognormal_mu_sigma
 from openghg_inversions.postprocessing.inversion_output import InversionOutput
 from openghg_inversions.serialization import reset_serialisation_multiindexes
 from openghg_inversions.utils import ncdf_encoding, write_netcdf_preserving_bounds_attrs
+
+
+_LEGACY_FIXEDBASIS_OUTPUT_FORMAT = "legacy_fixedbasis"
 
 
 def update_log_normal_prior(prior):
@@ -504,6 +508,40 @@ def _get_inversion_output(context: _OutputContext) -> InversionOutput:
     return context.inv_out
 
 
+def _prepare_legacy_fixedbasis_postprocess_args(context: _OutputContext) -> dict[str, object]:
+    """Select historical postprocessing inputs from a completed fixedbasis run.
+
+    Args:
+        context: Fixedbasis output context containing preparation, sampler, and
+            result values.
+
+    Returns:
+        Arguments accepted by ``inferpymc_postprocessouts``.
+
+    Raises:
+        RuntimeError: If the legacy sampler contract did not produce a required
+            postprocessing value.
+    """
+    available_args: dict[str, object] = dict(context.legacy_postprocess_args)
+    available_args.update(context.mcmc_args)
+    available_args.update(context.mcmc_results)
+
+    signature = inspect.signature(mcmc.inferpymc_postprocessouts)
+    missing = [
+        name
+        for name, parameter in signature.parameters.items()
+        if parameter.kind not in {inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD}
+        and parameter.default is inspect.Parameter.empty
+        and name not in available_args
+    ]
+    if missing:
+        raise RuntimeError(
+            f"Legacy fixedbasis postprocessing is missing required value(s): {', '.join(sorted(missing))}."
+        )
+
+    return {name: available_args[name] for name in signature.parameters if name in available_args}
+
+
 def _handle_core_output_artifacts(context: _OutputContext) -> None:
     """Write core inversion artifacts needed before final output dispatch."""
     trace_path = context.paths.get("trace")
@@ -537,6 +575,13 @@ def _finalize_output(context: _OutputContext) -> xr.Dataset | dict | InversionOu
         outputs = basic_output(_get_inversion_output(context), country_file=context.country_file)
         end_post = time.time()
         print(f"Post processing Complete. Time taken = {end_post - start_post:.2f} seconds")
+        return outputs
+
+    if context.output_format == _LEGACY_FIXEDBASIS_OUTPUT_FORMAT:
+        outputs = mcmc.inferpymc_postprocessouts(**_prepare_legacy_fixedbasis_postprocess_args(context))
+        end_post = time.time()
+        print(f"Post processing Complete. Time taken = {end_post - start_post:.2f} seconds")
+        print("---- Inversion completed ----")
         return outputs
 
     if context.output_format == "legacy":
@@ -689,6 +734,7 @@ def fixedbasisMCMC(
     output_format: Literal[
         "hbmcmc",
         "hbmcmc_postprocessing",
+        "legacy_fixedbasis",
         "legacy",
         "paris",
         "basic",
@@ -884,7 +930,11 @@ def fixedbasisMCMC(
             ),
         ),
     )
-    needs_modern_inv_out = output_format not in {"merged_data", "mcmc_args"} or bool(save_inversion_output)
+    needs_modern_inv_out = output_format not in {
+        "merged_data",
+        "mcmc_args",
+        _LEGACY_FIXEDBASIS_OUTPUT_FORMAT,
+    } or bool(save_inversion_output)
 
     start_data = time.time()
     prepared = prepare_fixedbasis_inversion_data(
@@ -944,6 +994,7 @@ def fixedbasisMCMC(
 
     output_format = cast(
         Literal[
+            "legacy_fixedbasis",
             "legacy",
             "paris",
             "basic",
@@ -1033,22 +1084,26 @@ def fixedbasisMCMC(
 
     print(f"MCMC Inversion complete. Time taken = {end_inversion - start_inversion:.2f} seconds")
 
-    inversion_output_args = _build_inversion_output_args(
-        prepared=prepared,
-        legacy_postprocess_args=legacy_postprocess_args,
-        mcmc_args=mcmc_args,
-        mcmc_results=mcmc_results,
-        sites=sites,
-        averaging_period=averaging_period,
-        start_date=start_date,
-        end_date=end_date,
-        species=species,
-        domain=domain,
-        output_format=output_format,
-        outputpath=outputpath,
-        outputname=outputname,
-        save_trace=save_trace,
-        save_inversion_output=save_inversion_output,
+    inversion_output_args = (
+        _build_inversion_output_args(
+            prepared=prepared,
+            legacy_postprocess_args=legacy_postprocess_args,
+            mcmc_args=mcmc_args,
+            mcmc_results=mcmc_results,
+            sites=sites,
+            averaging_period=averaging_period,
+            start_date=start_date,
+            end_date=end_date,
+            species=species,
+            domain=domain,
+            output_format=output_format,
+            outputpath=outputpath,
+            outputname=outputname,
+            save_trace=save_trace,
+            save_inversion_output=save_inversion_output,
+        )
+        if needs_modern_inv_out
+        else {}
     )
 
     output_context = _build_output_context(

--- a/openghg_inversions/hbmcmc/run_hbmcmc.py
+++ b/openghg_inversions/hbmcmc/run_hbmcmc.py
@@ -13,6 +13,8 @@ e.g.
 start - Start of date range to use for MCMC inversion (YYYY-MM-DD)
 end - End of date range to use for MCMC inversion (YYYY-MM-DD) (must be after start)
 -c / --config - configuration file. See config/ folder for templates and examples of this input file.
+--legacy-fixedbasis - explicitly run the deprecated fixedbasisMCMC/inferpymc
+compatibility path with untranslated legacy parameters. The default is run_rhime.
 
 If start and end are specified these will supersede the values within the configuration file, if present.
 If -c option is not specified, this script will look for configuration file within the
@@ -26,19 +28,22 @@ create a configuration file called `hbmcmc_input.ini` within your acrg_hbmcmc/ d
 This file will need to be edited to add parameters for your MCMC run.
 """
 
+import argparse
+import inspect
 import json
 import sys
-import argparse
+import warnings
 from pathlib import Path
 from shutil import copyfile
 from typing import Any
-import warnings
 
 import openghg_inversions.hbmcmc.hbmcmc_output as output
+import openghg_inversions.hbmcmc.inversion_pymc as inversion_pymc
 
 from openghg_inversions._timing import log_timing, timed, timer_seconds, timer_start
 from openghg_inversions.config import config
 from openghg_inversions.config.paths import Paths
+from openghg_inversions.hbmcmc.hbmcmc import _LEGACY_FIXEDBASIS_OUTPUT_FORMAT, fixedbasisMCMC
 from openghg_inversions.rhime import resolve_rhime_options, run_rhime
 from openghg_inversions.rhime.params import normalise_rhime_params
 
@@ -51,6 +56,10 @@ _RUN_HBMCMC_RHIME_ALIASES = {
 }
 _LOGNORMAL_PRIOR_NAMES = ("xprior", "x_prior", "bcprior", "bc_prior")
 _MIN_ERROR_METHODS = {"residual", "percentile"}
+_LEGACY_FIXEDBASIS_PARAM_NAMES = set(inspect.signature(fixedbasisMCMC).parameters) - {"kwargs"}
+_LEGACY_INFERPYMC_PARAM_NAMES = set(inspect.signature(inversion_pymc.inferpymc).parameters) - {"inv_inputs"}
+_LEGACY_FIXEDBASIS_EXTRA_PARAM_NAMES = {"flux_non_finite_check"}
+_LEGACY_FIXEDBASIS_OUTPUT_ALIASES = {"hbmcmc", "hbmcmc_postprocessing"}
 
 
 def fixed_basis_expected_param() -> list[str]:
@@ -229,6 +238,52 @@ def validate_rhime_params(params: dict[str, Any]) -> None:
     resolve_rhime_options(params=params, multisector=False)
 
 
+def _prepare_legacy_fixedbasis_params(params: dict[str, Any]) -> dict[str, Any]:
+    """Validate raw config values and select true legacy postprocessing.
+
+    Args:
+        params: Untranslated fixedbasis-style configuration parameters.
+
+    Returns:
+        A shallow copy suitable for calling ``fixedbasisMCMC``.
+
+    Raises:
+        ValueError: If an option is not accepted by ``fixedbasisMCMC`` or its
+            legacy sampler, or if ``output_format`` has an invalid type.
+    """
+    supported = (
+        _LEGACY_FIXEDBASIS_PARAM_NAMES | _LEGACY_INFERPYMC_PARAM_NAMES | _LEGACY_FIXEDBASIS_EXTRA_PARAM_NAMES
+    )
+    unsupported = sorted(set(params) - supported)
+    if unsupported:
+        raise ValueError(
+            "--legacy-fixedbasis does not support parameter(s): "
+            f"{', '.join(unsupported)}. Use legacy fixedbasis/inferpymc option names; "
+            "RHIME-only options are not translated in this mode."
+        )
+
+    legacy_params = dict(params)
+    raw_output_format = legacy_params.get("output_format")
+    if raw_output_format is not None and not isinstance(raw_output_format, str):
+        raise ValueError(
+            "--legacy-fixedbasis requires output_format to be a string or None; "
+            f"got {type(raw_output_format).__name__}."
+        )
+    if raw_output_format is None or raw_output_format.lower() in _LEGACY_FIXEDBASIS_OUTPUT_ALIASES:
+        legacy_params["output_format"] = _LEGACY_FIXEDBASIS_OUTPUT_FORMAT
+
+    return legacy_params
+
+
+def _validate_country_file(params: dict[str, Any]) -> None:
+    """Reject a configured country file that does not exist."""
+    country_file = params.get("country_file")
+    if country_file is not None and str(country_file).strip():
+        country_file_path = Path(country_file)
+        if not country_file_path.exists():
+            raise FileNotFoundError(f"Configured country_file does not exist: {country_file_path}")
+
+
 def hbmcmc_extract_param(
     config_file: str | Path,
     mcmc_type: str | None = "fixed_basis",
@@ -316,11 +371,19 @@ def build_parser(default_config_file: Path) -> argparse.ArgumentParser:
         "--output-path",
         help="Path to write ini file and results to.",
     )
+    parser.add_argument(
+        "--legacy-fixedbasis",
+        action="store_true",
+        help=(
+            "Run the deprecated fixedbasisMCMC/inferpymc workflow with untranslated legacy "
+            "parameters. This is an explicit compatibility opt-in; no RHIME fallback is attempted."
+        ),
+    )
     return parser
 
 
 def main(argv: list[str] | None = None) -> None:
-    """Run fixedbasis-style configs through the modern RHIME path."""
+    """Run a fixedbasis-style config through RHIME or the explicit legacy opt-in."""
     openghginv_path = Paths.openghginv
     config_file = openghginv_path / "hbmcmc" / "hbmcmc_input.ini"
 
@@ -357,9 +420,25 @@ def main(argv: list[str] | None = None) -> None:
 
     timing_start = timer_start()
     mcmc_type = extract_mcmc_type(config_file)
-    print(f"Using MCMC type: {mcmc_type} - routing fixedbasis-style config to run_rhime(...)")
     param = hbmcmc_extract_param(config_file, mcmc_type, **command_line_args)
     log_timing("run_hbmcmc.config_extract", timer_seconds(timing_start))
+
+    if args.legacy_fixedbasis:
+        if mcmc_type != "fixed_basis":
+            raise ValueError(f"--legacy-fixedbasis only supports mcmc_type='fixed_basis'; got {mcmc_type!r}.")
+        legacy_params = _prepare_legacy_fixedbasis_params(param)
+        _validate_country_file(legacy_params)
+        print(
+            "\n*** WARNING: --legacy-fixedbasis SELECTED ***\n"
+            "Running the deprecated fixedbasisMCMC/inferpymc workflow with untranslated "
+            "legacy parameters. No automatic fallback to run_rhime will be attempted.\n"
+        )
+        with timed("run_hbmcmc.config_copy"):
+            output.copy_config_file(str(config_file), param=param, **command_line_args)
+        fixedbasisMCMC(**legacy_params)
+        return
+
+    print(f"Using MCMC type: {mcmc_type} - routing fixedbasis-style config to run_rhime(...)")
 
     with timed("run_hbmcmc.fixedbasis_to_rhime_translation"):
         rhime_params = fixedbasis_params_to_rhime(param)
@@ -367,11 +446,7 @@ def main(argv: list[str] | None = None) -> None:
     with timed("run_hbmcmc.validation"):
         validate_rhime_params(rhime_params)
 
-    country_file = rhime_params.get("country_file")
-    if country_file is not None and str(country_file).strip():
-        country_file_path = Path(country_file)
-        if not country_file_path.exists():
-            raise FileNotFoundError(f"Configured country_file does not exist: {country_file_path}")
+    _validate_country_file(rhime_params)
 
     # TODO(#423): Validate BC and saved fp-basis files, including glob matches and readability.
     with timed("run_hbmcmc.config_copy"):

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -462,6 +462,85 @@ def test_fixedbasisMCMC_hbmcmc_output_uses_modern_legacy_formatter(monkeypatch, 
     assert result["xtrace_mean"].values.tolist() == [1.05]
 
 
+def test_fixedbasisMCMC_true_legacy_mode_calls_only_inferpymc_postprocessouts(monkeypatch, tmp_path):
+    """The runner-only output mode invokes the historical postprocessor exactly once."""
+    prepared = _minimal_fixedbasis_prepared_data(basis_objects={})
+    postprocess_calls: list[dict[str, object]] = []
+
+    def fake_prepare_fixedbasis_inversion_data(**kwargs):
+        assert kwargs["return_basis_objects"] is False
+        return prepared
+
+    def fake_inferpymc(**kwargs):
+        return {"xouts": np.array([[1.0]], dtype="float64")}
+
+    def fake_inferpymc_postprocessouts(
+        xouts,
+        Hx,
+        outputpath,
+        outputname,
+        emissions_name,
+        xprior,
+        nchain,
+        **kwargs,
+    ):
+        postprocess_calls.append(
+            {
+                "xouts": xouts,
+                "Hx": Hx,
+                "outputpath": outputpath,
+                "outputname": outputname,
+                "emissions_name": emissions_name,
+                "xprior": xprior,
+                "nchain": nchain,
+            }
+        )
+        return xr.Dataset({"xtrace": (("steps", "nx"), xouts)})
+
+    def fail_make_legacy_hbmcmc_output(*args, **kwargs):
+        raise AssertionError("True legacy mode must not use the modern legacy adapter.")
+
+    monkeypatch.setattr(
+        hbmcmc_module,
+        "prepare_fixedbasis_inversion_data",
+        fake_prepare_fixedbasis_inversion_data,
+    )
+    monkeypatch.setattr(hbmcmc_module.mcmc, "inferpymc", fake_inferpymc)
+    monkeypatch.setattr(
+        hbmcmc_module.mcmc,
+        "inferpymc_postprocessouts",
+        fake_inferpymc_postprocessouts,
+    )
+    monkeypatch.setattr(
+        legacy_outputs,
+        "make_legacy_hbmcmc_output",
+        fail_make_legacy_hbmcmc_output,
+    )
+
+    result = fixedbasisMCMC(
+        species="ch4",
+        sites=["TAC"],
+        domain="EUROPE",
+        averaging_period=["1H"],
+        start_date="2019-01-01",
+        end_date="2019-02-01",
+        outputpath=str(tmp_path),
+        outputname="true_legacy",
+        output_format=hbmcmc_module._LEGACY_FIXEDBASIS_OUTPUT_FORMAT,
+        emissions_name=["legacy-flux"],
+        xprior={"pdf": "normal", "mu": 1.0, "sigma": 1.0},
+        nchain=3,
+        use_bc=False,
+    )
+
+    assert len(postprocess_calls) == 1
+    assert postprocess_calls[0]["outputpath"] == str(tmp_path)
+    assert postprocess_calls[0]["outputname"] == "true_legacy"
+    assert postprocess_calls[0]["emissions_name"] == ["legacy-flux"]
+    assert postprocess_calls[0]["nchain"] == 3
+    assert isinstance(result, xr.Dataset)
+
+
 def test_fixedbasisMCMC_inv_out_returns_modern_output_without_legacy_adapter(monkeypatch, tmp_path):
     """The fixedbasis inv_out path returns modern InversionOutput without legacy adapters."""
     prepared = _minimal_fixedbasis_prepared_data()

--- a/tests/test_run_hbmcmc_shim.py
+++ b/tests/test_run_hbmcmc_shim.py
@@ -214,6 +214,145 @@ def test_run_hbmcmc_main_routes_to_run_rhime(monkeypatch: pytest.MonkeyPatch, tm
     assert seen["run_rhime_kwargs"]["output_filename_convention"] == "legacy"
 
 
+def test_run_hbmcmc_legacy_fixedbasis_parser_is_explicit(tmp_path: Path) -> None:
+    """The compatibility route is disabled unless its flag is supplied."""
+    parser = run_hbmcmc.build_parser(tmp_path / "hbmcmc.ini")
+
+    assert parser.parse_args([]).legacy_fixedbasis is False
+    assert parser.parse_args(["--legacy-fixedbasis"]).legacy_fixedbasis is True
+
+
+@pytest.mark.parametrize("output_format", [None, "hbmcmc", "hbmcmc_postprocessing"])
+def test_run_hbmcmc_legacy_fixedbasis_preserves_raw_params_and_selects_true_legacy_output(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    output_format: str | None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The explicit opt-in calls fixedbasisMCMC with untranslated legacy values."""
+    config_file = tmp_path / "hbmcmc.ini"
+    _fixedbasis_config(config_file)
+    if output_format is None:
+        config_file.write_text(
+            config_file.read_text(encoding="utf-8").replace('output_format = "hbmcmc"\n', ""),
+            encoding="utf-8",
+        )
+    elif output_format != "hbmcmc":
+        config_file.write_text(
+            config_file.read_text(encoding="utf-8").replace('hbmcmc"', f'{output_format}"'),
+            encoding="utf-8",
+        )
+    events: list[str] = []
+    seen: dict[str, Any] = {}
+
+    def fake_copy_config_file(config_file_arg: str, param: dict[str, Any], **command_line: Any) -> None:
+        events.append("copy")
+        seen["copy_param"] = param
+
+    def fake_fixedbasis_mcmc(**kwargs: Any) -> None:
+        events.append("fixedbasis")
+        seen["fixedbasis_kwargs"] = kwargs
+
+    def fail_run_rhime(**kwargs: Any) -> None:
+        raise AssertionError("The legacy opt-in must not fall back to RHIME.")
+
+    monkeypatch.setattr(run_hbmcmc.output, "copy_config_file", fake_copy_config_file)
+    monkeypatch.setattr(run_hbmcmc, "fixedbasisMCMC", fake_fixedbasis_mcmc)
+    monkeypatch.setattr(run_hbmcmc, "run_rhime", fail_run_rhime)
+
+    run_hbmcmc.main(["-c", str(config_file), "--legacy-fixedbasis"])
+
+    fixedbasis_kwargs = seen["fixedbasis_kwargs"]
+    assert events == ["copy", "fixedbasis"]
+    assert seen["copy_param"].get("output_format") == output_format
+    assert fixedbasis_kwargs["nit"] == 7
+    assert fixedbasis_kwargs["nchain"] == 3
+    assert fixedbasis_kwargs["emissions_name"] == ["total-ukghg-edgar7"]
+    assert fixedbasis_kwargs["sampler_kwargs"] == {"target_accept": 0.9}
+    assert fixedbasis_kwargs["outputpath"] == "out"
+    assert fixedbasis_kwargs["outputname"] == "legacy_run"
+    assert fixedbasis_kwargs["output_format"] == run_hbmcmc._LEGACY_FIXEDBASIS_OUTPUT_FORMAT
+    assert "draws" not in fixedbasis_kwargs
+    assert "chains" not in fixedbasis_kwargs
+    notice = capsys.readouterr().out
+    assert "WARNING: --legacy-fixedbasis SELECTED" in notice
+    assert "No automatic fallback to run_rhime" in notice
+
+
+def test_run_hbmcmc_legacy_fixedbasis_preserves_explicit_modern_legacy_output(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Explicit output_format=legacy remains the modern fixedbasis adapter mode."""
+    config_file = tmp_path / "hbmcmc.ini"
+    _fixedbasis_config(config_file)
+    config_file.write_text(
+        config_file.read_text(encoding="utf-8").replace(
+            'output_format = "hbmcmc"', 'output_format = "legacy"'
+        ),
+        encoding="utf-8",
+    )
+    seen: dict[str, Any] = {}
+
+    monkeypatch.setattr(run_hbmcmc.output, "copy_config_file", lambda *args, **kwargs: None)
+    monkeypatch.setattr(run_hbmcmc, "fixedbasisMCMC", lambda **kwargs: seen.update(kwargs))
+
+    run_hbmcmc.main(["-c", str(config_file), "--legacy-fixedbasis"])
+
+    assert seen["output_format"] == "legacy"
+
+
+def test_run_hbmcmc_legacy_fixedbasis_rejects_rhime_only_options_before_copy(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """RHIME-only option names fail clearly instead of being silently translated."""
+    config_file = tmp_path / "hbmcmc.ini"
+    _fixedbasis_config(config_file)
+
+    def fail_copy_config_file(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("Invalid legacy options must fail before config copying.")
+
+    monkeypatch.setattr(run_hbmcmc.output, "copy_config_file", fail_copy_config_file)
+
+    with pytest.raises(ValueError, match=r"--legacy-fixedbasis.*sample_kwargs"):
+        run_hbmcmc.main(
+            [
+                "-c",
+                str(config_file),
+                "--legacy-fixedbasis",
+                "--kwargs",
+                '{"sample_kwargs": {"target_accept": 0.95}}',
+            ]
+        )
+
+
+def test_run_hbmcmc_legacy_fixedbasis_checks_country_file_before_copy(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The compatibility route validates country_file before filesystem side effects."""
+    config_file = tmp_path / "hbmcmc.ini"
+    _fixedbasis_config(config_file)
+    missing_country_file = tmp_path / "missing_country_file.nc"
+    config_file.write_text(
+        config_file.read_text(encoding="utf-8")
+        + f'\n[INPUT.BASIS_CASE]\ncountry_file = "{missing_country_file}"\n',
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        run_hbmcmc.output,
+        "copy_config_file",
+        lambda *args, **kwargs: pytest.fail("country_file must be checked before config copying"),
+    )
+    monkeypatch.setattr(
+        run_hbmcmc,
+        "fixedbasisMCMC",
+        lambda **kwargs: pytest.fail("country_file must be checked before execution"),
+    )
+
+    with pytest.raises(FileNotFoundError, match="country_file"):
+        run_hbmcmc.main(["-c", str(config_file), "--legacy-fixedbasis"])
+
+
 def test_run_hbmcmc_main_validates_before_copying_config(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary

- add an explicit `--legacy-fixedbasis` escape hatch to `run_hbmcmc.py` while keeping `run_rhime` as the default
- preserve untranslated fixedbasis configuration vocabulary and route legacy output requests to `inferpymc_postprocessouts(...)` exactly once
- keep `output_format="legacy"` on the modern compatibility adapter, validate unsupported options and country files before side effects, and preserve config provenance
- document the temporary INI/SLURM compatibility workflow

## Why

Production users still need the historical HBMCMC NetCDF product and filename emitted by `inferpymc_postprocessouts(...)`. The existing compatibility aliases are intentionally canonicalized to the modern `make_legacy_hbmcmc_output(...)` adapter, so an explicit and isolated route is needed.

## Impact

Existing `run_hbmcmc.py` invocations are unchanged. Users who explicitly pass `--legacy-fixedbasis` get the current fixedbasis sampler plus the genuine historical postprocessor, with errors propagated and no fallback to RHIME.

## Validation

- `HOME=/tmp MPLCONFIGDIR=/tmp .venv/bin/pytest -q tests/test_run_hbmcmc_shim.py tests/test_postprocessing.py` (82 passed)
- `.venv/bin/ruff check` on changed Python/test files
- `.venv/bin/ruff format --check` on changed Python/test files
- `git diff --check`

Closes #588

Linear: OPE-42