### PR TITLE
Characterize RHIME workflow contracts

### DIFF
--- a/docs/plans/rhime_w1_contracts.md
+++ b/docs/plans/rhime_w1_contracts.md
@@ -1,134 +1,89 @@
 # RHIME W1 behavioural and usability contracts
 
-- **Status:** Characterization baseline for OPE-43
-- **Scope:** Current public RHIME behaviour only. This is not a design for the
-  W2--W7 workstreams, and does not make private runner helpers public API.
+- **Status:** Executable characterization baseline for OPE-43
+- **Scope:** Current public RHIME behaviour only. Production code and future
+  customization choices are outside this baseline.
 
-## Repeatable parity selection
+## Authoritative command
 
-Run the current public-path oracle with:
+Every contract below is selected by one command:
 
 ```bash
 tox -e py310-openghgCur -- -m rhime_contract
 ```
 
-The selected tests exercise both public Python entry points, their prepared
-input layouts, both installed CLI commands, config override forwarding, early
-unknown-parameter failure, and the current `run_hbmcmc.py` compatibility
-route. Broader schema, output, and legacy formatter cases remain in the
-ordinary focused RHIME test files and are listed below so later work can extend
-this selection deliberately rather than infer a contract from implementation
-structure.
+There is no second, prose-only contract suite. Parameterized node IDs below
+name the base node; every parameter case is selected by the marker.
 
-## Public routes and order
+## Executable contract map
 
-`run_rhime(...)` and `run_rhime_multisector(...)` accept direct keyword
-arguments or an INI file. With an INI file, keyword arguments override config
-values; the installed `run-rhime` and `run-rhime-multisector` commands forward
-their dates, output path, and JSON `--kwargs` as those keyword arguments.
+| Contract | Executable pytest node ID |
+| --- | --- |
+| Successful single-sector acquisition, scientific stage/timing order, distinctive Normal prior parameters and state dimension, modern in-memory output, filename, and serialized round-trip | `tests/test_rhime.py::test_run_rhime_api_smoke` |
+| Successful source-resolved multi-sector acquisition, sector priors, model output, and in-memory diagnostics | `tests/test_rhime.py::test_run_rhime_multisector_api_smoke` |
+| Standard CLI forwarding of config, dates, path, and JSON overrides | `tests/test_rhime.py::test_cli_run_rhime_passes_config_and_overrides` |
+| Multi-sector CLI forwarding of its configuration unchanged | `tests/test_rhime.py::test_cli_run_rhime_multisector_passes_config` |
+| Config normalization and early unknown-parameter failure | `tests/test_rhime.py::test_rhime_normalises_legacy_output_format_aliases`; `tests/test_rhime.py::test_run_rhime_rejects_unknown_parameter_before_data_preparation` |
+| Standard and source-resolved prepared layouts | `tests/test_rhime.py::test_prepare_rhime_inputs_single_sector_reloads_merged_data`; `tests/test_rhime.py::test_prepare_rhime_inputs_multisector_keeps_source_dimension` |
+| Scalar averaging-period normalization reaches shared preparation unchanged | `tests/test_rhime.py::test_run_rhime_leaves_scalar_averaging_period_for_shared_preparation` |
+| Indexed site/time identity and site-indicator alignment | `tests/test_prepared_inputs_serialisation.py::test_site_indicator_is_derived_from_measurement_sites` |
+| NetCDF and Zarr prepared-input dimensions, indexed and auxiliary coordinates, values, basis metadata, and replay without preparation | `tests/test_prepared_inputs_serialisation.py::test_real_prepared_inputs_save_load_and_run_without_repreparation` |
+| Current Dask eager boundaries and preservation of the caller's lazy arrays/chunks | `tests/test_rhime.py::test_rhime_dask_materialization_boundaries` |
+| Exact standard PyMC variable and dimension inventory | `tests/test_rhime.py::test_build_rhime_model_contains_expected_variables` |
+| Exact multi-sector PyMC variable and dimension inventory | `tests/test_rhime.py::test_build_rhime_multisector_model_contains_expected_variables` |
+| Optional global offset variables and dimensions | `tests/test_rhime.py::test_build_rhime_model_accepts_global_scalar_offset` |
+| Predictive variable selection and prior/posterior-predictive calls | `tests/test_rhime.py::test_rhime_sampler_runs_pymc_sampling_and_predictive_steps` |
+| Accepted standard output modes, rejection of unknown modes, and rejection of the multi-sector legacy combination | `tests/test_rhime.py::test_make_output_spec_accepts_supported_output_modes`; `tests/test_rhime.py::test_run_rhime_rejects_unsupported_output_format`; `tests/test_rhime.py::test_output_path_validation_rejects_multisector_legacy_output` |
+| Case-normalized output naming and the historical derived filename | `tests/test_rhime.py::test_make_output_spec_normalizes_filename_convention_case`; `tests/test_rhime.py::test_derived_output_filename_can_use_legacy_convention` |
+| `none` mode has no output filesystem side effects | `tests/test_rhime.py::test_run_rhime_from_prepared_inputs_defaults_sampler_and_skips_none_output_writes` |
+| Standard and multi-sector modern output-bundle contents | `tests/test_rhime.py::test_make_standard_output_bundle_returns_outputs_without_mutating_result`; `tests/test_rhime.py::test_make_multisector_output_bundle_returns_modern_inv_out` |
+| `basic`, `paris`, and `legacy` select the modern `InversionOutput` adapter | `tests/test_rhime.py::test_standard_basic_output_uses_modern_postprocessing_without_legacy_adapter`; `tests/test_rhime.py::test_standard_paris_output_uses_modern_postprocessing_without_legacy_adapter`; `tests/test_rhime.py::test_standard_legacy_output_uses_modern_inversion_output` |
+| Modern inversion-output schema, provenance, trace metadata, inputs, flux, and retained basis round-trip | `tests/test_rhime.py::test_modern_inversion_output_save_load_roundtrip` |
+| Standalone trace write, metadata, and serialized measurement coordinates | `tests/test_rhime.py::test_save_inferencedata_preserves_burn_attrs_and_resets_multiindex_coords` |
+| Current `run_hbmcmc.py` translation, config-copy side effect, legacy mode, and filename convention | `tests/test_run_hbmcmc_shim.py::test_run_hbmcmc_main_routes_to_run_rhime` |
+| Direct current `fixedbasisMCMC(...)` legacy schema, dimensions, values, historical filename, and NetCDF write | `tests/test_postprocessing.py::test_hbmcmc_postprocessing_preserves_expected_vars_attrs_and_coords` |
+| Direct current `fixedbasisMCMC(...)` trace and modern inversion-output paths, dimensions, values, and serialization | `tests/test_postprocessing.py::test_inv_out_and_trace_outputs_preserve_downstream_dims_and_custom_paths` |
 
-The observable current order is:
+## Current Dask boundary
 
-```text
-normalize and validate parameters
--> retrieve/reload data
--> filter sites and observations
--> construct/load retained basis functions
--> assemble canonical inversion inputs
--> build PyMC model
--> sample and generate predictive groups
--> make in-memory outputs and write requested artifacts
-```
+The current implementation is not lazy through sampling. Preparation's NaN
+check computes Dask-backed `H` and `H_bc`. Model construction then computes
+the Dask-backed `H`, `H_bc`, `mf`, `mf_error`, and `min_error` arrays while
+registering PyMC data, before sampling begins. Those operations leave the
+caller's Dask arrays and chunk layout in place. The Dask callback and named
+materialization counters in
+`tests/test_rhime.py::test_rhime_dask_materialization_boundaries` assert each
+part of this statement.
 
-`run_rhime_from_prepared_inputs(...)` begins after canonical input assembly;
-it validates the prepared layout, output compatibility, and retained basis
-before model construction. The names and placement of private helpers are not
-part of this contract. Timing records are emitted at runner setup, input
-preparation, model build/sample, sampling, and output-bundle boundaries.
+## Built-model inventory
 
-The legacy `run_hbmcmc.py` script currently translates its fixedbasis-style
-INI vocabulary to modern RHIME vocabulary, validates it, checks the country
-file, copies the configuration for provenance, then calls `run_rhime(...)`.
-Direct `fixedbasisMCMC(...)` remains a separate legacy Python path.
+The standard built model currently contains `Y`, `error`, `min_error`, `hx`,
+`x`, `mu`, `hbc`, `bc`, `mu_bc`, `sigma_site_index`,
+`sigma_period_index`, `sigma`, `epsilon`, and `y`. The multi-sector model
+replaces standard `hx`/`x`/`mu` with source-suffixed design, state, and
+contribution variables and retains total `mu`. A global offset adds
+`site_indicator`, scalar `offset_latent`, and observation-aligned `offset`.
+Prior and posterior predictive generation selects built-model variable `y`.
 
-## Inputs and scientific graph
+These inventories are copied from the exact `model.named_vars` and
+`model.named_vars_to_dims` equality assertions in the mapped model tests; they
+are not inferred from helper names or documentation.
 
-Prepared inputs retain the filtered `sites`, matching `averaging_period`,
-authoritative site metadata, and `BasisFunctions`. `nmeasure` carries the
-observation identity (normally the indexed `(site, time)` layout); site
-metadata must align with the site identity in that dimension. Inputs are
-borrowed xarray objects: callers must not mutate them in place, and ordinary
-inspection must not copy, compute, persist, densify, or rechunk them. PyMC
-sampling and serialization/product writing are explicit execution boundaries.
+## Ordinary scientist variation
 
-Standard sensitivity `H` has no `source` dimension and uses the retained
-region layout. Multi-sector `H` retains source-resolved state, including
-gathered ragged source/state layouts; it must not be rectangularized. Filtering
-happens before basis generation, and the basis metadata records whether the
-artifact was generated or loaded.
-
-The built-in standard graph exposes `mf`, `mf_error`, `min_error`, `x`, `mu`,
-`hx`, `y`, and `epsilon`; enabling boundary conditions adds `bc`, `mu_bc`, and
-`hbc`, while offsets add `offset`. Multi-sector graphs use sanitized sector
-suffixes such as `x_ff`, `mu_ff`, and `hx_ff`. Custom prepared-input builders
-may declare a different explicit variable-role/output manifest, so those names
-are a built-in-model contract rather than a universal custom-builder rule.
-
-## Outputs and side effects
-
-The supported public output modes are `none`, `inv_out`, `basic`, `paris`, and
-`legacy`. `legacy` is single-sector only. `none` writes no ordinary output
-products, although a multi-sector run still returns in-memory sector flux
-diagnostics. Derived output formats default not to save an `InversionOutput`;
-`inv_out` defaults to saving one. `save_trace` and explicit output saves require
-an output path where a default path is needed.
-
-The current standard names include
-`<name><start>_trace.nc`, `<name><start>_inversion_output.nc`, RHIME derived
-products named from the output/species/domain/start fields, and legacy derived
-products named `<SPECIES>_<domain>_<name>_<start>.nc`. Multi-sector runs can
-also write `<name><start>_sector_flux_diagnostics.nc`. Output creation may make
-parent directories, write NetCDF/trace artifacts, and record their paths plus
-the modern inversion-output contract in `RhimeResult.output_metadata`.
-
-The detailed output/schema oracle is in `tests/test_rhime.py` (output bundle,
-filename, and serialization tests), `tests/test_prepared_inputs_serialisation.py`,
-`tests/test_xarray_input_adapter.py`, and `tests/test_postprocessing.py`.
-
-## Scientist variation baseline and review checklist
-
-The current acquisition-to-output call accepts ordinary arguments such as
-`flux_sources`, `x_prior`, and `output_path`. Changing a prior is supported:
-
-```python
-result = run_rhime(
-    species="ch4",
-    sites=["TAC"],
-    averaging_period=["1h"],
-    domain="EUROPE",
-    start_date="2019-01-01",
-    end_date="2019-01-02",
-    flux_sources=["total-ukghg-edgar7"],
-    x_prior={"pdf": "normal", "mu": 1.0, "sigma": 0.5},
-    output_path="out",
-    output_name="prior_variation",
-)
-```
-
-Changing a likelihood or complete model at that same boundary is not currently
-supported: `model_builder` and `likelihood_builder` are accepted only by
-`run_rhime_from_prepared_inputs(...)`; passing either to `run_rhime(...)` is an
-early unsupported-parameter error. This is the baseline ergonomics limitation
-for W2, not a reason to add a new framework in W1.
+`tests/test_rhime.py::test_run_rhime_api_smoke` is the executable example. It
+starts from ordinary acquisition arguments, supplies
+`x_prior={"pdf": "normal", "mu": 1.25, "sigma": 0.125}`, builds the model,
+checks the actual PyMC `NormalRV` parameters and `region` dimension, samples
+deterministically, writes the modern output, reloads it, and compares inputs
+and trace values. Future builder behavior is intentionally not characterized
+by W1.
 
 Scientific-user review:
 
-1. Find `run_rhime(...)` or `run_rhime_multisector(...)` and see the route
-   above without needing private runner knowledge.
-2. Follow normalization, preparation, model, sampling, and output in order.
-3. Change a normal prior using ordinary acquisition arguments and retain the
-   output path/name.
-4. Run the explicit contract suite, then the focused RHIME tests for the
-   output mode being changed.
-5. Inspect `RhimeResult`, `output_metadata`, the saved trace/inversion output,
-   and any selected derived product.
+1. Find the standard or multi-sector public entry point in the first two rows.
+2. Follow the asserted timing labels through preparation, model, sampling, and
+   output.
+3. Change an ordinary prior as in the single-sector executable example.
+4. Run the authoritative command.
+5. Inspect the returned `RhimeResult` and the asserted serialized artifact.

--- a/docs/plans/rhime_w1_contracts.md
+++ b/docs/plans/rhime_w1_contracts.md
@@ -42,7 +42,7 @@ name the base node; every parameter case is selected by the marker.
 | Default concrete-model inversion-output identity, selected provenance, burn metadata, inputs, flux, and basis-matrix round-trip | `tests/test_rhime.py::test_default_model_inversion_output_save_load_roundtrip` |
 | Standalone trace write, metadata, and serialized measurement coordinates | `tests/test_rhime.py::test_save_inferencedata_preserves_burn_attrs_and_resets_multiindex_coords` |
 | Selected `run_hbmcmc.py` translation fields, exact config-copy contents, legacy mode, and historical filename convention | `tests/test_run_hbmcmc_shim.py::test_run_hbmcmc_main_routes_to_run_rhime` |
-| Direct current `fixedbasisMCMC(...)` legacy schema, dimensions, values, historical filename, and NetCDF write | `tests/test_postprocessing.py::test_hbmcmc_postprocessing_preserves_expected_vars_attrs_and_coords` |
+| Direct current `fixedbasisMCMC(...)` exact legacy variable/coordinate inventories and dimensions, selected deterministic observation/trace/sensitivity/reconstruction values, interval/country constraints, global attrs, historical filename, and NetCDF identity | `tests/test_postprocessing.py::test_hbmcmc_postprocessing_preserves_expected_vars_attrs_and_coords` |
 | Direct current `fixedbasisMCMC(...)` trace and modern inversion-output paths, dimensions, values, and serialization | `tests/test_postprocessing.py::test_inv_out_and_trace_outputs_preserve_downstream_dims_and_custom_paths` |
 
 ## Current Dask boundary

--- a/docs/plans/rhime_w1_contracts.md
+++ b/docs/plans/rhime_w1_contracts.md
@@ -21,7 +21,7 @@ name the base node; every parameter case is selected by the marker.
 | --- | --- |
 | Successful single-sector acquisition, scientific stage/timing order, distinctive Normal prior parameters and state dimension, modern in-memory output, filename, and serialized round-trip | `tests/test_rhime.py::test_run_rhime_api_smoke` |
 | Successful source-resolved multi-sector acquisition, sector priors, model output, and in-memory diagnostics | `tests/test_rhime.py::test_run_rhime_multisector_api_smoke` |
-| Standard CLI forwarding of config, dates, path, and JSON overrides | `tests/test_rhime.py::test_cli_run_rhime_passes_config_and_overrides` |
+| Standard CLI parses a real config, applies keyword-over-config precedence, and routes winning scientific, model, sampler, and output values through the runner | `tests/test_rhime.py::test_cli_run_rhime_passes_config_and_overrides` |
 | Multi-sector CLI forwarding of its configuration unchanged | `tests/test_rhime.py::test_cli_run_rhime_multisector_passes_config` |
 | Config normalization and early unknown-parameter failure | `tests/test_rhime.py::test_rhime_normalises_legacy_output_format_aliases`; `tests/test_rhime.py::test_run_rhime_rejects_unknown_parameter_before_data_preparation` |
 | Standard and source-resolved prepared layouts | `tests/test_rhime.py::test_prepare_rhime_inputs_single_sector_reloads_merged_data`; `tests/test_rhime.py::test_prepare_rhime_inputs_multisector_keeps_source_dimension` |

--- a/docs/plans/rhime_w1_contracts.md
+++ b/docs/plans/rhime_w1_contracts.md
@@ -19,7 +19,7 @@ name the base node; every parameter case is selected by the marker.
 
 | Contract | Executable pytest node ID |
 | --- | --- |
-| Successful single-sector acquisition, scientific stage/timing order, distinctive Normal prior parameters and state dimension, modern in-memory output, filename, and serialized round-trip | `tests/test_rhime.py::test_run_rhime_api_smoke` |
+| Successful single-sector acquisition, exact observation `long_name` attributes, scientific stage/timing order, distinctive Normal prior parameters and state dimension, modern in-memory output, filename, and serialized round-trip | `tests/test_rhime.py::test_run_rhime_api_smoke` |
 | Successful source-resolved multi-sector acquisition, sector priors, model output, and in-memory diagnostics | `tests/test_rhime.py::test_run_rhime_multisector_api_smoke` |
 | Standard CLI parses a real config, applies keyword-over-config precedence, and routes winning scientific, model, sampler, and output values through the runner | `tests/test_rhime.py::test_cli_run_rhime_passes_config_and_overrides` |
 | Multi-sector CLI forwarding of its configuration unchanged | `tests/test_rhime.py::test_cli_run_rhime_multisector_passes_config` |
@@ -37,10 +37,11 @@ name the base node; every parameter case is selected by the marker.
 | Case-normalized output naming and the historical derived filename | `tests/test_rhime.py::test_make_output_spec_normalizes_filename_convention_case`; `tests/test_rhime.py::test_derived_output_filename_can_use_legacy_convention` |
 | `none` mode has no output filesystem side effects | `tests/test_rhime.py::test_run_rhime_from_prepared_inputs_defaults_sampler_and_skips_none_output_writes` |
 | Standard and multi-sector modern output-bundle contents | `tests/test_rhime.py::test_make_standard_output_bundle_returns_outputs_without_mutating_result`; `tests/test_rhime.py::test_make_multisector_output_bundle_returns_modern_inv_out` |
-| `basic`, `paris`, and `legacy` select the modern `InversionOutput` adapter | `tests/test_rhime.py::test_standard_basic_output_uses_modern_postprocessing_without_legacy_adapter`; `tests/test_rhime.py::test_standard_paris_output_uses_modern_postprocessing_without_legacy_adapter`; `tests/test_rhime.py::test_standard_legacy_output_uses_modern_inversion_output` |
-| Modern inversion-output schema, provenance, trace metadata, inputs, flux, and retained basis round-trip | `tests/test_rhime.py::test_modern_inversion_output_save_load_roundtrip` |
+| Selected real basic product variables; selected latest-PARIS schema fields, dtypes, covariance shape, and NetCDF reloads; and selected real legacy product variables and NetCDF reload | `tests/test_rhime.py::test_basic_output_processes_modern_output`; `tests/test_rhime.py::test_latest_paris_output_processes_modern_output`; `tests/test_rhime.py::test_standard_legacy_output_uses_modern_inversion_output` |
+| Real multi-sector latest-PARIS total/sector flux variables and sector-diagnostic mean variables, with NetCDF reloads | `tests/test_rhime.py::test_make_multisector_output_bundle_builds_latest_paris_flux` |
+| Default concrete-model inversion-output identity, selected provenance, burn metadata, inputs, flux, and basis-matrix round-trip | `tests/test_rhime.py::test_default_model_inversion_output_save_load_roundtrip` |
 | Standalone trace write, metadata, and serialized measurement coordinates | `tests/test_rhime.py::test_save_inferencedata_preserves_burn_attrs_and_resets_multiindex_coords` |
-| Current `run_hbmcmc.py` translation, config-copy side effect, legacy mode, and filename convention | `tests/test_run_hbmcmc_shim.py::test_run_hbmcmc_main_routes_to_run_rhime` |
+| Selected `run_hbmcmc.py` translation fields, exact config-copy contents, legacy mode, and historical filename convention | `tests/test_run_hbmcmc_shim.py::test_run_hbmcmc_main_routes_to_run_rhime` |
 | Direct current `fixedbasisMCMC(...)` legacy schema, dimensions, values, historical filename, and NetCDF write | `tests/test_postprocessing.py::test_hbmcmc_postprocessing_preserves_expected_vars_attrs_and_coords` |
 | Direct current `fixedbasisMCMC(...)` trace and modern inversion-output paths, dimensions, values, and serialization | `tests/test_postprocessing.py::test_inv_out_and_trace_outputs_preserve_downstream_dims_and_custom_paths` |
 

--- a/docs/plans/rhime_w1_contracts.md
+++ b/docs/plans/rhime_w1_contracts.md
@@ -1,0 +1,134 @@
+# RHIME W1 behavioural and usability contracts
+
+- **Status:** Characterization baseline for OPE-43
+- **Scope:** Current public RHIME behaviour only. This is not a design for the
+  W2--W7 workstreams, and does not make private runner helpers public API.
+
+## Repeatable parity selection
+
+Run the current public-path oracle with:
+
+```bash
+tox -e py310-openghgCur -- -m rhime_contract
+```
+
+The selected tests exercise both public Python entry points, their prepared
+input layouts, both installed CLI commands, config override forwarding, early
+unknown-parameter failure, and the current `run_hbmcmc.py` compatibility
+route. Broader schema, output, and legacy formatter cases remain in the
+ordinary focused RHIME test files and are listed below so later work can extend
+this selection deliberately rather than infer a contract from implementation
+structure.
+
+## Public routes and order
+
+`run_rhime(...)` and `run_rhime_multisector(...)` accept direct keyword
+arguments or an INI file. With an INI file, keyword arguments override config
+values; the installed `run-rhime` and `run-rhime-multisector` commands forward
+their dates, output path, and JSON `--kwargs` as those keyword arguments.
+
+The observable current order is:
+
+```text
+normalize and validate parameters
+-> retrieve/reload data
+-> filter sites and observations
+-> construct/load retained basis functions
+-> assemble canonical inversion inputs
+-> build PyMC model
+-> sample and generate predictive groups
+-> make in-memory outputs and write requested artifacts
+```
+
+`run_rhime_from_prepared_inputs(...)` begins after canonical input assembly;
+it validates the prepared layout, output compatibility, and retained basis
+before model construction. The names and placement of private helpers are not
+part of this contract. Timing records are emitted at runner setup, input
+preparation, model build/sample, sampling, and output-bundle boundaries.
+
+The legacy `run_hbmcmc.py` script currently translates its fixedbasis-style
+INI vocabulary to modern RHIME vocabulary, validates it, checks the country
+file, copies the configuration for provenance, then calls `run_rhime(...)`.
+Direct `fixedbasisMCMC(...)` remains a separate legacy Python path.
+
+## Inputs and scientific graph
+
+Prepared inputs retain the filtered `sites`, matching `averaging_period`,
+authoritative site metadata, and `BasisFunctions`. `nmeasure` carries the
+observation identity (normally the indexed `(site, time)` layout); site
+metadata must align with the site identity in that dimension. Inputs are
+borrowed xarray objects: callers must not mutate them in place, and ordinary
+inspection must not copy, compute, persist, densify, or rechunk them. PyMC
+sampling and serialization/product writing are explicit execution boundaries.
+
+Standard sensitivity `H` has no `source` dimension and uses the retained
+region layout. Multi-sector `H` retains source-resolved state, including
+gathered ragged source/state layouts; it must not be rectangularized. Filtering
+happens before basis generation, and the basis metadata records whether the
+artifact was generated or loaded.
+
+The built-in standard graph exposes `mf`, `mf_error`, `min_error`, `x`, `mu`,
+`hx`, `y`, and `epsilon`; enabling boundary conditions adds `bc`, `mu_bc`, and
+`hbc`, while offsets add `offset`. Multi-sector graphs use sanitized sector
+suffixes such as `x_ff`, `mu_ff`, and `hx_ff`. Custom prepared-input builders
+may declare a different explicit variable-role/output manifest, so those names
+are a built-in-model contract rather than a universal custom-builder rule.
+
+## Outputs and side effects
+
+The supported public output modes are `none`, `inv_out`, `basic`, `paris`, and
+`legacy`. `legacy` is single-sector only. `none` writes no ordinary output
+products, although a multi-sector run still returns in-memory sector flux
+diagnostics. Derived output formats default not to save an `InversionOutput`;
+`inv_out` defaults to saving one. `save_trace` and explicit output saves require
+an output path where a default path is needed.
+
+The current standard names include
+`<name><start>_trace.nc`, `<name><start>_inversion_output.nc`, RHIME derived
+products named from the output/species/domain/start fields, and legacy derived
+products named `<SPECIES>_<domain>_<name>_<start>.nc`. Multi-sector runs can
+also write `<name><start>_sector_flux_diagnostics.nc`. Output creation may make
+parent directories, write NetCDF/trace artifacts, and record their paths plus
+the modern inversion-output contract in `RhimeResult.output_metadata`.
+
+The detailed output/schema oracle is in `tests/test_rhime.py` (output bundle,
+filename, and serialization tests), `tests/test_prepared_inputs_serialisation.py`,
+`tests/test_xarray_input_adapter.py`, and `tests/test_postprocessing.py`.
+
+## Scientist variation baseline and review checklist
+
+The current acquisition-to-output call accepts ordinary arguments such as
+`flux_sources`, `x_prior`, and `output_path`. Changing a prior is supported:
+
+```python
+result = run_rhime(
+    species="ch4",
+    sites=["TAC"],
+    averaging_period=["1h"],
+    domain="EUROPE",
+    start_date="2019-01-01",
+    end_date="2019-01-02",
+    flux_sources=["total-ukghg-edgar7"],
+    x_prior={"pdf": "normal", "mu": 1.0, "sigma": 0.5},
+    output_path="out",
+    output_name="prior_variation",
+)
+```
+
+Changing a likelihood or complete model at that same boundary is not currently
+supported: `model_builder` and `likelihood_builder` are accepted only by
+`run_rhime_from_prepared_inputs(...)`; passing either to `run_rhime(...)` is an
+early unsupported-parameter error. This is the baseline ergonomics limitation
+for W2, not a reason to add a new framework in W1.
+
+Scientific-user review:
+
+1. Find `run_rhime(...)` or `run_rhime_multisector(...)` and see the route
+   above without needing private runner knowledge.
+2. Follow normalization, preparation, model, sampling, and output in order.
+3. Change a normal prior using ordinary acquisition arguments and retain the
+   output path/name.
+4. Run the explicit contract suite, then the focused RHIME tests for the
+   output mode being changed.
+5. Inspect `RhimeResult`, `output_metadata`, the saved trace/inversion output,
+   and any selected derived product.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,7 @@ testpaths = ["tests"]
 markers = [
   "create_frozen: tests that generate/update frozen regression outputs (not run by default)",
   "country_file_smoke: optional real country-file HDF5 backend smoke tests",
+  "rhime_contract: current public RHIME workflow compatibility contracts",
   "slow: tests that take a long time",
 ]
 addopts = "-m 'not create_frozen and not slow'"

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -1274,12 +1274,13 @@ def test_paris_postprocessing_compatibility_matches_paris_output_format(
     assert explicit["Yapost"].dims == compat["Yapost"].dims
 
 
+@pytest.mark.rhime_contract
 def test_hbmcmc_postprocessing_preserves_expected_vars_attrs_and_coords(
     mcmc_args,
     tmpdir,
     deterministic_sampler,
 ):
-    """Legacy-style postprocessing keeps its core vars, attrs, and coords."""
+    """Legacy fixedbasis output preserves its schema, values, and historical file."""
     mcmc_args["output_format"] = "hbmcmc_postprocessing"
     mcmc_args["outputpath"] = str(tmpdir)
 
@@ -1304,18 +1305,28 @@ def test_hbmcmc_postprocessing_preserves_expected_vars_attrs_and_coords(
     assert outputs["Yobs"].dims == ("nmeasure",)
     assert outputs["Ymod68"].dims == ("nmeasure", "nUI")
     assert outputs["country68"].dims == ("countrynames", "nUI")
+    inv_inputs = deterministic_sampler[0]["inv_inputs"]
+    assert isinstance(inv_inputs, xr.Dataset)
+    np.testing.assert_allclose(outputs["Yobs"].values, inv_inputs["mf"].values, rtol=1e-7)
+    np.testing.assert_allclose(outputs["Yerror"].values, inv_inputs["mf_error"].values, rtol=1e-7)
     for interval_name in ("Ymod68", "Ymod95", "country68", "country95"):
         assert np.isfinite(outputs[interval_name].values).sum() == outputs[interval_name].size
     assert "UInum" in outputs.coords
     assert "countrynames" in outputs.coords
 
+    output_path = Path(tmpdir) / "CH4_EUROPE_test_run_2019-01-01.nc"
+    assert output_path.exists()
+    with xr.open_dataset(output_path) as saved_outputs:
+        xr.testing.assert_identical(saved_outputs.load(), outputs)
 
+
+@pytest.mark.rhime_contract
 def test_inv_out_and_trace_outputs_preserve_downstream_dims_and_custom_paths(
     mcmc_args,
     tmpdir,
     deterministic_sampler,
 ):
-    """Saved trace and inversion output files preserve downstream-facing dims."""
+    """Fixedbasis trace and inversion serialization preserve values and dimensions."""
     trace_path = Path(tmpdir) / "custom_trace.nc"
     inv_out_path = Path(tmpdir) / "custom_inv_out.nc"
     mcmc_args["output_format"] = "inv_out"
@@ -1337,3 +1348,18 @@ def test_inv_out_and_trace_outputs_preserve_downstream_dims_and_custom_paths(
     assert "time" not in inv_out.flux.dims
     if "flux_time" in inv_out.flux.coords:
         assert "flux_time" in inv_out.flux.dims
+
+    saved_trace = az.from_netcdf(trace_path)
+    try:
+        assert saved_trace.posterior["x"].dims == ("chain", "draw", "nx")
+        np.testing.assert_array_equal(
+            saved_trace.posterior["x"].values,
+            inv_out.trace.posterior["x"].values,
+        )
+    finally:
+        saved_trace.close()
+
+    saved_inv_out = InversionOutput.load(inv_out_path)
+    xr.testing.assert_identical(saved_inv_out.inv_inputs, inv_out.inv_inputs)
+    xr.testing.assert_identical(saved_inv_out.trace.posterior["x"], inv_out.trace.posterior["x"])
+    assert isinstance(saved_inv_out.basis_functions, BasisFunctions)

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -1287,32 +1287,222 @@ def test_hbmcmc_postprocessing_preserves_expected_vars_attrs_and_coords(
     outputs = fixedbasisMCMC(**mcmc_args)
     assert isinstance(outputs, xr.Dataset)
 
-    expected_vars = [
-        "Yobs",
-        "Yerror",
-        "Yerror_repeatability",
-        "Yerror_variability",
-        "Yapriori",
-        "Ymod68",
-        "country68",
-        "fluxapriori",
-        "basisfunctions",
-    ]
-    for var_name in expected_vars:
-        assert var_name in outputs
-        assert "longname" in outputs[var_name].attrs
+    expected_dims = {
+        "Yobs": ("nmeasure",),
+        "Yerror": ("nmeasure",),
+        "Yerror_repeatability": ("nmeasure",),
+        "Yerror_variability": ("nmeasure",),
+        "min_model_error": ("nmeasure",),
+        "Ytime": ("nmeasure",),
+        "Yapriori": ("nmeasure",),
+        "Ymodmean": ("nmeasure",),
+        "Ymodmedian": ("nmeasure",),
+        "Ymodmode": ("nmeasure",),
+        "Ymod68": ("nmeasure", "nUI"),
+        "Ymod95": ("nmeasure", "nUI"),
+        "Yoffmean": ("nmeasure",),
+        "Yoffmedian": ("nmeasure",),
+        "Yoffmode": ("nmeasure",),
+        "Yoff68": ("nmeasure", "nUI"),
+        "Yoff95": ("nmeasure", "nUI"),
+        "xtrace": ("steps", "nparam"),
+        "sigtrace": ("steps", "nsigma_site", "nsigma_time"),
+        "siteindicator": ("nmeasure",),
+        "sigmafreqindex": ("nmeasure",),
+        "sitenames": ("nsite",),
+        "sitelons": ("nsite",),
+        "sitelats": ("nsite",),
+        "fluxapriori": ("lat", "lon"),
+        "fluxmode": ("lat", "lon", "flux_time"),
+        "scalingmean": ("lat", "lon"),
+        "scalingmode": ("lat", "lon"),
+        "basisfunctions": ("lat", "lon"),
+        "countrymean": ("countrynames",),
+        "countrymedian": ("countrynames",),
+        "countrymode": ("countrynames",),
+        "countrysd": ("countrynames",),
+        "country68": ("countrynames", "nUI"),
+        "country95": ("countrynames", "nUI"),
+        "countryapriori": ("countrynames",),
+        "countrydefinition": ("lat", "lon"),
+        "xsensitivity": ("nmeasure", "nparam"),
+        "YaprioriBC": ("nmeasure",),
+        "YmodmeanBC": ("nmeasure",),
+        "YmodmedianBC": ("nmeasure",),
+        "YmodmodeBC": ("nmeasure",),
+        "Ymod95BC": ("nmeasure", "nUI"),
+        "Ymod68BC": ("nmeasure", "nUI"),
+        "bctrace": ("steps", "nBC"),
+        "bcsensitivity": ("nmeasure", "nBC"),
+    }
+    assert {name: outputs[name].dims for name in outputs.data_vars} == expected_dims
+    assert all("longname" in outputs[name].attrs for name in outputs.data_vars)
 
-    assert outputs["Yobs"].dims == ("nmeasure",)
-    assert outputs["Ymod68"].dims == ("nmeasure", "nUI")
-    assert outputs["country68"].dims == ("countrynames", "nUI")
+    expected_coord_dims = {
+        "nmeasure": ("nmeasure",),
+        "UInum": ("nUI",),
+        "nsite": ("nsite",),
+        "lat": ("lat",),
+        "lon": ("lon",),
+        "flux_time": ("flux_time",),
+        "countrynames": ("countrynames",),
+        "stepnum": ("steps",),
+        "paramnum": ("nparam",),
+        "measurenum": ("nmeasure",),
+        "nsigma_site": ("nsigma_site",),
+        "nsigma_time": ("nsigma_time",),
+        "numBC": ("nBC",),
+    }
+    assert {name: outputs[name].dims for name in outputs.coords} == expected_coord_dims
+
     inv_inputs = deterministic_sampler[0]["inv_inputs"]
     assert isinstance(inv_inputs, xr.Dataset)
-    np.testing.assert_allclose(outputs["Yobs"].values, inv_inputs["mf"].values, rtol=1e-7)
-    np.testing.assert_allclose(outputs["Yerror"].values, inv_inputs["mf_error"].values, rtol=1e-7)
-    for interval_name in ("Ymod68", "Ymod95", "country68", "country95"):
-        assert np.isfinite(outputs[interval_name].values).sum() == outputs[interval_name].size
-    assert "UInum" in outputs.coords
-    assert "countrynames" in outputs.coords
+    source_observation_vars = {
+        "Yobs": "mf",
+        "Yerror": "mf_error",
+        "Yerror_repeatability": "mf_repeatability",
+        "Yerror_variability": "mf_variability",
+        "min_model_error": "min_error",
+    }
+    for output_name, input_name in source_observation_vars.items():
+        np.testing.assert_allclose(outputs[output_name].values, inv_inputs[input_name].values, rtol=1e-7)
+    np.testing.assert_array_equal(outputs["Ytime"].values, inv_inputs["time"].values)
+    np.testing.assert_array_equal(outputs["siteindicator"].values, inv_inputs["site_indicator"].values)
+    np.testing.assert_array_equal(outputs["sigmafreqindex"].values, inv_inputs["sigma_freq_index"].values)
+    np.testing.assert_array_equal(
+        outputs["sitenames"].values,
+        pd.unique(inv_inputs.indexes["nmeasure"].get_level_values("site")),
+    )
+    assert np.all(np.isnan(outputs[["sitelons", "sitelats"]].to_array().values))
+
+    for coord_name, dim_name in {
+        "nmeasure": "nmeasure",
+        "UInum": "nUI",
+        "nsite": "nsite",
+        "stepnum": "steps",
+        "paramnum": "nparam",
+        "measurenum": "nmeasure",
+        "nsigma_site": "nsigma_site",
+        "nsigma_time": "nsigma_time",
+        "numBC": "nBC",
+    }.items():
+        np.testing.assert_array_equal(outputs[coord_name].values, np.arange(outputs.sizes[dim_name]))
+    np.testing.assert_array_equal(
+        outputs["flux_time"].values,
+        np.array([mcmc_args["start_date"]], dtype="datetime64[ns]"),
+    )
+    assert np.all(np.diff(outputs["lat"].values) > 0)
+    assert np.all(np.diff(outputs["lon"].values) > 0)
+    assert outputs["countrynames"].values[0] == "OCEAN"
+    assert len(np.unique(outputs["countrynames"].values)) == outputs.sizes["countrynames"]
+
+    draw_offsets = np.linspace(-0.1, 0.1, outputs.sizes["steps"])
+    expected_xtrace = 1.0 + draw_offsets[:, None] + 0.01 * np.arange(outputs.sizes["nparam"])[None, :]
+    expected_sigtrace = np.broadcast_to(
+        1.0 + draw_offsets[:, None, None],
+        (outputs.sizes["steps"], outputs.sizes["nsigma_site"], outputs.sizes["nsigma_time"]),
+    )
+    expected_bctrace = 1.0 + 0.5 * draw_offsets[:, None] + 0.01 * np.arange(outputs.sizes["nBC"])[None, :]
+    np.testing.assert_allclose(outputs["xtrace"].values, expected_xtrace, rtol=1e-7)
+    np.testing.assert_allclose(outputs["sigtrace"].values, expected_sigtrace, rtol=1e-7)
+    np.testing.assert_allclose(outputs["bctrace"].values, expected_bctrace, rtol=1e-7)
+
+    emissions_sensitivity = inv_inputs["H"].transpose("nmeasure", "region").values
+    bc_sensitivity = inv_inputs["H_bc"].transpose("nmeasure", "bc_region").values
+    np.testing.assert_allclose(outputs["xsensitivity"].values, emissions_sensitivity, rtol=1e-7)
+    np.testing.assert_allclose(outputs["bcsensitivity"].values, bc_sensitivity, rtol=1e-7)
+
+    expected_posterior_concentration = (
+        expected_xtrace @ emissions_sensitivity.T + expected_bctrace @ bc_sensitivity.T
+    )
+    expected_posterior_bc = expected_bctrace @ bc_sensitivity.T
+    concentration_expectations = {
+        "Yapriori": emissions_sensitivity.sum(axis=1) + bc_sensitivity.sum(axis=1),
+        "Ymodmean": expected_posterior_concentration.mean(axis=0),
+        "Ymodmedian": np.median(expected_posterior_concentration, axis=0),
+        "YaprioriBC": bc_sensitivity.sum(axis=1),
+        "YmodmeanBC": expected_posterior_bc.mean(axis=0),
+        "YmodmedianBC": np.median(expected_posterior_bc, axis=0),
+    }
+    for output_name, expected_values in concentration_expectations.items():
+        np.testing.assert_allclose(outputs[output_name].values, expected_values, rtol=1e-6)
+
+    for offset_name in ("Yoffmean", "Yoffmedian", "Yoffmode", "Yoff68", "Yoff95"):
+        np.testing.assert_array_equal(outputs[offset_name].values, 0.0)
+
+    for hdi68_name, hdi95_name, mean_name, median_name, mode_name in (
+        ("Ymod68", "Ymod95", "Ymodmean", "Ymodmedian", "Ymodmode"),
+        ("Ymod68BC", "Ymod95BC", "YmodmeanBC", "YmodmedianBC", "YmodmodeBC"),
+    ):
+        hdi68 = outputs[hdi68_name].values
+        hdi95 = outputs[hdi95_name].values
+        mean = outputs[mean_name].values
+        median = outputs[median_name].values
+        mode = outputs[mode_name].values
+        assert np.all(np.isfinite([hdi68, hdi95]))
+        assert np.all(hdi68[:, 0] <= hdi68[:, 1])
+        assert np.all(hdi95[:, 0] <= hdi95[:, 1])
+        assert np.all(hdi95[:, 0] <= hdi68[:, 0])
+        assert np.all(hdi68[:, 1] <= hdi95[:, 1])
+        for estimate in (mean, median, mode):
+            assert np.all(hdi95[:, 0] <= estimate)
+            assert np.all(estimate <= hdi95[:, 1])
+
+    country_scalar_names = (
+        "countrymean",
+        "countrymedian",
+        "countrymode",
+        "countrysd",
+        "countryapriori",
+    )
+    assert all(np.all(np.isfinite(outputs[name].values)) for name in country_scalar_names)
+    assert all(np.all(outputs[name].values >= 0.0) for name in country_scalar_names)
+    np.testing.assert_array_equal(outputs["countrymean"].values, outputs["countrymedian"].values)
+    np.testing.assert_array_equal(outputs["countrymean"].values, outputs["countryapriori"].values)
+    country68 = outputs["country68"].values
+    country95 = outputs["country95"].values
+    assert np.all(np.isfinite([country68, country95]))
+    assert np.all(country68 >= 0.0)
+    assert np.all(country95 >= 0.0)
+    assert np.all(country68[:, 0] <= country68[:, 1])
+    assert np.all(country95[:, 0] <= country95[:, 1])
+    assert np.all(country95[:, 0] <= country68[:, 0])
+    assert np.all(country68[:, 1] <= country95[:, 1])
+    assert np.all(country95[:, 0] <= outputs["countrymode"].values)
+    assert np.all(outputs["countrymode"].values <= country95[:, 1])
+
+    basis_values, basis_counts = np.unique(outputs["basisfunctions"].values, return_counts=True)
+    np.testing.assert_array_equal(basis_values, np.arange(outputs.sizes["nparam"]))
+    np.testing.assert_array_equal(basis_counts, [28470, 28665, 28616, 28812])
+    np.testing.assert_array_equal(
+        outputs["scalingmean"].values,
+        (1.0 + 0.01 * outputs["basisfunctions"].values).astype("float32"),
+    )
+    for name in ("fluxapriori", "fluxmode", "scalingmode"):
+        assert np.all(np.isfinite(outputs[name].values))
+    assert np.all(outputs["scalingmode"].values >= 0.0)
+    assert np.all(np.isfinite(outputs["countrydefinition"].values))
+    assert np.all(outputs["countrydefinition"].values >= 0.0)
+    np.testing.assert_array_equal(
+        outputs["countrydefinition"].values,
+        outputs["countrydefinition"].values.astype(int),
+    )
+
+    expected_attrs = {
+        "Start date": mcmc_args["start_date"],
+        "End date": mcmc_args["end_date"],
+        "Convergence": "Unavailable",
+        "Burn in": "0",
+        "Tuning steps": "0",
+        "Number of chains": "1",
+        "Error for each site": "True",
+        "Emissions Prior": "pdf,truncatednormal,mu,1.0,sigma,1.0,lower,0.0",
+        "Model error Prior": "pdf,uniform,lower,0.1,upper,3",
+        "BCs Prior": "pdf,truncatednormal,mu,1.0,sigma,0.1,lower,0.0",
+        "basis_reconstruction_path": "operator-backed",
+        "basis_artifact_source": "generated",
+    }
+    assert {name: outputs.attrs[name] for name in expected_attrs} == expected_attrs
 
     output_path = Path(tmpdir) / "CH4_EUROPE_test_run_2019-01-01.nc"
     assert output_path.exists()

--- a/tests/test_prepared_inputs_serialisation.py
+++ b/tests/test_prepared_inputs_serialisation.py
@@ -463,6 +463,7 @@ def test_prepared_inputs_roundtrip_observation_aligned_release_metadata() -> Non
     assert "release_lon" not in restored.site_metadata
 
 
+@pytest.mark.rhime_contract
 def test_site_indicator_is_derived_from_measurement_sites() -> None:
     """Supplied positional codes are replaced by the labeled measurement relation."""
     original = _prepared_inputs()
@@ -482,6 +483,7 @@ def test_site_indicator_is_derived_from_measurement_sites() -> None:
     np.testing.assert_array_equal(decoded, restored.inv_inputs["site"].values)
 
 
+@pytest.mark.rhime_contract
 @pytest.mark.parametrize("suffix", [".nc", ".zarr"])
 def test_real_prepared_inputs_save_load_and_run_without_repreparation(
     monkeypatch: pytest.MonkeyPatch,
@@ -489,7 +491,12 @@ def test_real_prepared_inputs_save_load_and_run_without_repreparation(
     prepared_from_real_route: RhimePreparedInputs,
     suffix: str,
 ) -> None:
-    """Real RHIME preparation survives both stores and runs without repeating preparation."""
+    """Freeze the labeled prepared-input round-trip and replay contract.
+
+    Both NetCDF and Zarr must preserve dimensions, indexed and auxiliary
+    coordinates, values, site alignment, and retained-basis metadata. Replaying
+    either artifact must also bypass data preparation.
+    """
     prepared = prepared_from_real_route
     serialized = prepared.to_datatree()
     encoded_inputs = serialized["inv_inputs"].to_dataset()

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -7,12 +7,14 @@ from types import SimpleNamespace
 from typing import Any, Callable, cast
 
 import arviz as az
+import dask.array as da
 import numpy as np
 import pandas as pd
 import pymc as pm
 import pytest
 import xarray as xr
 from pytensor.compile.mode import Mode
+from dask.callbacks import Callback
 
 import openghg_inversions.hbmcmc.inversion_pymc as legacy_mcmc
 import openghg_inversions.inversion_data.preparation as prep_module
@@ -918,15 +920,46 @@ def test_compile_loop_sum_resolves_zero_activity_across_shared_state_terms() -> 
     assert compiled.latents["shared"] is model["x_shared_active"]
 
 
+@pytest.mark.rhime_contract
 def test_build_rhime_model_contains_expected_variables(
     rhime_inv_inputs: xr.Dataset, builder_args: dict
 ) -> None:
-    """Build the low-level model with explicitly prepared sigma alignment."""
+    """Freeze the exact standard built-model variable and dimension inventory."""
     model = build_rhime_model(rhime_inv_inputs, **builder_args)
 
     assert isinstance(model, pm.Model)
-    expected = {"x", "mu", "bc", "mu_bc", "sigma", "epsilon", "y"}
-    assert expected.issubset(model.named_vars)
+    assert set(model.named_vars) == {
+        "Y",
+        "bc",
+        "epsilon",
+        "error",
+        "hbc",
+        "hx",
+        "min_error",
+        "mu",
+        "mu_bc",
+        "sigma",
+        "sigma_period_index",
+        "sigma_site_index",
+        "x",
+        "y",
+    }
+    assert model.named_vars_to_dims == {
+        "Y": ("nmeasure",),
+        "bc": ("bc_region",),
+        "epsilon": ("nmeasure",),
+        "error": ("nmeasure",),
+        "hbc": ("nmeasure", "bc_region"),
+        "hx": ("nmeasure", "region"),
+        "min_error": ("nmeasure",),
+        "mu": ("nmeasure",),
+        "mu_bc": ("nmeasure",),
+        "sigma": ("nsigma_site", "nsigma_time"),
+        "sigma_period_index": ("nmeasure",),
+        "sigma_site_index": ("nmeasure",),
+        "x": ("region",),
+        "y": ("nmeasure",),
+    }
 
 
 def test_build_rhime_model_accepts_student_t_likelihood_builder(
@@ -966,11 +999,13 @@ def test_build_rhime_model_accepts_student_t_likelihood_builder(
     }
 
 
+@pytest.mark.rhime_contract
 def test_build_rhime_model_accepts_global_scalar_offset(
     rhime_inv_inputs: xr.Dataset,
     builder_args: dict,
 ) -> None:
     """The built-in graph can broadcast one scalar offset over observations."""
+    base_model = build_rhime_model(rhime_inv_inputs, **builder_args)
     model = build_rhime_model(
         rhime_inv_inputs,
         **{
@@ -980,6 +1015,13 @@ def test_build_rhime_model_accepts_global_scalar_offset(
         },
     )
 
+    assert set(model.named_vars) - set(base_model.named_vars) == {
+        "offset",
+        "offset_latent",
+        "site_indicator",
+    }
+    assert "offset_latent" not in model.named_vars_to_dims
+    assert model.named_vars_to_dims["offset"] == ("nmeasure",)
     assert model["offset_latent"].ndim == 0
     assert model["offset"].eval().shape == (rhime_inv_inputs.sizes["nmeasure"],)
 
@@ -990,29 +1032,116 @@ def test_modern_inv_inputs_omit_component_owned_sigma_index(rhime_inv_inputs: xr
     assert "sigma_period_index" not in rhime_inv_inputs
 
 
+@pytest.mark.rhime_contract
 def test_build_rhime_multisector_model_contains_expected_variables(
     multisector_inv_inputs: xr.Dataset, builder_args: dict
 ) -> None:
-    """Build the multisector model with explicitly prepared sigma alignment."""
+    """Freeze the exact multi-sector built-model variable and dimension inventory."""
     sectors = ["total-ukghg-edgar7", "sector-2"]
     model = build_rhime_multisector_model(multisector_inv_inputs, sectors=sectors, **builder_args)
 
-    expected = {
+    assert set(model.named_vars) == {
+        "Y",
+        "bc",
+        "epsilon",
+        "error",
+        "hbc",
+        "hx_sector_2",
+        "hx_total_ukghg_edgar7",
+        "min_error",
+        "mu",
         "x_total_ukghg_edgar7",
         "mu_total_ukghg_edgar7",
         "x_sector_2",
         "mu_sector_2",
-        "mu",
-        "bc",
         "mu_bc",
         "sigma",
-        "epsilon",
+        "sigma_period_index",
+        "sigma_site_index",
         "y",
     }
-    assert expected.issubset(model.named_vars)
+    assert model.named_vars_to_dims == {
+        "Y": ("nmeasure",),
+        "bc": ("bc_region",),
+        "epsilon": ("nmeasure",),
+        "error": ("nmeasure",),
+        "hbc": ("nmeasure", "bc_region"),
+        "hx_sector_2": ("nmeasure", "region"),
+        "hx_total_ukghg_edgar7": ("nmeasure", "region"),
+        "min_error": ("nmeasure",),
+        "mu": ("nmeasure",),
+        "mu_bc": ("nmeasure",),
+        "mu_sector_2": ("nmeasure",),
+        "mu_total_ukghg_edgar7": ("nmeasure",),
+        "sigma": ("nsigma_site", "nsigma_time"),
+        "sigma_period_index": ("nmeasure",),
+        "sigma_site_index": ("nmeasure",),
+        "x_sector_2": ("region",),
+        "x_total_ukghg_edgar7": ("region",),
+        "y": ("nmeasure",),
+    }
     region_coord = model.coords["region"]
     assert region_coord is not None
     assert len(region_coord) == multisector_inv_inputs.sizes["region"]
+
+
+@pytest.mark.rhime_contract
+def test_rhime_dask_materialization_boundaries(
+    rhime_inv_inputs: xr.Dataset,
+    builder_args: dict,
+) -> None:
+    """Observe eager sensitivity checks and PyMC registration without mutating lazy inputs."""
+    lazy_inputs = rhime_inv_inputs.copy()
+    lazy_names = ("H", "H_bc", "mf", "mf_error", "min_error")
+    lazy_arrays: dict[str, da.Array] = {}
+    materializations = dict.fromkeys(lazy_names, 0)
+
+    def record_materialization(block: np.ndarray, *, variable: str) -> np.ndarray:
+        """Record materialization of a named Dask-backed input.
+
+        Args:
+            block: Materialized NumPy block supplied by Dask.
+            variable: Input variable whose counter is incremented.
+
+        Returns:
+            The input block unchanged.
+
+        Side Effects:
+            Increments ``materializations[variable]``.
+        """
+        materializations[variable] += 1
+        return block
+
+    for name in lazy_names:
+        eager = rhime_inv_inputs[name]
+        lazy = da.from_array(eager.data, chunks=eager.shape).map_blocks(
+            record_materialization,
+            variable=name,
+            name=f"ope43-{name}",
+            meta=np.array((), dtype=eager.dtype),
+        )
+        lazy_inputs[name] = eager.copy(data=lazy)
+        lazy_arrays[name] = lazy
+
+    preparation_tasks: list[object] = []
+    with Callback(pretask=lambda key, _dsk, _state: preparation_tasks.append(key)):
+        prep_module._warn_for_nan_inputs(lazy_inputs, use_bc=True)
+
+    assert preparation_tasks
+    assert materializations == {"H": 1, "H_bc": 1, "mf": 0, "mf_error": 0, "min_error": 0}
+
+    materializations.update(dict.fromkeys(lazy_names, 0))
+    model_tasks: list[object] = []
+    with Callback(pretask=lambda key, _dsk, _state: model_tasks.append(key)):
+        model = build_rhime_model(lazy_inputs, **builder_args)
+
+    assert model_tasks
+    for name in lazy_names:
+        assert materializations[name] > 0
+        assert lazy_inputs[name].data is lazy_arrays[name]
+        assert lazy_inputs[name].chunks == lazy_arrays[name].chunks
+    np.testing.assert_array_equal(model["hx"].get_value(), rhime_inv_inputs["H"].T)
+    np.testing.assert_array_equal(model["hbc"].get_value(), rhime_inv_inputs["H_bc"].T)
 
 
 def test_build_rhime_multisector_model_uses_sector_names_for_variables(
@@ -2206,6 +2335,7 @@ def test_run_rhime_from_prepared_inputs_rejects_flag_h_layout_mismatch_before_ex
         run_rhime_from_prepared_inputs(prepared_inputs=prepared, run_spec=run_spec)
 
 
+@pytest.mark.rhime_contract
 def test_run_rhime_from_prepared_inputs_defaults_sampler_and_skips_none_output_writes(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -2501,6 +2631,7 @@ def test_legacy_sampling_names_are_not_rhime_config_aliases() -> None:
         ("legacy", "legacy"),
     ],
 )
+@pytest.mark.rhime_contract
 def test_rhime_normalises_legacy_output_format_aliases(
     legacy_output_format: str, expected_output_format: str
 ) -> None:
@@ -2736,6 +2867,7 @@ def test_rhime_model_spec_rejects_unknown_builder_strategy() -> None:
         )
 
 
+@pytest.mark.rhime_contract
 def test_rhime_sampler_runs_pymc_sampling_and_predictive_steps(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -5195,27 +5327,8 @@ def test_run_rhime_rejects_unknown_parameter_before_data_preparation(tmp_path: P
 
 
 @pytest.mark.rhime_contract
-def test_run_rhime_rejects_prepared_input_model_builder_before_data_preparation(tmp_path: Path) -> None:
-    """Reject model_builder at acquisition entry before input preparation."""
-    args = {
-        "species": "ch4",
-        "sites": ["TAC"],
-        "averaging_period": ["1h"],
-        "domain": "EUROPE",
-        "start_date": "2019-01-01",
-        "end_date": "2019-01-02",
-        "flux_sources": ["total-ukghg-edgar7"],
-        "output_path": str(tmp_path),
-        "output_name": "prior_variation",
-        "x_prior": {"pdf": "normal", "mu": 1.0, "sigma": 0.5},
-        "model_builder": object(),
-    }
-
-    with pytest.raises(ValueError, match="Unsupported RHIME parameter.*model_builder"):
-        run_rhime(**args)
-
-
 def test_run_rhime_rejects_unsupported_output_format(tmp_path: Path) -> None:
+    """Reject an output mode outside the accepted standard inventory."""
     args = {
         "species": "ch4",
         "sites": ["TAC"],
@@ -5360,7 +5473,9 @@ def test_runner_setup_defaults_inv_out_save_only_for_inv_out_format(tmp_path: Pa
     assert paris_setup.run_spec.output.save_inversion_output is False
 
 
+@pytest.mark.rhime_contract
 def test_output_path_validation_rejects_multisector_legacy_output() -> None:
+    """Reject the single-sector-only legacy format for multi-sector runs."""
     with pytest.raises(ValueError, match="single-sector"):
         rhime_specs.validate_output_path_settings(
             output_format="legacy",
@@ -5386,7 +5501,31 @@ def test_make_output_spec_validates_trace_save_path() -> None:
         )
 
 
+@pytest.mark.rhime_contract
+@pytest.mark.parametrize("output_format", ["none", "inv_out", "basic", "paris", "legacy"])
+def test_make_output_spec_accepts_supported_output_modes(
+    tmp_path: Path,
+    output_format: str,
+) -> None:
+    """Accept every supported standard RHIME output mode."""
+    spec = rhime_specs.make_output_spec(
+        output_format=output_format,
+        output_path=str(tmp_path),
+        output_name="test",
+        save_trace=False,
+        save_inversion_output=False,
+        country_file=None,
+        paris_postprocessing_kwargs=None,
+        output_filename_convention="rhime",
+        multisector=False,
+    )
+
+    assert spec.output_format == output_format
+
+
+@pytest.mark.rhime_contract
 def test_make_output_spec_normalizes_filename_convention_case() -> None:
+    """Normalize supported output and filename convention aliases."""
     spec = rhime_specs.make_output_spec(
         output_format="Legacy",
         output_path="outputs",
@@ -5403,7 +5542,9 @@ def test_make_output_spec_normalizes_filename_convention_case() -> None:
     assert spec.output_filename_convention == "legacy"
 
 
+@pytest.mark.rhime_contract
 def test_derived_output_filename_can_use_legacy_convention(tmp_path: Path) -> None:
+    """Freeze the historical derived-product filename convention."""
     spec = RhimeOutputSpec(
         output_format="legacy",
         output_path=str(tmp_path),
@@ -5423,7 +5564,9 @@ def test_derived_output_filename_can_use_legacy_convention(tmp_path: Path) -> No
     assert filename == tmp_path / "CH4_EUROPE_legacy_test_2019-01-01.nc"
 
 
+@pytest.mark.rhime_contract
 def test_make_standard_output_bundle_returns_outputs_without_mutating_result() -> None:
+    """Return the standard modern output bundle with aligned release coordinates."""
     model_spec, output_spec, run_spec = _minimal_output_specs()
     inv_inputs = _minimal_output_inv_inputs().assign_coords(
         release_lat=("nmeasure", [51.0]),
@@ -5483,6 +5626,7 @@ def test_output_bundle_serializes_state_activity_spec() -> None:
     assert policy["fixed_value"] == 2.0
 
 
+@pytest.mark.rhime_contract
 def test_make_multisector_output_bundle_returns_modern_inv_out() -> None:
     """Multi-sector RHIME outputs retain the same modern inversion-output contract."""
     sectors = (
@@ -5615,6 +5759,7 @@ def test_make_multisector_output_bundle_builds_latest_paris_flux(
     assert tuple(paris_flux.sector.values) == ("ff", "ocean")
 
 
+@pytest.mark.rhime_contract
 def test_modern_inversion_output_save_load_roundtrip(tmp_path: Path) -> None:
     """Modern output preserves January annual flux metadata for a June run."""
     model_spec, output_spec, _ = _minimal_output_specs()
@@ -6334,6 +6479,7 @@ def test_latest_paris_concentration_fills_missing_bc_with_nan(europe_country_fil
         assert np.isnan(conc_outputs[name].values).all()
 
 
+@pytest.mark.rhime_contract
 def test_standard_basic_output_uses_modern_postprocessing_without_legacy_adapter(monkeypatch) -> None:
     """RHIME basic postprocessing consumes modern output without legacy adapters."""
     model_spec, output_spec, run_spec = _minimal_output_specs(output_format="basic")
@@ -6372,6 +6518,7 @@ def test_standard_basic_output_uses_modern_postprocessing_without_legacy_adapter
     assert "basic" in bundle.outputs
 
 
+@pytest.mark.rhime_contract
 def test_standard_paris_output_uses_modern_postprocessing_without_legacy_adapter(monkeypatch) -> None:
     """RHIME PARIS postprocessing consumes modern output without legacy adapters."""
     model_spec, output_spec, run_spec = _minimal_output_specs(output_format="paris")
@@ -6424,6 +6571,7 @@ def test_standard_paris_output_uses_modern_postprocessing_without_legacy_adapter
     assert "paris_concentration" in bundle.outputs
 
 
+@pytest.mark.rhime_contract
 def test_standard_legacy_output_uses_modern_inversion_output(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -6526,6 +6674,7 @@ def test_save_inferencedata_falls_back_after_h5netcdf_failure(tmp_path: Path) ->
     ]
 
 
+@pytest.mark.rhime_contract
 def test_save_inferencedata_preserves_burn_attrs_and_resets_multiindex_coords(tmp_path: Path) -> None:
     """Standalone trace saving preserves burn metadata and serializable coordinates."""
     nmeasure_index = pd.MultiIndex.from_arrays(
@@ -6607,13 +6756,15 @@ def test_run_rhime_multisector_rejects_single_flux_source(tac_ch4_data_args, tmp
         run_rhime_multisector(**args)
 
 
+@pytest.mark.rhime_contract
 def test_run_rhime_api_smoke(
     monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
     tac_ch4_data_args: dict[str, Any],
     tmp_path: Path,
     default_bc_basis_directory: Path,
 ) -> None:
-    """Run the single-sector API with real preparation, outputs, and mocked sampling."""
+    """Run a custom Normal prior, ordered timings, and serialized-output round-trip."""
     args = tac_ch4_data_args.copy()
     args.update(
         {
@@ -6629,7 +6780,7 @@ def test_run_rhime_api_smoke(
             "tune": 0,
             "chains": 1,
             "reload_merged_data": False,
-            "x_prior": {"pdf": "normal", "mu": 1.0, "sigma": 1.0},
+            "x_prior": {"pdf": "normal", "mu": 1.25, "sigma": 0.125},
             "bc_prior": {"pdf": "normal", "mu": 1.0, "sigma": 1.0},
             "sigma_prior": {"pdf": "uniform", "lower": 0.1, "upper": 10.0},
             "sample_kwargs": {"random_seed": 123, "compute_convergence_checks": False},
@@ -6646,22 +6797,34 @@ def test_run_rhime_api_smoke(
     result = run_rhime(**args)
 
     assert isinstance(result, RhimeResult)
+    assert result.model is not None
     assert isinstance(result.basis_functions, BasisFunctions)
     assert not hasattr(result, "basis_objects")
     posterior = cast(Any, result.idata).posterior
     assert "x" in posterior
     assert "mu" in posterior
     assert result.run_spec.split_by_sectors is False
+    assert result.model_spec.sectors[0].x_prior == {
+        "pdf": "normal",
+        "mu": 1.25,
+        "sigma": 0.125,
+    }
+    assert result.model.named_vars_to_dims["x"] == ("region",)
+    x_owner = result.model["x"].owner
+    assert x_owner is not None
+    assert type(x_owner.op).__name__ == "NormalRV"
+    np.testing.assert_allclose(pm.draw(x_owner.inputs[-2]), 1.25)
+    np.testing.assert_allclose(pm.draw(x_owner.inputs[-1]), 0.125)
+    assert result.inv_inputs["H"].dims == ("region", "nmeasure")
+    assert result.inv_inputs.sizes["region"] == 4
+    assert result.inv_inputs.sizes["nmeasure"] == 24
+    nmeasure_index = result.inv_inputs.indexes["nmeasure"]
+    assert isinstance(nmeasure_index, pd.MultiIndex)
+    assert nmeasure_index.names == ["site", "time"]
+    assert nmeasure_index.get_level_values("site").unique().tolist() == ["TAC"]
     assert "inversion_output" in result.outputs
     assert isinstance(result.inv_out, InversionOutput)
     assert result.output_metadata["inversion_output_contract"] == "modern"
-    inv_input_long_names = [
-        result.inv_inputs.mf.attrs.get("long_name", ""),
-        result.inv_inputs.mf_error.attrs.get("long_name", ""),
-        result.inv_inputs.mf_repeatability.attrs.get("long_name", ""),
-        result.inv_inputs.mf_variability.attrs.get("long_name", ""),
-    ]
-    assert all("number_of_observations" not in long_name for long_name in inv_input_long_names)
     output_file = tmp_path / "rhime_test2019-01-01_inversion_output.nc"
     assert output_file.exists()
     reloaded = InversionOutput.load(output_file)
@@ -6669,13 +6832,28 @@ def test_run_rhime_api_smoke(
     assert reloaded.domain == args["domain"]
     assert isinstance(reloaded.basis_functions, BasisFunctions)
     xr.testing.assert_identical(reloaded.inv_inputs, result.inv_inputs)
-    obs_long_names = [
-        reloaded.inv_inputs.mf.attrs.get("long_name", ""),
-        reloaded.inv_inputs.mf_error.attrs.get("long_name", ""),
-        reloaded.inv_inputs.mf_repeatability.attrs.get("long_name", ""),
-        reloaded.inv_inputs.mf_variability.attrs.get("long_name", ""),
-    ]
-    assert all("number_of_observations" not in long_name for long_name in obs_long_names)
+    xr.testing.assert_identical(reloaded.trace.posterior, result.idata.posterior)
+
+    timing_output = capsys.readouterr().out
+    previous_position = -1
+    for label in (
+        "rhime.runner_setup",
+        "rhime.prepare_inputs.merged_data",
+        "rhime.prepare_inputs.obs_filtering",
+        "rhime.prepare_inputs.basis_build",
+        "rhime.prepare_inputs.footprint_sensitivity_total",
+        "rhime.prepare_inputs.make_inv_inputs",
+        "rhime.prepare_inputs.prepared_dims",
+        "rhime.prepare_inputs",
+        "rhime.model_build",
+        "rhime.sampler_total",
+        "rhime.output.inversion_output_create",
+        "rhime.output.inversion_output_save",
+        "rhime.output_bundle_total",
+    ):
+        position = timing_output.index(f"TIMING {label} ")
+        assert position > previous_position
+        previous_position = position
 
 
 @pytest.mark.rhime_contract

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -2065,13 +2065,9 @@ def test_likelihood_builder_provenance_is_saved_with_result_metadata(
         likelihood_builder=verification_gaussian,
     )
 
-    assert result.output_metadata["likelihood_builder"]["qualname"].endswith(
-        "verification_gaussian"
-    )
+    assert result.output_metadata["likelihood_builder"]["qualname"].endswith("verification_gaussian")
     assert result.model_build_result is not None
-    assert result.model_build_result.metadata["likelihood"]["family"] == (
-        "absolute_sigma_gaussian"
-    )
+    assert result.model_build_result.metadata["likelihood"]["family"] == ("absolute_sigma_gaussian")
     assert result.inv_out is not None
     saved_builder = result.inv_out.model_metadata["builder"]
     assert saved_builder["likelihood_builder"] == result.output_metadata["likelihood_builder"]
@@ -3643,9 +3639,11 @@ def test_multisector_runner_rejects_shared_basis_h_layout_mismatch() -> None:
         )
 
 
+@pytest.mark.rhime_contract
 def test_prepare_rhime_inputs_single_sector_reloads_merged_data(
     tac_ch4_data_args, merged_data_dir, merged_data_file_name, default_bc_basis_directory
 ) -> None:
+    """Characterize reload preparation as a single-sector public contract."""
     args = _rhime_preparation_args(
         tac_ch4_data_args,
         tac_ch4_data_args["emissions_name"],
@@ -3670,9 +3668,11 @@ def test_prepare_rhime_inputs_single_sector_reloads_merged_data(
         assert not hasattr(prepared, legacy_attr)
 
 
+@pytest.mark.rhime_contract
 def test_prepare_rhime_inputs_multisector_keeps_source_dimension(
     tac_ch4_data_args, default_bc_basis_directory
 ) -> None:
+    """Characterize source-preserving multi-sector preparation."""
     flux_sources = ["total-ukghg-edgar7", "total-ukghg-edgar7-shuffled"]
     args = _rhime_preparation_args(tac_ch4_data_args, flux_sources, default_bc_basis_directory)
     args["split_by_sectors"] = True
@@ -4495,9 +4495,11 @@ def test_prepare_rhime_inputs_rejects_non_string_averaging_period_values(
         )
 
 
+@pytest.mark.rhime_contract
 def test_run_rhime_leaves_scalar_averaging_period_for_shared_preparation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Ensure scalar averaging periods reach shared preparation unchanged."""
     captured_averaging_period: object = None
     original_signature = inspect.signature(prepare_rhime_inputs)
 
@@ -5172,7 +5174,9 @@ output_name = "test"
         params_from_config(config_file)
 
 
+@pytest.mark.rhime_contract
 def test_run_rhime_rejects_unknown_parameter_before_data_preparation(tmp_path: Path) -> None:
+    """Reject unknown acquisition parameters before preparation begins."""
     args = {
         "species": "ch4",
         "sites": ["TAC"],
@@ -5187,6 +5191,27 @@ def test_run_rhime_rejects_unknown_parameter_before_data_preparation(tmp_path: P
     }
 
     with pytest.raises(ValueError, match="Unsupported RHIME parameter"):
+        run_rhime(**args)
+
+
+@pytest.mark.rhime_contract
+def test_run_rhime_rejects_prepared_input_model_builder_before_data_preparation(tmp_path: Path) -> None:
+    """Reject model_builder at acquisition entry before input preparation."""
+    args = {
+        "species": "ch4",
+        "sites": ["TAC"],
+        "averaging_period": ["1h"],
+        "domain": "EUROPE",
+        "start_date": "2019-01-01",
+        "end_date": "2019-01-02",
+        "flux_sources": ["total-ukghg-edgar7"],
+        "output_path": str(tmp_path),
+        "output_name": "prior_variation",
+        "x_prior": {"pdf": "normal", "mu": 1.0, "sigma": 0.5},
+        "model_builder": object(),
+    }
+
+    with pytest.raises(ValueError, match="Unsupported RHIME parameter.*model_builder"):
         run_rhime(**args)
 
 
@@ -6653,13 +6678,14 @@ def test_run_rhime_api_smoke(
     assert all("number_of_observations" not in long_name for long_name in obs_long_names)
 
 
+@pytest.mark.rhime_contract
 def test_run_rhime_multisector_api_smoke(
     monkeypatch: pytest.MonkeyPatch,
     tac_ch4_data_args: dict[str, Any],
     tmp_path: Path,
     default_bc_basis_directory: Path,
 ) -> None:
-    """Run the multisector API with real diagnostics and mocked sampling."""
+    """Exercise the multi-sector public API with deterministic sampling."""
     args = tac_ch4_data_args.copy()
     args.update(
         {
@@ -6724,7 +6750,9 @@ def test_run_rhime_multisector_api_smoke(
     assert "flux_total_posterior_mean" in result.outputs["sector_flux_diagnostics"]
 
 
+@pytest.mark.rhime_contract
 def test_cli_run_rhime_passes_config_and_overrides(monkeypatch, tmp_path: Path) -> None:
+    """Forward run-rhime CLI dates, output path, and JSON overrides."""
     config_file = tmp_path / "rhime.ini"
     config_file.write_text('[RHIME.OUTPUT]\noutput_name = "test"\n', encoding="utf-8")
     seen = {}
@@ -6756,7 +6784,9 @@ def test_cli_run_rhime_passes_config_and_overrides(monkeypatch, tmp_path: Path) 
     assert seen["kwargs"]["draws"] == 1
 
 
+@pytest.mark.rhime_contract
 def test_cli_run_rhime_multisector_passes_config(monkeypatch, tmp_path: Path) -> None:
+    """Forward the multi-sector CLI configuration unchanged."""
     config_file = tmp_path / "rhime.ini"
     config_file.write_text('[RHIME.OUTPUT]\noutput_name = "test"\n', encoding="utf-8")
     seen = {}

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -6929,17 +6929,65 @@ def test_run_rhime_multisector_api_smoke(
 
 
 @pytest.mark.rhime_contract
-def test_cli_run_rhime_passes_config_and_overrides(monkeypatch, tmp_path: Path) -> None:
-    """Forward run-rhime CLI dates, output path, and JSON overrides."""
+def test_cli_run_rhime_passes_config_and_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Merge a real config with winning CLI values across RHIME pipeline seams."""
     config_file = tmp_path / "rhime.ini"
-    config_file.write_text('[RHIME.OUTPUT]\noutput_name = "test"\n', encoding="utf-8")
-    seen = {}
+    config_file.write_text(
+        """
+[INPUT.MEASUREMENTS]
+species = "co2"
+sites = ["MHD"]
+averaging_period = ["2h"]
+start_date = "2018-01-01"
+end_date = "2018-01-02"
 
-    def fake_run_rhime(*, config_file, **kwargs):
-        seen["config_file"] = config_file
-        seen["kwargs"] = kwargs
+[INPUT.STORES]
+bc_store = "config-bc-store"
 
-    monkeypatch.setattr("openghg_inversions.rhime.run_rhime", fake_run_rhime)
+[INPUT.PRIORS]
+domain = "CONFIG-DOMAIN"
+flux_sources = ["config-source"]
+
+[INPUT.BASIS_CASE]
+basis_algorithm = "quadtree"
+
+[RHIME.PDF]
+x_prior = {"pdf": "uniform", "lower": 0.5, "upper": 1.5}
+
+[RHIME.ITERATIONS]
+draws = 17
+
+[RHIME.OUTPUT]
+output_path = "config-output"
+output_name = "config-name"
+output_format = "inv_out"
+""",
+        encoding="utf-8",
+    )
+    prepared = RhimePreparedInputs(
+        inv_inputs=_minimal_output_inv_inputs(),
+        basis_functions=_fake_basis_functions(),
+        site_metadata=_prepared_site_metadata(),
+    )
+    seen: dict[str, Any] = {}
+
+    def fake_prepare_rhime_inputs(**kwargs: Any) -> RhimePreparedInputs:
+        """Capture post-merge preparation arguments and return minimal inputs."""
+        seen["preparation"] = kwargs
+        return prepared
+
+    setattr(fake_prepare_rhime_inputs, "__signature__", inspect.signature(prepare_rhime_inputs))
+
+    def fake_execute_prepared_rhime(**kwargs: Any) -> RhimeResult:
+        """Capture the model, sampler, and output specs after config merging."""
+        seen["execution"] = kwargs
+        return cast(RhimeResult, SimpleNamespace())
+
+    monkeypatch.setattr(rhime_module, "prepare_rhime_inputs", fake_prepare_rhime_inputs)
+    monkeypatch.setattr(rhime_module, "_execute_prepared_rhime", fake_execute_prepared_rhime)
 
     main(
         [
@@ -6951,15 +6999,48 @@ def test_cli_run_rhime_passes_config_and_overrides(monkeypatch, tmp_path: Path) 
             "--output-path",
             str(tmp_path),
             "--kwargs",
-            '{"draws": 1}',
+            (
+                '{"species": "ch4", "sites": ["TAC"], '
+                '"averaging_period": ["1h"], "domain": "DIRECT-DOMAIN", '
+                '"flux_sources": ["direct-source"], "basis_algorithm": "weighted", '
+                '"x_prior": {"pdf": "normal", "mu": 1.25, "sigma": 0.125}, '
+                '"draws": 7, "output_name": "direct-name", "output_format": "none"}'
+            ),
         ]
     )
 
-    assert seen["config_file"] == str(config_file)
-    assert seen["kwargs"]["start_date"] == "2019-01-01"
-    assert seen["kwargs"]["end_date"] == "2019-01-02"
-    assert seen["kwargs"]["output_path"] == str(tmp_path)
-    assert seen["kwargs"]["draws"] == 1
+    preparation = seen["preparation"]
+    assert preparation["species"] == "ch4"
+    assert preparation["sites"] == ["TAC"]
+    assert preparation["averaging_period"] == ["1h"]
+    assert preparation["domain"] == "DIRECT-DOMAIN"
+    assert preparation["start_date"] == "2019-01-01"
+    assert preparation["end_date"] == "2019-01-02"
+    assert preparation["flux_sources"] == ["direct-source"]
+    assert preparation["basis_algorithm"] == "weighted"
+    assert preparation["bc_store"] == "config-bc-store"
+    assert preparation["output_name"] == "direct-name"
+
+    execution = seen["execution"]
+    assert execution["prepared"] is prepared
+    assert execution["multisector"] is False
+    run_spec = execution["run_spec"]
+    assert run_spec.start_date == "2019-01-01"
+    assert run_spec.end_date == "2019-01-02"
+    assert run_spec.sites == ("TAC",)
+    assert run_spec.averaging_period == ("1h",)
+    assert run_spec.model.species == "ch4"
+    assert run_spec.model.domain == "DIRECT-DOMAIN"
+    assert run_spec.model.sectors[0].flux_source == "direct-source"
+    assert run_spec.model.sectors[0].x_prior == {
+        "pdf": "normal",
+        "mu": 1.25,
+        "sigma": 0.125,
+    }
+    assert execution["sampler"].draws == 7
+    assert run_spec.output.output_path == str(tmp_path)
+    assert run_spec.output.output_name == "direct-name"
+    assert run_spec.output.output_format == "none"
 
 
 @pytest.mark.rhime_contract

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -5687,12 +5687,14 @@ def test_make_multisector_output_bundle_returns_modern_inv_out() -> None:
     assert bundle.outputs["inversion_output"] is bundle.inv_out
 
 
+@pytest.mark.rhime_contract
 def test_make_multisector_output_bundle_builds_latest_paris_flux(
     europe_country_file: Path,
     fake_multisector_basis_functions_matching_country_grid: Callable[..., BasisFunctions],
     multisector_postprocessing_inv_out: Callable[..., InversionOutput],
+    tmp_path: Path,
 ) -> None:
-    """Multi-sector PARIS output builds explicit latest total and sector flux output."""
+    """Serialize real multi-sector PARIS flux and sector diagnostics products."""
     sectors = (
         SectorSpec(
             name="FF",
@@ -5710,6 +5712,7 @@ def test_make_multisector_output_bundle_builds_latest_paris_flux(
     model_spec = RhimeModelSpec(species="ch4", domain="EUROPE", sectors=sectors)
     output_spec = RhimeOutputSpec(
         output_format="paris",
+        output_path=str(tmp_path),
         output_name="test",
         save_inversion_output=False,
         paris_postprocessing_kwargs={
@@ -5758,8 +5761,62 @@ def test_make_multisector_output_bundle_builds_latest_paris_flux(
     assert "flux_ocean_posterior" in paris_flux
     assert tuple(paris_flux.sector.values) == ("ff", "ocean")
 
+    paris_flux_path = Path(bundle.output_metadata["paris_flux_path"])
+    diagnostics_path = Path(bundle.output_metadata["sector_flux_diagnostics_path"])
+    assert paris_flux_path.exists()
+    assert diagnostics_path.exists()
+    with xr.open_dataset(paris_flux_path) as reloaded_paris_flux:
+        assert "flux_total_posterior" in reloaded_paris_flux
+        assert "flux_ff_posterior" in reloaded_paris_flux
+        assert "flux_ocean_posterior" in reloaded_paris_flux
+    with xr.open_dataset(diagnostics_path) as reloaded_diagnostics:
+        assert "flux_ff_posterior_mean" in reloaded_diagnostics
+        assert "flux_ocean_posterior_mean" in reloaded_diagnostics
+        assert "flux_total_posterior_mean" in reloaded_diagnostics
+
 
 @pytest.mark.rhime_contract
+def test_default_model_inversion_output_save_load_roundtrip(tmp_path: Path) -> None:
+    """Round-trip default-model metadata, trace attrs, inputs, and retained basis."""
+    model_spec, output_spec, run_spec = _minimal_output_specs()
+    prepared = RhimePreparedInputs(
+        inv_inputs=_minimal_output_inv_inputs(),
+        basis_functions=_fake_basis_functions(artifact_source="unit-test"),
+        site_metadata=_prepared_site_metadata(),
+    )
+    idata = _minimal_output_idata()
+    idata.attrs["burn"] = 1000
+    cast(Any, idata).posterior.attrs["burn"] = 1000
+    bundle = rhime_outputs.make_standard_output_bundle(
+        output_spec=output_spec,
+        run_spec=run_spec,
+        model_spec=model_spec,
+        idata=idata,
+        prepared=prepared,
+        country_file=None,
+    )
+    assert bundle.inv_out is not None
+
+    output_file = tmp_path / "default_model_inv_out.nc"
+    bundle.inv_out.save(output_file)
+    reloaded = InversionOutput.load(output_file)
+
+    assert reloaded.species == "ch4"
+    assert reloaded.domain == "EUROPE"
+    assert reloaded.run_metadata["basis_artifact_source"] == "unit-test"
+    assert reloaded.provenance["basis_representation"] == "operator-backed"
+    assert reloaded.output_metadata["output_format"] == "inv_out"
+    assert reloaded.model_metadata["builder_strategy"] == "concrete"
+    assert reloaded.trace.attrs["burn"] == 1000
+    assert cast(Any, reloaded.trace).posterior.attrs["burn"] == 1000
+    xr.testing.assert_identical(reloaded.inv_inputs, prepared.inv_inputs)
+    xr.testing.assert_identical(reloaded.basis_functions.flux, prepared.basis_functions.flux)
+    xr.testing.assert_equal(
+        reloaded.basis_functions.operator.basis_matrix,
+        prepared.basis_functions.operator.basis_matrix,
+    )
+
+
 def test_modern_inversion_output_save_load_roundtrip(tmp_path: Path) -> None:
     """Modern output preserves January annual flux metadata for a June run."""
     model_spec, output_spec, _ = _minimal_output_specs()
@@ -6197,8 +6254,9 @@ def test_standard_postprocessing_rejects_multisector_outputs() -> None:
         basic_output(inv_out)
 
 
+@pytest.mark.rhime_contract
 def test_basic_output_processes_modern_output(europe_country_file: Path) -> None:
-    """Real basic postprocessing accepts modern output directly."""
+    """Produce key observation, error, predictive, flux, and country variables."""
     from openghg_inversions.postprocessing.make_outputs import basic_output
 
     outputs = basic_output(
@@ -6330,8 +6388,9 @@ def test_paris_concentration_column_prior_factor_is_added_to_totals_not_bc(europ
     assert float(conc_outputs["Yobs_prior_upper_level_factor"].squeeze()) == pytest.approx(0.3 * units)
 
 
+@pytest.mark.rhime_contract
 def test_latest_paris_output_processes_modern_output(europe_country_file: Path, tmp_path: Path) -> None:
-    """Explicit latest PARIS output uses the new concentration and flux templates."""
+    """Validate selected latest-PARIS schema fields and serialized dtypes."""
     from openghg_inversions.postprocessing.make_paris_outputs import (
         make_paris_outputs,
     )
@@ -6479,7 +6538,6 @@ def test_latest_paris_concentration_fills_missing_bc_with_nan(europe_country_fil
         assert np.isnan(conc_outputs[name].values).all()
 
 
-@pytest.mark.rhime_contract
 def test_standard_basic_output_uses_modern_postprocessing_without_legacy_adapter(monkeypatch) -> None:
     """RHIME basic postprocessing consumes modern output without legacy adapters."""
     model_spec, output_spec, run_spec = _minimal_output_specs(output_format="basic")
@@ -6518,7 +6576,6 @@ def test_standard_basic_output_uses_modern_postprocessing_without_legacy_adapter
     assert "basic" in bundle.outputs
 
 
-@pytest.mark.rhime_contract
 def test_standard_paris_output_uses_modern_postprocessing_without_legacy_adapter(monkeypatch) -> None:
     """RHIME PARIS postprocessing consumes modern output without legacy adapters."""
     model_spec, output_spec, run_spec = _minimal_output_specs(output_format="paris")
@@ -6573,10 +6630,13 @@ def test_standard_paris_output_uses_modern_postprocessing_without_legacy_adapter
 
 @pytest.mark.rhime_contract
 def test_standard_legacy_output_uses_modern_inversion_output(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    europe_country_file: Path,
+    tmp_path: Path,
 ) -> None:
-    """RHIME legacy output is formatted from modern InversionOutput."""
-    model_spec, output_spec, run_spec = _minimal_output_specs(output_format="legacy")
+    """Create and reload a real legacy product from modern inversion output."""
+    modern_output = _modern_postprocessing_inv_out(europe_country_file)
+    model_spec, _, base_run_spec = _minimal_output_specs(output_format="legacy")
+    model_spec = replace(model_spec, use_bc=False)
     output_spec = RhimeOutputSpec(
         output_format="legacy",
         output_path=str(tmp_path),
@@ -6584,57 +6644,52 @@ def test_standard_legacy_output_uses_modern_inversion_output(
         save_inversion_output=False,
     )
     run_spec = RhimeRunSpec(
-        run_spec.start_date,
-        run_spec.end_date,
-        run_spec.sites,
-        run_spec.averaging_period,
+        base_run_spec.start_date,
+        base_run_spec.end_date,
+        base_run_spec.sites,
+        base_run_spec.averaging_period,
         model_spec,
         output_spec,
     )
+    inv_inputs = modern_output.inv_inputs.assign(
+        sigma_freq_index=("nmeasure", np.zeros(modern_output.inv_inputs.sizes["nmeasure"], dtype=int))
+    )
     prepared = RhimePreparedInputs(
-        inv_inputs=_minimal_output_inv_inputs(),
-        basis_functions=_fake_basis_functions(),
+        inv_inputs=inv_inputs,
+        basis_functions=modern_output.basis_functions,
         site_metadata=_prepared_site_metadata(),
     )
-    captured: dict[str, Any] = {}
-
-    def fail_inferpymc_postprocessouts(**kwargs: Any) -> None:
-        raise AssertionError("run_rhime legacy output must not call inferpymc_postprocessouts")
-
-    def fake_make_legacy_hbmcmc_output(
-        inv_out: InversionOutput,
-        country_file: str | None = None,
-        use_bc: bool = False,
-    ) -> xr.Dataset:
-        captured["inv_out"] = inv_out
-        captured["country_file"] = country_file
-        captured["use_bc"] = use_bc
-        return xr.Dataset({"legacy": ((), 1)})
-
-    monkeypatch.setattr(legacy_mcmc, "inferpymc_postprocessouts", fail_inferpymc_postprocessouts)
-    monkeypatch.setattr(
-        "openghg_inversions.postprocessing.legacy_outputs.make_legacy_hbmcmc_output",
-        fake_make_legacy_hbmcmc_output,
+    idata = cast(Any, az.InferenceData)(
+        **{
+            group: modern_output.trace[group].drop_vars("hx")
+            if group == "constant_data"
+            else modern_output.trace[group]
+            for group in modern_output.trace.groups()
+        }
     )
 
     bundle = rhime_outputs.make_standard_output_bundle(
         output_spec=output_spec,
         run_spec=run_spec,
         model_spec=model_spec,
-        idata=_minimal_output_idata(),
+        idata=idata,
         prepared=prepared,
-        country_file="countries.json",
+        country_file=str(europe_country_file),
     )
 
     assert isinstance(bundle.inv_out, InversionOutput)
-    assert captured["inv_out"] is bundle.inv_out
-    assert captured["country_file"] == "countries.json"
-    assert captured["use_bc"] is True
     assert bundle.output_metadata["postprocessing_input_contract"] == "modern_inversion_output"
     assert "legacy" in bundle.outputs
+    legacy_output = bundle.outputs["legacy"]
+    for variable in ("Yobs", "Ymodmean", "fluxmode", "countrymean", "xtrace", "sigtrace"):
+        assert variable in legacy_output
     expected_path = tmp_path / "legacy_test_ch4_EUROPE_2019-01-01.nc"
     assert expected_path.exists()
     assert bundle.output_metadata["legacy_output_path"] == str(expected_path)
+    with xr.open_dataset(expected_path) as reloaded:
+        assert reloaded.sizes["nmeasure"] == legacy_output.sizes["nmeasure"]
+        assert "fluxmode" in reloaded
+        assert "countrymean" in reloaded
 
 
 def test_save_inferencedata_prefers_h5netcdf(tmp_path: Path) -> None:
@@ -6764,7 +6819,7 @@ def test_run_rhime_api_smoke(
     tmp_path: Path,
     default_bc_basis_directory: Path,
 ) -> None:
-    """Run a custom Normal prior, ordered timings, and serialized-output round-trip."""
+    """Run a custom prior, exact observation metadata, timings, and output round-trip."""
     args = tac_ch4_data_args.copy()
     args.update(
         {
@@ -6818,6 +6873,15 @@ def test_run_rhime_api_smoke(
     assert result.inv_inputs["H"].dims == ("region", "nmeasure")
     assert result.inv_inputs.sizes["region"] == 4
     assert result.inv_inputs.sizes["nmeasure"] == 24
+    assert {
+        name: result.inv_inputs[name].attrs["long_name"]
+        for name in ("mf", "mf_error", "mf_repeatability", "mf_variability")
+    } == {
+        "mf": "mole_fraction_of_methane_in_air",
+        "mf_error": "mole_fraction_of_methane_in_air_error",
+        "mf_repeatability": "mole_fraction_of_methane_in_air_repeatability",
+        "mf_variability": "mole_fraction_of_methane_in_air_variability",
+    }
     nmeasure_index = result.inv_inputs.indexes["nmeasure"]
     assert isinstance(nmeasure_index, pd.MultiIndex)
     assert nmeasure_index.names == ["site", "time"]

--- a/tests/test_run_hbmcmc_shim.py
+++ b/tests/test_run_hbmcmc_shim.py
@@ -172,21 +172,17 @@ def test_fixedbasis_params_to_rhime_preserves_explicit_inversion_output_save(tmp
 
 @pytest.mark.rhime_contract
 def test_run_hbmcmc_main_routes_to_run_rhime(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """Route legacy CLI parameters through run_rhime with legacy outputs."""
+    """Route legacy CLI parameters through run_rhime and copy the effective config."""
     config_file = tmp_path / "hbmcmc.ini"
     output_path = tmp_path / "outputs"
     _fixedbasis_config(config_file)
+    original_config = config_file.read_text(encoding="utf-8")
     seen: dict[str, Any] = {}
 
-    def fake_copy_config_file(config_file_arg: str, param: dict[str, Any], **command_line: Any) -> None:
-        seen["copy_config_file"] = config_file_arg
-        seen["copy_param"] = param
-        seen["copy_command_line"] = command_line
-
     def fake_run_rhime(**kwargs: Any) -> None:
+        """Capture translated keyword arguments without running an inversion."""
         seen["run_rhime_kwargs"] = kwargs
 
-    monkeypatch.setattr(run_hbmcmc.output, "copy_config_file", fake_copy_config_file)
     monkeypatch.setattr(run_hbmcmc, "run_rhime", fake_run_rhime)
 
     run_hbmcmc.main(
@@ -202,10 +198,14 @@ def test_run_hbmcmc_main_routes_to_run_rhime(monkeypatch: pytest.MonkeyPatch, tm
         ]
     )
 
-    assert seen["copy_config_file"] == str(config_file)
-    assert seen["copy_command_line"]["start_date"] == "2020-01-01"
-    assert seen["copy_command_line"]["end_date"] == "2020-02-01"
-    assert seen["copy_command_line"]["outputpath"] == str(output_path)
+    copied_config = output_path / "CH4_EUROPE_legacy_run_2020-01-01.ini"
+    expected_config = (
+        original_config.replace('start_date = "2019-01-01"', "start_date = '2020-01-01'")
+        .replace('end_date = "2019-01-02"', "end_date = '2020-02-01'")
+        .replace('outputpath = "out"', f"outputpath = '{output_path}'")
+        .replace("nchain = 3", "nchain = 2")
+    )
+    assert copied_config.read_text(encoding="utf-8") == expected_config
     assert seen["run_rhime_kwargs"]["start_date"] == "2020-01-01"
     assert seen["run_rhime_kwargs"]["end_date"] == "2020-02-01"
     assert seen["run_rhime_kwargs"]["output_path"] == str(output_path)

--- a/tests/test_run_hbmcmc_shim.py
+++ b/tests/test_run_hbmcmc_shim.py
@@ -170,7 +170,9 @@ def test_fixedbasis_params_to_rhime_preserves_explicit_inversion_output_save(tmp
     assert translated["save_inversion_output"] == "explicit_inv_out.nc"
 
 
+@pytest.mark.rhime_contract
 def test_run_hbmcmc_main_routes_to_run_rhime(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Route legacy CLI parameters through run_rhime with legacy outputs."""
     config_file = tmp_path / "hbmcmc.ini"
     output_path = tmp_path / "outputs"
     _fixedbasis_config(config_file)


### PR DESCRIPTION
* **Summary of changes**

  - Adds the `rhime_contract` marker and one advertised selector for the current RHIME public routes.
  - Characterizes successful single- and multi-sector acquisition, configuration/CLI forwarding, prepared-input dimensions and coordinates, current Dask materialization boundaries, and exact inventories derived from built PyMC models.
  - Exercises ordinary prior variation, real basic/PARIS/legacy outputs, multisector diagnostic serialization, NetCDF/Zarr and modern output round-trips, and direct current `fixedbasisMCMC(...)` legacy/modern serialization.
  - Maps every claimed contract to a selected executable pytest node in `docs/plans/rhime_w1_contracts.md`; future builder behavior remains intentionally outside this baseline.

* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx (OPE-43 is tracked in Linear; no dedicated GitHub issue is closed.)
- [x] Tests added and passing
- [x] Documentation and tutorials updated/added
- [ ] Added an entry to the `CHANGELOG.md` file (test/documentation-only change)
- [ ] Added any new requirements to `requirements.txt`

Validation: `tox -e py310-openghgCur -- -m rhime_contract` (40 passed); Ruff check, format check, and `git diff --check` passed.