### PR TITLE
[OPE-52] Add the low-ceremony run_rhime likelihood seam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
   [#455](https://github.com/openghg/openghg_inversions/issues/455)
 
 - Added direct-Python RHIME likelihood and complete-model builder contracts.
+  The top-level `run_rhime` and `run_rhime_multisector` entry points now accept
+  a keyword-only `likelihood_builder` callable, so ordinary acquisition-to-output
+  runs can replace the observation component without constructing prepared
+  inputs or a complete model.
   Custom builders declare semantic variable roles, supported output formats,
   and serializable provenance metadata, which are validated before sampling
   and preserved in inversion outputs. Built-in concrete, compiled, and

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,14 @@
+/*
+ * PyData Sphinx Theme caps both the page and article widths. That keeps prose
+ * narrow, but it also means widening the browser cannot give long examples
+ * more room and forces unnecessary horizontal scrolling. Let the standard
+ * responsive layout use the available viewport; code blocks retain the
+ * theme's overflow behaviour as a fallback on genuinely narrow screens.
+ */
+.bd-page-width {
+  max-width: none;
+}
+
+.bd-main .bd-content .bd-article-container {
+  max-width: none;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -82,3 +82,4 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # html_theme = 'alabaster'
 html_theme = 'pydata_sphinx_theme'
 html_static_path = ['_static']
+html_css_files = ['custom.css']

--- a/docs/reference/openghg_inversions.models.rhime_likelihood.rst
+++ b/docs/reference/openghg_inversions.models.rhime_likelihood.rst
@@ -1,6 +1,47 @@
 openghg\_inversions.models.rhime\_likelihood
 ============================================
 
+This module defines the Python-only likelihood boundary used by the ordinary
+RHIME runners. Pass a :class:`RhimeLikelihoodBuilder` to ``run_rhime`` or
+``run_rhime_multisector``; the runner creates the context while the active
+PyMC model is being built. Builders are not read from configuration or stored
+as executable state in run or model specifications.
+
+Builder contract
+----------------
+
+A builder receives :class:`RhimeLikelihoodContext`, adds the complete error
+and observed-distribution component to the active model, and returns
+:class:`RhimeLikelihoodResult`. The result must declare:
+
+* semantic variable roles, including ``concentration`` for the observed
+  variable;
+* every RHIME output format that the likelihood supports; and
+* JSON-compatible metadata for result and serialized-output provenance.
+
+Roles drive posterior-predictive selection, and output compatibility is
+validated before sampling. The runner separately records the builder's module
+and qualified name; it never serializes callable code.
+
+Reusable construction helpers
+-----------------------------
+
+:func:`build_rhime_observation_state` retains RHIME's current mean and error
+construction while allowing a builder to replace only the observed
+distribution. :class:`RhimeObservationState` exposes the observed values,
+combined mean, independent variance, resolved aggregation error, and marginal
+error scale.
+
+:func:`build_gaussian_rhime_likelihood` implements the default
+pollution-event-scaled Gaussian. The opt-in
+:func:`build_absolute_sigma_gaussian_likelihood` instead treats inferred sigma
+as an absolute observation-aligned contribution. For a complete editable
+Student-t example and the minimal runner call, see
+:doc:`../usage/customising_rhime`.
+
+API reference
+-------------
+
 .. automodule:: openghg_inversions.models.rhime_likelihood
    :members:
    :show-inheritance:

--- a/docs/usage/concrete_rhime_model.rst
+++ b/docs/usage/concrete_rhime_model.rst
@@ -336,9 +336,11 @@ component namespaces are not implemented. They are tracked in
 Alternative models and likelihoods
 ----------------------------------
 
-Direct-Python likelihood and complete-model builders enter only at
-``run_rhime_from_prepared_inputs``. Callables are deliberately not stored on
-``RhimeModelSpec``, so model and run specs remain serializable. There is no
+Direct-Python likelihood builders enter through ``run_rhime``,
+``run_rhime_multisector``, or ``run_rhime_from_prepared_inputs``.
+Complete-model builders remain available only at the prepared-input boundary.
+Callables are never read from configuration or stored on ``RhimeModelSpec`` or
+``RhimeRunSpec``, so model and run specs remain serializable. There is no
 entry-point or config-file plugin registry.
 
 A likelihood builder owns the complete observation component, including its

--- a/docs/usage/concrete_rhime_model.rst
+++ b/docs/usage/concrete_rhime_model.rst
@@ -351,24 +351,25 @@ error policies, aggregation-error mode, and output dimension. This boundary
 avoids a misleading contract in which the runner builds half an error model
 before calling user code.
 
-For the absolute-sigma Gaussian above, no custom modelling function is needed:
+For the absolute-sigma Gaussian above, pass the helper directly to the
+ordinary runner:
 
 .. code-block:: python
 
    from openghg_inversions.rhime import (
        build_absolute_sigma_gaussian_likelihood,
-       run_rhime_from_prepared_inputs,
+       run_rhime,
    )
 
-   result = run_rhime_from_prepared_inputs(
-       prepared_inputs=prepared,
-       run_spec=run_spec,
+   result = run_rhime(
+       config_file="config.ini",
        likelihood_builder=build_absolute_sigma_gaussian_likelihood,
    )
 
-Set ``add_offset=True`` and ``offset_args={"per_site": False}`` on
-``RhimeModelSpec`` to combine it with one global scalar offset. The default
-``per_site=True`` retains the existing site or site-period offset design.
+Pass ``add_offset=True`` and ``offset_args={"per_site": False}`` as Python or
+configuration options to combine it with one global scalar offset. The
+default ``per_site=True`` retains the existing site or site-period offset
+design.
 
 The helper ``build_rhime_observation_state`` is available when only the
 distribution should change. For example, this replaces Normal observations
@@ -382,9 +383,8 @@ scale:
    from openghg_inversions.rhime import (
        RhimeLikelihoodContext,
        RhimeLikelihoodResult,
-       RhimeSampler,
        build_rhime_observation_state,
-       run_rhime_from_prepared_inputs,
+       run_rhime,
    )
 
 
@@ -414,10 +414,8 @@ scale:
        )
 
 
-   result = run_rhime_from_prepared_inputs(
-       prepared_inputs=prepared,
-       run_spec=run_spec,
-       sampler=RhimeSampler(draws=1000, tune=1000, chains=4),
+   result = run_rhime(
+       config_file="config.ini",
        likelihood_builder=student_t_likelihood,
    )
 

--- a/docs/usage/concrete_rhime_model.rst
+++ b/docs/usage/concrete_rhime_model.rst
@@ -371,53 +371,9 @@ configuration options to combine it with one global scalar offset. The
 default ``per_site=True`` retains the existing site or site-period offset
 design.
 
-The helper ``build_rhime_observation_state`` is available when only the
-distribution should change. For example, this replaces Normal observations
-with a Student-t distribution while retaining the current RHIME mean and error
-scale:
-
-.. code-block:: python
-
-   import pymc as pm
-
-   from openghg_inversions.rhime import (
-       RhimeLikelihoodContext,
-       RhimeLikelihoodResult,
-       build_rhime_observation_state,
-       run_rhime,
-   )
-
-
-   def student_t_likelihood(
-       context: RhimeLikelihoodContext,
-   ) -> RhimeLikelihoodResult:
-       state = build_rhime_observation_state(context)
-       if state.aggregation_error.mode not in {"none", "diagonal"}:
-           raise ValueError("This Student-t model assumes independent observations.")
-       observed = pm.StudentT(
-           "student_y",
-           nu=4.0,
-           mu=state.mean,
-           sigma=state.error_scale,
-           observed=state.observed,
-           dims=context.output_dim,
-       )
-       return RhimeLikelihoodResult(
-           likelihood=observed,
-           error_scale=state.error_scale,
-           variable_roles={
-               "concentration": "student_y",
-               "model_error": "epsilon",
-           },
-           supported_output_formats=("none", "inv_out"),
-           metadata={"family": "student_t", "degrees_of_freedom": 4.0},
-       )
-
-
-   result = run_rhime(
-       config_file="config.ini",
-       likelihood_builder=student_t_likelihood,
-   )
+Keep scientific customization implementations in one tested location. The
+:doc:`customising_rhime` guide contains the editable Student-t example and the
+minimal ordinary-runner call; this concrete-model page does not duplicate it.
 
 ``RhimeSampler`` receives the returned role manifest. Posterior-predictive
 settings may use a semantic role such as ``"concentration"``. For backwards

--- a/docs/usage/customising_rhime.rst
+++ b/docs/usage/customising_rhime.rst
@@ -1,12 +1,62 @@
-Customising the complete RHIME workflow
-=======================================
+Customising a RHIME likelihood
+==============================
+
+Preferred: pass a Python likelihood
+-----------------------------------
+
+For an ordinary likelihood variation, keep RHIME's complete
+acquisition-to-output workflow and pass one direct-Python callable to
+``run_rhime``. The callable is deliberately unavailable to INI files: it is
+not imported from configuration or stored in a run or model specification.
+
+This example selects the absolute-sigma Gaussian likelihood in place of
+RHIME's default pollution-event-scaled Gaussian. The likelihood is the same
+one used by the complete copied runner below, so the difference between the
+examples is orchestration ceremony rather than scientific behaviour.
+
+The project-owned likelihood selection is one small module:
+
+.. literalinclude:: ../../examples/rhime_customisation/likelihoods.py
+   :language: python
+   :linenos:
+
+The preferred runner keeps the full standard pipeline in one ``run_rhime``
+call:
+
+.. literalinclude:: ../../examples/rhime_customisation/run_with_likelihood.py
+   :language: python
+   :linenos:
+
+Run the short form with a normal RHIME configuration and optional JSON
+overrides::
+
+   python -m package_name.run_with_likelihood config.ini \
+       --kwargs '{"output_path": "outputs", "output_format": "inv_out"}'
+
+The callable's safe module and qualified name, together with its
+JSON-compatible likelihood metadata, are recorded in result and serialized
+output provenance. Executable Python code is not serialized.
+
+A builder is called as ``likelihood_builder(context)`` while the PyMC model is
+active and returns ``RhimeLikelihoodResult``. Its semantic roles drive
+predictive sampling, its supported output formats are validated before
+sampling, and its metadata must be JSON-compatible. The ordinary caller does
+not construct the context, a specification, or a role/output manifest.
+
+``run_rhime_multisector`` accepts the same Python-only builder contract. The
+standard multi-sector model retains sector flux components and roles, then
+passes their combined observation mean to the likelihood, so no special case
+or semantic compromise is required.
+
+Advanced: copy the complete runner
+----------------------------------
 
 The copied runner below is an advanced, version-coupled escape hatch for
-scientific changes that do not fit an ordinary ``run_rhime`` option. It makes
-the major stages visible while importing their implementations from the
-supported public RHIME API. Prefer the standard runner when configuration is
-enough, and prefer ``run_rhime_from_prepared_inputs`` when replaying prepared
-inputs or deliberately starting from a different preparation graph.
+scientific changes beyond the likelihood seam. It makes the major stages
+visible while importing their implementations from the
+supported public RHIME API. Prefer ``run_rhime_from_prepared_inputs`` when
+replaying prepared inputs, replacing the complete model, or deliberately
+starting from a different preparation graph.
 
 The deliberate change is the likelihood passed to
 ``build_standard_rhime_model``: the example selects
@@ -16,11 +66,12 @@ labelled input assembly, the eager PyMC boundary, sampling, predictive
 selection, filenames, and output handling remain library-owned.
 
 In a project created with the `OpenGHG project cookiecutter
-<https://github.com/openghg/openghg-project-cookiecutter>`_, copy this exact
-module to ``src/<package_name>/rhime_runner.py``. Keep the short orchestration
-spine in the project and import the scientific stage implementations from
-``openghg_inversions.rhime``; do not copy those implementations into the
-project.
+<https://github.com/openghg/openghg-project-cookiecutter>`_, copy the preferred
+modules to ``src/<package_name>/likelihoods.py`` and
+``src/<package_name>/run_with_likelihood.py``. Copy the complete module below
+to ``src/<package_name>/rhime_runner.py`` only when the project needs to own a
+deeper orchestration change. Import scientific stage implementations from
+``openghg_inversions.rhime`` rather than copying those implementations.
 
 Run it with a normal RHIME configuration and optional overrides::
 
@@ -33,8 +84,8 @@ Less common Python/config options can be supplied as a JSON object::
    python -m package_name.rhime_runner config.ini \
        --kwargs '{"reload_merged_data": true, "output_format": "inv_out"}'
 
-The source below is also imported and executed by the integration test, so the
-documentation and runnable example cannot drift apart.
+All three sources are imported and executed by the integration test, so the
+documentation and runnable examples cannot drift apart.
 
 .. literalinclude:: ../../examples/rhime_customisation/runner.py
    :language: python

--- a/docs/usage/customising_rhime.rst
+++ b/docs/usage/customising_rhime.rst
@@ -9,40 +9,38 @@ acquisition-to-output workflow and pass one direct-Python callable to
 ``run_rhime``. The callable is deliberately unavailable to INI files: it is
 not imported from configuration or stored in a run or model specification.
 
-This example replaces RHIME's Gaussian observation distribution with an
-editable Student-t likelihood while reusing RHIME's current mean and error
-construction. The likelihood is the same one used by the complete copied
-runner below, so the difference between the examples is orchestration ceremony
-rather than scientific behaviour.
+The complete integration is one named argument:
 
-The project-owned likelihood selection is one small module:
+.. code-block:: python
 
-.. literalinclude:: ../../examples/rhime_customisation/likelihoods.py
-   :language: python
-   :linenos:
+   from my_project.likelihoods import likelihood_builder
+   from openghg_inversions.rhime import run_rhime
 
-The preferred runner keeps the full standard pipeline in one ``run_rhime``
-call:
-
-.. literalinclude:: ../../examples/rhime_customisation/run_with_likelihood.py
-   :language: python
-   :linenos:
-
-Run the short form with a normal RHIME configuration and optional JSON
-overrides::
-
-   python -m package_name.run_with_likelihood config.ini \
-       --kwargs '{"output_path": "outputs", "output_format": "inv_out"}'
-
-The callable's safe module and qualified name, together with its
-JSON-compatible likelihood metadata, are recorded in result and serialized
-output provenance. Executable Python code is not serialized.
+   result = run_rhime(
+       config_file="config.ini",
+       likelihood_builder=likelihood_builder,
+   )
 
 A builder is called as ``likelihood_builder(context)`` while the PyMC model is
 active and returns ``RhimeLikelihoodResult``. Its semantic roles drive
 predictive sampling, its supported output formats are validated before
 sampling, and its metadata must be JSON-compatible. The ordinary caller does
 not construct the context, a specification, or a role/output manifest.
+
+Editable likelihood
+~~~~~~~~~~~~~~~~~~~
+
+The tested project-owned example replaces RHIME's Gaussian observation
+distribution with Student-t while reusing RHIME's current mean and error
+construction:
+
+.. literalinclude:: ../../examples/rhime_customisation/likelihoods.py
+   :language: python
+   :linenos:
+
+The callable's safe module and qualified name, together with its
+JSON-compatible likelihood metadata, are recorded in result and serialized
+output provenance. Executable Python code is not serialized.
 
 The example makes those owned invariants explicit: ``student_y`` is declared
 as the ``concentration`` role, RHIME's ``epsilon`` remains the ``model_error``
@@ -51,6 +49,21 @@ Student-t family and degrees of freedom are recorded as JSON metadata. It
 rejects dense and low-rank aggregation covariance because the example uses an
 independent Student-t distribution; supporting those modes would require a
 multivariate likelihood rather than a hidden approximation.
+
+Optional project CLI
+~~~~~~~~~~~~~~~~~~~~
+
+The short wrapper below packages the same one-call integration as a reusable
+Python function and command-line entry point:
+
+.. literalinclude:: ../../examples/rhime_customisation/run_with_likelihood.py
+   :language: python
+   :linenos:
+
+Run it with a normal RHIME configuration and optional JSON overrides::
+
+   python -m package_name.run_with_likelihood config.ini \
+       --kwargs '{"output_path": "outputs", "output_format": "inv_out"}'
 
 ``run_rhime_multisector`` accepts the same Python-only builder contract. The
 standard multi-sector model retains sector flux components and roles, then

--- a/docs/usage/customising_rhime.rst
+++ b/docs/usage/customising_rhime.rst
@@ -9,10 +9,11 @@ acquisition-to-output workflow and pass one direct-Python callable to
 ``run_rhime``. The callable is deliberately unavailable to INI files: it is
 not imported from configuration or stored in a run or model specification.
 
-This example selects the absolute-sigma Gaussian likelihood in place of
-RHIME's default pollution-event-scaled Gaussian. The likelihood is the same
-one used by the complete copied runner below, so the difference between the
-examples is orchestration ceremony rather than scientific behaviour.
+This example replaces RHIME's Gaussian observation distribution with an
+editable Student-t likelihood while reusing RHIME's current mean and error
+construction. The likelihood is the same one used by the complete copied
+runner below, so the difference between the examples is orchestration ceremony
+rather than scientific behaviour.
 
 The project-owned likelihood selection is one small module:
 
@@ -43,6 +44,14 @@ predictive sampling, its supported output formats are validated before
 sampling, and its metadata must be JSON-compatible. The ordinary caller does
 not construct the context, a specification, or a role/output manifest.
 
+The example makes those owned invariants explicit: ``student_y`` is declared
+as the ``concentration`` role, RHIME's ``epsilon`` remains the ``model_error``
+role, only ``none`` and ``inv_out`` outputs are declared compatible, and the
+Student-t family and degrees of freedom are recorded as JSON metadata. It
+rejects dense and low-rank aggregation covariance because the example uses an
+independent Student-t distribution; supporting those modes would require a
+multivariate likelihood rather than a hidden approximation.
+
 ``run_rhime_multisector`` accepts the same Python-only builder contract. The
 standard multi-sector model retains sector flux components and roles, then
 passes their combined observation mean to the likelihood, so no special case
@@ -59,11 +68,10 @@ replaying prepared inputs, replacing the complete model, or deliberately
 starting from a different preparation graph.
 
 The deliberate change is the likelihood passed to
-``build_standard_rhime_model``: the example selects
-``build_absolute_sigma_gaussian_likelihood`` in place of RHIME's default
-pollution-event-scaled Gaussian. Acquisition, filtering, basis construction,
-labelled input assembly, the eager PyMC boundary, sampling, predictive
-selection, filenames, and output handling remain library-owned.
+``build_standard_rhime_model``: the example selects the same project-owned
+Student-t builder as the preferred form. Acquisition, filtering, basis
+construction, labelled input assembly, the eager PyMC boundary, sampling,
+predictive selection, filenames, and output handling remain library-owned.
 
 In a project created with the `OpenGHG project cookiecutter
 <https://github.com/openghg/openghg-project-cookiecutter>`_, copy the preferred
@@ -84,8 +92,9 @@ Less common Python/config options can be supplied as a JSON object::
    python -m package_name.rhime_runner config.ini \
        --kwargs '{"reload_merged_data": true, "output_format": "inv_out"}'
 
-All three sources are imported and executed by the integration test, so the
-documentation and runnable examples cannot drift apart.
+The test suite imports all three sources, exercises both runners, and validates
+the likelihood contract directly, so the documentation and runnable examples
+cannot drift apart.
 
 .. literalinclude:: ../../examples/rhime_customisation/runner.py
    :language: python

--- a/examples/rhime_customisation/__init__.py
+++ b/examples/rhime_customisation/__init__.py
@@ -1,0 +1,1 @@
+"""Executable preferred and advanced RHIME customization examples."""

--- a/examples/rhime_customisation/likelihoods.py
+++ b/examples/rhime_customisation/likelihoods.py
@@ -11,11 +11,11 @@ not build a model, retrieve data, sample, or write outputs.
 
 import pymc as pm
 
-from openghg_inversions.observation_error import resolve_aggregation_error
 from openghg_inversions.rhime import (
     RhimeLikelihoodContext,
     RhimeLikelihoodResult,
     build_rhime_observation_state,
+    select_aggregation_error_mode,
 )
 
 
@@ -45,12 +45,11 @@ def likelihood_builder(context: RhimeLikelihoodContext) -> RhimeLikelihoodResult
         output writes. Unsupported aggregation modes are rejected before any
         nodes are added.
     """
-    aggregation_error = resolve_aggregation_error(
+    aggregation_error_mode = select_aggregation_error_mode(
         context.data,
         context.aggregation_error_mode,
-        output_dim=context.output_dim,
     )
-    if aggregation_error.mode not in {"none", "diagonal"}:
+    if aggregation_error_mode not in {"none", "diagonal"}:
         raise ValueError("This Student-t model assumes independent observations.")
     state = build_rhime_observation_state(context)
     observed = pm.StudentT(

--- a/examples/rhime_customisation/likelihoods.py
+++ b/examples/rhime_customisation/likelihoods.py
@@ -1,0 +1,19 @@
+"""Likelihood selected by both RHIME customization examples.
+
+The public absolute-sigma Gaussian builder is re-exported here so a consumer
+project has one plainly named module for its scientific customization. It
+treats inferred sigma as an absolute observation-aligned error contribution,
+rather than scaling it by the modeled pollution event.
+
+``likelihood_builder`` is the exported runner seam. Importing this module does
+not build a model, retrieve data, sample, or write outputs.
+"""
+
+from openghg_inversions.rhime import (
+    RhimeLikelihoodBuilder,
+    build_absolute_sigma_gaussian_likelihood,
+)
+
+likelihood_builder: RhimeLikelihoodBuilder = build_absolute_sigma_gaussian_likelihood
+
+__all__ = ["build_absolute_sigma_gaussian_likelihood", "likelihood_builder"]

--- a/examples/rhime_customisation/likelihoods.py
+++ b/examples/rhime_customisation/likelihoods.py
@@ -1,19 +1,76 @@
-"""Likelihood selected by both RHIME customization examples.
+"""Editable Student-t likelihood shared by both RHIME examples.
 
-The public absolute-sigma Gaussian builder is re-exported here so a consumer
-project has one plainly named module for its scientific customization. It
-treats inferred sigma as an absolute observation-aligned error contribution,
-rather than scaling it by the modeled pollution event.
+This project-owned function changes RHIME's observation distribution while
+reusing its current mean and error construction. It demonstrates the result
+roles, compatible outputs, and JSON-compatible metadata that a likelihood
+builder owns.
 
 ``likelihood_builder`` is the exported runner seam. Importing this module does
 not build a model, retrieve data, sample, or write outputs.
 """
 
+import pymc as pm
+
+from openghg_inversions.observation_error import resolve_aggregation_error
 from openghg_inversions.rhime import (
-    RhimeLikelihoodBuilder,
-    build_absolute_sigma_gaussian_likelihood,
+    RhimeLikelihoodContext,
+    RhimeLikelihoodResult,
+    build_rhime_observation_state,
 )
 
-likelihood_builder: RhimeLikelihoodBuilder = build_absolute_sigma_gaussian_likelihood
 
-__all__ = ["build_absolute_sigma_gaussian_likelihood", "likelihood_builder"]
+def likelihood_builder(context: RhimeLikelihoodContext) -> RhimeLikelihoodResult:
+    """Build a Student-t observation model with RHIME's current error scale.
+
+    Degrees of freedom are fixed at 4.0. RHIME's ``epsilon`` is passed as the
+    Student-t scale, not its marginal standard deviation; for four degrees of
+    freedom the marginal standard deviation is ``epsilon * sqrt(2)``.
+
+    Args:
+        context: Labelled RHIME means, observations, and error settings for
+            the active PyMC model.
+
+    Returns:
+        Observed Student-t variable with semantic roles, conservative output
+        support, and serializable provenance metadata.
+
+    Raises:
+        ValueError: If dense or low-rank aggregation error would require a
+            multivariate Student-t likelihood.
+
+    Notes:
+        On success, this adds RHIME's named observation-state nodes (``Y``,
+        ``error``, ``min_error``, and ``sigma`` or ``epsilon`` as applicable)
+        plus ``student_y`` to the active PyMC model. It performs no sampling or
+        output writes. Unsupported aggregation modes are rejected before any
+        nodes are added.
+    """
+    aggregation_error = resolve_aggregation_error(
+        context.data,
+        context.aggregation_error_mode,
+        output_dim=context.output_dim,
+    )
+    if aggregation_error.mode not in {"none", "diagonal"}:
+        raise ValueError("This Student-t model assumes independent observations.")
+    state = build_rhime_observation_state(context)
+    observed = pm.StudentT(
+        "student_y",
+        nu=4.0,
+        mu=state.mean,
+        sigma=state.error_scale,
+        observed=state.observed,
+        dims=context.output_dim,
+    )
+    return RhimeLikelihoodResult(
+        likelihood=observed,
+        error_scale=state.error_scale,
+        variable_roles={
+            "concentration": "student_y",
+            "model_error": "epsilon",
+        },
+        supported_output_formats=("none", "inv_out"),
+        metadata={"family": "student_t", "degrees_of_freedom": 4.0},
+    )
+
+
+__all__ = ["likelihood_builder"]

--- a/examples/rhime_customisation/run_with_likelihood.py
+++ b/examples/rhime_customisation/run_with_likelihood.py
@@ -1,0 +1,103 @@
+"""Run ordinary RHIME with the absolute-sigma Gaussian likelihood.
+
+This is the preferred low-ceremony customization route. It keeps RHIME's
+complete acquisition-to-output pipeline and changes only the direct-Python
+likelihood callable passed to :func:`openghg_inversions.rhime.run_rhime`.
+Use :func:`run_with_likelihood` from Python or :func:`main` from the command
+line with a normal RHIME configuration. The workflow may retrieve or reload
+data, materializes related model arrays together at the named PyMC boundary,
+samples, and writes requested outputs while canonical xarray/Dask inputs remain
+borrowed.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Sequence
+import json
+from pathlib import Path
+from typing import Any
+
+from openghg_inversions.rhime import RhimeResult, run_rhime
+
+from .likelihoods import likelihood_builder
+
+build_absolute_sigma_gaussian_likelihood = likelihood_builder
+
+
+def run_with_likelihood(
+    *,
+    config_file: str | Path | None = None,
+    **kwargs: Any,
+) -> RhimeResult:
+    """Run standard RHIME with an absolute-sigma Gaussian likelihood.
+
+    Args:
+        config_file: Optional RHIME INI configuration file.
+        **kwargs: Standard RHIME option names that override values from
+            ``config_file``.
+
+    Returns:
+        The sampled result and any outputs requested by the RHIME options.
+
+    Notes:
+        This workflow may retrieve or reload data, eagerly materializes PyMC
+        model inputs, runs sampling, and writes configured outputs.
+    """
+    return run_rhime(
+        config_file=config_file,
+        likelihood_builder=likelihood_builder,
+        **kwargs,
+    )
+
+
+def _json_object(value: str) -> dict[str, Any]:
+    """Parse one command-line JSON object containing RHIME option overrides.
+
+    Args:
+        value: JSON text to parse.
+
+    Returns:
+        The decoded JSON object.
+
+    Raises:
+        argparse.ArgumentTypeError: If the text is invalid JSON or decodes to
+            a non-object value.
+    """
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise argparse.ArgumentTypeError(f"invalid JSON: {exc.msg}") from exc
+    if not isinstance(parsed, dict):
+        raise argparse.ArgumentTypeError("--kwargs must decode to a JSON object")
+    return parsed
+
+
+def main(argv: Sequence[str] | None = None) -> RhimeResult:
+    """Parse command-line options and run the customized RHIME workflow.
+
+    Args:
+        argv: Command-line tokens excluding the program name. ``None`` reads
+            tokens from :data:`sys.argv`.
+
+    Returns:
+        The RHIME result returned by :func:`run_with_likelihood`.
+
+    Raises:
+        SystemExit: If argument parsing fails or help is requested.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("config_file", nargs="?", type=Path, help="RHIME INI configuration file")
+    parser.add_argument(
+        "--kwargs",
+        type=_json_object,
+        default={},
+        metavar="JSON",
+        help="additional RHIME options as a JSON object",
+    )
+    args = parser.parse_args(argv)
+    return run_with_likelihood(config_file=args.config_file, **args.kwargs)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/rhime_customisation/run_with_likelihood.py
+++ b/examples/rhime_customisation/run_with_likelihood.py
@@ -1,4 +1,4 @@
-"""Run ordinary RHIME with the absolute-sigma Gaussian likelihood.
+"""Run ordinary RHIME with a project-owned Student-t likelihood.
 
 This is the preferred low-ceremony customization route. It keeps RHIME's
 complete acquisition-to-output pipeline and changes only the direct-Python
@@ -22,15 +22,13 @@ from openghg_inversions.rhime import RhimeResult, run_rhime
 
 from .likelihoods import likelihood_builder
 
-build_absolute_sigma_gaussian_likelihood = likelihood_builder
-
 
 def run_with_likelihood(
     *,
     config_file: str | Path | None = None,
     **kwargs: Any,
 ) -> RhimeResult:
-    """Run standard RHIME with an absolute-sigma Gaussian likelihood.
+    """Run standard RHIME with a project-owned Student-t likelihood.
 
     Args:
         config_file: Optional RHIME INI configuration file.
@@ -40,9 +38,15 @@ def run_with_likelihood(
     Returns:
         The sampled result and any outputs requested by the RHIME options.
 
+    Raises:
+        TypeError: If the likelihood builder returns an invalid result type.
+        ValueError: If required options are missing, aggregation or output is
+            unsupported, or likelihood roles or metadata are invalid.
+
     Notes:
-        This workflow may retrieve or reload data, eagerly materializes PyMC
-        model inputs, runs sampling, and writes configured outputs.
+        This workflow may retrieve or reload data, materializes related model
+        arrays together at the named PyMC boundary without mutating canonical
+        prepared inputs, runs sampling, and writes configured outputs.
     """
     return run_rhime(
         config_file=config_file,

--- a/examples/rhime_customisation/runner.py
+++ b/examples/rhime_customisation/runner.py
@@ -1,7 +1,7 @@
 """Advanced copy-and-modify runner for a standard RHIME inversion.
 
-This example deliberately replaces RHIME's default likelihood with the public
-absolute-sigma Gaussian helper.  The orchestration is intentionally copied so
+This example deliberately replaces RHIME's default likelihood with a
+project-owned Student-t builder. The orchestration is intentionally copied so
 that a project can make deeper scientific changes while continuing to reuse
 the supported acquisition, preparation, model, sampling, and output stages.
 Use :func:`run_custom_rhime` from Python or :func:`main` from the command line.
@@ -37,15 +37,13 @@ from openghg_inversions.rhime import (
 
 from .likelihoods import likelihood_builder
 
-build_absolute_sigma_gaussian_likelihood = likelihood_builder
-
 
 def run_custom_rhime(
     *,
     config_file: str | Path | None = None,
     **kwargs: Any,
 ) -> RhimeResult:
-    """Run standard RHIME with an absolute-sigma Gaussian likelihood.
+    """Run standard RHIME with a project-owned Student-t likelihood.
 
     Args:
         config_file: Optional RHIME INI configuration file.
@@ -55,9 +53,15 @@ def run_custom_rhime(
     Returns:
         The sampled result and any outputs requested by the RHIME options.
 
+    Raises:
+        TypeError: If the likelihood builder returns an invalid result type.
+        ValueError: If required options are missing, aggregation or output is
+            unsupported, or likelihood roles or metadata are invalid.
+
     Notes:
-        This workflow may retrieve or reload data, eagerly materializes PyMC
-        model inputs, runs sampling, and writes outputs requested by the
+        This workflow may retrieve or reload data, materializes related model
+        arrays together at the named PyMC boundary without mutating canonical
+        prepared inputs, runs sampling, and writes outputs requested by the
         resolved RHIME options.
     """
     params = (

--- a/examples/rhime_customisation/runner.py
+++ b/examples/rhime_customisation/runner.py
@@ -22,7 +22,6 @@ from typing import Any
 from openghg_inversions.rhime import (
     RhimeResult,
     assemble_rhime_inputs,
-    build_absolute_sigma_gaussian_likelihood,
     build_rhime_basis,
     build_rhime_sensitivities,
     build_standard_rhime_model,
@@ -35,6 +34,10 @@ from openghg_inversions.rhime import (
     sample_rhime_model,
     with_prepared_rhime_sites,
 )
+
+from .likelihoods import likelihood_builder
+
+build_absolute_sigma_gaussian_likelihood = likelihood_builder
 
 
 def run_custom_rhime(
@@ -86,7 +89,7 @@ def run_custom_rhime(
         model_inputs=model_inputs,
         run_spec=run_spec,
         # This is the deliberate scientific replacement in the copied runner.
-        likelihood_builder=build_absolute_sigma_gaussian_likelihood,
+        likelihood_builder=likelihood_builder,
     )
     idata = sample_rhime_model(
         model_build_result,
@@ -101,7 +104,7 @@ def run_custom_rhime(
         model_build_result=model_build_result,
         idata=idata,
         build_and_sample_seconds=perf_counter() - build_and_sample_start,
-        likelihood_builder=build_absolute_sigma_gaussian_likelihood,
+        likelihood_builder=likelihood_builder,
     )
 
 

--- a/openghg_inversions/rhime/__init__.py
+++ b/openghg_inversions/rhime/__init__.py
@@ -21,6 +21,7 @@ from openghg_inversions.models.rhime_likelihood import (
     build_gaussian_rhime_likelihood,
     build_rhime_observation_state,
 )
+from openghg_inversions.observation_error import select_aggregation_error_mode
 
 from .builders import RhimeModelBuilder, RhimeModelBuilderContext, RhimeModelBuildResult
 from .params import params_from_config, resolve_flux_sources
@@ -80,5 +81,6 @@ __all__ = [
     "run_rhime_from_prepared_inputs",
     "run_rhime_multisector",
     "sample_rhime_model",
+    "select_aggregation_error_mode",
     "with_prepared_rhime_sites",
 ]

--- a/openghg_inversions/rhime/builders.py
+++ b/openghg_inversions/rhime/builders.py
@@ -1,11 +1,15 @@
-"""Public extension contracts for complete RHIME model builders."""
+"""Public model-build contracts and validation for RHIME customizations.
+
+The validation applies both to complete-model builders and to built-in model
+results that wrap a custom likelihood builder.
+"""
 
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 import json
-from typing import Any, Protocol
+from typing import Any, Literal, Protocol
 
 import pymc as pm
 
@@ -13,9 +17,7 @@ from openghg_inversions.inversion_data import RhimePreparedInputs
 from openghg_inversions.rhime.specs import OutputFormat, RhimeRunSpec
 
 
-_OUTPUT_FORMATS: frozenset[OutputFormat] = frozenset(
-    {"none", "inv_out", "basic", "paris", "legacy"}
-)
+_OUTPUT_FORMATS: frozenset[OutputFormat] = frozenset({"none", "inv_out", "basic", "paris", "legacy"})
 
 
 @dataclass(frozen=True)
@@ -66,8 +68,7 @@ class RhimeModelBuildResult:
         """Copy and validate the serializable portion of the result."""
         if not isinstance(self.model, pm.Model):
             raise TypeError(
-                "`RhimeModelBuildResult.model` must be a `pymc.Model`; "
-                f"got {type(self.model).__name__}."
+                f"`RhimeModelBuildResult.model` must be a `pymc.Model`; got {type(self.model).__name__}."
             )
 
         roles = {str(role): str(name) for role, name in self.variable_roles.items()}
@@ -116,10 +117,31 @@ def validate_model_build_result(
     result: RhimeModelBuildResult,
     *,
     context: RhimeModelBuilderContext,
+    builder_kind: Literal["model", "likelihood"] = "model",
 ) -> None:
-    """Validate a custom build result before sampling or postprocessing."""
+    """Validate a custom build result before sampling or postprocessing.
+
+    Args:
+        result: Complete model build result to validate.
+        context: Prepared inputs and run settings for the active model build.
+        builder_kind: Customization seam responsible for the result. This is
+            used only to label the unsupported-output diagnostic; it does not
+            change validation.
+
+    Raises:
+        ValueError: If the requested output is unsupported or declared
+            variable roles are incomplete or refer to absent variables.
+    """
     output_format = context.run_spec.output.output_format
     if output_format not in result.supported_output_formats:
+        if builder_kind == "likelihood":
+            raise ValueError(
+                "Custom RHIME likelihood builder does not declare "
+                f"output_format={output_format!r} compatible. Declared formats: "
+                f"{list(result.supported_output_formats)!r}. Use output_format='none' or "
+                "return `RhimeLikelihoodResult` with the requested format in "
+                "`supported_output_formats`."
+            )
         raise ValueError(
             f"Custom RHIME model builder does not declare output_format={output_format!r} compatible. "
             f"Declared formats: {list(result.supported_output_formats)!r}. Use output_format='none' or "
@@ -127,9 +149,7 @@ def validate_model_build_result(
         )
 
     available_names = set(result.model.named_vars) | set(context.prepared_inputs.inv_inputs.variables)
-    missing = {
-        role: name for role, name in result.variable_roles.items() if name not in available_names
-    }
+    missing = {role: name for role, name in result.variable_roles.items() if name not in available_names}
     if missing:
         details = ", ".join(f"{role}={name!r}" for role, name in sorted(missing.items()))
         raise ValueError(

--- a/openghg_inversions/rhime/runner.py
+++ b/openghg_inversions/rhime/runner.py
@@ -666,6 +666,21 @@ def _validated_custom_model_build(
     return model_build_result
 
 
+def _validate_likelihood_builder(likelihood_builder: object | None) -> None:
+    """Reject non-callable likelihood builders at the public boundary.
+
+    Args:
+        likelihood_builder: Candidate direct-Python likelihood builder.
+
+    Raises:
+        TypeError: If the candidate is neither callable nor ``None``.
+    """
+    if likelihood_builder is not None and not callable(likelihood_builder):
+        raise TypeError(
+            f"`likelihood_builder` must be callable or None; got {type(likelihood_builder).__name__}."
+        )
+
+
 def build_standard_rhime_model(
     *,
     prepared: RhimePreparedInputs,
@@ -688,17 +703,24 @@ def build_standard_rhime_model(
             later outputs.
         model_inputs: Materialized PyMC inputs.
         run_spec: Retained-site-aligned run specification.
-        model_builder: Optional advanced complete-model builder.
+        model_builder: Optional advanced complete-model builder. Mutually
+            exclusive with ``likelihood_builder``; when both are supplied the
+            stage rejects them before either executes.
         likelihood_builder: Optional likelihood builder used by the built-in
-            model.
+            model. Mutually exclusive with ``model_builder``; when both are
+            supplied the stage rejects them before either executes.
 
     Returns:
         Built model with validated roles and output capabilities.
 
     Raises:
-        TypeError: If a complete-model builder returns the wrong type.
-        ValueError: If builder roles or output capabilities are invalid.
+        TypeError: If a complete-model builder or likelihood builder returns
+            the wrong result type.
+        ValueError: If both builder seams are supplied or builder roles or
+            output capabilities are invalid.
     """
+    if model_builder is not None and likelihood_builder is not None:
+        raise ValueError("Pass either `model_builder` or `likelihood_builder`, not both.")
     timing_start = timer_start()
     builder_context = RhimeModelBuilderContext(
         prepared_inputs=prepared,
@@ -722,7 +744,11 @@ def build_standard_rhime_model(
             multisector=False,
         )
     if likelihood_builder is not None:
-        validate_model_build_result(model_build_result, context=builder_context)
+        validate_model_build_result(
+            model_build_result,
+            context=builder_context,
+            builder_kind="likelihood",
+        )
     log_timing("rhime.model_build", timer_seconds(timing_start), multisector=False)
     return model_build_result
 
@@ -749,17 +775,24 @@ def build_multisector_rhime_model(
         prepared: Canonical prepared inputs and source-specific basis metadata.
         model_inputs: Materialized PyMC inputs.
         run_spec: Retained-site-aligned multi-sector run specification.
-        model_builder: Optional advanced complete-model builder.
+        model_builder: Optional advanced complete-model builder. Mutually
+            exclusive with ``likelihood_builder``; when both are supplied the
+            stage rejects them before either executes.
         likelihood_builder: Optional likelihood builder used by the built-in
-            model.
+            model. Mutually exclusive with ``model_builder``; when both are
+            supplied the stage rejects them before either executes.
 
     Returns:
         Built multi-sector model with validated roles and capabilities.
 
     Raises:
-        TypeError: If a complete-model builder returns the wrong type.
-        ValueError: If basis state coordinates or builder contracts disagree.
+        TypeError: If a complete-model builder or likelihood builder returns
+            the wrong result type.
+        ValueError: If both builder seams are supplied or basis state
+            coordinates or builder contracts disagree.
     """
+    if model_builder is not None and likelihood_builder is not None:
+        raise ValueError("Pass either `model_builder` or `likelihood_builder`, not both.")
     timing_start = timer_start()
     _validate_multisector_basis_layout(
         prepared.basis_functions,
@@ -788,7 +821,11 @@ def build_multisector_rhime_model(
             multisector=True,
         )
     if likelihood_builder is not None:
-        validate_model_build_result(model_build_result, context=builder_context)
+        validate_model_build_result(
+            model_build_result,
+            context=builder_context,
+            builder_kind="likelihood",
+        )
     log_timing("rhime.model_build", timer_seconds(timing_start), multisector=True)
     return model_build_result
 
@@ -1041,11 +1078,18 @@ def run_rhime_from_prepared_inputs(
         requested outputs.
 
     Raises:
+        TypeError: If ``likelihood_builder`` is not callable, or either
+            builder returns the wrong result type.
         ValueError: If both builder seams are supplied, the model specification
             contains no sectors, the sector
             count, prepared ``H`` layout, and prepared-data layout flag
             disagree, or output settings are invalid.
+
+    Notes:
+        A non-callable likelihood builder is rejected before prepared inputs
+        are validated, materialized, or otherwise touched.
     """
+    _validate_likelihood_builder(likelihood_builder)
     if model_builder is not None and likelihood_builder is not None:
         raise ValueError("Pass either `model_builder` or `likelihood_builder`, not both.")
     prepared_inputs = prepared_inputs.validated()
@@ -1197,11 +1241,17 @@ def run_rhime(
         output metadata, and generated outputs.
 
     Raises:
-        TypeError: If a likelihood builder returns the wrong result type.
+        TypeError: If a likelihood builder is not callable or returns the
+            wrong result type.
         ValueError: If required parameters are missing, unsupported parameters
             are supplied, the flux-source count is invalid, or likelihood
             roles, metadata, or requested-output compatibility are invalid.
+
+    Notes:
+        A non-callable likelihood builder is rejected before configuration is
+        parsed or data is acquired, prepared, or materialized.
     """
+    _validate_likelihood_builder(likelihood_builder)
     params = (
         params_from_config(config_file, extra_kwargs=kwargs, normalise=False)
         if config_file is not None
@@ -1238,36 +1288,18 @@ def run_rhime(
         aggregation_error_mode=run_spec.model.aggregation_error_mode,
     )
     build_and_sample_start = timer_start()
-    if likelihood_builder is None:
-        model_build_result = build_standard_rhime_model(
-            prepared=prepared,
-            model_inputs=model_inputs,
-            run_spec=run_spec,
-        )
-        idata = sample_rhime_model(model_build_result, setup.sampler)
-    else:
-        model_build_result = build_standard_rhime_model(
-            prepared=prepared,
-            model_inputs=model_inputs,
-            run_spec=run_spec,
-            likelihood_builder=likelihood_builder,
-        )
-        idata = sample_rhime_model(
-            model_build_result,
-            setup.sampler,
-            use_variable_roles=True,
-        )
+    model_build_result = build_standard_rhime_model(
+        prepared=prepared,
+        model_inputs=model_inputs,
+        run_spec=run_spec,
+        likelihood_builder=likelihood_builder,
+    )
+    idata = sample_rhime_model(
+        model_build_result,
+        setup.sampler,
+        use_variable_roles=likelihood_builder is not None,
+    )
 
-    if likelihood_builder is not None:
-        return make_standard_rhime_result(
-            prepared=prepared,
-            run_spec=run_spec,
-            sampler=setup.sampler,
-            model_build_result=model_build_result,
-            idata=idata,
-            build_and_sample_seconds=timer_seconds(build_and_sample_start),
-            likelihood_builder=likelihood_builder,
-        )
     return make_standard_rhime_result(
         prepared=prepared,
         run_spec=run_spec,
@@ -1275,6 +1307,7 @@ def run_rhime(
         model_build_result=model_build_result,
         idata=idata,
         build_and_sample_seconds=timer_seconds(build_and_sample_start),
+        likelihood_builder=likelihood_builder,
     )
 
 
@@ -1310,12 +1343,18 @@ def run_rhime_multisector(
         output metadata, and sector diagnostics.
 
     Raises:
-        TypeError: If a likelihood builder returns the wrong result type.
+        TypeError: If a likelihood builder is not callable or returns the
+            wrong result type.
         ValueError: If required parameters are missing, unsupported parameters
             are supplied, fewer than two flux sources are provided, or
             likelihood roles, metadata, or requested-output compatibility are
             invalid.
+
+    Notes:
+        A non-callable likelihood builder is rejected before configuration is
+        parsed or data is acquired, prepared, or materialized.
     """
+    _validate_likelihood_builder(likelihood_builder)
     params = (
         params_from_config(config_file, extra_kwargs=kwargs, normalise=False)
         if config_file is not None
@@ -1351,38 +1390,20 @@ def run_rhime_multisector(
         aggregation_error_mode=run_spec.model.aggregation_error_mode,
     )
     build_and_sample_start = timer_start()
-    if likelihood_builder is None:
-        model_build_result = build_multisector_rhime_model(
-            prepared=prepared,
-            model_inputs=model_inputs,
-            run_spec=run_spec,
-        )
-        idata = sample_rhime_model(model_build_result, setup.sampler)
-    else:
-        model_build_result = build_multisector_rhime_model(
-            prepared=prepared,
-            model_inputs=model_inputs,
-            run_spec=run_spec,
-            likelihood_builder=likelihood_builder,
-        )
-        idata = sample_rhime_model(
-            model_build_result,
-            setup.sampler,
-            use_variable_roles=True,
-        )
+    model_build_result = build_multisector_rhime_model(
+        prepared=prepared,
+        model_inputs=model_inputs,
+        run_spec=run_spec,
+        likelihood_builder=likelihood_builder,
+    )
+    idata = sample_rhime_model(
+        model_build_result,
+        setup.sampler,
+        use_variable_roles=likelihood_builder is not None,
+    )
 
     # Multi-sector output owns sector diagnostics and its distinct format
     # constraints; it is intentionally not hidden behind the standard stage.
-    if likelihood_builder is not None:
-        return make_multisector_rhime_result(
-            prepared=prepared,
-            run_spec=run_spec,
-            sampler=setup.sampler,
-            model_build_result=model_build_result,
-            idata=idata,
-            build_and_sample_seconds=timer_seconds(build_and_sample_start),
-            likelihood_builder=likelihood_builder,
-        )
     return make_multisector_rhime_result(
         prepared=prepared,
         run_spec=run_spec,
@@ -1390,4 +1411,5 @@ def run_rhime_multisector(
         model_build_result=model_build_result,
         idata=idata,
         build_and_sample_seconds=timer_seconds(build_and_sample_start),
+        likelihood_builder=likelihood_builder,
     )

--- a/openghg_inversions/rhime/runner.py
+++ b/openghg_inversions/rhime/runner.py
@@ -12,6 +12,12 @@ result. Canonical xarray and Dask inputs remain borrowed until the named
 materialization boundary; acquisition, sampling, and result stages may perform
 documented I/O.
 
+``run_rhime`` and ``run_rhime_multisector`` accept an optional Python-only
+likelihood builder outside configuration and serializable specifications. Its
+declared variable roles drive predictive selection, its output capabilities
+are validated before sampling, and only safe callable identity plus
+JSON-compatible metadata are retained as provenance.
+
 Terminology used by the RHIME API:
 
 - ``species`` is the primary gas or tracer name used for object-store lookup
@@ -1163,6 +1169,7 @@ def run_rhime_from_prepared_inputs(
 def run_rhime(
     *,
     config_file: str | Path | None = None,
+    likelihood_builder: RhimeLikelihoodBuilder | None = None,
     **kwargs: Any,
 ) -> RhimeResult:
     """Run a standard single-sector RHIME inversion.
@@ -1170,6 +1177,13 @@ def run_rhime(
     Args:
         config_file: Optional INI configuration file. Values in ``kwargs``
             override values read from this file.
+        likelihood_builder: Optional Python-only callable invoked with a
+            ``RhimeLikelihoodContext`` in the active PyMC model and returning
+            ``RhimeLikelihoodResult``. The result declares semantic variable
+            roles, supported output formats, and JSON-compatible metadata;
+            roles drive predictive selection and output compatibility is
+            validated before sampling. The callable is never read from
+            configuration or stored in run/model specifications.
         **kwargs: RHIME run parameters using snake-case names, such as
             ``output_path``, ``output_name``, ``flux_sources``, and
             ``x_prior``. ``species`` names the primary gas or tracer used for
@@ -1183,8 +1197,10 @@ def run_rhime(
         output metadata, and generated outputs.
 
     Raises:
+        TypeError: If a likelihood builder returns the wrong result type.
         ValueError: If required parameters are missing, unsupported parameters
-            are supplied, or the flux-source count is invalid.
+            are supplied, the flux-source count is invalid, or likelihood
+            roles, metadata, or requested-output compatibility are invalid.
     """
     params = (
         params_from_config(config_file, extra_kwargs=kwargs, normalise=False)
@@ -1222,13 +1238,36 @@ def run_rhime(
         aggregation_error_mode=run_spec.model.aggregation_error_mode,
     )
     build_and_sample_start = timer_start()
-    model_build_result = build_standard_rhime_model(
-        prepared=prepared,
-        model_inputs=model_inputs,
-        run_spec=run_spec,
-    )
-    idata = sample_rhime_model(model_build_result, setup.sampler)
+    if likelihood_builder is None:
+        model_build_result = build_standard_rhime_model(
+            prepared=prepared,
+            model_inputs=model_inputs,
+            run_spec=run_spec,
+        )
+        idata = sample_rhime_model(model_build_result, setup.sampler)
+    else:
+        model_build_result = build_standard_rhime_model(
+            prepared=prepared,
+            model_inputs=model_inputs,
+            run_spec=run_spec,
+            likelihood_builder=likelihood_builder,
+        )
+        idata = sample_rhime_model(
+            model_build_result,
+            setup.sampler,
+            use_variable_roles=True,
+        )
 
+    if likelihood_builder is not None:
+        return make_standard_rhime_result(
+            prepared=prepared,
+            run_spec=run_spec,
+            sampler=setup.sampler,
+            model_build_result=model_build_result,
+            idata=idata,
+            build_and_sample_seconds=timer_seconds(build_and_sample_start),
+            likelihood_builder=likelihood_builder,
+        )
     return make_standard_rhime_result(
         prepared=prepared,
         run_spec=run_spec,
@@ -1242,6 +1281,7 @@ def run_rhime(
 def run_rhime_multisector(
     *,
     config_file: str | Path | None = None,
+    likelihood_builder: RhimeLikelihoodBuilder | None = None,
     **kwargs: Any,
 ) -> RhimeResult:
     """Run a shared-basis multi-sector RHIME inversion.
@@ -1249,6 +1289,13 @@ def run_rhime_multisector(
     Args:
         config_file: Optional INI configuration file. Values in ``kwargs``
             override values read from this file.
+        likelihood_builder: Optional Python-only callable invoked with a
+            ``RhimeLikelihoodContext`` in the active PyMC model and returning
+            ``RhimeLikelihoodResult``. The result declares semantic variable
+            roles, supported output formats, and JSON-compatible metadata;
+            roles drive predictive selection and output compatibility is
+            validated before sampling. The callable is never read from
+            configuration or stored in run/model specifications.
         **kwargs: RHIME run parameters using snake-case names. Multi-sector
             runs require at least two ``flux_sources`` and may include
             a complete ``sector_priors`` mapping keyed by sector name. When
@@ -1263,8 +1310,11 @@ def run_rhime_multisector(
         output metadata, and sector diagnostics.
 
     Raises:
+        TypeError: If a likelihood builder returns the wrong result type.
         ValueError: If required parameters are missing, unsupported parameters
-            are supplied, or fewer than two flux sources are provided.
+            are supplied, fewer than two flux sources are provided, or
+            likelihood roles, metadata, or requested-output compatibility are
+            invalid.
     """
     params = (
         params_from_config(config_file, extra_kwargs=kwargs, normalise=False)
@@ -1301,15 +1351,38 @@ def run_rhime_multisector(
         aggregation_error_mode=run_spec.model.aggregation_error_mode,
     )
     build_and_sample_start = timer_start()
-    model_build_result = build_multisector_rhime_model(
-        prepared=prepared,
-        model_inputs=model_inputs,
-        run_spec=run_spec,
-    )
-    idata = sample_rhime_model(model_build_result, setup.sampler)
+    if likelihood_builder is None:
+        model_build_result = build_multisector_rhime_model(
+            prepared=prepared,
+            model_inputs=model_inputs,
+            run_spec=run_spec,
+        )
+        idata = sample_rhime_model(model_build_result, setup.sampler)
+    else:
+        model_build_result = build_multisector_rhime_model(
+            prepared=prepared,
+            model_inputs=model_inputs,
+            run_spec=run_spec,
+            likelihood_builder=likelihood_builder,
+        )
+        idata = sample_rhime_model(
+            model_build_result,
+            setup.sampler,
+            use_variable_roles=True,
+        )
 
     # Multi-sector output owns sector diagnostics and its distinct format
     # constraints; it is intentionally not hidden behind the standard stage.
+    if likelihood_builder is not None:
+        return make_multisector_rhime_result(
+            prepared=prepared,
+            run_spec=run_spec,
+            sampler=setup.sampler,
+            model_build_result=model_build_result,
+            idata=idata,
+            build_and_sample_seconds=timer_seconds(build_and_sample_start),
+            likelihood_builder=likelihood_builder,
+        )
     return make_multisector_rhime_result(
         prepared=prepared,
         run_spec=run_spec,

--- a/tests/integration/test_custom_rhime_runner.py
+++ b/tests/integration/test_custom_rhime_runner.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import importlib.util
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -10,12 +9,39 @@ from typing import Any
 import pytest
 import xarray as xr
 
+from examples.rhime_customisation import likelihoods
+from examples.rhime_customisation import runner as custom_runner
+from examples.rhime_customisation import run_with_likelihood as short_runner
 
-_RUNNER_PATH = Path(__file__).parents[2] / "examples" / "rhime_customisation" / "runner.py"
-_RUNNER_SPEC = importlib.util.spec_from_file_location("rhime_customisation_runner", _RUNNER_PATH)
-assert _RUNNER_SPEC is not None and _RUNNER_SPEC.loader is not None
-custom_runner = importlib.util.module_from_spec(_RUNNER_SPEC)
-_RUNNER_SPEC.loader.exec_module(custom_runner)
+
+def test_short_and_full_examples_share_likelihood_and_supported_output(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The preferred form selects the full runner's likelihood and output mode."""
+    config_file = tmp_path / "rhime.ini"
+    expected = object()
+    seen: dict[str, Any] = {}
+
+    def run_rhime(**kwargs: Any) -> Any:
+        """Capture the preferred one-call example without executing RHIME."""
+        seen.update(kwargs)
+        return expected
+
+    monkeypatch.setattr(short_runner, "run_rhime", run_rhime)
+    result = short_runner.run_with_likelihood(
+        config_file=config_file,
+        output_format="none",
+    )
+
+    assert result is expected
+    assert short_runner.likelihood_builder is likelihoods.likelihood_builder
+    assert custom_runner.likelihood_builder is likelihoods.likelihood_builder
+    assert seen == {
+        "config_file": config_file,
+        "likelihood_builder": custom_runner.likelihood_builder,
+        "output_format": "none",
+    }
 
 
 @pytest.mark.parametrize("reload_merged_data", [False, True])

--- a/tests/integration/test_custom_rhime_runner.py
+++ b/tests/integration/test_custom_rhime_runner.py
@@ -161,11 +161,11 @@ def test_custom_runner_uses_supported_stages_for_acquisition_and_reload(
         return model_inputs
 
     def build(**kwargs: Any) -> Any:
-        """Record the custom absolute-sigma likelihood handoff."""
+        """Record the project-owned Student-t likelihood handoff."""
         assert kwargs["prepared"] is prepared
         assert kwargs["model_inputs"] is model_inputs
         assert kwargs["run_spec"] is aligned_spec
-        assert kwargs["likelihood_builder"] is custom_runner.build_absolute_sigma_gaussian_likelihood
+        assert kwargs["likelihood_builder"] is custom_runner.likelihood_builder
         calls.append("build")
         return build_result
 
@@ -183,7 +183,7 @@ def test_custom_runner_uses_supported_stages_for_acquisition_and_reload(
         assert kwargs["sampler"] is sampler
         assert kwargs["model_build_result"] is build_result
         assert kwargs["idata"] is idata
-        assert kwargs["likelihood_builder"] is custom_runner.build_absolute_sigma_gaussian_likelihood
+        assert kwargs["likelihood_builder"] is custom_runner.likelihood_builder
         assert kwargs["build_and_sample_seconds"] >= 0.0
         calls.append("result")
         return expected_result

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -2318,10 +2318,24 @@ def test_run_rhime_from_prepared_inputs_routes_without_preparation(
 
 
 @pytest.mark.parametrize(
-    ("runner_name", "build_stage", "result_stage", "multisector"),
+    ("runner_name", "build_stage", "result_stage", "multisector", "custom_likelihood"),
     [
-        ("run_rhime", "build_standard_rhime_model", "make_standard_rhime_result", False),
-        ("run_rhime_multisector", "build_multisector_rhime_model", "make_multisector_rhime_result", True),
+        ("run_rhime", "build_standard_rhime_model", "make_standard_rhime_result", False, False),
+        ("run_rhime", "build_standard_rhime_model", "make_standard_rhime_result", False, True),
+        (
+            "run_rhime_multisector",
+            "build_multisector_rhime_model",
+            "make_multisector_rhime_result",
+            True,
+            False,
+        ),
+        (
+            "run_rhime_multisector",
+            "build_multisector_rhime_model",
+            "make_multisector_rhime_result",
+            True,
+            True,
+        ),
     ],
 )
 def test_public_rhime_runners_follow_named_stage_order(
@@ -2330,8 +2344,9 @@ def test_public_rhime_runners_follow_named_stage_order(
     build_stage: str,
     result_stage: str,
     multisector: bool,
+    custom_likelihood: bool,
 ) -> None:
-    """Standard and multisector recipes call their named public stages in order."""
+    """Ordinary recipes preserve stage handoffs with default or custom likelihoods."""
     _, _, run_spec = _minimal_output_specs(output_format="none")
     prepared = RhimePreparedInputs(
         inv_inputs=_minimal_output_inv_inputs(),
@@ -2410,16 +2425,26 @@ def test_public_rhime_runners_follow_named_stage_order(
 
     def build(**kwargs: Any) -> RhimeModelBuildResult:
         """Record the recipe-specific public model build."""
+        if custom_likelihood:
+            assert kwargs["likelihood_builder"] is build_absolute_sigma_gaussian_likelihood
+        else:
+            assert "likelihood_builder" not in kwargs
         calls.append("build")
         return build_result
 
     def sample(*args: Any, **kwargs: Any) -> az.InferenceData:
         """Record public sampling."""
+        assert args == (build_result, sampler)
+        assert kwargs == ({"use_variable_roles": True} if custom_likelihood else {})
         calls.append("sample")
         return idata
 
     def result(**kwargs: Any) -> RhimeResult:
         """Record the recipe-specific public result stage."""
+        if custom_likelihood:
+            assert kwargs["likelihood_builder"] is build_absolute_sigma_gaussian_likelihood
+        else:
+            assert "likelihood_builder" not in kwargs
         calls.append("result")
         return expected
 
@@ -2435,7 +2460,10 @@ def test_public_rhime_runners_follow_named_stage_order(
     monkeypatch.setattr(rhime_module, "sample_rhime_model", sample)
     monkeypatch.setattr(rhime_module, result_stage, result)
 
-    actual = getattr(rhime_module, runner_name)(species="ch4")
+    runner_kwargs: dict[str, Any] = {"species": "ch4"}
+    if custom_likelihood:
+        runner_kwargs["likelihood_builder"] = build_absolute_sigma_gaussian_likelihood
+    actual = getattr(rhime_module, runner_name)(**runner_kwargs)
 
     assert actual is expected
     assert calls == [
@@ -2451,6 +2479,15 @@ def test_public_rhime_runners_follow_named_stage_order(
         "sample",
         "result",
     ]
+
+
+@pytest.mark.parametrize("runner", [run_rhime, run_rhime_multisector])
+def test_ordinary_runners_expose_keyword_only_likelihood_builder(runner: Callable[..., Any]) -> None:
+    """Ordinary runners expose likelihood_builder as keyword-only and omit model_builder."""
+    parameters = inspect.signature(runner).parameters
+
+    assert parameters["likelihood_builder"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert "model_builder" not in parameters
 
 
 def test_rhime_public_package_exports_supported_orchestration_stages() -> None:
@@ -2747,6 +2784,61 @@ def test_custom_model_builder_rejects_undeclared_output_before_sampling(
             run_spec=run_spec,
             model_builder=sampling_only_builder,
         )
+
+
+@pytest.mark.rhime_contract
+def test_run_rhime_rejects_unsupported_custom_likelihood_output_before_sampling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ordinary custom likelihoods reject unsupported output before sampling."""
+    model_spec, _, run_spec = _minimal_output_specs(output_format="inv_out")
+    model_spec = replace(model_spec, use_bc=False)
+    run_spec = replace(run_spec, model=model_spec)
+    inv_inputs = _minimal_output_inv_inputs()
+    inv_inputs["H"] = inv_inputs["H"].assign_coords(source=model_spec.sectors[0].flux_source)
+    inv_inputs["min_error"] = xr.zeros_like(inv_inputs["mf"])
+    prepared = RhimePreparedInputs(
+        inv_inputs=inv_inputs,
+        basis_functions=_fake_basis_functions(),
+        site_metadata=_prepared_site_metadata(),
+    )
+    setup = SimpleNamespace(
+        data_args={"species": "ch4"},
+        run_spec=run_spec,
+        sampler=RhimeSampler(),
+    )
+
+    def sampling_only_likelihood(context: RhimeLikelihoodContext) -> RhimeLikelihoodResult:
+        """Build a valid likelihood that supports sampling-only runs."""
+        state = build_rhime_observation_state(context)
+        likelihood = pm.Normal(
+            "sampling_only_y",
+            mu=state.mean,
+            sigma=state.error_scale,
+            observed=state.observed,
+            dims=context.output_dim,
+        )
+        return RhimeLikelihoodResult(
+            likelihood=likelihood,
+            error_scale=state.error_scale,
+            variable_roles={"concentration": "sampling_only_y", "model_error": "epsilon"},
+            supported_output_formats=("none",),
+        )
+
+    def fail_sample(*args: Any, **kwargs: Any) -> None:
+        """Prove compatibility validation precedes sampler execution."""
+        raise AssertionError("unsupported likelihood output must fail before sampling")
+
+    monkeypatch.setattr(rhime_module, "resolve_rhime_options", lambda **kwargs: setup)
+    monkeypatch.setattr(rhime_module, "retrieve_or_reload_rhime_data", lambda *args, **kwargs: object())
+    monkeypatch.setattr(rhime_module, "filter_rhime_observations", lambda *args, **kwargs: object())
+    monkeypatch.setattr(rhime_module, "build_rhime_basis", lambda *args, **kwargs: prepared.basis_functions)
+    monkeypatch.setattr(rhime_module, "build_rhime_sensitivities", lambda *args, **kwargs: object())
+    monkeypatch.setattr(rhime_module, "assemble_rhime_inputs", lambda *args, **kwargs: prepared)
+    monkeypatch.setattr(RhimeSampler, "sample", fail_sample)
+
+    with pytest.raises(ValueError, match="does not declare output_format='inv_out' compatible"):
+        run_rhime(species="ch4", likelihood_builder=sampling_only_likelihood)
 
 
 @pytest.mark.parametrize(
@@ -5816,6 +5908,44 @@ output_name = "test"
 
 
 @pytest.mark.rhime_contract
+def test_run_rhime_rejects_configured_likelihood_builder_before_retrieval(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """INI files cannot resolve Python likelihood callables or start retrieval."""
+    config_file = tmp_path / "rhime.ini"
+    config_file.write_text(
+        """
+[INPUT.MEASUREMENTS]
+species = "ch4"
+sites = ["TAC"]
+averaging_period = ["1h"]
+start_date = "2019-01-01"
+end_date = "2019-01-02"
+
+[INPUT.PRIORS]
+domain = "EUROPE"
+flux_sources = ["total-ukghg-edgar7"]
+
+[RHIME.MCMC]
+likelihood_builder = "some.module.callable"
+
+[RHIME.OUTPUT]
+output_name = "test"
+""",
+        encoding="utf-8",
+    )
+
+    def fail_retrieval(*args: Any, **kwargs: Any) -> None:
+        """Prove invalid executable configuration fails before acquisition."""
+        raise AssertionError("configured likelihood builders must fail before retrieval")
+
+    monkeypatch.setattr(rhime_module, "retrieve_or_reload_rhime_data", fail_retrieval)
+    with pytest.raises(ValueError, match="likelihood_builder"):
+        run_rhime(config_file=config_file)
+
+
+@pytest.mark.rhime_contract
 def test_run_rhime_rejects_unknown_parameter_before_data_preparation(tmp_path: Path) -> None:
     """Reject unknown acquisition parameters before preparation begins."""
     args = {
@@ -7314,14 +7444,16 @@ def test_run_rhime_multisector_rejects_single_flux_source(tac_ch4_data_args, tmp
 
 
 @pytest.mark.rhime_contract
+@pytest.mark.parametrize("custom_likelihood", [False, True])
 def test_run_rhime_api_smoke(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
     tac_ch4_data_args: dict[str, Any],
     tmp_path: Path,
     default_bc_basis_directory: Path,
+    custom_likelihood: bool,
 ) -> None:
-    """Run a custom prior, exact observation metadata, timings, and output round-trip."""
+    """Run default and custom likelihoods through acquisition and output round-trip."""
     args = tac_ch4_data_args.copy()
     args.update(
         {
@@ -7344,14 +7476,31 @@ def test_run_rhime_api_smoke(
         }
     )
 
-    def fake_sample(self: RhimeSampler, model: pm.Model) -> az.InferenceData:
-        """Return deterministic scale and modeled-concentration posteriors."""
+    def ordinary_absolute_sigma(context: RhimeLikelihoodContext) -> RhimeLikelihoodResult:
+        """Vary only the ordinary runner's observation likelihood."""
+        return build_absolute_sigma_gaussian_likelihood(context)
+
+    def fake_sample(
+        self: RhimeSampler,
+        model: pm.Model,
+        *,
+        variable_roles: dict[str, str] | None = None,
+    ) -> az.InferenceData:
+        """Return deterministic posteriors after checking predictive role selection."""
         assert self.draws == 1
+        if custom_likelihood:
+            assert variable_roles is not None
+            assert variable_roles["concentration"] == "y"
+        else:
+            assert variable_roles is None
         return _posterior_only_idata(model, ("x", "mu"))
 
     monkeypatch.setattr(RhimeSampler, "sample", fake_sample)
 
-    result = run_rhime(**args)
+    runner_kwargs: dict[str, Any] = {}
+    if custom_likelihood:
+        runner_kwargs["likelihood_builder"] = ordinary_absolute_sigma
+    result = run_rhime(**args, **runner_kwargs)
 
     assert isinstance(result, RhimeResult)
     assert result.model is not None
@@ -7391,12 +7540,26 @@ def test_run_rhime_api_smoke(
     assert "inversion_output" in result.outputs
     assert isinstance(result.inv_out, InversionOutput)
     assert result.output_metadata["inversion_output_contract"] == "modern"
+    assert result.model_build_result is not None
+    if custom_likelihood:
+        assert result.output_metadata["likelihood_builder"]["qualname"].endswith("ordinary_absolute_sigma")
+        assert result.model_build_result.metadata["likelihood"]["family"] == ("absolute_sigma_gaussian")
+    else:
+        assert "likelihood_builder" not in result.output_metadata
     output_file = tmp_path / "rhime_test2019-01-01_inversion_output.nc"
     assert output_file.exists()
     reloaded = InversionOutput.load(output_file)
     assert reloaded.species == "ch4"
     assert reloaded.domain == args["domain"]
     assert isinstance(reloaded.basis_functions, BasisFunctions)
+    if custom_likelihood:
+        assert (
+            reloaded.model_metadata["builder"]["likelihood_builder"]
+            == result.output_metadata["likelihood_builder"]
+        )
+        assert reloaded.model_metadata["builder"]["likelihood"]["sigma_interpretation"] == "absolute"
+    else:
+        assert "likelihood_builder" not in reloaded.model_metadata["builder"]
     xr.testing.assert_identical(reloaded.inv_inputs, result.inv_inputs)
     xr.testing.assert_identical(reloaded.trace.posterior, result.idata.posterior)
 
@@ -7423,13 +7586,15 @@ def test_run_rhime_api_smoke(
 
 
 @pytest.mark.rhime_contract
+@pytest.mark.parametrize("custom_likelihood", [False, True])
 def test_run_rhime_multisector_api_smoke(
     monkeypatch: pytest.MonkeyPatch,
     tac_ch4_data_args: dict[str, Any],
     tmp_path: Path,
     default_bc_basis_directory: Path,
+    custom_likelihood: bool,
 ) -> None:
-    """Exercise the multi-sector public API with deterministic sampling."""
+    """Exercise default and custom likelihoods through the multi-sector API."""
     args = tac_ch4_data_args.copy()
     args.update(
         {
@@ -7461,19 +7626,42 @@ def test_run_rhime_multisector_api_smoke(
     )
     args.pop("emissions_name")
 
-    def fake_sample(self: RhimeSampler, model: pm.Model) -> az.InferenceData:
-        """Return deterministic posterior scale factors for both sectors."""
+    def multisector_absolute_sigma(context: RhimeLikelihoodContext) -> RhimeLikelihoodResult:
+        """Vary only the multi-sector observation likelihood."""
+        return build_absolute_sigma_gaussian_likelihood(context)
+
+    def fake_sample(
+        self: RhimeSampler,
+        model: pm.Model,
+        *,
+        variable_roles: dict[str, str] | None = None,
+    ) -> az.InferenceData:
+        """Return deterministic scale factors after checking declared roles."""
         assert self.draws == 1
+        if custom_likelihood:
+            assert variable_roles is not None
+            assert variable_roles["concentration"] == "y"
+            assert variable_roles["flux_scale:FF"] == "x_ff"
+            assert variable_roles["flux_scale:ocean"] == "x_ocean"
+        else:
+            assert variable_roles is None
         return _posterior_only_idata(model, ("x_ff", "x_ocean"))
 
     monkeypatch.setattr(RhimeSampler, "sample", fake_sample)
 
-    result = run_rhime_multisector(**args)
+    runner_kwargs: dict[str, Any] = {}
+    if custom_likelihood:
+        runner_kwargs["likelihood_builder"] = multisector_absolute_sigma
+    result = run_rhime_multisector(**args, **runner_kwargs)
 
     assert isinstance(result, RhimeResult)
     assert isinstance(result.basis_functions, BasisFunctions)
     assert not hasattr(result, "basis_objects")
     assert result.run_spec.split_by_sectors is True
+    if custom_likelihood:
+        assert result.output_metadata["likelihood_builder"]["qualname"].endswith("multisector_absolute_sigma")
+    else:
+        assert "likelihood_builder" not in result.output_metadata
     assert [sector.name for sector in result.model_spec.sectors] == ["FF", "ocean"]
     assert result.model_spec.sectors[0].x_prior == {
         "pdf": "uniform",

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -1027,6 +1027,7 @@ def test_editable_example_builder_returns_student_t_contract(
 @pytest.mark.parametrize("aggregation_error_mode", ["dense", "low_rank"])
 def test_editable_example_builder_rejects_correlated_aggregation_error(
     aggregation_error_mode: str,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The independent Student-t example rejects correlated error representations."""
     data = _minimal_output_inv_inputs()
@@ -1050,6 +1051,15 @@ def test_editable_example_builder_rejects_correlated_aggregation_error(
         frequency="3h",
         anchor_time="2019-01-01",
     )
+    selected_modes: list[str] = []
+    original_select = example_likelihoods.select_aggregation_error_mode
+
+    def select_mode(data: xr.Dataset, requested: Any) -> Any:
+        """Record the cheap public preflight used by the example."""
+        selected_modes.append(requested)
+        return original_select(data, requested)
+
+    monkeypatch.setattr(example_likelihoods, "select_aggregation_error_mode", select_mode)
 
     with pm.Model(coords={"nmeasure": np.arange(data.sizes["nmeasure"])}) as model:
         context = RhimeLikelihoodContext(
@@ -1066,6 +1076,7 @@ def test_editable_example_builder_rejects_correlated_aggregation_error(
         )
         with pytest.raises(ValueError, match="assumes independent observations"):
             example_likelihoods.likelihood_builder(context)
+    assert selected_modes == [aggregation_error_mode]
     assert model.named_vars == {}
 
 
@@ -2627,6 +2638,12 @@ def test_rhime_public_package_exports_supported_orchestration_stages() -> None:
     for name in stage_names:
         assert getattr(rhime_public, name) is getattr(rhime_module, name)
         assert name in rhime_public.__all__
+
+
+def test_rhime_public_package_exports_aggregation_error_mode_selector() -> None:
+    """Likelihood examples can preflight covariance mode through the RHIME API."""
+    assert rhime_public.select_aggregation_error_mode is rhime_module.select_aggregation_error_mode
+    assert "select_aggregation_error_mode" in rhime_public.__all__
 
 
 def test_public_stages_compose_as_complete_external_runner(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -17,6 +17,7 @@ import xarray as xr
 from pytensor.compile.mode import Mode
 from dask.callbacks import Callback
 
+from examples.rhime_customisation import likelihoods as example_likelihoods
 import openghg_inversions.hbmcmc.inversion_pymc as legacy_mcmc
 import openghg_inversions.inversion_data.preparation as prep_module
 import openghg_inversions.models as models
@@ -998,6 +999,74 @@ def test_build_rhime_model_accepts_student_t_likelihood_builder(
         "concentration": "student_y",
         "model_error": "epsilon",
     }
+
+
+def test_editable_example_builder_returns_student_t_contract(
+    rhime_inv_inputs: xr.Dataset,
+    builder_args: dict[str, Any],
+) -> None:
+    """The project-owned example returns its documented Student-t contract."""
+    example_model = build_rhime_model(
+        rhime_inv_inputs,
+        **builder_args,
+        likelihood_builder=example_likelihoods.likelihood_builder,
+    )
+    example_result = rhime_models_module.get_rhime_likelihood_result(example_model)
+
+    assert example_likelihoods.likelihood_builder.__module__ == example_likelihoods.__name__
+    assert isinstance(example_result, RhimeLikelihoodResult)
+    assert example_result.variable_roles == {
+        "concentration": "student_y",
+        "model_error": "epsilon",
+    }
+    assert example_result.supported_output_formats == ("none", "inv_out")
+    assert example_result.metadata == {"family": "student_t", "degrees_of_freedom": 4.0}
+    assert type(example_model["student_y"].owner.op).__name__ == "StudentTRV"
+
+
+@pytest.mark.parametrize("aggregation_error_mode", ["dense", "low_rank"])
+def test_editable_example_builder_rejects_correlated_aggregation_error(
+    aggregation_error_mode: str,
+) -> None:
+    """The independent Student-t example rejects correlated error representations."""
+    data = _minimal_output_inv_inputs()
+    data["min_error"] = xr.zeros_like(data["mf"])
+    if aggregation_error_mode == "dense":
+        data["aggregation_error_covariance"] = (
+            ("nmeasure", "nmeasure_cov"),
+            np.eye(data.sizes["nmeasure"]),
+        )
+    else:
+        data["low_rank_factor"] = (
+            ("nmeasure", "aggregation_rank"),
+            np.ones((data.sizes["nmeasure"], 1)),
+        )
+        data["diagonal_residual_variance"] = (
+            "nmeasure",
+            np.zeros(data.sizes["nmeasure"]),
+        )
+    sigma_alignment = SigmaAlignment.from_frequency(
+        data["site_indicator"],
+        frequency="3h",
+        anchor_time="2019-01-01",
+    )
+
+    with pm.Model(coords={"nmeasure": np.arange(data.sizes["nmeasure"])}) as model:
+        context = RhimeLikelihoodContext(
+            data=data,
+            flux_mean=pm.math.constant(np.zeros(data.sizes["nmeasure"])),
+            boundary_mean=None,
+            offset=None,
+            sigma_alignment=sigma_alignment,
+            sigma_prior={"pdf": "uniform", "lower": 0.1, "upper": 10.0},
+            power=1.99,
+            pollution_events_from_obs=False,
+            no_model_error=False,
+            aggregation_error_mode=cast(Any, aggregation_error_mode),
+        )
+        with pytest.raises(ValueError, match="assumes independent observations"):
+            example_likelihoods.likelihood_builder(context)
+    assert model.named_vars == {}
 
 
 @pytest.mark.rhime_contract
@@ -2425,26 +2494,22 @@ def test_public_rhime_runners_follow_named_stage_order(
 
     def build(**kwargs: Any) -> RhimeModelBuildResult:
         """Record the recipe-specific public model build."""
-        if custom_likelihood:
-            assert kwargs["likelihood_builder"] is build_absolute_sigma_gaussian_likelihood
-        else:
-            assert "likelihood_builder" not in kwargs
+        expected_builder = build_absolute_sigma_gaussian_likelihood if custom_likelihood else None
+        assert kwargs["likelihood_builder"] is expected_builder
         calls.append("build")
         return build_result
 
     def sample(*args: Any, **kwargs: Any) -> az.InferenceData:
         """Record public sampling."""
         assert args == (build_result, sampler)
-        assert kwargs == ({"use_variable_roles": True} if custom_likelihood else {})
+        assert kwargs == {"use_variable_roles": custom_likelihood}
         calls.append("sample")
         return idata
 
     def result(**kwargs: Any) -> RhimeResult:
         """Record the recipe-specific public result stage."""
-        if custom_likelihood:
-            assert kwargs["likelihood_builder"] is build_absolute_sigma_gaussian_likelihood
-        else:
-            assert "likelihood_builder" not in kwargs
+        expected_builder = build_absolute_sigma_gaussian_likelihood if custom_likelihood else None
+        assert kwargs["likelihood_builder"] is expected_builder
         calls.append("result")
         return expected
 
@@ -2488,6 +2553,57 @@ def test_ordinary_runners_expose_keyword_only_likelihood_builder(runner: Callabl
 
     assert parameters["likelihood_builder"].kind is inspect.Parameter.KEYWORD_ONLY
     assert "model_builder" not in parameters
+
+
+@pytest.mark.parametrize("runner", [run_rhime, run_rhime_multisector])
+def test_ordinary_runners_reject_noncallable_likelihood_before_config_and_preparation(
+    monkeypatch: pytest.MonkeyPatch,
+    runner: Callable[..., RhimeResult],
+) -> None:
+    """Non-callable likelihoods fail before config, acquisition, or materialization."""
+
+    def fail_stage(*args: Any, **kwargs: Any) -> None:
+        """Prove no downstream runner boundary is entered."""
+        raise AssertionError("invalid likelihood must fail at the public boundary")
+
+    for stage in (
+        "params_from_config",
+        "resolve_rhime_options",
+        "retrieve_or_reload_rhime_data",
+        "assemble_rhime_inputs",
+        "materialize_pymc_inputs",
+    ):
+        monkeypatch.setattr(rhime_module, stage, fail_stage)
+
+    with pytest.raises(TypeError, match="likelihood_builder.*callable"):
+        runner(
+            config_file=Path("unused.ini"),
+            likelihood_builder=cast(Any, "not-a-callable"),
+        )
+
+
+def test_prepared_runner_rejects_noncallable_likelihood_before_validation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Prepared-input runs reject invalid likelihoods before touching borrowed inputs."""
+    _, _, run_spec = _minimal_output_specs(output_format="none")
+    prepared = RhimePreparedInputs(
+        inv_inputs=_minimal_output_inv_inputs(),
+        basis_functions=_fake_basis_functions(),
+        site_metadata=_prepared_site_metadata(),
+    )
+
+    def fail_validation(self: RhimePreparedInputs) -> RhimePreparedInputs:
+        """Prove the borrowed prepared object remains untouched."""
+        raise AssertionError("invalid likelihood must fail before prepared validation")
+
+    monkeypatch.setattr(RhimePreparedInputs, "validated", fail_validation)
+    with pytest.raises(TypeError, match="likelihood_builder.*callable"):
+        run_rhime_from_prepared_inputs(
+            prepared_inputs=prepared,
+            run_spec=run_spec,
+            likelihood_builder=cast(Any, 42),
+        )
 
 
 def test_rhime_public_package_exports_supported_orchestration_stages() -> None:
@@ -2705,6 +2821,39 @@ def test_complete_model_builder_validates_aggregation_error_before_execution() -
     assert built_contexts == []
 
 
+@pytest.mark.parametrize(
+    "build_stage",
+    [rhime_module.build_standard_rhime_model, rhime_module.build_multisector_rhime_model],
+)
+def test_public_build_stages_reject_simultaneous_model_and_likelihood_builders(
+    build_stage: Callable[..., RhimeModelBuildResult],
+) -> None:
+    """Public build stages reject ambiguous builder ownership before either executes."""
+    _, _, run_spec = _minimal_output_specs(output_format="none")
+    prepared = RhimePreparedInputs(
+        inv_inputs=_minimal_output_inv_inputs(),
+        basis_functions=_fake_basis_functions(),
+        site_metadata=_prepared_site_metadata(),
+    )
+    builder_calls: list[RhimeModelBuilderContext] = []
+
+    def complete_model_builder(context: RhimeModelBuilderContext) -> RhimeModelBuildResult:
+        """Record any erroneous complete-model builder execution."""
+        builder_calls.append(context)
+        return RhimeModelBuildResult(model=pm.Model(), variable_roles={"concentration": "y"})
+
+    with pytest.raises(ValueError, match="either.*model_builder.*likelihood_builder"):
+        build_stage(
+            prepared=prepared,
+            model_inputs=prepared.inv_inputs,
+            run_spec=run_spec,
+            model_builder=complete_model_builder,
+            likelihood_builder=build_absolute_sigma_gaussian_likelihood,
+        )
+
+    assert builder_calls == []
+
+
 def test_likelihood_builder_provenance_is_saved_with_result_metadata(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -2837,8 +2986,14 @@ def test_run_rhime_rejects_unsupported_custom_likelihood_output_before_sampling(
     monkeypatch.setattr(rhime_module, "assemble_rhime_inputs", lambda *args, **kwargs: prepared)
     monkeypatch.setattr(RhimeSampler, "sample", fail_sample)
 
-    with pytest.raises(ValueError, match="does not declare output_format='inv_out' compatible"):
+    with pytest.raises(ValueError) as exc_info:
         run_rhime(species="ch4", likelihood_builder=sampling_only_likelihood)
+
+    diagnostic = str(exc_info.value).lower()
+    assert "likelihood" in diagnostic
+    assert "model builder" not in diagnostic
+    assert "build result" not in diagnostic
+    assert "output_format='inv_out'" in diagnostic
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
* **Summary of changes**

Adds the low-ceremony Python-only likelihood seam requested by OPE-52:

- adds an explicit keyword-only `likelihood_builder: RhimeLikelihoodBuilder | None = None` to `run_rhime`;
- exposes the same seam on `run_rhime_multisector`, whose existing contract remains valid because sector roles stay stage-owned and the combined observation mean enters the shared likelihood context;
- uses declared variable roles for custom-likelihood predictive selection and validates output capabilities before sampling;
- rejects non-callable likelihood builders before configuration, acquisition, prepared-input validation, or materialization;
- rejects simultaneous complete-model and likelihood builders before either executes;
- keeps one build/sample/result orchestration path for default and custom likelihoods;
- reports likelihood-specific output compatibility guidance;
- records safe callable identity and JSON-compatible likelihood metadata in `RhimeResult` and serialized provenance;
- keeps callables out of INI parsing, `RhimeRunSpec`, `RhimeModelSpec`, and serialized executable state;
- retains `run_rhime_from_prepared_inputs` as the advanced complete-model/replay boundary;
- adds a preferred one-call executable example using the same project-owned Student-t variation as the retained full copied runner;
- updates the customization and concrete-model documentation.

Default public runner behavior remains unchanged when the seam is omitted. No `model_builder`, strategy class, registry, plugin discovery, or generic orchestration layer is added.

Part of #587.
Linear: [OPE-52](https://linear.app/openghg-inversions/issue/OPE-52/p0-w2a-add-the-low-ceremony-run-rhime-likelihood-strategy-seam).

* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx (OPE-52 is tracked in Linear; this PR is part of #587)
- [x] Tests added and passing
- [x] Documentation and tutorials updated/added
- [ ] Added an entry to the `CHANGELOG.md` file
- [ ] Added any new requirements to `requirements.txt`

**Validation**

- `tox -p --parallel-no-spinner`
- `tox -e py310-openghgCur -- -m rhime_contract`
- `tox -e lint`
- focused OPE-52 and review-regression runner, likelihood, output, serialization, config, multisector, and example tests
- Ruff check and format check on changed Python files
- focused Mypy check on the five implementation/example files
- `git diff --check`

The Sphinx build read the updated customization page and all literal includes, then stopped in an unrelated executable grouped-basis notebook because the configured Jupyter kernel has an older OpenGHG without `cf_ureg`. The configured broad Mypy environment also reports existing package-wide typing/stub failures; the focused changed-file check is clean.