### PR TITLE
[OPE-44] Publish a complete custom RHIME runner

### DIFF
--- a/docs/usage/customising_rhime.rst
+++ b/docs/usage/customising_rhime.rst
@@ -1,0 +1,41 @@
+Customising the complete RHIME workflow
+=======================================
+
+The copied runner below is an advanced, version-coupled escape hatch for
+scientific changes that do not fit an ordinary ``run_rhime`` option. It makes
+the major stages visible while importing their implementations from the
+supported public RHIME API. Prefer the standard runner when configuration is
+enough, and prefer ``run_rhime_from_prepared_inputs`` when replaying prepared
+inputs or deliberately starting from a different preparation graph.
+
+The deliberate change is the likelihood passed to
+``build_standard_rhime_model``: the example selects
+``build_absolute_sigma_gaussian_likelihood`` in place of RHIME's default
+pollution-event-scaled Gaussian. Acquisition, filtering, basis construction,
+labelled input assembly, the eager PyMC boundary, sampling, predictive
+selection, filenames, and output handling remain library-owned.
+
+In a project created with the `OpenGHG project cookiecutter
+<https://github.com/openghg/openghg-project-cookiecutter>`_, copy this exact
+module to ``src/<package_name>/rhime_runner.py``. Keep the short orchestration
+spine in the project and import the scientific stage implementations from
+``openghg_inversions.rhime``; do not copy those implementations into the
+project.
+
+Run it with a normal RHIME configuration and optional overrides::
+
+   python -m package_name.rhime_runner config.ini \
+       --start-date 2020-01-01 --end-date 2020-02-01 \
+       --output-path outputs --draws 1000 --tune 1000 --chains 4
+
+Less common Python/config options can be supplied as a JSON object::
+
+   python -m package_name.rhime_runner config.ini \
+       --kwargs '{"reload_merged_data": true, "output_format": "inv_out"}'
+
+The source below is also imported and executed by the integration test, so the
+documentation and runnable example cannot drift apart.
+
+.. literalinclude:: ../../examples/rhime_customisation/runner.py
+   :language: python
+   :linenos:

--- a/docs/usage/usage.rst
+++ b/docs/usage/usage.rst
@@ -9,4 +9,5 @@ Using OpenGHG Inversions
    getting_started
    grouped_basis_layout
    rhime
+   customising_rhime
    concrete_rhime_model

--- a/examples/rhime_customisation/runner.py
+++ b/examples/rhime_customisation/runner.py
@@ -1,0 +1,173 @@
+"""Advanced copy-and-modify runner for a standard RHIME inversion.
+
+This example deliberately replaces RHIME's default likelihood with the public
+absolute-sigma Gaussian helper.  The orchestration is intentionally copied so
+that a project can make deeper scientific changes while continuing to reuse
+the supported acquisition, preparation, model, sampling, and output stages.
+Use :func:`run_custom_rhime` from Python or :func:`main` from the command line.
+The standard single-sector stages are preserved, model inputs materialize only
+at the explicit PyMC boundary, and a run may acquire or reload data, sample a
+model, and write its configured outputs.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Sequence
+import json
+from pathlib import Path
+from time import perf_counter
+from typing import Any
+
+from openghg_inversions.rhime import (
+    RhimeResult,
+    assemble_rhime_inputs,
+    build_absolute_sigma_gaussian_likelihood,
+    build_rhime_basis,
+    build_rhime_sensitivities,
+    build_standard_rhime_model,
+    filter_rhime_observations,
+    make_standard_rhime_result,
+    materialize_pymc_inputs,
+    params_from_config,
+    resolve_rhime_options,
+    retrieve_or_reload_rhime_data,
+    sample_rhime_model,
+    with_prepared_rhime_sites,
+)
+
+
+def run_custom_rhime(
+    *,
+    config_file: str | Path | None = None,
+    **kwargs: Any,
+) -> RhimeResult:
+    """Run standard RHIME with an absolute-sigma Gaussian likelihood.
+
+    Args:
+        config_file: Optional RHIME INI configuration file.
+        **kwargs: Standard RHIME option names that override values from
+            ``config_file``.
+
+    Returns:
+        The sampled result and any outputs requested by the RHIME options.
+
+    Notes:
+        This workflow may retrieve or reload data, eagerly materializes PyMC
+        model inputs, runs sampling, and writes outputs requested by the
+        resolved RHIME options.
+    """
+    params = (
+        params_from_config(config_file, extra_kwargs=kwargs, normalise=False)
+        if config_file is not None
+        else dict(kwargs)
+    )
+    setup = resolve_rhime_options(params=params, multisector=False)
+
+    merged = retrieve_or_reload_rhime_data(setup.data_args, multisector=False)
+    filtered = filter_rhime_observations(merged, setup.data_args)
+    basis_functions = build_rhime_basis(filtered, setup.data_args)
+    site_data = build_rhime_sensitivities(
+        filtered,
+        basis_functions,
+        setup.data_args,
+        multisector=False,
+    )
+    prepared = assemble_rhime_inputs(filtered, basis_functions, site_data, setup.data_args)
+    run_spec = with_prepared_rhime_sites(setup.run_spec, prepared)
+
+    model_inputs = materialize_pymc_inputs(
+        prepared,
+        aggregation_error_mode=run_spec.model.aggregation_error_mode,
+    )
+    build_and_sample_start = perf_counter()
+    model_build_result = build_standard_rhime_model(
+        prepared=prepared,
+        model_inputs=model_inputs,
+        run_spec=run_spec,
+        # This is the deliberate scientific replacement in the copied runner.
+        likelihood_builder=build_absolute_sigma_gaussian_likelihood,
+    )
+    idata = sample_rhime_model(
+        model_build_result,
+        setup.sampler,
+        use_variable_roles=True,
+    )
+
+    return make_standard_rhime_result(
+        prepared=prepared,
+        run_spec=run_spec,
+        sampler=setup.sampler,
+        model_build_result=model_build_result,
+        idata=idata,
+        build_and_sample_seconds=perf_counter() - build_and_sample_start,
+        likelihood_builder=build_absolute_sigma_gaussian_likelihood,
+    )
+
+
+def _json_object(value: str) -> dict[str, Any]:
+    """Parse one command-line JSON object containing additional RHIME options.
+
+    Args:
+        value: JSON text to parse.
+
+    Returns:
+        The decoded JSON object.
+
+    Raises:
+        argparse.ArgumentTypeError: If the text is invalid JSON or decodes to
+            a non-object value.
+    """
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise argparse.ArgumentTypeError(f"invalid JSON: {exc.msg}") from exc
+    if not isinstance(parsed, dict):
+        raise argparse.ArgumentTypeError("--kwargs must decode to a JSON object")
+    return parsed
+
+
+def main(argv: Sequence[str] | None = None) -> RhimeResult:
+    """Parse command-line options and run the customized RHIME workflow.
+
+    This performs the same acquisition, materialization, sampling, and output
+    side effects as :func:`run_custom_rhime`.
+
+    Args:
+        argv: Command-line tokens excluding the program name. ``None`` reads
+            tokens from :data:`sys.argv`.
+
+    Returns:
+        The RHIME result returned by :func:`run_custom_rhime`.
+
+    Raises:
+        SystemExit: If argument parsing fails or help is requested.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("config_file", nargs="?", type=Path, help="RHIME INI configuration file")
+    parser.add_argument("--start-date")
+    parser.add_argument("--end-date")
+    parser.add_argument("--output-path", type=Path)
+    parser.add_argument("--output-name")
+    parser.add_argument("--draws", type=int)
+    parser.add_argument("--tune", type=int)
+    parser.add_argument("--chains", type=int)
+    parser.add_argument(
+        "--kwargs",
+        type=_json_object,
+        default={},
+        metavar="JSON",
+        help="additional RHIME options as a JSON object",
+    )
+    args = parser.parse_args(argv)
+
+    overrides = dict(args.kwargs)
+    for name in ("start_date", "end_date", "output_path", "output_name", "draws", "tune", "chains"):
+        value = getattr(args, name)
+        if value is not None:
+            overrides[name] = value
+    return run_custom_rhime(config_file=args.config_file, **overrides)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/test_custom_rhime_runner.py
+++ b/tests/integration/test_custom_rhime_runner.py
@@ -1,0 +1,250 @@
+"""Integration tests for the executable RHIME customisation example."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import xarray as xr
+
+
+_RUNNER_PATH = Path(__file__).parents[2] / "examples" / "rhime_customisation" / "runner.py"
+_RUNNER_SPEC = importlib.util.spec_from_file_location("rhime_customisation_runner", _RUNNER_PATH)
+assert _RUNNER_SPEC is not None and _RUNNER_SPEC.loader is not None
+custom_runner = importlib.util.module_from_spec(_RUNNER_SPEC)
+_RUNNER_SPEC.loader.exec_module(custom_runner)
+
+
+@pytest.mark.parametrize("reload_merged_data", [False, True])
+def test_custom_runner_uses_supported_stages_for_acquisition_and_reload(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    reload_merged_data: bool,
+) -> None:
+    """Carry ordinary acquisition and reload requests through every public stage."""
+    config_file = tmp_path / "rhime.ini"
+    config_file.write_text('[RHIME.OUTPUT]\noutput_format = "none"\n', encoding="utf-8")
+    overrides = {"reload_merged_data": reload_merged_data, "draws": 3}
+    parsed_params = {"from_config": True, **overrides}
+    data_args = {"reload_merged_data": reload_merged_data}
+    sampler = object()
+    initial_spec = SimpleNamespace(model=SimpleNamespace(aggregation_error_mode="diagonal"))
+    aligned_spec = SimpleNamespace(model=SimpleNamespace(aggregation_error_mode="low_rank"))
+    setup = SimpleNamespace(data_args=data_args, run_spec=initial_spec, sampler=sampler)
+
+    merged = object()
+    filtered = object()
+    basis = object()
+    site_data = object()
+    prepared = SimpleNamespace(
+        inv_inputs=xr.Dataset({"mf": ("nmeasure", [1.0])}),
+        sites=("MHD",),
+        basis_artifact_source="test-basis",
+    )
+    model_inputs = xr.Dataset({"mf": ("nmeasure", [1.0])})
+    build_result = object()
+    idata = object()
+    expected_result = object()
+    calls: list[str] = []
+
+    def parse_config(
+        actual_config: str | Path,
+        *,
+        extra_kwargs: dict[str, Any],
+        normalise: bool,
+    ) -> dict[str, Any]:
+        """Record configuration parsing at the workflow boundary."""
+        assert actual_config == config_file
+        assert extra_kwargs == overrides
+        assert normalise is False
+        return parsed_params
+
+    def resolve(*, params: dict[str, Any], multisector: bool) -> Any:
+        """Record public option resolution."""
+        assert params is parsed_params
+        assert multisector is False
+        calls.append("resolve")
+        return setup
+
+    def retrieve(actual_data_args: dict[str, Any], *, multisector: bool) -> Any:
+        """Record ordinary acquisition or controlled merged-data reload."""
+        assert actual_data_args is data_args
+        assert actual_data_args["reload_merged_data"] is reload_merged_data
+        assert multisector is False
+        calls.append("retrieve")
+        return merged
+
+    def filter_observations(actual: Any, actual_data_args: dict[str, Any]) -> Any:
+        """Record public observation filtering."""
+        assert actual is merged
+        assert actual_data_args is data_args
+        calls.append("filter")
+        return filtered
+
+    def build_basis(actual: Any, actual_data_args: dict[str, Any]) -> Any:
+        """Record public basis construction."""
+        assert actual is filtered
+        assert actual_data_args is data_args
+        calls.append("basis")
+        return basis
+
+    def build_sensitivities(
+        actual: Any,
+        actual_basis: Any,
+        actual_data_args: dict[str, Any],
+        *,
+        multisector: bool,
+    ) -> Any:
+        """Record public sensitivity construction."""
+        assert actual is filtered
+        assert actual_basis is basis
+        assert actual_data_args is data_args
+        assert multisector is False
+        calls.append("sensitivities")
+        return site_data
+
+    def assemble(
+        actual: Any,
+        actual_basis: Any,
+        actual_site_data: Any,
+        actual_data_args: dict[str, Any],
+    ) -> Any:
+        """Record public labelled-input assembly."""
+        assert actual is filtered
+        assert actual_basis is basis
+        assert actual_site_data is site_data
+        assert actual_data_args is data_args
+        calls.append("assemble")
+        return prepared
+
+    def align(actual_spec: Any, actual_prepared: Any) -> Any:
+        """Record retained-site alignment."""
+        assert actual_spec is initial_spec
+        assert actual_prepared is prepared
+        calls.append("align")
+        return aligned_spec
+
+    def materialize(actual: Any, *, aggregation_error_mode: str) -> xr.Dataset:
+        """Record the explicit eager model-input boundary."""
+        assert actual is prepared
+        assert aggregation_error_mode == "low_rank"
+        calls.append("materialize")
+        return model_inputs
+
+    def build(**kwargs: Any) -> Any:
+        """Record the custom absolute-sigma likelihood handoff."""
+        assert kwargs["prepared"] is prepared
+        assert kwargs["model_inputs"] is model_inputs
+        assert kwargs["run_spec"] is aligned_spec
+        assert kwargs["likelihood_builder"] is custom_runner.build_absolute_sigma_gaussian_likelihood
+        calls.append("build")
+        return build_result
+
+    def sample(*args: Any, **kwargs: Any) -> Any:
+        """Record public sampling."""
+        assert args == (build_result, sampler)
+        assert kwargs == {"use_variable_roles": True}
+        calls.append("sample")
+        return idata
+
+    def make_result(**kwargs: Any) -> Any:
+        """Record the supported output stage and its complete handoff."""
+        assert kwargs["prepared"] is prepared
+        assert kwargs["run_spec"] is aligned_spec
+        assert kwargs["sampler"] is sampler
+        assert kwargs["model_build_result"] is build_result
+        assert kwargs["idata"] is idata
+        assert kwargs["likelihood_builder"] is custom_runner.build_absolute_sigma_gaussian_likelihood
+        assert kwargs["build_and_sample_seconds"] >= 0.0
+        calls.append("result")
+        return expected_result
+
+    monkeypatch.setattr(custom_runner, "params_from_config", parse_config)
+    monkeypatch.setattr(custom_runner, "resolve_rhime_options", resolve)
+    monkeypatch.setattr(custom_runner, "retrieve_or_reload_rhime_data", retrieve)
+    monkeypatch.setattr(custom_runner, "filter_rhime_observations", filter_observations)
+    monkeypatch.setattr(custom_runner, "build_rhime_basis", build_basis)
+    monkeypatch.setattr(custom_runner, "build_rhime_sensitivities", build_sensitivities)
+    monkeypatch.setattr(custom_runner, "assemble_rhime_inputs", assemble)
+    monkeypatch.setattr(custom_runner, "with_prepared_rhime_sites", align)
+    monkeypatch.setattr(custom_runner, "materialize_pymc_inputs", materialize)
+    monkeypatch.setattr(custom_runner, "build_standard_rhime_model", build)
+    monkeypatch.setattr(custom_runner, "sample_rhime_model", sample)
+    monkeypatch.setattr(custom_runner, "make_standard_rhime_result", make_result)
+
+    result = custom_runner.run_custom_rhime(config_file=config_file, **overrides)
+
+    assert result is expected_result
+    assert calls == [
+        "resolve",
+        "retrieve",
+        "filter",
+        "basis",
+        "sensitivities",
+        "assemble",
+        "align",
+        "materialize",
+        "build",
+        "sample",
+        "result",
+    ]
+
+
+def test_custom_runner_main_forwards_cli_config_and_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Return the run result after forwarding typed CLI and JSON overrides."""
+    config_file = tmp_path / "rhime.ini"
+    output_path = tmp_path / "outputs"
+    expected_result = object()
+    seen: dict[str, Any] = {}
+
+    def run_custom_rhime(*, config_file: str | Path | None, **kwargs: Any) -> Any:
+        """Capture the command-line handoff without starting a real inversion."""
+        seen["config_file"] = config_file
+        seen["kwargs"] = kwargs
+        return expected_result
+
+    monkeypatch.setattr(custom_runner, "run_custom_rhime", run_custom_rhime)
+
+    result = custom_runner.main(
+        [
+            str(config_file),
+            "--start-date",
+            "2019-01-01",
+            "--end-date",
+            "2019-02-01",
+            "--output-path",
+            str(output_path),
+            "--output-name",
+            "cli-name",
+            "--draws",
+            "5",
+            "--tune",
+            "2",
+            "--chains",
+            "1",
+            "--kwargs",
+            '{"draws": 99, "species": "ch4", "reload_merged_data": true}',
+        ]
+    )
+
+    assert result is expected_result
+    assert seen == {
+        "config_file": config_file,
+        "kwargs": {
+            "species": "ch4",
+            "reload_merged_data": True,
+            "start_date": "2019-01-01",
+            "end_date": "2019-02-01",
+            "output_path": output_path,
+            "output_name": "cli-name",
+            "draws": 5,
+            "tune": 2,
+            "chains": 1,
+        },
+    }


### PR DESCRIPTION
* **Summary of changes**

Adds the canonical, executable copy-and-modify RHIME runner for OPE-44. The example:

- copies only the public single-sector orchestration spine;
- deliberately replaces the default likelihood with `build_absolute_sigma_gaussian_likelihood`;
- retains supported acquisition, filtering, basis, materialization, sampling, predictive selection, and output stages;
- provides a real CLI with config and useful overrides;
- is rendered directly into the new customization guide with `literalinclude`;
- is imported and executed by focused integration coverage for acquisition/reload, stage handoffs, likelihood provenance, and CLI precedence.

This is the advanced, version-coupled before-state that OPE-52 will shorten through the low-ceremony likelihood seam. It also documents placement as `src/<package_name>/rhime_runner.py` in a generated OpenGHG project.

Part of #587.
Linear: OPE-44.

* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx (OPE-44 is tracked in Linear; this PR is part of #587)
- [x] Tests added and passing
- [x] Documentation and tutorials updated/added
- [ ] Added an entry to the `CHANGELOG.md` file
- [ ] Added any new requirements to `requirements.txt`

**Validation**

- `tox -p --parallel-no-spinner`
- `uv run pytest tests/integration/test_custom_rhime_runner.py -q` (3 passed)
- `uv run pytest tests/test_rhime.py -m rhime_contract -q` (34 passed)
- Ruff check and format check on the changed Python files

The strict Sphinx build rendered `usage/customising_rhime` and resolved its `literalinclude`, but the repository-wide `-W` build remains non-green because of existing warnings and docutils errors in unrelated modules. A focused Mypy invocation likewise reached only existing package-wide typing/stub failures and reported no OPE-44-specific diagnostic.