### PR TITLE
Add composed custom RHIME basis runner example

### DIFF
--- a/docs/usage/customising_rhime.rst
+++ b/docs/usage/customising_rhime.rst
@@ -75,10 +75,10 @@ Advanced: copy the complete runner
 
 The copied runner below is an advanced, version-coupled escape hatch for
 scientific changes beyond the likelihood seam. It makes the major stages
-visible while importing their implementations from the
-supported public RHIME API. Prefer ``run_rhime_from_prepared_inputs`` when
-replaying prepared inputs, replacing the complete model, or deliberately
-starting from a different preparation graph.
+visible while importing their implementations from the supported public RHIME
+API. Prefer ``run_rhime_from_prepared_inputs`` when replaying prepared inputs,
+replacing the complete model, or deliberately starting from a different
+preparation graph.
 
 The deliberate change is the likelihood passed to
 ``build_standard_rhime_model``: the example selects the same project-owned
@@ -110,5 +110,105 @@ the likelihood contract directly, so the documentation and runnable examples
 cannot drift apart.
 
 .. literalinclude:: ../../examples/rhime_customisation/runner.py
+   :language: python
+   :linenos:
+
+Advanced: compose a custom basis stage
+--------------------------------------
+
+The second complete runner replaces one call in the preparation spine:
+``build_project_basis`` replaces ``build_rhime_basis``. The project function
+composes public basis primitives instead of selecting a built-in basis
+algorithm. It:
+
+* derives and normalizes a two-dimensional weight field with
+  ``basis_weights_from_fp_all``;
+* loads the public country grid and reduces positive country codes to ``land``
+  and the remaining cells to ``ocean``;
+* creates physical north-south/east-west coordinates with
+  ``LatLonGridGeometry``;
+* uses balanced inertial splits, decomposes every proposed child into
+  four-neighbour connected components, and rejects splits whose children
+  exceed the configured PCA eccentricity guard;
+* generates class-safe labels with ``region_constrained_basis``; and
+* wraps the flat labels and current run flux in retained ``BasisFunctions``
+  with ``basis_functions_from_fp_all_flat_basis``.
+
+The nested split strategy follows the latest selected-country guarded-basis
+variant in the ``verification-games`` project. That variant gives the UK,
+Ireland, France, Germany, Italy, Belgium, and the Netherlands separate classes,
+while remaining land and ocean form two more. This smaller example deliberately
+uses the land/ocean class variant so the composition stays readable. To adopt
+the selected-country policy, replace ``_land_ocean_classes`` with a project
+function that maps the loaded integer country codes or country names to those
+classes. Keep this classification outside OpenGHG Inversions unless it becomes
+a broadly supported policy.
+
+The weighting is deliberately not identical to that later verification-games
+preparation step. Verification-games sums absolute cached ``fp_x_flux`` after
+those sensitivities exist. At this earlier visible-runner basis boundary they
+have not been constructed yet, so the example uses the public
+``basis_weights_from_fp_all`` field while preserving the guarded split strategy
+and class composition.
+
+The flat labels and retained object record namespaced provenance for the class
+policy, normalized weight source, connected balanced-inertial strategy,
+connectivity, and eccentricity threshold. Those fields travel with a saved
+``BasisFunctions`` artifact and make the project choice inspectable later.
+
+Acquisition, filtering, sensitivity construction, labelled input assembly,
+the standard likelihood and model, the eager PyMC boundary, sampling,
+predictive selection, filenames, and output handling remain library-owned.
+
+The project owns the scientific validity of its classification, coverage,
+region count, eccentricity threshold, and split policy. ``BasisFunctions`` and
+the unchanged downstream stages validate the grid, coordinates, sources, site
+alignment, state layout, and model inputs they consume; they cannot certify
+that the project's scientific partition is appropriate. Malformed artifacts
+fail while loading; structurally valid artifacts fail later if they violate a
+downstream alignment contract.
+
+The example exposes ``project_basis_path`` separately from standard RHIME
+options. Point it at a self-contained ``.nc`` or ``.zarr`` artifact written by
+``BasisFunctions.save`` to bypass fitting::
+
+   python -m package_name.custom_basis_runner config.ini \
+       --project-basis-path cache/project-basis.zarr
+
+The eccentricity guard is also a visible project-owned option, rather than an
+opaque library default. It defaults to ``10`` and is removed before standard
+RHIME option resolution::
+
+   python -m package_name.custom_basis_runner config.ini \
+       --max-child-pca-eccentricity 10
+
+``BasisFunctions.load`` eagerly loads the saved operator, metadata, and flux,
+then closes the artifact. The serialized flux is deliberately retained. Use
+the standard public ``load_basis_functions`` helper instead when loading a
+named RHIME basis cache that should take its retained flux from the current
+``fp_all`` acquisition.
+
+Without an artifact, basis generation is a named eager boundary: the public
+weight adapter eagerly materializes a derived two-dimensional weight field
+from borrowed inputs; normalization, geometry construction, country-class
+loading, and guarded region splitting then compute eager class and label
+fields. Before that boundary, the filtered xarray objects are borrowed and may
+be Dask-backed. The compatibility adapter retains the current run's flux with
+the generated labels at this visible runner boundary, and the resulting
+``BasisFunctions`` object flows unchanged through sensitivity construction and
+labelled assembly. Model arrays are materialized separately and explicitly by
+``materialize_pymc_inputs``.
+
+Copy ``examples/rhime_customisation/custom_basis_runner.py`` to
+``src/<package_name>/custom_basis_runner.py`` and keep the project basis rule
+beside the copied orchestration spine. This source is imported and executed by
+integration tests and rendered here, so the documentation and runnable example
+cannot drift apart.
+
+This guarded composition is intentionally project-specific and is not yet a
+common, stable strategy that warrants another lower-ceremony ``run_rhime``
+option.
+
+.. literalinclude:: ../../examples/rhime_customisation/custom_basis_runner.py
    :language: python
    :linenos:

--- a/docs/usage/customising_rhime.rst
+++ b/docs/usage/customising_rhime.rst
@@ -1,12 +1,38 @@
-Customising a RHIME likelihood
-==============================
+Customising RHIME
+=================
 
-Preferred: pass a Python likelihood
------------------------------------
+RHIME is built from reusable functions for data preparation, basis
+construction, model construction, sampling, and output. This is a deliberate
+design choice: when the standard workflow does not express the science you
+need, you should be able to start from a working example and replace the
+smallest relevant part.
+
+The examples on this page use a procedural style. Data is passed from one
+function to the next in the order that the inversion runs, so readers do not
+need to design a new class hierarchy or framework before changing a model.
+Some library functions return structured objects that group related values,
+but the examples show how to use those objects directly.
+
+Reusing the components does not make every custom workflow automatic. A
+replacement function is responsible for the scientific choices it introduces,
+and a deeper change may also need different data preparation. The remaining
+RHIME stages can only validate the inputs and assumptions covered by their
+documented interfaces.
+
+Choose the smallest starting point that fits the change:
+
+* To change only the likelihood, pass a Python function to ``run_rhime``.
+* To change a preparation stage such as basis construction, copy the visible
+  runner and replace that stage.
+* To start from prepared data or replace the complete model, use
+  ``run_rhime_from_prepared_inputs``.
+
+Change the likelihood with a Python function
+--------------------------------------------
 
 For an ordinary likelihood variation, keep RHIME's complete
-acquisition-to-output workflow and pass one direct-Python callable to
-``run_rhime``. The callable is deliberately unavailable to INI files: it is
+acquisition-to-output workflow and pass one Python function to ``run_rhime``.
+The function is deliberately unavailable to INI files: it is
 not imported from configuration or stored in a run or model specification.
 
 The complete integration is one named argument:
@@ -21,34 +47,41 @@ The complete integration is one named argument:
        likelihood_builder=likelihood_builder,
    )
 
-A builder is called as ``likelihood_builder(context)`` while the PyMC model is
-active and returns ``RhimeLikelihoodResult``. Its semantic roles drive
-predictive sampling, its supported output formats are validated before
-sampling, and its metadata must be JSON-compatible. The ordinary caller does
-not construct the context, a specification, or a role/output manifest.
+RHIME calls the function as ``likelihood_builder(context)`` while constructing
+the PyMC model. It returns a
+:class:`~openghg_inversions.models.RhimeLikelihoodResult`, which contains the
+new observed variable and the small amount of information RHIME needs for
+sampling and output. An ordinary caller does not construct the context or
+these supporting records.
 
 Editable likelihood
 ~~~~~~~~~~~~~~~~~~~
 
-The tested project-owned example replaces RHIME's Gaussian observation
-distribution with Student-t while reusing RHIME's current mean and error
+The following example replaces RHIME's Gaussian observation distribution with
+a Student-t distribution while reusing RHIME's current mean and error
 construction:
 
 .. literalinclude:: ../../examples/rhime_customisation/likelihoods.py
    :language: python
    :linenos:
 
-The callable's safe module and qualified name, together with its
-JSON-compatible likelihood metadata, are recorded in result and serialized
-output provenance. Executable Python code is not serialized.
+RHIME records the function's module and name, together with its likelihood
+metadata, in the result and in saved output. It does not copy the Python source
+code into the output, so a project should keep the source and environment used
+for an inversion.
 
-The example makes those owned invariants explicit: ``student_y`` is declared
-as the ``concentration`` role, RHIME's ``epsilon`` remains the ``model_error``
-role, only ``none`` and ``inv_out`` outputs are declared compatible, and the
-Student-t family and degrees of freedom are recorded as JSON metadata. It
-rejects dense and low-rank aggregation covariance because the example uses an
-independent Student-t distribution; supporting those modes would require a
-multivariate likelihood rather than a hidden approximation.
+The returned ``RhimeLikelihoodResult`` maps standard meanings to the PyMC
+variable names used by this model. For example, it tells RHIME that
+``student_y`` is the modelled concentration and ``epsilon`` is the model-error
+scale. Sampling and output code can then find these quantities even though the
+custom model uses different names. It also lists the output formats that have
+been checked with this likelihood; this example supports no file output
+(``none``) and the ``inv_out`` format. The Student-t family and degrees of
+freedom are stored as simple metadata.
+
+The example rejects dense and low-rank aggregation covariance because it uses
+an independent Student-t distribution. Supporting those aggregation-error
+modes would require a multivariate likelihood.
 
 Optional project CLI
 ~~~~~~~~~~~~~~~~~~~~
@@ -70,8 +103,8 @@ standard multi-sector model retains sector flux components and roles, then
 passes their combined observation mean to the likelihood, so no special case
 or semantic compromise is required.
 
-Advanced: copy the complete runner
-----------------------------------
+Copy the complete runner
+------------------------
 
 The copied runner below is an advanced, version-coupled escape hatch for
 scientific changes beyond the likelihood seam. It makes the major stages
@@ -83,8 +116,9 @@ preparation graph.
 The deliberate change is the likelihood passed to
 ``build_standard_rhime_model``: the example selects the same project-owned
 Student-t builder as the preferred form. Acquisition, filtering, basis
-construction, labelled input assembly, the eager PyMC boundary, sampling,
-predictive selection, filenames, and output handling remain library-owned.
+construction, labelled input assembly, conversion of delayed arrays for PyMC,
+sampling, predictive selection, filenames, and output handling remain
+library-owned.
 
 In a project created with the `OpenGHG project cookiecutter
 <https://github.com/openghg/openghg-project-cookiecutter>`_, copy the preferred
@@ -113,15 +147,15 @@ cannot drift apart.
    :language: python
    :linenos:
 
-Advanced: compose a custom basis stage
---------------------------------------
+Compose a custom basis stage
+----------------------------
 
 The second complete runner replaces one call in the preparation spine:
 ``build_project_basis`` replaces ``build_rhime_basis``. The project function
 composes public basis primitives instead of selecting a built-in basis
 algorithm. It:
 
-* derives and normalizes a two-dimensional weight field with
+* derives and normalises a two-dimensional weight field with
   ``basis_weights_from_fp_all``;
 * loads the public country grid and reduces positive country codes to ``land``
   and the remaining cells to ``ocean``;
@@ -152,13 +186,14 @@ have not been constructed yet, so the example uses the public
 and class composition.
 
 The flat labels and retained object record namespaced provenance for the class
-policy, normalized weight source, connected balanced-inertial strategy,
+policy, normalised weight source, connected balanced-inertial strategy,
 connectivity, and eccentricity threshold. Those fields travel with a saved
 ``BasisFunctions`` artifact and make the project choice inspectable later.
 
 Acquisition, filtering, sensitivity construction, labelled input assembly,
-the standard likelihood and model, the eager PyMC boundary, sampling,
-predictive selection, filenames, and output handling remain library-owned.
+the standard likelihood and model, conversion of delayed arrays for PyMC,
+sampling, predictive selection, filenames, and output handling remain
+library-owned.
 
 The project owns the scientific validity of its classification, coverage,
 region count, eccentricity threshold, and split policy. ``BasisFunctions`` and
@@ -182,22 +217,27 @@ RHIME option resolution::
    python -m package_name.custom_basis_runner config.ini \
        --max-child-pca-eccentricity 10
 
-``BasisFunctions.load`` eagerly loads the saved operator, metadata, and flux,
-then closes the artifact. The serialized flux is deliberately retained. Use
+``BasisFunctions.load`` loads the saved operator, metadata, and flux into
+memory, then closes the artifact. The saved flux is deliberately retained. Use
 the standard public ``load_basis_functions`` helper instead when loading a
 named RHIME basis cache that should take its retained flux from the current
 ``fp_all`` acquisition.
 
-Without an artifact, basis generation is a named eager boundary: the public
-weight adapter eagerly materializes a derived two-dimensional weight field
-from borrowed inputs; normalization, geometry construction, country-class
-loading, and guarded region splitting then compute eager class and label
-fields. Before that boundary, the filtered xarray objects are borrowed and may
-be Dask-backed. The compatibility adapter retains the current run's flux with
-the generated labels at this visible runner boundary, and the resulting
-``BasisFunctions`` object flows unchanged through sensitivity construction and
-labelled assembly. Model arrays are materialized separately and explicitly by
-``materialize_pymc_inputs``.
+Without an artifact, the basis-building function computes the arrays needed by
+the splitting algorithm. Before that point, the filtered xarray objects may
+still defer their calculations with Dask. The function derives and normalises
+the two-dimensional weights, loads the country classes, constructs the
+geometry, and creates the region labels. It then combines the labels with the
+current run's flux in a ``BasisFunctions`` object. That object flows unchanged
+through sensitivity construction and labelled assembly. The arrays needed by
+PyMC are converted separately by ``materialize_pymc_inputs`` immediately
+before model construction.
+
+The customisation is concentrated in ``_guarded_basis``. The runner's one
+deliberate substitution is marked by an inline comment where
+``build_project_basis`` replaces the standard ``build_rhime_basis`` call. The
+complete source remains below because the test suite executes the same file
+that the documentation displays.
 
 Copy ``examples/rhime_customisation/custom_basis_runner.py`` to
 ``src/<package_name>/custom_basis_runner.py`` and keep the project basis rule

--- a/examples/rhime_customisation/custom_basis_runner.py
+++ b/examples/rhime_customisation/custom_basis_runner.py
@@ -1,0 +1,400 @@
+"""Run standard RHIME with project-owned emissions basis construction.
+
+This copy-and-modify example keeps RHIME's supported acquisition, filtering,
+sensitivity, labelled-input, model, sampling, and output stages.  Only the
+emissions-basis stage is replaced by :func:`build_project_basis`.  The example
+either loads a self-contained retained ``BasisFunctions`` artifact or creates
+a guarded region-constrained basis whose regions stay within land/ocean
+classes, remain connected, and satisfy a project eccentricity threshold.
+The verification-games workflow weights that strategy with summed absolute
+cached ``fp_x_flux``. At this earlier runner stage projected sensitivities do
+not exist, so the example deliberately substitutes the public
+``basis_weights_from_fp_all`` field while preserving the guarded strategy and
+class composition.
+
+Use :func:`run_custom_rhime` from Python or :func:`main` from the command line.
+Acquired xarray objects are treated as borrowed.  Generated-basis fitting is
+an explicit eager algorithm boundary, artifact loading materializes the saved
+artifact, and model arrays materialize later at the named PyMC boundary.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Mapping, Sequence
+import json
+from pathlib import Path
+from time import perf_counter
+from typing import Any
+
+import numpy as np
+import xarray as xr
+
+from openghg_inversions.basis import (
+    BasisFunctions,
+    basis_functions_from_fp_all_flat_basis,
+    basis_weights_from_fp_all,
+    load_country_region_classes,
+)
+from openghg_inversions.basis.algorithms import (
+    ConnectedComponentPartitionStep,
+    ConnectedComponentSplitStrategy,
+    GreedySplitStrategy,
+    InertialSplitStep,
+    LatLonGridGeometry,
+    MaxChildPCAEccentricity,
+    region_constrained_basis,
+)
+from openghg_inversions.inversion_data import RhimeMergedData
+from openghg_inversions.rhime import (
+    RhimeResult,
+    assemble_rhime_inputs,
+    build_rhime_sensitivities,
+    build_standard_rhime_model,
+    filter_rhime_observations,
+    make_standard_rhime_result,
+    materialize_pymc_inputs,
+    params_from_config,
+    resolve_rhime_options,
+    retrieve_or_reload_rhime_data,
+    sample_rhime_model,
+    with_prepared_rhime_sites,
+)
+
+
+DEFAULT_MAX_CHILD_PCA_ECCENTRICITY = 10.0
+
+
+def _land_ocean_classes(
+    *,
+    domain: str,
+    country_directory: str | Path | None = None,
+) -> xr.DataArray:
+    """Reduce the public country grid to the project's land/ocean classes.
+
+    Args:
+        domain: RHIME domain used to select the country grid.
+        country_directory: Optional directory containing the domain country
+            file.
+
+    Returns:
+        An eager object-valued ``(lat, lon)`` class grid preserving the loaded
+        coordinates. Positive country codes are ``land``; null, zero, and
+        negative codes are ``ocean``.
+
+    Raises:
+        FileNotFoundError: If the requested country grid does not exist.
+        KeyError: If the country-grid artifact does not contain ``country``.
+    """
+    country_classes = load_country_region_classes(
+        domain,
+        country_directory,
+    )
+    return xr.where(country_classes > 0, "land", "ocean").astype(object).rename("basis_class")
+
+
+def _guarded_basis(
+    merged: RhimeMergedData,
+    data_args: Mapping[str, Any],
+    *,
+    max_child_pca_eccentricity: float,
+) -> BasisFunctions:
+    """Build the project's connected, eccentricity-guarded retained basis.
+
+    The public weight adapter intentionally materializes a derived 2-D weight
+    field from borrowed footprint and flux inputs here. The project then owns
+    normalization, class composition, guarded splitting, and conversion of the
+    flat labels to retained ``BasisFunctions`` without mutating ``merged``.
+
+    Args:
+        merged: Filtered, borrowed RHIME observations and flux data.
+        data_args: Resolved standard RHIME data and basis options. This stage
+            consumes required ``domain`` and optional ``flux_sources``,
+            ``nbasis``, and ``country_directory``.
+        max_child_pca_eccentricity: Project limit on each proposed child's
+            physical-coordinate PCA eccentricity.
+
+    Returns:
+        Retained basis functions fitted within connected land/ocean regions.
+
+    Raises:
+        FileNotFoundError: If the requested country grid does not exist.
+        KeyError: If ``domain`` or country-grid content is missing.
+        ValueError: If zero-filled weights do not have a positive finite
+            maximum, or geometry, allocation, or guarded splitting is invalid.
+    """
+    weights = basis_weights_from_fp_all(
+        merged.fp_all,
+        data_args.get("flux_sources"),
+        abs_flux=True,
+    )
+    finite_weights = weights.fillna(0.0).astype(np.float64)
+    maximum = float(finite_weights.max())
+    if not np.isfinite(maximum) or maximum <= 0.0:
+        raise ValueError("Project basis weights must have a positive finite maximum.")
+    normalized_weights = finite_weights / maximum
+
+    region_classes = _land_ocean_classes(
+        domain=data_args["domain"],
+        country_directory=data_args.get("country_directory"),
+    )
+    geometry = LatLonGridGeometry.from_dataarray(normalized_weights)
+    strategy = ConnectedComponentSplitStrategy(
+        split_strategy=GreedySplitStrategy(
+            split_step=ConnectedComponentPartitionStep(
+                split_step=InertialSplitStep(
+                    balanced=True,
+                    geometry=geometry,
+                ),
+                connectivity=1,
+            ),
+            split_acceptance=MaxChildPCAEccentricity(
+                max_child_pca_eccentricity=max_child_pca_eccentricity,
+                geometry=geometry,
+            ),
+        ),
+        connectivity=1,
+    )
+    basis_flat = (
+        region_constrained_basis(
+            normalized_weights,
+            region_classes,
+            int(data_args.get("nbasis", 100)),
+            allocation="weight",
+            min_regions_per_class=1,
+            split_strategy=strategy,
+        )
+        .astype(np.int16)
+        .rename("basis")
+    )
+    provenance: dict[str, str | int | float] = {
+        "openghg_inversions:basis_artifact_source": "project-guarded",
+        "openghg_inversions:project_basis_strategy": "connected_component_balanced_inertial",
+        "openghg_inversions:project_basis_connectivity": 1,
+        "openghg_inversions:project_basis_max_child_pca_eccentricity": float(max_child_pca_eccentricity),
+        "openghg_inversions:project_basis_class_policy": "land_ocean",
+        "openghg_inversions:project_basis_weights": "basis_weights_from_fp_all_abs_flux_normalized",
+    }
+    basis_flat.attrs.update(provenance)
+    return basis_functions_from_fp_all_flat_basis(
+        fp_all=merged.fp_all,
+        basis_flat=basis_flat,
+        metadata=provenance,
+    )
+
+
+def build_project_basis(
+    merged: RhimeMergedData,
+    data_args: Mapping[str, Any],
+    *,
+    project_basis_path: str | Path | None = None,
+    max_child_pca_eccentricity: float = DEFAULT_MAX_CHILD_PCA_ECCENTRICITY,
+) -> BasisFunctions:
+    """Return the project-selected retained emissions basis.
+
+    Args:
+        merged: Filtered, borrowed RHIME observations and flux data.
+        data_args: Resolved standard RHIME data and basis options.
+        project_basis_path: Optional ``.nc`` or ``.zarr`` artifact previously
+            written by :meth:`BasisFunctions.save`.  The artifact is
+            self-contained, so its serialized operator, metadata, and flux are
+            retained rather than replaced with flux from ``merged``.
+        max_child_pca_eccentricity: Project limit passed to the guarded split
+            policy when generating a basis. Defaults to ``10`` and is ignored
+            when ``project_basis_path`` is supplied.
+
+    Returns:
+        Loaded or newly fitted retained basis functions.
+
+    Raises:
+        OSError: If the requested artifact cannot be opened.
+        KeyError: If required artifact content or generated-basis options are
+            missing.
+        ValueError: If the artifact or generated-basis configuration is
+            invalid.
+
+    Notes:
+        Loading eagerly materializes the artifact so no open file handle is
+        retained.  Without a path, project basis fitting is the named eager
+        basis-generation boundary.
+    """
+    if project_basis_path is not None:
+        return BasisFunctions.load(project_basis_path)
+    return _guarded_basis(
+        merged,
+        data_args,
+        max_child_pca_eccentricity=max_child_pca_eccentricity,
+    )
+
+
+def run_custom_rhime(
+    *,
+    config_file: str | Path | None = None,
+    project_basis_path: str | Path | None = None,
+    max_child_pca_eccentricity: float | None = None,
+    **kwargs: Any,
+) -> RhimeResult:
+    """Run standard single-sector RHIME with a project-owned basis stage.
+
+    Args:
+        config_file: Optional RHIME INI configuration file.
+        project_basis_path: Optional self-contained ``BasisFunctions`` artifact
+            to use instead of fitting the project guarded basis.
+        max_child_pca_eccentricity: Optional project split-policy threshold.
+            When omitted, the merged config/keyword value is used, falling back
+            to ``10``. This option is removed before standard RHIME resolution.
+        **kwargs: Standard RHIME option names that override values from
+            ``config_file``.
+
+    Returns:
+        The sampled result and any outputs requested by the RHIME options.
+
+    Raises:
+        OSError: If configured artifact, input, or output I/O fails.
+        ValueError: If RHIME options, the custom basis, or prepared inputs are
+            invalid.
+
+    Notes:
+        This workflow may retrieve or reload data, may eagerly fit or load a
+        basis, eagerly materializes PyMC model inputs, runs sampling, and writes
+        outputs requested by the resolved RHIME options.
+    """
+    params = (
+        params_from_config(config_file, extra_kwargs=kwargs, normalise=False)
+        if config_file is not None
+        else dict(kwargs)
+    )
+    configured_project_basis_path = params.pop("project_basis_path", None)
+    if project_basis_path is None:
+        project_basis_path = configured_project_basis_path
+    configured_eccentricity = params.pop(
+        "max_child_pca_eccentricity",
+        DEFAULT_MAX_CHILD_PCA_ECCENTRICITY,
+    )
+    if max_child_pca_eccentricity is None:
+        max_child_pca_eccentricity = float(configured_eccentricity)
+    setup = resolve_rhime_options(params=params, multisector=False)
+
+    merged = retrieve_or_reload_rhime_data(setup.data_args, multisector=False)
+    filtered = filter_rhime_observations(merged, setup.data_args)
+    basis_functions = build_project_basis(
+        filtered,
+        dict(setup.data_args),
+        project_basis_path=project_basis_path,
+        max_child_pca_eccentricity=max_child_pca_eccentricity,
+    )
+    site_data = build_rhime_sensitivities(
+        filtered,
+        basis_functions,
+        setup.data_args,
+        multisector=False,
+    )
+    prepared = assemble_rhime_inputs(filtered, basis_functions, site_data, setup.data_args)
+    run_spec = with_prepared_rhime_sites(setup.run_spec, prepared)
+
+    # Cross the explicit eager PyMC boundary without changing canonical inputs.
+    model_inputs = materialize_pymc_inputs(
+        prepared,
+        aggregation_error_mode=run_spec.model.aggregation_error_mode,
+    )
+    build_and_sample_start = perf_counter()
+    model_build_result = build_standard_rhime_model(
+        prepared=prepared,
+        model_inputs=model_inputs,
+        run_spec=run_spec,
+    )
+    idata = sample_rhime_model(model_build_result, setup.sampler)
+
+    return make_standard_rhime_result(
+        prepared=prepared,
+        run_spec=run_spec,
+        sampler=setup.sampler,
+        model_build_result=model_build_result,
+        idata=idata,
+        build_and_sample_seconds=perf_counter() - build_and_sample_start,
+    )
+
+
+def _json_object(value: str) -> dict[str, Any]:
+    """Parse one command-line JSON object containing additional RHIME options.
+
+    Args:
+        value: JSON text to parse.
+
+    Returns:
+        The decoded JSON object.
+
+    Raises:
+        argparse.ArgumentTypeError: If the text is invalid JSON or decodes to
+            a non-object value.
+    """
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise argparse.ArgumentTypeError(f"invalid JSON: {exc.msg}") from exc
+    if not isinstance(parsed, dict):
+        raise argparse.ArgumentTypeError("--kwargs must decode to a JSON object")
+    return parsed
+
+
+def main(argv: Sequence[str] | None = None) -> RhimeResult:
+    """Parse command-line options and run the custom-basis RHIME workflow.
+
+    Args:
+        argv: Command-line tokens excluding the program name. ``None`` reads
+            tokens from :data:`sys.argv`.
+
+    Returns:
+        The RHIME result returned by :func:`run_custom_rhime`.
+
+    Raises:
+        SystemExit: If argument parsing fails or help is requested.
+
+    Notes:
+        Data access, eager basis and model materialization, sampling, and
+        requested output writes are delegated to :func:`run_custom_rhime`; its
+        exceptions propagate unchanged.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("config_file", nargs="?", type=Path, help="RHIME INI configuration file")
+    parser.add_argument(
+        "--project-basis-path",
+        type=Path,
+        help="self-contained BasisFunctions .nc or .zarr artifact",
+    )
+    parser.add_argument(
+        "--max-child-pca-eccentricity",
+        type=float,
+        help="project guarded-basis threshold (default: 10)",
+    )
+    parser.add_argument("--start-date")
+    parser.add_argument("--end-date")
+    parser.add_argument("--output-path", type=Path)
+    parser.add_argument("--output-name")
+    parser.add_argument("--draws", type=int)
+    parser.add_argument("--tune", type=int)
+    parser.add_argument("--chains", type=int)
+    parser.add_argument(
+        "--kwargs",
+        type=_json_object,
+        default={},
+        metavar="JSON",
+        help="additional standard RHIME options as a JSON object",
+    )
+    args = parser.parse_args(argv)
+
+    overrides = dict(args.kwargs)
+    for name in ("start_date", "end_date", "output_path", "output_name", "draws", "tune", "chains"):
+        value = getattr(args, name)
+        if value is not None:
+            overrides[name] = value
+    return run_custom_rhime(
+        config_file=args.config_file,
+        project_basis_path=args.project_basis_path,
+        max_child_pca_eccentricity=args.max_child_pca_eccentricity,
+        **overrides,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/rhime_customisation/custom_basis_runner.py
+++ b/examples/rhime_customisation/custom_basis_runner.py
@@ -123,6 +123,7 @@ def _guarded_basis(
         ValueError: If zero-filled weights do not have a positive finite
             maximum, or geometry, allocation, or guarded splitting is invalid.
     """
+    # 1. Turn the filtered footprints and flux into one spatial importance map.
     weights = basis_weights_from_fp_all(
         merged.fp_all,
         data_args.get("flux_sources"),
@@ -134,11 +135,13 @@ def _guarded_basis(
         raise ValueError("Project basis weights must have a positive finite maximum.")
     normalized_weights = finite_weights / maximum
 
+    # 2. Define scientific boundaries that no basis region may cross.
     region_classes = _land_ocean_classes(
         domain=data_args["domain"],
         country_directory=data_args.get("country_directory"),
     )
     geometry = LatLonGridGeometry.from_dataarray(normalized_weights)
+    # 3. Compose the split algorithm and its shape/connectivity safeguards.
     strategy = ConnectedComponentSplitStrategy(
         split_strategy=GreedySplitStrategy(
             split_step=ConnectedComponentPartitionStep(
@@ -155,6 +158,7 @@ def _guarded_basis(
         ),
         connectivity=1,
     )
+    # 4. Allocate and split regions within the land/ocean classes.
     basis_flat = (
         region_constrained_basis(
             normalized_weights,
@@ -176,6 +180,7 @@ def _guarded_basis(
         "openghg_inversions:project_basis_weights": "basis_weights_from_fp_all_abs_flux_normalized",
     }
     basis_flat.attrs.update(provenance)
+    # 5. Attach the current flux so standard RHIME sensitivity code can use it.
     return basis_functions_from_fp_all_flat_basis(
         fp_all=merged.fp_all,
         basis_flat=basis_flat,
@@ -277,6 +282,10 @@ def run_custom_rhime(
 
     merged = retrieve_or_reload_rhime_data(setup.data_args, multisector=False)
     filtered = filter_rhime_observations(merged, setup.data_args)
+
+    # CUSTOMISATION POINT: the standard runner calls build_rhime_basis here.
+    # This project function either loads a saved basis or composes the guarded
+    # basis-building tools above. Every stage after this call is standard RHIME.
     basis_functions = build_project_basis(
         filtered,
         dict(setup.data_args),

--- a/openghg_inversions/basis/__init__.py
+++ b/openghg_inversions/basis/__init__.py
@@ -1,12 +1,16 @@
 """Basis construction, projection, and retained covariance-product interfaces.
 
-The package provides basis-generation functions, flux-weighted preparation
-wrappers, prior-width projection helpers, and the public OPE-17 retained
-covariance-product API. Basis operators own grid/state geometry: their bucket
-matrix is a prolongation from retained scalings to the native grid, not an
-automatic retained restriction. ``FluxWeightedBasis`` pairs that geometry with
-flux for sensitivity projection and reconstruction; it does not own native
-covariance transforms.
+The package exposes built-in basis algorithms and their weight-first building
+blocks, retained :class:`BasisFunctions` artifacts, prior-width projection
+helpers, and the public retained covariance-product API. Project-owned
+workflows may compose the algorithms and convert flat labels with
+``basis_functions_from_fp_all_flat_basis`` while preserving current-run flux
+and avoiding private preparation internals.
+
+Basis operators own grid/state geometry: their bucket matrix is a prolongation
+from retained scalings to the native grid, not an automatic retained
+restriction. ``BasisFunctions`` pairs that geometry with flux for sensitivity
+projection and reconstruction; it does not own native covariance transforms.
 
 Native covariance actions live in :mod:`openghg_inversions.native_covariance`
 and :mod:`openghg_inversions.source_covariance`. The interfaces re-exported
@@ -14,6 +18,10 @@ here choose a compatible restriction/prolongation pair and prepare labelled
 product blocks. They are a low-level input to later coherent reduction and do
 not themselves construct the centred reduced likelihood, unresolved
 covariance, or a complete coherent-reduction artifact.
+
+``basis_weights_from_fp_all`` computes a derived two-dimensional weight field
+in memory. Artifact loaders similarly load and close their files rather than
+retaining live file handles.
 """
 
 from ._functions import (
@@ -37,6 +45,7 @@ from ._wrapper import (
     load_basis_functions,
     make_basis_functions,
 )
+from .basis_functions import BasisFunctions, basis_functions_from_fp_all_flat_basis
 from .prior_uncertainty import (
     MEAN_TOTAL_TARGET_STATISTIC,
     MEDIAN_RELATIVE_TARGET_STATISTIC,
@@ -53,7 +62,9 @@ from .covariance_products import (
 
 __all__ = [
     "basis_functions_wrapper",
+    "basis_functions_from_fp_all_flat_basis",
     "basis_weights_from_fp_all",
+    "BasisFunctions",
     "bucket_basis_from_weights",
     "bucket_basis_function",
     "bucketbasisfunction",

--- a/openghg_inversions/basis/__init__.py
+++ b/openghg_inversions/basis/__init__.py
@@ -1,16 +1,16 @@
 """Basis construction, projection, and retained covariance-product interfaces.
 
-The package exposes built-in basis algorithms and their weight-first building
-blocks, retained :class:`BasisFunctions` artifacts, prior-width projection
-helpers, and the public retained covariance-product API. Project-owned
-workflows may compose the algorithms and convert flat labels with
-``basis_functions_from_fp_all_flat_basis`` while preserving current-run flux
-and avoiding private preparation internals.
+The package provides basis-generation functions, flux-weighted preparation
+wrappers, prior-width projection helpers, and the public OPE-17 retained
+covariance-product API.
 
 Basis operators own grid/state geometry: their bucket matrix is a prolongation
 from retained scalings to the native grid, not an automatic retained
-restriction. ``BasisFunctions`` pairs that geometry with flux for sensitivity
-projection and reconstruction; it does not own native covariance transforms.
+restriction. ``FluxWeightedBasis``, exported here as ``BasisFunctions``, pairs
+that geometry with flux for sensitivity projection and reconstruction; it does
+not own native covariance transforms. Project-owned workflows can compose the
+basis algorithms and use ``basis_functions_from_fp_all_flat_basis`` to attach
+current-run flux without importing private preparation functions.
 
 Native covariance actions live in :mod:`openghg_inversions.native_covariance`
 and :mod:`openghg_inversions.source_covariance`. The interfaces re-exported
@@ -18,10 +18,6 @@ here choose a compatible restriction/prolongation pair and prepare labelled
 product blocks. They are a low-level input to later coherent reduction and do
 not themselves construct the centred reduced likelihood, unresolved
 covariance, or a complete coherent-reduction artifact.
-
-``basis_weights_from_fp_all`` computes a derived two-dimensional weight field
-in memory. Artifact loaders similarly load and close their files rather than
-retaining live file handles.
 """
 
 from ._functions import (

--- a/openghg_inversions/basis/basis_functions.py
+++ b/openghg_inversions/basis/basis_functions.py
@@ -520,20 +520,33 @@ def basis_functions_from_fp_all_flat_basis(
 ) -> FluxWeightedBasis:
     """Compatibility adapter that constructs a basis object from flat basis data.
 
-    Legacy flat basis artifacts remain readable for a transition period, but
-    modern preparation and postprocessing should consume the returned
-    ``BasisFunctions`` object rather than the flat representation directly.
+    This is also the public handoff for project-owned flat-basis algorithms in
+    copied RHIME runners. A single two-dimensional array defines a shared
+    spatial basis. A source-keyed mapping defines source-specific bases and is
+    restricted and ordered to match runtime flux sources when ``fp_all`` is
+    sector resolved. In both cases the retained flux is reconstructed from the
+    current ``fp_all`` input rather than from the flat-basis producer.
 
     Args:
         fp_all: Legacy merged-data dictionary containing a ``".flux"`` side
             channel and optional ``".split_by_sectors"`` flag.
-        basis_flat: Flat basis array, or source-keyed flat basis arrays, from
-            the legacy basis-generation/loading path.
+        basis_flat: Two-dimensional shared flat basis array, or source-keyed
+            two-dimensional flat basis arrays, produced by a compatible basis
+            algorithm or legacy loading path.
         metadata: Optional namespaced metadata to carry on the basis object.
 
     Returns:
         A retained ``BasisFunctions`` object with flux reconstructed from
         ``fp_all``.
+
+    Raises:
+        TypeError: If a runtime flux entry or basis input has an unsupported
+            type.
+        ValueError: If runtime flux is missing or inconsistent, a
+            source-specific basis omits a runtime source, or basis labels and
+            dimensions violate the retained-basis contract.
+        xarray.AlignmentError: If basis and current-run flux grids are not
+            physically compatible.
     """
     flux = flux_from_fp_all(fp_all)
     if isinstance(basis_flat, Mapping):

--- a/tests/integration/test_custom_basis_rhime_runner.py
+++ b/tests/integration/test_custom_basis_rhime_runner.py
@@ -1,0 +1,468 @@
+"""Integration tests for the executable custom-basis RHIME example."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from openghg_inversions.basis.basis_functions import BasisFunctions
+
+
+_RUNNER_PATH = Path(__file__).parents[2] / "examples" / "rhime_customisation" / "custom_basis_runner.py"
+_RUNNER_SPEC = importlib.util.spec_from_file_location("custom_basis_rhime_runner", _RUNNER_PATH)
+assert _RUNNER_SPEC is not None and _RUNNER_SPEC.loader is not None
+custom_basis_runner = importlib.util.module_from_spec(_RUNNER_SPEC)
+_RUNNER_SPEC.loader.exec_module(custom_basis_runner)
+
+
+def _basis_functions(*, artifact_source: str = "project-generated") -> BasisFunctions:
+    """Build a small supported basis object for orchestration tests."""
+    basis_flat = xr.DataArray(
+        [[1, 1], [2, 2]],
+        dims=("lat", "lon"),
+        coords={"lat": [50.0, 51.0], "lon": [-2.0, -1.0]},
+        name="basis",
+    )
+    flux = xr.DataArray(
+        np.ones((2, 2)),
+        dims=("lat", "lon"),
+        coords=basis_flat.coords,
+        name="flux",
+    )
+    return BasisFunctions.from_flat_basis(
+        basis_flat=basis_flat,
+        flux=flux,
+        metadata={"openghg_inversions:basis_artifact_source": artifact_source},
+    )
+
+
+@pytest.mark.parametrize("reload_merged_data", [False, True])
+def test_custom_basis_runner_replaces_only_basis_stage(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    reload_merged_data: bool,
+) -> None:
+    """Carry acquisition and reload through output with only a custom basis stage."""
+    config_file = tmp_path / "rhime.ini"
+    config_file.write_text('[RHIME.OUTPUT]\noutput_format = "none"\n', encoding="utf-8")
+    project_basis_path = tmp_path / "external-basis.nc"
+    overrides = {"reload_merged_data": reload_merged_data, "draws": 3}
+    parsed_params = {
+        "from_config": True,
+        "max_child_pca_eccentricity": 6.5,
+        **overrides,
+    }
+    resolved_data_args = {"reload_merged_data": reload_merged_data}
+    sampler = object()
+    initial_spec = SimpleNamespace(model=SimpleNamespace(aggregation_error_mode="diagonal"))
+    aligned_spec = SimpleNamespace(model=SimpleNamespace(aggregation_error_mode="low_rank"))
+    setup = SimpleNamespace(data_args=resolved_data_args, run_spec=initial_spec, sampler=sampler)
+
+    merged = object()
+    filtered = object()
+    basis = _basis_functions()
+    site_data = object()
+    prepared = SimpleNamespace(
+        inv_inputs=xr.Dataset({"mf": ("nmeasure", [1.0])}),
+        basis_functions=basis,
+        sites=("MHD",),
+        basis_artifact_source=basis.basis_artifact_source,
+    )
+    model_inputs = xr.Dataset({"mf": ("nmeasure", [1.0])})
+    build_result = object()
+    idata = object()
+    expected_result = object()
+    calls: list[str] = []
+    workflow_data_args: dict[str, Any] | None = None
+
+    def parse_config(
+        actual_config: str | Path,
+        *,
+        extra_kwargs: dict[str, Any],
+        normalise: bool,
+    ) -> dict[str, Any]:
+        """Record configuration parsing at the workflow boundary."""
+        assert actual_config == config_file
+        assert extra_kwargs == overrides
+        assert normalise is False
+        return parsed_params
+
+    def resolve(*, params: dict[str, Any], multisector: bool) -> Any:
+        """Record public option resolution."""
+        assert params is parsed_params
+        assert "max_child_pca_eccentricity" not in params
+        assert multisector is False
+        calls.append("resolve")
+        return setup
+
+    def retrieve(actual_data_args: dict[str, Any], *, multisector: bool) -> Any:
+        """Record ordinary acquisition or controlled merged-data reload."""
+        nonlocal workflow_data_args
+        workflow_data_args = actual_data_args
+        assert actual_data_args is resolved_data_args
+        assert actual_data_args["reload_merged_data"] is reload_merged_data
+        assert "project_basis_path" not in actual_data_args
+        assert multisector is False
+        calls.append("retrieve")
+        return merged
+
+    def filter_observations(actual: Any, actual_data_args: dict[str, Any]) -> Any:
+        """Record unchanged public observation filtering."""
+        assert actual is merged
+        assert actual_data_args is workflow_data_args
+        calls.append("filter")
+        return filtered
+
+    def build_project_basis(
+        actual: Any,
+        actual_data_args: dict[str, Any],
+        *,
+        project_basis_path: str | Path | None,
+        max_child_pca_eccentricity: float,
+    ) -> BasisFunctions:
+        """Record the sole custom replacement stage and its supported result."""
+        assert actual is filtered
+        assert actual_data_args == workflow_data_args
+        assert actual_data_args is not workflow_data_args
+        assert "project_basis_path" not in actual_data_args
+        assert "max_child_pca_eccentricity" not in actual_data_args
+        assert project_basis_path == tmp_path / "external-basis.nc"
+        assert max_child_pca_eccentricity == 6.5
+        calls.append("project-basis")
+        return basis
+
+    def build_sensitivities(
+        actual: Any,
+        actual_basis: BasisFunctions,
+        actual_data_args: dict[str, Any],
+        *,
+        multisector: bool,
+    ) -> Any:
+        """Record unchanged sensitivity construction with the custom basis."""
+        assert actual is filtered
+        assert actual_basis is basis
+        assert isinstance(actual_basis, BasisFunctions)
+        assert actual_data_args is workflow_data_args
+        assert multisector is False
+        calls.append("sensitivities")
+        return site_data
+
+    def assemble(
+        actual: Any,
+        actual_basis: BasisFunctions,
+        actual_site_data: Any,
+        actual_data_args: dict[str, Any],
+    ) -> Any:
+        """Record unchanged labelled-input assembly with the custom basis."""
+        assert actual is filtered
+        assert actual_basis is basis
+        assert actual_site_data is site_data
+        assert actual_data_args is workflow_data_args
+        calls.append("assemble")
+        return prepared
+
+    def align(actual_spec: Any, actual_prepared: Any) -> Any:
+        """Record retained-site alignment."""
+        assert actual_spec is initial_spec
+        assert actual_prepared is prepared
+        calls.append("align")
+        return aligned_spec
+
+    def materialize(actual: Any, *, aggregation_error_mode: str) -> xr.Dataset:
+        """Record the explicit eager model-input boundary."""
+        assert actual is prepared
+        assert aggregation_error_mode == "low_rank"
+        calls.append("materialize")
+        return model_inputs
+
+    def build(**kwargs: Any) -> Any:
+        """Record the unchanged standard model stage."""
+        assert kwargs == {
+            "prepared": prepared,
+            "model_inputs": model_inputs,
+            "run_spec": aligned_spec,
+        }
+        calls.append("build")
+        return build_result
+
+    def sample(*args: Any, **kwargs: Any) -> Any:
+        """Record unchanged public sampling."""
+        assert args == (build_result, sampler)
+        assert kwargs == {}
+        calls.append("sample")
+        return idata
+
+    def make_result(**kwargs: Any) -> Any:
+        """Record the supported output stage and retained custom basis."""
+        assert kwargs["prepared"] is prepared
+        assert kwargs["prepared"].basis_functions is basis
+        assert kwargs["run_spec"] is aligned_spec
+        assert kwargs["sampler"] is sampler
+        assert kwargs["model_build_result"] is build_result
+        assert kwargs["idata"] is idata
+        assert kwargs["build_and_sample_seconds"] >= 0.0
+        assert set(kwargs) == {
+            "prepared",
+            "run_spec",
+            "sampler",
+            "model_build_result",
+            "idata",
+            "build_and_sample_seconds",
+        }
+        calls.append("result")
+        return expected_result
+
+    monkeypatch.setattr(custom_basis_runner, "params_from_config", parse_config)
+    monkeypatch.setattr(custom_basis_runner, "resolve_rhime_options", resolve)
+    monkeypatch.setattr(custom_basis_runner, "retrieve_or_reload_rhime_data", retrieve)
+    monkeypatch.setattr(custom_basis_runner, "filter_rhime_observations", filter_observations)
+    monkeypatch.setattr(custom_basis_runner, "build_project_basis", build_project_basis)
+    monkeypatch.setattr(custom_basis_runner, "build_rhime_sensitivities", build_sensitivities)
+    monkeypatch.setattr(custom_basis_runner, "assemble_rhime_inputs", assemble)
+    monkeypatch.setattr(custom_basis_runner, "with_prepared_rhime_sites", align)
+    monkeypatch.setattr(custom_basis_runner, "materialize_pymc_inputs", materialize)
+    monkeypatch.setattr(custom_basis_runner, "build_standard_rhime_model", build)
+    monkeypatch.setattr(custom_basis_runner, "sample_rhime_model", sample)
+    monkeypatch.setattr(custom_basis_runner, "make_standard_rhime_result", make_result)
+
+    result = custom_basis_runner.run_custom_rhime(
+        config_file=config_file,
+        project_basis_path=project_basis_path,
+        **overrides,
+    )
+
+    assert result is expected_result
+    assert calls == [
+        "resolve",
+        "retrieve",
+        "filter",
+        "project-basis",
+        "sensitivities",
+        "assemble",
+        "align",
+        "materialize",
+        "build",
+        "sample",
+        "result",
+    ]
+
+
+def test_project_basis_artifact_bypasses_calculation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Load a self-contained artifact without calculating a new basis."""
+    stored = _basis_functions(artifact_source="external-project")
+    artifact_path = tmp_path / "project-basis.nc"
+    stored.save(artifact_path)
+    merged = SimpleNamespace(
+        fp_all={
+            ".flux": {"current-inventory": 2.0 * stored.flux},
+            ".split_by_sectors": False,
+        }
+    )
+
+    def fail_calculation(actual: Any, data_args: dict[str, Any]) -> BasisFunctions:
+        """Fail if the cached ingress route tries to calculate a basis."""
+        raise AssertionError(f"unexpected basis calculation for {actual!r} with {data_args!r}")
+
+    monkeypatch.setattr(custom_basis_runner, "_guarded_basis", fail_calculation)
+
+    loaded = custom_basis_runner.build_project_basis(
+        merged,
+        {},
+        project_basis_path=artifact_path,
+    )
+
+    assert isinstance(loaded, BasisFunctions)
+    assert loaded.basis_artifact_source == "external-project"
+    xr.testing.assert_identical(loaded.operator.basis_matrix, stored.operator.basis_matrix)
+    xr.testing.assert_identical(loaded.flux, stored.flux)
+
+
+def test_generated_project_basis_uses_guarded_connected_inertial_composition(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Return a retained basis from the guarded connected-inertial policy."""
+    weights = xr.DataArray(
+        [[np.nan, 2.0], [4.0, 1.0]],
+        dims=("lat", "lon"),
+        coords={"lat": [50.0, 51.0], "lon": [-1.0, 1.0]},
+        name="weight",
+    )
+    country_classes = xr.DataArray(
+        [[0, 4], [9, 0]],
+        dims=weights.dims,
+        coords=weights.coords,
+        name="country",
+    )
+    generated_labels = xr.DataArray(
+        [[0, 1], [2, 0]],
+        dims=weights.dims,
+        coords=weights.coords,
+        name="raw_labels",
+    )
+    expected_basis = _basis_functions()
+    fp_all = object()
+    merged = SimpleNamespace(fp_all=fp_all)
+    data_args = {
+        "species": "ch4",
+        "domain": "EUROPE",
+        "start_date": "2019-01-01",
+        "flux_sources": ["inventory"],
+        "nbasis": 8,
+        "country_directory": Path("/project/country-classes"),
+    }
+
+    def basis_weights(
+        actual_fp_all: Any,
+        emissions_name: list[str],
+        *,
+        abs_flux: bool,
+    ) -> xr.DataArray:
+        """Return deterministic weights at the public custom-basis boundary."""
+        assert actual_fp_all is fp_all
+        assert emissions_name == ["inventory"]
+        assert abs_flux is True
+        return weights
+
+    def load_classes(domain: str, country_directory: str | Path | None) -> xr.DataArray:
+        """Return deterministic country codes at the public class-map boundary."""
+        assert domain == "EUROPE"
+        assert country_directory == Path("/project/country-classes")
+        return country_classes
+
+    def build_labels(
+        normalized_weights: xr.DataArray,
+        region_classes: xr.DataArray,
+        nbasis: int,
+        **kwargs: Any,
+    ) -> xr.DataArray:
+        """Validate the guarded connected-inertial algorithm composition."""
+        xr.testing.assert_identical(
+            normalized_weights,
+            xr.DataArray(
+                [[0.0, 0.5], [1.0, 0.25]],
+                dims=weights.dims,
+                coords=weights.coords,
+                name="weight",
+            ),
+        )
+        assert region_classes.name == "basis_class"
+        np.testing.assert_array_equal(region_classes, [["ocean", "land"], ["land", "ocean"]])
+        assert nbasis == 8
+        assert kwargs.keys() == {"allocation", "min_regions_per_class", "split_strategy"}
+        assert kwargs["allocation"] == "weight"
+        assert kwargs["min_regions_per_class"] == 1
+
+        strategy = kwargs["split_strategy"]
+        assert isinstance(strategy, custom_basis_runner.ConnectedComponentSplitStrategy)
+        assert strategy.connectivity == 1
+        greedy = strategy.split_strategy
+        assert isinstance(greedy, custom_basis_runner.GreedySplitStrategy)
+        partition_step = greedy.split_step
+        assert isinstance(partition_step, custom_basis_runner.ConnectedComponentPartitionStep)
+        assert partition_step.connectivity == 1
+        inertial_step = partition_step.split_step
+        assert isinstance(inertial_step, custom_basis_runner.InertialSplitStep)
+        assert inertial_step.balanced is True
+        assert isinstance(inertial_step.geometry, custom_basis_runner.LatLonGridGeometry)
+        guard = greedy.split_acceptance
+        assert isinstance(guard, custom_basis_runner.MaxChildPCAEccentricity)
+        assert guard.max_child_pca_eccentricity == 7.5
+        assert guard.geometry is inertial_step.geometry
+        return generated_labels
+
+    def retain_basis(**kwargs: Any) -> BasisFunctions:
+        """Validate conversion of flat labels to the supported retained object."""
+        expected_metadata = {
+            "openghg_inversions:basis_artifact_source": "project-guarded",
+            "openghg_inversions:project_basis_strategy": ("connected_component_balanced_inertial"),
+            "openghg_inversions:project_basis_connectivity": 1,
+            "openghg_inversions:project_basis_max_child_pca_eccentricity": 7.5,
+            "openghg_inversions:project_basis_class_policy": "land_ocean",
+            "openghg_inversions:project_basis_weights": ("basis_weights_from_fp_all_abs_flux_normalized"),
+        }
+        assert kwargs["fp_all"] is fp_all
+        assert kwargs["basis_flat"].name == "basis"
+        assert kwargs["basis_flat"].dtype == np.dtype(np.int16)
+        xr.testing.assert_equal(kwargs["basis_flat"], generated_labels.astype(np.int16).rename("basis"))
+        assert kwargs["basis_flat"].attrs == expected_metadata
+        assert kwargs["metadata"] == expected_metadata
+        return expected_basis
+
+    monkeypatch.setattr(custom_basis_runner, "basis_weights_from_fp_all", basis_weights)
+    monkeypatch.setattr(custom_basis_runner, "load_country_region_classes", load_classes)
+    monkeypatch.setattr(custom_basis_runner, "region_constrained_basis", build_labels)
+    monkeypatch.setattr(custom_basis_runner, "basis_functions_from_fp_all_flat_basis", retain_basis)
+
+    actual = custom_basis_runner.build_project_basis(
+        merged,
+        data_args,
+        max_child_pca_eccentricity=7.5,
+    )
+
+    assert actual is expected_basis
+    assert isinstance(actual, BasisFunctions)
+    assert bool(weights.isnull().any())
+
+
+def test_incompatible_project_basis_failure_remains_owned_by_sensitivity_stage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Let the unchanged downstream stage explain an incompatible custom basis."""
+    setup = SimpleNamespace(data_args={}, run_spec=object(), sampler=object())
+    merged = object()
+    filtered = object()
+    incompatible_basis = object()
+
+    monkeypatch.setattr(
+        custom_basis_runner,
+        "resolve_rhime_options",
+        lambda *, params, multisector: setup,
+    )
+    monkeypatch.setattr(
+        custom_basis_runner,
+        "retrieve_or_reload_rhime_data",
+        lambda data_args, *, multisector: merged,
+    )
+    monkeypatch.setattr(
+        custom_basis_runner,
+        "filter_rhime_observations",
+        lambda actual, data_args: filtered,
+    )
+    monkeypatch.setattr(
+        custom_basis_runner,
+        "build_project_basis",
+        lambda actual, data_args, *, project_basis_path, max_child_pca_eccentricity: incompatible_basis,
+    )
+
+    def reject_incompatible_basis(
+        actual: Any,
+        actual_basis: Any,
+        data_args: dict[str, Any],
+        *,
+        multisector: bool,
+    ) -> Any:
+        """Represent validation owned by the public sensitivity stage."""
+        assert actual is filtered
+        assert actual_basis is incompatible_basis
+        raise TypeError("build_rhime_sensitivities requires compatible BasisFunctions")
+
+    monkeypatch.setattr(
+        custom_basis_runner,
+        "build_rhime_sensitivities",
+        reject_incompatible_basis,
+    )
+
+    with pytest.raises(
+        TypeError,
+        match="build_rhime_sensitivities requires compatible BasisFunctions",
+    ):
+        custom_basis_runner.run_custom_rhime(species="ch4")


### PR DESCRIPTION
## Summary

- add a separate executable RHIME runner that replaces only the public basis-construction stage
- mirror the current verification-games guarded basis composition using public OpenGHG Inversions primitives:
  - normalised `fp_all` response weights
  - public country-grid loading and project land/ocean classes
  - physical `LatLonGridGeometry`
  - connected-component, balanced inertial splitting
  - `MaxChildPCAEccentricity` split acceptance
  - class-safe `region_constrained_basis`
- expose the eccentricity limit as a project-owned CLI/Python option outside standard RHIME resolution
- publicly export the retained-basis adapter so copied runners can attach current-run flux without private imports
- preserve self-contained cached `BasisFunctions` ingress and all unchanged downstream RHIME stages
- make “Customising RHIME” a general page with a procedural, scientist-facing introduction and likelihood, copied-runner, and custom-basis sections

Closes OPE-54.

## User impact

Downstream projects have a tested example of composing basis tools in a way that the standard `run_rhime` basis options cannot express. It follows verification-games' latest selected-country guarded-basis strategy; the compact example uses that workflow's land/ocean class variant.

The page explains the reusable-component design and its limits before introducing extension APIs. Likelihood roles, output support, and recorded function identity are described in plain language. The custom basis source numbers its five scientific steps and marks the one substituted runner call inline.

The guide also records one boundary difference: verification-games weights the strategy with summed absolute cached `fp_x_flux`, while this earlier visible-runner stage uses `basis_weights_from_fp_all` because projected sensitivities do not yet exist.

## Follow-up documentation

- [OPE-64](https://linear.app/openghg-inversions/issue/OPE-64/write-a-scientist-facing-guide-to-openghg-inversions-programming) — scientist-facing programming concepts
- [OPE-65](https://linear.app/openghg-inversions/issue/OPE-65/document-rhime-aggregation-error-modes-for-scientific-users) — aggregation-error modes
- [OPE-66](https://linear.app/openghg-inversions/issue/OPE-66/document-rhime-variable-roles-output-capabilities-and-custom-function) — roles, output capabilities, and custom-function provenance
- [OPE-67](https://linear.app/openghg-inversions/issue/OPE-67/define-british-english-spelling-policy-for-documentation-and-public) — British-English spelling policy for prose and APIs

## Validation

- focused custom-runner plus newly merged covariance suites — 73 passed
- `tox -e docs` — succeeded; 4 pre-existing warnings and none from the customisation or native-covariance pages
- Ruff check and format check on the affected Python files — passed
- Pyright on the executable example — 0 errors
- `git diff --check` — passed

## Reconciliation

Rebased onto `origin/devel` at `3826e6c6` after #583 merged. Both documentation changes are retained without merging their scopes:

- `customising_rhime.rst` owns procedural workflow/model modification and the custom-basis example;
- `native_covariance.rst` remains the dedicated mathematical and retained-covariance guide from #583;
- the basis package overview keeps #583's covariance ownership explanation and adds only the public `BasisFunctions`/flat-basis adapter seam required by OPE-54.