### PR TITLE
Tidy native covariance projection boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,11 @@ laziness.
 See `docs/plans/numerical_data_ownership_and_execution_boundaries.md` for the
 full rationale, terminology, and review checklist.
 
+Consolidate validation at the boundary which owns an input, then trust locally
+constructed intermediates. Prefer ordinary xarray transpose/alignment patterns
+and Pint unit conversion to repeated custom runtime assertions; see
+`docs/development/validation_and_xarray.rst`.
+
 ## Testing
 
 The default local tox workflow tests against the current OpenGHG release and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,10 @@
   covariance, covariance-compatible restriction/prolongation operators,
   dense or diagonal observation covariance products, a basis-owned canonical
   multisource expansion, explicit eager execution boundaries, and a units
-  contract for dimensionless scaling states. Product persistence and durable
+  contract for dimensionless scaling states. The numerical path uses one
+  explicit xarray alignment/materialization boundary and trusts the products
+  constructed within it; repository guidance now documents this validation
+  policy and common labelled-array patterns. Product persistence and durable
   identities are deferred to OPE-40. This is the low-level native covariance
   foundation tracked by Linear OPE-17; centred coherent reduction, unresolved
   covariance, and likelihood integration are follow-up work.

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -8,3 +8,4 @@ development. They are normative for new RHIME work.
    :maxdepth: 2
 
    rhime_model_development
+   validation_and_xarray

--- a/docs/development/rhime_model_development.rst
+++ b/docs/development/rhime_model_development.rst
@@ -206,6 +206,7 @@ serialization must happen at named boundaries and must not be hidden behind a
 property or model framework.
 
 Further guidance is in
+``docs/development/validation_and_xarray.rst``,
 ``docs/plans/numerical_data_ownership_and_execution_boundaries.md`` and the
 active ``run_rhime`` plan in
 ``docs/plans/run_rhime_readability_and_modifiability.md``.

--- a/docs/development/validation_and_xarray.rst
+++ b/docs/development/validation_and_xarray.rst
@@ -95,11 +95,14 @@ calculation's canonical units, and dequantify if the numerical kernel requires
 ordinary arrays. Pint owns dimensional compatibility and conversion; xarray
 independently owns coordinate alignment.
 
-Do not reproduce unit algebra with attribute-string construction and then
-revalidate those derived strings throughout a kernel. If a kernel accepts
-dequantified values, document their canonical-unit contract and trust the
-preparation boundary. Handle missing or incompatible units once where the
-independent data is normalized.
+After that conversion, a kernel may propagate or derive ``units`` attributes
+to document known output algebra (for example, covariance has squared
+sensitivity units). Treat those strings as descriptive metadata, not as
+dimensional validation. Do not construct unit strings and then revalidate them
+throughout a kernel as a substitute for Pint. If a kernel accepts dequantified
+values, document their canonical-unit contract and trust the preparation
+boundary. Handle missing or incompatible units once where the independent data
+is normalized.
 
 Tests rather than production assertions
 ---------------------------------------

--- a/docs/development/validation_and_xarray.rst
+++ b/docs/development/validation_and_xarray.rst
@@ -1,0 +1,122 @@
+Validation and labelled-array patterns
+======================================
+
+Scientific code should make its equations and data flow easy to inspect.
+Validate in proportion to the failure prevented, and establish compatibility
+once at the boundary that first combines independently prepared data. Do not
+make every numerical function distrust canonical objects produced locally by
+this package.
+
+Choose the validation boundary
+------------------------------
+
+Public APIs should document their required dimensions, coordinates, units,
+and numerical assumptions. Put checks at the boundary which owns those
+assumptions:
+
+* use static types for ordinary Python type contracts; do not add routine
+  ``isinstance`` checks only to improve errors for callers which ignore type
+  checking;
+* normalize configuration and user choices once at the runner boundary;
+* align and normalize independently sourced xarray inputs at ingestion,
+  preparation, or a named scientific composition boundary;
+* check results from dynamic extensions, such as custom strategies, where
+  they re-enter package code;
+* let the operation that needs an invariant enforce it: check a positive
+  batch size before batching, and let a required Cholesky factorization report
+  a matrix which cannot be used as positive definite; and
+* validate serialized or cached artifacts in their loader against a published
+  schema, rather than repeating those checks in every downstream kernel.
+
+After such a boundary, trust locally constructed intermediates. In particular,
+avoid repeatedly checking types, dimensions, finite values, derived unit
+attributes, construction identities, or solve residuals at each layer. Avoid
+full eigendecompositions merely to pre-validate a factorization which the
+algorithm performs anyway. A one-use ``_require_*`` helper is usually a sign
+that validation is obscuring the equations.
+
+Keep a production check when it defines scientific policy, protects an I/O or
+extension boundary, prevents a library's permissive behaviour from changing
+the calculation's meaning, or gives a materially clearer failure before
+expensive or irreversible work. Otherwise, an equation-level test is often
+the clearer home for the invariant.
+
+Transpose, align, compute
+-------------------------
+
+For independently prepared labelled arrays, the usual strict pattern is:
+
+.. code-block:: python
+
+   mean = mean.transpose(*native_dims)
+   sensitivity = sensitivity.transpose(observation_dim, *native_dims)
+   basis = basis.transpose(*native_dims, state_dim)
+
+   # xr.dot otherwise uses an inner join and could silently discard cells.
+   mean, sensitivity, basis = xr.align(
+       mean,
+       sensitivity,
+       basis,
+       join="exact",
+       copy=False,
+   )
+
+   mean, sensitivity, basis = dask.compute(
+       to_dense(mean),
+       to_dense(sensitivity),
+       to_dense(basis),
+   )
+
+``transpose`` states the semantic dimension order and naturally rejects
+missing or extra dimensions. Use ``...`` only when extra dimensions are part
+of the contract. ``xr.align(..., join="exact", copy=False)`` is the ordinary
+strict compatibility check; always use the arrays it returns. Select
+``inner``, ``outer``, ``left``, ``right``, or ``override`` only when that join
+is an explicit scientific policy, and comment non-obvious choices. Use
+``xr.broadcast`` when broadcasting is intentional.
+
+Exact alignment compares indexes when they exist, but does not require every
+dimension to have an index. When later code selects or dispatches by label,
+require an indexed dimension coordinate once at that public boundary.
+
+Keep labelled xarray operations until labels have performed their alignment
+role. Convert to NumPy at a named eager, SciPy, PyMC, or serialization
+boundary. Materialize related Dask-backed arrays together so shared graphs are
+not executed repeatedly. Indexed dimension coordinates are normally eager;
+avoid inspecting lazy auxiliary-coordinate payloads merely for validation.
+
+Units
+-----
+
+OpenGHG normally supplies unit metadata, and importing OpenGHG enables
+pint-xarray. At the preparation or composition boundary for independently
+sourced quantities, quantify them, convert compatible quantities to the
+calculation's canonical units, and dequantify if the numerical kernel requires
+ordinary arrays. Pint owns dimensional compatibility and conversion; xarray
+independently owns coordinate alignment.
+
+Do not reproduce unit algebra with attribute-string construction and then
+revalidate those derived strings throughout a kernel. If a kernel accepts
+dequantified values, document their canonical-unit contract and trust the
+preparation boundary. Handle missing or incompatible units once where the
+independent data is normalized.
+
+Tests rather than production assertions
+---------------------------------------
+
+Use tests to establish scientific identities against an independent oracle,
+strict and intentionally permissive alignment behaviour, unit conversion and
+incompatibility at the unit boundary, lazy execution boundaries, and genuine
+algorithm failures such as rank deficiency. Avoid tests whose only purpose is
+corrupting a package-created intermediate dataclass unless that object is a
+supported external or deserialization boundary.
+
+During review, ask:
+
+* Where was this input first normalized?
+* Is this check defending a real boundary or distrusting local construction?
+* Can xarray alignment, Pint, static typing, or the numerical operation express
+  the requirement directly?
+* Does the check unexpectedly compute lazy data?
+* Does it obscure the scientific equation?
+* Would a test document the invariant more clearly?

--- a/docs/usage/native_covariance.rst
+++ b/docs/usage/native_covariance.rst
@@ -147,6 +147,14 @@ from a strategy-supplied lift. OPE-17 returns :math:`C_\alpha`,
 :math:`H U_*`, :math:`H B \Pi^\mathsf{T}`, and either dense
 :math:`H B H^\mathsf{T}` or its diagonal.
 
+The retained solve also records a cheap LAPACK reciprocal 1-norm condition
+estimate while its Cholesky factor is already available. A restriction whose
+retained covariance is effectively rank deficient at float64 precision is
+rejected with a basis-design diagnostic. This is not an eigendecomposition of
+the observation-sized covariance, nor a requirement that the unresolved
+aggregation covariance be independently factorable before observation and
+model-error covariance are added.
+
 What OPE-17 does not construct
 ------------------------------
 
@@ -181,7 +189,10 @@ Native and retained scaling perturbations are dimensionless. Accordingly,
 :math:`\Pi`, :math:`U_*`, and :math:`C_\alpha` carry units ``1``;
 :math:`H U_*` and :math:`H B\Pi^\mathsf{T}` inherit the sensitivity units;
 and :math:`H B H^\mathsf{T}` (including its diagonal view) carries their
-square. This low-level result is in-memory only. OPE-40 owns durable identities,
+square as descriptive output metadata. Dimensional compatibility and
+conversion of independently sourced quantities belong to the preparation
+boundary and use OpenGHG's Pint registry; these derived attributes are not a
+substitute for quantification. This low-level result is in-memory only. OPE-40 owns durable identities,
 typed coordinate persistence, schema compatibility, and DataTree/NetCDF I/O.
 
 Memory and execution boundary
@@ -189,11 +200,11 @@ Memory and execution boundary
 
 The structured covariance action stores axis factors rather than dense native
 :math:`B`, but the numerical product kernel is otherwise eager. The upstream
-pipeline must materialize the related sensitivity and canonical basis
-prolongation together before calling it; lazy inputs are rejected rather than
-computed implicitly. A custom restriction may remain sparse or Dask-backed
-until the explicit projection boundary, where it is materialized and densified
-once. The eager restriction is then reused across retained-state
+pipeline may pass a related sensitivity and canonical basis prolongation with
+sparse or Dask-backed payloads; the explicit projection boundary densifies
+them where needed and materializes them together. A custom restriction may
+also remain sparse or Dask-backed until it is selected, when it is materialized
+and densified once. The eager restriction is then reused across retained-state
 right-hand-side blocks, avoiding repeated execution of its lazy graph. For
 native size :math:`N`, retained size
 :math:`d`, and observation count :math:`M`, important dense storage includes

--- a/openghg_inversions/basis/covariance_products.py
+++ b/openghg_inversions/basis/covariance_products.py
@@ -20,24 +20,30 @@ persistence are intentionally deferred to the artifact-I/O layer.
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-from numbers import Integral
-from typing import Literal, Protocol
+import sys
+from typing import Literal, NoReturn, Protocol
 
+if sys.version_info >= (3, 11):
+    from typing import assert_never
+else:
+
+    def assert_never(value: NoReturn) -> NoReturn:
+        """Backport typing.assert_never until Python 3.10 support is removed."""
+        raise AssertionError(f"Expected an unreachable value, got {value!r}")
+
+from dask.base import compute
 import numpy as np
 import pandas as pd
 from scipy.linalg import cho_factor, cho_solve
 import xarray as xr
-from xarray.namedarray.pycompat import is_chunked_array
 
 from openghg_inversions._labelled_matrices import (
     matrix_column_dim,
     renamed_column_coordinates,
     to_column_axis,
-    with_square_matrix_diagnostics,
 )
+from openghg_inversions.array_ops import to_dense
 from openghg_inversions.native_covariance import InvertibleNativeCovarianceAction
-
-MAX_DENSE_EIGEN_DIAGNOSTIC_SIZE = 512
 
 
 @dataclass(frozen=True, slots=True, eq=False)
@@ -89,11 +95,6 @@ class PreserveBucketProlongation:
 
     name: str = "preserve_bucket_prolongation"
 
-    def __post_init__(self) -> None:
-        """Require a stable non-empty strategy identifier."""
-        if not isinstance(self.name, str) or not self.name:
-            raise ValueError("Projection strategy name must be a non-empty string")
-
     def projection(
         self,
         covariance: InvertibleNativeCovarianceAction,
@@ -116,9 +117,7 @@ class PreserveBucketProlongation:
         Raises:
             ValueError: If ``U`` is invalid or lacks full column rank.
         """
-        prolongation = _validated_prolongation(
-            basis_prolongation, native_dims=native_dims, state_dim=state_dim
-        )
+        prolongation = basis_prolongation
         state_column_dim = matrix_column_dim(
             state_dim,
             {str(name) for name in (*prolongation.dims, *prolongation.coords)},
@@ -133,17 +132,9 @@ class PreserveBucketProlongation:
             state_dim, state_column_dim
         )
         gram_values = np.asarray(gram.values, dtype=np.float64)
-        _require_symmetric(gram_values, "U.T B^-1 U")
+        gram_values = (gram_values + gram_values.T) * 0.5
         try:
             factor = cho_factor(gram_values, lower=True, check_finite=True)
-            cholesky_diagonal = np.diag(factor[0])
-            largest_pivot = float(np.max(np.abs(cholesky_diagonal)))
-            if (
-                not cholesky_diagonal.size
-                or largest_pivot <= 0.0
-                or float(np.min(np.abs(cholesky_diagonal))) <= 1e-6 * largest_pivot
-            ):
-                raise np.linalg.LinAlgError("numerically rank-deficient Gram matrix")
             covariance_values = cho_solve(factor, np.eye(gram_values.shape[0]), check_finite=False)
         except np.linalg.LinAlgError as exc:
             raise ValueError(
@@ -255,36 +246,31 @@ def project_native_covariance(
         ``H`` inherit its units; observation covariance uses squared ``H``
         units when supplied.
 
-        The kernel trusts the covariance action's declared self-adjoint
-        positive-definite semantics; it does not globally certify a
-        matrix-free ``B``. Runtime checks diagnose only the requested products
-        and covariance-action outputs encountered here.
+        The kernel trusts the covariance action's declared real,
+        self-adjoint, positive-definite semantics. It does not globally
+        certify a matrix-free ``B`` or revalidate products constructed here.
 
     Raises:
-        TypeError: If ``observation_batch_size`` is not an integral non-Boolean.
-        ValueError: If arrays are lazy, labels or dimensions disagree, values
-            are invalid, or an option is unsupported.
+        ValueError: If labelled inputs cannot be exactly aligned, the batch
+            size is not positive, or a required Cholesky factorization fails.
     """
     native_dims = tuple(covariance.native_dims)
-    if len({*native_dims, state_dim, observation_dim}) != len(native_dims) + 2:
-        raise ValueError("Native, retained-state, and observation dimension names must be distinct")
-    if isinstance(observation_batch_size, bool) or not isinstance(observation_batch_size, Integral):
-        raise TypeError("observation_batch_size must be an integral non-Boolean value")
-    batch_size = int(observation_batch_size)
+    batch_size = observation_batch_size
     if batch_size <= 0:
         raise ValueError("observation_batch_size must be positive")
-    if observation_covariance not in {"dense", "diagonal"}:
-        raise ValueError("observation_covariance must be 'dense' or 'diagonal'")
 
-    sensitivity = _validated_sensitivity(
-        native_sensitivity,
-        native_dims=native_dims,
-        observation_dim=observation_dim,
+    sensitivity = native_sensitivity.transpose(observation_dim, *native_dims)
+    prolongation = basis_prolongation.transpose(*native_dims, state_dim)
+    # xr.dot otherwise uses an inner join and could silently discard native
+    # cells. Establish the shared grid once before the eager product boundary.
+    sensitivity, prolongation = xr.align(
+        sensitivity,
+        prolongation,
+        join="exact",
+        copy=False,
     )
-    prolongation = _validated_prolongation(basis_prolongation, native_dims=native_dims, state_dim=state_dim)
-    _validate_exact_native_coordinates(
-        prolongation, sensitivity, native_dims=native_dims, role="prolongation"
-    )
+    sensitivity, prolongation = compute(to_dense(sensitivity), to_dense(prolongation))
+
     projection_strategy = strategy if strategy is not None else PreserveBucketProlongation()
     projection = projection_strategy.projection(
         covariance,
@@ -292,7 +278,7 @@ def project_native_covariance(
         native_dims=native_dims,
         state_dim=state_dim,
     )
-    projection = _validated_projection(
+    projection = _prepare_projection(
         projection,
         native_reference=sensitivity,
         native_dims=native_dims,
@@ -318,10 +304,12 @@ def project_native_covariance(
         column_dim=state_column_dim,
         rhs_block_size=batch_size,
     )
-    state_covariance = with_square_matrix_diagnostics(
-        state_covariance.rename("state_covariance").assign_attrs(units="1"),
+    state_covariance_values = np.asarray(state_covariance.values, dtype=np.float64)
+    state_covariance = state_covariance.copy(
+        data=(state_covariance_values + state_covariance_values.T) * 0.5
+    ).rename("state_covariance").assign_attrs(
         mathematical_name="C_alpha",
-        require_positive_definite=True,
+        units="1",
     )
     prolongation = _derive_covariance_natural_prolongation(
         projection.restriction,
@@ -384,13 +372,7 @@ def _apply_restriction_blocks(
             column_dim=column_dim,
             leading_dims=native_dims,
         )
-        blocks.append(
-            _validated_covariance_apply(
-                covariance,
-                rhs,
-                context="B Pi.T",
-            )
-        )
+        blocks.append(covariance.apply(rhs))
     return xr.concat(blocks, dim=column_dim).transpose(*native_dims, column_dim)
 
 
@@ -411,41 +393,6 @@ def _restriction_product_blocks(
     return xr.concat(blocks, dim=state_dim).transpose(state_dim, column_dim)
 
 
-def _validated_covariance_apply(
-    covariance: InvertibleNativeCovarianceAction,
-    rhs: xr.DataArray,
-    *,
-    context: str,
-) -> xr.DataArray:
-    """Apply ``B`` and reject invalid action output.
-
-    Args:
-        covariance: Native covariance action.
-        rhs: Labelled right-hand sides.
-        context: Product name included in validation errors.
-
-    Returns:
-        The labelled finite-real action result.
-
-    Raises:
-        ValueError: If the result is not a DataArray or contains complex or
-            non-finite values.
-    """
-    result = covariance.apply(rhs)
-    if not isinstance(result, xr.DataArray):
-        raise ValueError(
-            f"covariance.apply action-contract violation while computing {context}: "
-            "expected an xarray.DataArray"
-        )
-    values = np.asarray(result.values)
-    if np.iscomplexobj(values) or not np.all(np.isfinite(values)):
-        raise ValueError(
-            f"covariance.apply action-contract violation while computing {context}: "
-            "output must contain only finite real values"
-        )
-    return result
-
-
 def _observation_covariance(
     covariance: InvertibleNativeCovarianceAction,
     sensitivity: xr.DataArray,
@@ -456,16 +403,22 @@ def _observation_covariance(
     batch_size: int,
 ) -> xr.DataArray:
     """Compute ``H B H.T`` in eager observation RHS blocks."""
+    if output == "dense":
+        dense_output = True
+    elif output == "diagonal":
+        dense_output = False
+    else:
+        assert_never(output)
     column_dim = matrix_column_dim(
         observation_dim,
         {str(name) for name in (*sensitivity.dims, *sensitivity.coords)},
     )
     count = sensitivity.sizes[observation_dim]
     values = np.empty(
-        (count, count) if output == "dense" else count,
+        (count, count) if dense_output else count,
         dtype=np.result_type(sensitivity.dtype, np.float64),
     )
-    diagonal_error_bounds = np.empty(count, dtype=np.float64) if output == "diagonal" else None
+    diagonal_error_bounds = None if dense_output else np.empty(count, dtype=np.float64)
     native_size = int(np.prod([sensitivity.sizes[dim] for dim in native_dims]))
     machine_epsilon = np.finfo(np.dtype(values.dtype)).eps
     contraction_error_factor = 8.0 * native_size * machine_epsilon
@@ -477,12 +430,8 @@ def _observation_covariance(
             column_dim=column_dim,
             leading_dims=native_dims,
         )
-        b_rhs = _validated_covariance_apply(
-            covariance,
-            rhs,
-            context="H B H.T",
-        )
-        if output == "dense":
+        b_rhs = covariance.apply(rhs)
+        if dense_output:
             block = xr.dot(sensitivity, b_rhs, dim=list(native_dims)).transpose(observation_dim, column_dim)
             values[:, start:stop] = np.asarray(block.values)
         else:
@@ -504,7 +453,8 @@ def _observation_covariance(
         for name, coordinate in sensitivity.coords.items()
         if set(coordinate.dims).issubset({observation_dim})
     }
-    if output == "dense":
+    if dense_output:
+        values = (values + values.T) * 0.5
         result = xr.DataArray(
             values,
             dims=(observation_dim, column_dim),
@@ -515,16 +465,8 @@ def _observation_covariance(
             attrs=unit_attrs,
             name="native_observation_covariance",
         )
-        return with_square_matrix_diagnostics(
-            result,
-            mathematical_name="H B H.T",
-            maximum_eigen_diagnostic_size=MAX_DENSE_EIGEN_DIAGNOSTIC_SIZE,
-        )
-    if not np.all(np.isfinite(values)):
-        raise ValueError("diag(H B H.T) must contain only finite real values")
+        return result.assign_attrs(mathematical_name="H B H.T")
     assert diagonal_error_bounds is not None
-    if not np.all(np.isfinite(diagonal_error_bounds)):
-        raise ValueError("diag(H B H.T) numerical error bounds must be finite")
     if np.any(values < -diagonal_error_bounds):
         raise ValueError("diag(H B H.T) contains materially negative covariance values")
     values = np.where(values < 0.0, 0.0, values)
@@ -545,87 +487,30 @@ def _observation_covariance(
     return result
 
 
-def _validated_projection(
+def _prepare_projection(
     projection: RetainedProjection,
     *,
     native_reference: xr.DataArray,
     native_dims: tuple[str, ...],
     state_dim: str,
 ) -> RetainedProjection:
-    """Validate labels and materialize a custom restriction exactly once."""
-    if not isinstance(projection, RetainedProjection):
-        raise ValueError("Projection strategy must return a RetainedProjection")
-    if not isinstance(projection.strategy, str) or not projection.strategy:
-        raise ValueError("Projection strategy must return a non-empty strategy identifier")
-    if not isinstance(projection.restriction, xr.DataArray):
-        raise ValueError("Projection strategy restriction must be an xarray.DataArray")
-    expected = {state_dim, *native_dims}
-    if (
-        set(projection.restriction.dims) != expected
-        or len(projection.restriction.dims) != len(expected)
-    ):
-        raise ValueError("Projection strategy restriction has invalid labelled dimensions")
+    """Canonicalize and materialize a strategy result at the extension seam."""
     restriction = projection.restriction.transpose(state_dim, *native_dims).assign_attrs(
         {**projection.restriction.attrs, "units": "1"}
     )
-    _validate_exact_native_coordinates(
+    # A custom strategy is an extension boundary. Exact alignment prevents its
+    # restriction from silently contracting over only part of the native grid.
+    restriction, _ = xr.align(
         restriction,
         native_reference,
-        native_dims=native_dims,
-        role="restriction",
+        join="exact",
+        copy=False,
     )
-    if state_dim not in restriction.coords:
-        raise ValueError("Projection strategy restriction requires state labels")
-    _require_reference_native_coordinates(
-        restriction,
-        native_reference,
-        native_dims=native_dims,
-        role="restriction",
-    )
-    restriction = _materialize_dense_preserving_coordinates(restriction)
-    restriction_values = np.asarray(restriction.values)
-    if np.iscomplexobj(restriction_values) or not np.all(np.isfinite(restriction_values)):
-        raise ValueError("Projection strategy restriction must contain only finite real values")
+    (restriction,) = compute(to_dense(restriction))
+    values = np.asarray(restriction.values)
+    if np.iscomplexobj(values) or not np.all(np.isfinite(values)):
+        raise ValueError("Projection strategy restriction must contain finite real values")
     return replace(projection, restriction=restriction)
-
-
-def _require_reference_native_coordinates(
-    array: xr.DataArray,
-    reference: xr.DataArray,
-    *,
-    native_dims: tuple[str, ...],
-    role: str,
-) -> None:
-    """Require all reference native-only and scalar coordinates on a projection array."""
-    native_set = set(native_dims)
-    expected = {
-        str(name): coordinate
-        for name, coordinate in reference.coords.items()
-        if set(coordinate.dims).issubset(native_set)
-    }
-    for name, coordinate in expected.items():
-        if name not in array.coords:
-            raise ValueError(f"Projection {role} is missing compatible native coordinate {name!r}")
-        actual = array.coords[name]
-        if actual.dims != coordinate.dims or not actual.equals(coordinate):
-            raise ValueError(f"Projection {role} native coordinate {name!r} is incompatible")
-
-
-def _validate_exact_native_coordinates(
-    array: xr.DataArray,
-    reference: xr.DataArray,
-    *,
-    native_dims: tuple[str, ...],
-    role: str,
-) -> None:
-    """Require exact ordered native indexes before labelled contractions."""
-    for dim in native_dims:
-        if dim not in array.coords:
-            raise ValueError(f"Projection {role} is missing native coordinate {dim!r}")
-        if not array.get_index(dim).equals(reference.get_index(dim)):
-            raise ValueError(
-                f"Projection {role} native coordinate {dim!r} must exactly match the covariance grid"
-            )
 
 
 def _derive_covariance_natural_prolongation(
@@ -691,77 +576,3 @@ def _derive_covariance_natural_prolongation(
         },
         name="prolongation",
     )
-
-
-def _validated_prolongation(
-    prolongation: xr.DataArray,
-    *,
-    native_dims: tuple[str, ...],
-    state_dim: str,
-) -> xr.DataArray:
-    """Validate an eager labelled native-by-retained prolongation."""
-    expected = {*native_dims, state_dim}
-    if set(prolongation.dims) != expected or len(prolongation.dims) != len(expected):
-        raise ValueError(
-            f"prolongation must have exactly native and retained-state dimensions; got {prolongation.dims!r}"
-        )
-    if is_chunked_array(prolongation.data):
-        raise ValueError(
-            "basis_prolongation is lazy; materialize canonical U explicitly at the upstream "
-            "pipeline boundary before calling project_native_covariance"
-        )
-    result = _materialize_dense_preserving_coordinates(prolongation).transpose(*native_dims, state_dim)
-    values = np.asarray(result.values)
-    if np.iscomplexobj(values) or not np.all(np.isfinite(values)):
-        raise ValueError("prolongation must contain only finite real values")
-    if result.sizes[state_dim] == 0 or np.any(np.all(values == 0.0, axis=tuple(range(len(native_dims))))):
-        raise ValueError("prolongation contains an empty retained state")
-    return result
-
-
-def _validated_sensitivity(
-    sensitivity: xr.DataArray,
-    *,
-    native_dims: tuple[str, ...],
-    observation_dim: str,
-) -> xr.DataArray:
-    """Validate canonical eager sensitivity without a disposable B apply."""
-    expected = {*native_dims, observation_dim}
-    if set(sensitivity.dims) != expected or len(sensitivity.dims) != len(expected):
-        raise ValueError(
-            "native_sensitivity must have exactly observation and native dimensions; "
-            f"got {sensitivity.dims!r}"
-        )
-    if observation_dim not in sensitivity.coords:
-        raise ValueError(f"native_sensitivity is missing observation coordinate {observation_dim!r}")
-    if is_chunked_array(sensitivity.data):
-        raise ValueError(
-            "native_sensitivity is lazy; materialize canonical H explicitly at the upstream "
-            "pipeline boundary before calling project_native_covariance"
-        )
-    result = _materialize_dense_preserving_coordinates(sensitivity).transpose(observation_dim, *native_dims)
-    if result.sizes[observation_dim] == 0:
-        raise ValueError("native_sensitivity must contain at least one observation")
-    values = np.asarray(result.values)
-    if np.iscomplexobj(values) or not np.all(np.isfinite(values)):
-        raise ValueError("native_sensitivity must contain only finite real values")
-    return result
-
-
-def _require_symmetric(values: np.ndarray, name: str, tolerance: float = 1e-10) -> None:
-    """Require a square numeric array to be symmetric within tolerance."""
-    if values.ndim != 2 or values.shape[0] != values.shape[1]:
-        raise ValueError(f"{name} must be square")
-    asymmetry = float(np.max(np.abs(values - values.T))) if values.size else 0.0
-    scale = max(1.0, float(np.max(np.abs(values))) if values.size else 1.0)
-    if asymmetry > tolerance * scale:
-        raise ValueError(f"{name} is not symmetric within tolerance {tolerance:g}")
-
-
-def _materialize_dense_preserving_coordinates(array: xr.DataArray) -> xr.DataArray:
-    """Materialize dense payloads without reconstructing typed xarray indexes."""
-    materialized = array.compute()
-    data = materialized.data
-    if hasattr(data, "todense"):
-        data = data.todense()
-    return materialized.copy(data=np.asarray(data))

--- a/openghg_inversions/basis/covariance_products.py
+++ b/openghg_inversions/basis/covariance_products.py
@@ -33,7 +33,6 @@ else:
 
 from dask.base import compute
 import numpy as np
-import pandas as pd
 from scipy.linalg import cho_factor, cho_solve
 import xarray as xr
 
@@ -141,24 +140,23 @@ class PreserveBucketProlongation:
                 "The bucket prolongation contains redundant retained states; "
                 "U.T B^-1 U must be positive definite"
             ) from exc
+        state_coordinates = {
+            str(name): coordinate
+            for name, coordinate in prolongation.coords.items()
+            if set(coordinate.dims).issubset({state_dim})
+        }
         state_covariance = xr.DataArray(
             covariance_values,
             dims=(state_dim, state_column_dim),
+            coords={
+                **state_coordinates,
+                **renamed_column_coordinates(
+                    prolongation,
+                    row_dim=state_dim,
+                    column_dim=state_column_dim,
+                ),
+            },
             attrs={"units": "1"},
-        )
-        state_index = prolongation.get_index(state_dim)
-        if isinstance(state_index, pd.MultiIndex):
-            state_covariance = state_covariance.assign_coords(
-                xr.Coordinates.from_pandas_multiindex(state_index, state_dim)
-            )
-        else:
-            state_covariance = state_covariance.assign_coords({state_dim: prolongation.coords[state_dim]})
-        state_covariance = state_covariance.assign_coords(
-            renamed_column_coordinates(
-                prolongation,
-                row_dim=state_dim,
-                column_dim=state_column_dim,
-            )
         )
         restriction = xr.dot(state_covariance, precision_prolongation, dim=state_column_dim).transpose(
             state_dim, *native_dims
@@ -269,7 +267,14 @@ def project_native_covariance(
         join="exact",
         copy=False,
     )
-    sensitivity, prolongation = compute(to_dense(sensitivity), to_dense(prolongation))
+    dense_sensitivity = to_dense(sensitivity)
+    dense_prolongation = to_dense(prolongation)
+    sensitivity_data, prolongation_data = compute(
+        dense_sensitivity.data,
+        dense_prolongation.data,
+    )
+    sensitivity = sensitivity.copy(data=sensitivity_data)
+    prolongation = prolongation.copy(data=prolongation_data)
 
     projection_strategy = strategy if strategy is not None else PreserveBucketProlongation()
     projection = projection_strategy.projection(
@@ -506,7 +511,9 @@ def _prepare_projection(
         join="exact",
         copy=False,
     )
-    (restriction,) = compute(to_dense(restriction))
+    dense_restriction = to_dense(restriction)
+    (restriction_data,) = compute(dense_restriction.data)
+    restriction = restriction.copy(data=restriction_data)
     values = np.asarray(restriction.values)
     if np.iscomplexobj(values) or not np.all(np.isfinite(values)):
         raise ValueError("Projection strategy restriction must contain finite real values")

--- a/openghg_inversions/basis/covariance_products.py
+++ b/openghg_inversions/basis/covariance_products.py
@@ -1,10 +1,11 @@
 """Labelled in-memory native-covariance products for retained scaling states.
 
-This module is an eager numerical kernel. Callers supply a canonical, eager
-native sensitivity ``H`` and basis prolongation ``U``; basis operators own any
-source expansion and the pipeline owns materialization. Custom restrictions
-may remain sparse or Dask-backed until the named projection boundary, where
-they are materialized once and reused by all retained-state RHS blocks.
+This module is an eager numerical kernel. Callers supply a canonical native
+sensitivity ``H`` and basis prolongation ``U``; basis operators own any source
+expansion. Their payloads may remain sparse or Dask-backed until the named
+projection boundary, where related arrays are materialized together. Custom
+restrictions are likewise materialized once and reused by all retained-state
+RHS blocks.
 
 For native covariance ``B`` and retained restriction ``Pi``, the kernel returns
 ``C_alpha = Pi B Pi.T``, ``H U_*``, ``H B Pi.T``, and ``H B H.T`` (or its
@@ -34,6 +35,7 @@ else:
 from dask.base import compute
 import numpy as np
 from scipy.linalg import cho_factor, cho_solve
+from scipy.linalg.lapack import dpocon
 import xarray as xr
 
 from openghg_inversions._labelled_matrices import (
@@ -43,6 +45,9 @@ from openghg_inversions._labelled_matrices import (
 )
 from openghg_inversions.array_ops import to_dense
 from openghg_inversions.native_covariance import InvertibleNativeCovarianceAction
+
+
+MIN_RETAINED_RECIPROCAL_CONDITION = float(np.sqrt(np.finfo(np.float64).eps))
 
 
 @dataclass(frozen=True, slots=True, eq=False)
@@ -227,10 +232,10 @@ def project_native_covariance(
 
     Args:
         covariance: Labelled native covariance action with a compatible solve.
-        basis_prolongation: Canonical eager ``U`` from the basis-side native
+        basis_prolongation: Canonical labelled ``U`` from the basis-side native
             expansion boundary.
         state_dim: Retained-state dimension shared by ``U`` and ``Pi``.
-        native_sensitivity: Canonical eager native sensitivity ``H``.
+        native_sensitivity: Canonical labelled native sensitivity ``H``.
         observation_dim: Observation dimension in ``H``.
         observation_covariance: Return dense ``H B H.T`` or its diagonal.
         observation_batch_size: Positive integral number of covariance
@@ -316,13 +321,17 @@ def project_native_covariance(
         mathematical_name="C_alpha",
         units="1",
     )
-    prolongation = _derive_covariance_natural_prolongation(
+    prolongation, reciprocal_condition = _derive_covariance_natural_prolongation(
         projection.restriction,
         state_covariance,
         b_pi_t,
         native_dims=native_dims,
         state_dim=state_dim,
         state_column_dim=state_column_dim,
+    )
+    state_covariance = state_covariance.assign_attrs(
+        estimated_reciprocal_condition_number=reciprocal_condition,
+        condition_number_norm="1",
     )
     h_units = sensitivity.attrs.get("units")
     linear_units = {"units": h_units} if h_units is not None else {}
@@ -366,7 +375,7 @@ def _apply_restriction_blocks(
     state_dim: str,
     column_dim: str,
     rhs_block_size: int,
-) -> xr.DataArray:
+) -> tuple[xr.DataArray, float]:
     """Apply covariance to explicit dense retained-state RHS blocks."""
     blocks: list[xr.DataArray] = []
     for start in range(0, restriction.sizes[state_dim], rhs_block_size):
@@ -543,7 +552,8 @@ def _derive_covariance_natural_prolongation(
         state_column_dim: Distinct retained-state column dimension.
 
     Returns:
-        The dimensionless covariance-natural prolongation ``U_*``.
+        The dimensionless covariance-natural prolongation ``U_*`` and the
+        estimated reciprocal 1-norm condition number of ``C_alpha``.
 
     Raises:
         ValueError: If ``C_alpha`` cannot be factored as positive definite.
@@ -551,6 +561,22 @@ def _derive_covariance_natural_prolongation(
     covariance_values = np.asarray(state_covariance.values, dtype=np.float64)
     try:
         factor = cho_factor(covariance_values, lower=True, check_finite=True)
+        reciprocal_condition, condition_info = dpocon(
+            factor[0],
+            np.linalg.norm(covariance_values, ord=1),
+            uplo="L",
+        )
+        if condition_info != 0:
+            raise np.linalg.LinAlgError(
+                f"LAPACK condition estimation failed with info={condition_info}"
+            )
+        if reciprocal_condition < MIN_RETAINED_RECIPROCAL_CONDITION:
+            raise ValueError(
+                "C_alpha is too ill-conditioned for a stable retained solve "
+                f"(estimated reciprocal 1-norm condition {reciprocal_condition:.3e}; "
+                f"minimum {MIN_RETAINED_RECIPROCAL_CONDITION:.3e}); use a "
+                "non-redundant retained restriction"
+            )
         b_pi_values = np.asarray(b_pi_t.transpose(*native_dims, state_column_dim).values)
         native_shape = tuple(b_pi_t.sizes[dim] for dim in native_dims)
         solved = cho_solve(
@@ -582,4 +608,4 @@ def _derive_covariance_natural_prolongation(
             "units": "1",
         },
         name="prolongation",
-    )
+    ), float(reciprocal_condition)

--- a/openghg_inversions/basis/covariance_products.py
+++ b/openghg_inversions/basis/covariance_products.py
@@ -375,7 +375,7 @@ def _apply_restriction_blocks(
     state_dim: str,
     column_dim: str,
     rhs_block_size: int,
-) -> tuple[xr.DataArray, float]:
+) -> xr.DataArray:
     """Apply covariance to explicit dense retained-state RHS blocks."""
     blocks: list[xr.DataArray] = []
     for start in range(0, restriction.sizes[state_dim], rhs_block_size):
@@ -537,7 +537,7 @@ def _derive_covariance_natural_prolongation(
     native_dims: tuple[str, ...],
     state_dim: str,
     state_column_dim: str,
-) -> xr.DataArray:
+) -> tuple[xr.DataArray, float]:
     """Derive labelled ``U_* = B Pi.T C_alpha^-1`` from authoritative ``Pi``.
 
     The result has dimensions ``(*native_dims, state_dim)`` and preserves

--- a/openghg_inversions/basis/covariance_products.py
+++ b/openghg_inversions/basis/covariance_products.py
@@ -40,7 +40,7 @@ from openghg_inversions.native_covariance import InvertibleNativeCovarianceActio
 MAX_DENSE_EIGEN_DIAGNOSTIC_SIZE = 512
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class RetainedProjection:
     """A labelled retained restriction selected by one strategy.
 
@@ -184,7 +184,7 @@ class PreserveBucketProlongation:
         )
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class NativeCovarianceProducts:
     """Labelled in-memory product blocks induced by one retained restriction.
 
@@ -384,7 +384,6 @@ def _apply_restriction_blocks(
             column_dim=column_dim,
             leading_dims=native_dims,
         )
-        rhs = _materialize_dense_preserving_coordinates(rhs)
         blocks.append(
             _validated_covariance_apply(
                 covariance,
@@ -404,12 +403,10 @@ def _restriction_product_blocks(
     column_dim: str,
     rhs_block_size: int,
 ) -> xr.DataArray:
-    """Form ``Pi B Pi.T`` while materializing explicit restriction row blocks."""
+    """Form ``Pi B Pi.T`` from the already materialized restriction."""
     blocks: list[xr.DataArray] = []
     for start in range(0, restriction.sizes[state_dim], rhs_block_size):
-        rows = _materialize_dense_preserving_coordinates(
-            restriction.isel({state_dim: slice(start, start + rhs_block_size)})
-        )
+        rows = restriction.isel({state_dim: slice(start, start + rhs_block_size)})
         blocks.append(xr.dot(rows, b_pi_t, dim=list(native_dims)))
     return xr.concat(blocks, dim=state_dim).transpose(state_dim, column_dim)
 
@@ -556,14 +553,21 @@ def _validated_projection(
     state_dim: str,
 ) -> RetainedProjection:
     """Validate labels and materialize a custom restriction exactly once."""
+    if not isinstance(projection, RetainedProjection):
+        raise ValueError("Projection strategy must return a RetainedProjection")
     if not isinstance(projection.strategy, str) or not projection.strategy:
         raise ValueError("Projection strategy must return a non-empty strategy identifier")
+    if not isinstance(projection.restriction, xr.DataArray):
+        raise ValueError("Projection strategy restriction must be an xarray.DataArray")
+    expected = {state_dim, *native_dims}
+    if (
+        set(projection.restriction.dims) != expected
+        or len(projection.restriction.dims) != len(expected)
+    ):
+        raise ValueError("Projection strategy restriction has invalid labelled dimensions")
     restriction = projection.restriction.transpose(state_dim, *native_dims).assign_attrs(
         {**projection.restriction.attrs, "units": "1"}
     )
-    expected = {state_dim, *native_dims}
-    if set(restriction.dims) != expected or len(restriction.dims) != len(expected):
-        raise ValueError("Projection strategy restriction has invalid labelled dimensions")
     _validate_exact_native_coordinates(
         restriction,
         native_reference,

--- a/openghg_inversions/native_covariance.py
+++ b/openghg_inversions/native_covariance.py
@@ -477,7 +477,7 @@ class SeparableExponentialCovariance:
         Returns:
             Covariance-applied values with the same shape as ``matrix``.
         """
-        if not self._class_masks:
+        if len(self._class_masks) <= 1:
             return self._apply_separable(matrix)
         result = np.zeros_like(matrix, dtype=np.result_type(matrix.dtype, np.float64))
         for mask in self._class_masks:

--- a/openghg_inversions/native_covariance.py
+++ b/openghg_inversions/native_covariance.py
@@ -312,7 +312,7 @@ class SeparableExponentialCovariance:
             ValueError: If native dimensions or coordinates are missing or
                 misaligned, or if values are non-numeric or non-finite.
         """
-        matrix, original_dims, rhs_dims = self._validated_matrix(rhs)
+        matrix, original_dims, rhs_dims = self._aligned_matrix(rhs)
         applied = self._apply_matrix(matrix)
         return self._restore(applied, rhs, original_dims, rhs_dims)
 
@@ -337,7 +337,7 @@ class SeparableExponentialCovariance:
             numpy.linalg.LinAlgError: If a class-blocked iterative solve does
                 not converge.
         """
-        matrix, original_dims, rhs_dims = self._validated_matrix(rhs)
+        matrix, original_dims, rhs_dims = self._aligned_matrix(rhs)
         if len(self._class_masks) <= 1:
             solved = self._solve_separable(matrix)
         else:
@@ -565,8 +565,8 @@ class SeparableExponentialCovariance:
             solved[..., rhs_index] = solution.reshape(n_lat, n_lon)
         return solved
 
-    def _validated_matrix(self, rhs: xr.DataArray) -> tuple[np.ndarray, tuple[str, ...], tuple[str, ...]]:
-        """Validate and eagerly reshape a labelled right-hand side.
+    def _aligned_matrix(self, rhs: xr.DataArray) -> tuple[np.ndarray, tuple[str, ...], tuple[str, ...]]:
+        """Align and eagerly reshape a labelled right-hand side.
 
         Args:
             rhs: Candidate right-hand side containing the native dimensions.
@@ -576,28 +576,27 @@ class SeparableExponentialCovariance:
             ordered non-native right-hand-side dimensions.
 
         Raises:
-            TypeError: If ``rhs`` is not an xarray data array.
             ValueError: If native dimensions or coordinates are missing or
-                misaligned, or if values are non-numeric or non-finite.
+                cannot be aligned exactly with the configured grid.
         """
-        if not isinstance(rhs, xr.DataArray):
-            raise TypeError("rhs must be an xarray.DataArray")
-        for dim, expected in zip(self.native_dims, (self._latitude, self._longitude), strict=True):
-            if dim not in rhs.dims:
-                raise ValueError(f"rhs is missing native dimension {dim!r}")
-            if dim not in rhs.coords:
-                raise ValueError(f"rhs is missing coordinate labels for native dimension {dim!r}")
-            actual_values = np.asarray(rhs.coords[dim].values)
-            if actual_values.shape != expected.shape or not np.array_equal(actual_values, expected.values):
-                raise ValueError(f"rhs coordinate {dim!r} does not align with the covariance grid")
         original_dims = tuple(str(dim) for dim in rhs.dims)
         rhs_dims = tuple(dim for dim in original_dims if dim not in self.native_dims)
         transposed = rhs.transpose(*self.native_dims, *rhs_dims)
+        # xr.align treats an unindexed dimension as positional when its size
+        # matches, but this public action requires an explicitly labelled grid.
+        for dim in self.native_dims:
+            if dim not in transposed.indexes:
+                raise ValueError(f"rhs is missing indexed native coordinate {dim!r}")
+        grid = xr.Dataset(
+            coords={
+                self.native_dims[0]: self._latitude,
+                self.native_dims[1]: self._longitude,
+            }
+        )
+        # The action is positional below this point. Exact alignment prevents
+        # applying it to values from a different native grid.
+        transposed, _ = xr.align(transposed, grid, join="exact", copy=False)
         values = np.asarray(transposed.values)
-        if not np.issubdtype(values.dtype, np.number):
-            raise ValueError("rhs values must be numeric")
-        if not np.all(np.isfinite(values)):
-            raise ValueError("rhs values must be finite (no NaN or infinity)")
         n_lat = self._latitude.size
         n_lon = self._longitude.size
         n_rhs = int(np.prod([transposed.sizes[dim] for dim in rhs_dims], dtype=np.intp))

--- a/openghg_inversions/source_covariance.py
+++ b/openghg_inversions/source_covariance.py
@@ -449,7 +449,7 @@ class IndependentSourceCovariance:
         *,
         operation: Literal["apply", "solve"],
     ) -> xr.DataArray:
-        """Validate labels and dispatch one covariance operation per source.
+        """Align labels and dispatch one covariance operation per source.
 
         Args:
             rhs: Candidate labelled right-hand side.
@@ -459,25 +459,23 @@ class IndependentSourceCovariance:
             Concatenated block results transposed to the input dimension order.
 
         Raises:
-            TypeError: If ``rhs`` is not an xarray data array.
-            ValueError: If source or spatial labels are missing or do not
-                exactly match the configured labels, or values are invalid.
+            ValueError: If source or spatial labels do not exactly match the
+                configured labels.
             numpy.linalg.LinAlgError: If a requested class-blocked solve does
                 not converge.
         """
-        if not isinstance(rhs, xr.DataArray):
-            raise TypeError("rhs must be an xarray.DataArray")
-        if self.source_dim not in rhs.dims or self.source_dim not in rhs.coords:
-            raise ValueError(f"rhs must contain labelled source dimension coordinate {self.source_dim!r}")
         expected = xr.DataArray(
             list(self.source_labels),
             dims=self.source_dim,
             coords={self.source_dim: list(self.source_labels)},
         )
-        try:
-            aligned_rhs, _ = xr.align(rhs, expected, join="exact", copy=False)
-        except xr.AlignmentError as error:
-            raise ValueError("rhs source labels/order do not match covariance configuration") from error
+        # As for native grids, xarray treats an unindexed equal-sized dimension
+        # positionally. Source blocks must instead be selected by explicit label.
+        if self.source_dim not in rhs.indexes:
+            raise ValueError(f"rhs is missing indexed source coordinate {self.source_dim!r}")
+        # Each block is selected by label below, so prohibit xarray's usual
+        # permissive alignment from dropping or introducing source blocks.
+        aligned_rhs, _ = xr.align(rhs, expected, join="exact", copy=False)
 
         original_dims = tuple(str(dim) for dim in rhs.dims)
         results: list[xr.DataArray] = []

--- a/tests/test_covariance_products.py
+++ b/tests/test_covariance_products.py
@@ -6,7 +6,6 @@ import pytest
 import xarray as xr
 from dask import delayed
 from dask import array as da
-from xarray.core.indexes import PandasIndex
 
 from openghg_inversions.basis.covariance_products import (
     NativeCovarianceProducts,
@@ -136,14 +135,6 @@ def test_preserve_bucket_strategy_derives_compatible_restriction() -> None:
     )
 
 
-def test_retained_projection_public_contract_contains_only_pi_and_strategy() -> None:
-    """External projection results expose only restriction and strategy."""
-    assert tuple(RetainedProjection.__dataclass_fields__) == (
-        "restriction",
-        "strategy",
-    )
-
-
 def test_array_product_handoffs_use_identity_equality() -> None:
     """Array-bearing handoffs do not invoke ambiguous xarray value equality."""
     covariance, basis_operator, h, _ = _problem()
@@ -268,34 +259,6 @@ def test_dense_and_diagonal_products_are_invariant_to_rhs_batching() -> None:
     np.testing.assert_allclose(diagonal.native_observation_covariance, expected_diagonal)
 
 
-def test_dense_batching_preallocates_instead_of_concatenating(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Dense observation batching avoids the former xr.concat block-assembly path."""
-    covariance, basis_operator, h, _ = _problem()
-
-    original_concat = xr.concat
-
-    def reject_observation_concat(*args: object, **kwargs: object):
-        """Allow state blocking but fail on former observation block assembly."""
-        dim = kwargs.get("dim")
-        if dim in {"observation", "observation_cov"}:
-            raise AssertionError(f"unexpected observation xr.concat call: {args!r}, {kwargs!r}")
-        return original_concat(*args, **kwargs)
-
-    monkeypatch.setattr(xr, "concat", reject_observation_concat)
-
-    products = _project(
-        covariance,
-        basis_operator,
-        h,
-        observation_covariance="dense",
-        observation_batch_size=1,
-    )
-
-    assert products.native_observation_covariance.shape == (3, 3)
-
-
 def test_single_source_native_prolongation_preserves_native_auxiliary_coordinates() -> None:
     """Canonical single-source U retains native-axis and scalar context coordinates."""
     covariance, basis_operator, h, _ = _problem()
@@ -319,16 +282,12 @@ def test_single_source_native_prolongation_preserves_native_auxiliary_coordinate
     assert prolongation.coords["grid_mapping"].item() == "latitude_longitude"
 
 
-@pytest.mark.parametrize(
-    "invalid_batch_size",
-    [True, "2", 1.9],
-    ids=["boolean", "string", "non-integral-float"],
-)
-def test_observation_batch_size_requires_integral_non_boolean(invalid_batch_size: object) -> None:
-    """The RHS block size rejects values that merely coerce to an integer."""
+@pytest.mark.parametrize("invalid_batch_size", [0, -1])
+def test_observation_batch_size_must_be_positive(invalid_batch_size: int) -> None:
+    """The batching operation requires a positive block size."""
     covariance, basis_operator, h, _ = _problem()
 
-    with pytest.raises((TypeError, ValueError), match="integer|integral|Boolean"):
+    with pytest.raises(ValueError, match="positive"):
         _project(
             covariance,
             basis_operator,
@@ -337,20 +296,12 @@ def test_observation_batch_size_requires_integral_non_boolean(invalid_batch_size
         )
 
 
-def test_observation_batch_size_accepts_numpy_integral() -> None:
-    """NumPy integer scalars satisfy the public integral block-size contract."""
+def test_fractional_batch_size_is_not_silently_truncated() -> None:
+    """Static typing does not justify changing a supplied numerical value."""
     covariance, basis_operator, h, _ = _problem()
 
-    products = _project(
-        covariance,
-        basis_operator,
-        h,
-        observation_batch_size=np.int64(2),
-    )
-
-    assert products.native_observation_covariance.shape == (3, 3)
-
-
+    with pytest.raises(TypeError):
+        _project(covariance, basis_operator, h, observation_batch_size=1.9)
 @pytest.mark.parametrize("collision", ["observation-dimension", "auxiliary-coordinate"])
 def test_state_column_name_avoids_observation_namespace_collisions(collision: str) -> None:
     """The generated state column avoids observation dimensions and coordinates."""
@@ -377,52 +328,6 @@ def test_state_column_name_avoids_observation_namespace_collisions(collision: st
     assert state_column_dim != observation_dim
     assert state_column_dim not in h.coords
     assert products.observation_state_cross_covariance.shape == (3, 2)
-
-
-def test_diagonal_observation_covariance_rejects_overflow() -> None:
-    """The diagonal view rejects non-finite values produced by finite huge H."""
-    covariance, basis_operator, h, _ = _problem()
-    huge_h = xr.full_like(h, 1e308)
-
-    with np.errstate(over="ignore", invalid="ignore"):
-        with pytest.raises(ValueError, match="finite|non-finite"):
-            _project(
-                covariance,
-                basis_operator,
-                huge_h,
-                observation_covariance="diagonal",
-            )
-
-
-@pytest.mark.parametrize("output", ["dense", "diagonal"])
-@pytest.mark.parametrize("invalid_output", ["complex", "nonfinite"])
-def test_covariance_products_reject_invalid_covariance_action_output(
-    monkeypatch: pytest.MonkeyPatch,
-    output: str,
-    invalid_output: str,
-) -> None:
-    """Dense and diagonal paths reject complex or non-finite B RHS before casting."""
-    covariance, basis_operator, h, _ = _problem()
-    original_apply = type(covariance).apply
-
-    def invalid_apply(self, rhs):
-        """Corrupt only observation covariance actions, leaving Pi derivation valid."""
-        rhs_dim = next(dim for dim in rhs.dims if dim not in covariance.native_dims)
-        if not str(rhs_dim).startswith("observation"):
-            return original_apply(self, rhs)
-        if invalid_output == "complex":
-            return rhs.astype(complex) * (1.0 + 1.0j)
-        return xr.full_like(rhs, np.nan)
-
-    monkeypatch.setattr(type(covariance), "apply", invalid_apply)
-
-    with pytest.raises(ValueError, match="finite real|complex|non-finite"):
-        _project(
-            covariance,
-            basis_operator,
-            h,
-            observation_covariance=output,
-        )
 
 
 @pytest.mark.parametrize(
@@ -498,22 +403,24 @@ def test_diagonal_observation_covariance_allows_tiny_local_roundoff(
     assert products.native_observation_covariance.attrs["diagonal_nonnegative"] is True
 
 
-def test_lazy_sensitivity_is_rejected_at_explicit_materialization_boundary() -> None:
-    """The eager kernel rejects Dask H instead of silently computing its full graph."""
+def test_lazy_sensitivity_is_materialized_at_explicit_eager_boundary() -> None:
+    """The product boundary accepts lazy H and returns eager products."""
     covariance, basis_operator, h, _ = _problem()
     lazy_h = h.chunk({"observation": 1})
     basis_prolongation = to_dense(
         basis_operator.native_prolongation(h, native_dims=covariance.native_dims)
     ).compute()
 
-    with pytest.raises(ValueError, match="upstream materialization|lazy|Dask"):
-        project_native_covariance(
-            covariance=covariance,
-            basis_prolongation=basis_prolongation,
-            state_dim="state",
-            native_sensitivity=lazy_h,
-            observation_dim="observation",
-        )
+    expected = _project(covariance, basis_operator, h)
+    actual = project_native_covariance(
+        covariance=covariance,
+        basis_prolongation=basis_prolongation,
+        state_dim="state",
+        native_sensitivity=lazy_h,
+        observation_dim="observation",
+    )
+
+    xr.testing.assert_allclose(actual.native_observation_covariance, expected.native_observation_covariance)
 
 
 def test_lazy_custom_restriction_is_materialized_in_explicit_rhs_blocks() -> None:
@@ -648,44 +555,6 @@ def test_square_products_preserve_typed_row_and_column_indexes(multiindex: bool)
         assert matrix.coords["time_cov"].attrs["semantic_role"] == "sample_time"
 
 
-@pytest.mark.parametrize(
-    "index",
-    [
-        pytest.param(
-            pd.CategoricalIndex(
-                ["MHD", "TAC", "RGL"],
-                categories=["RGL", "TAC", "MHD"],
-                ordered=True,
-                name="observation",
-            ),
-            id="categorical",
-        ),
-        pytest.param(
-            pd.period_range("2020-01", periods=3, freq="M", name="observation"),
-            id="period",
-        ),
-        pytest.param(pd.RangeIndex(5, 8, name="observation"), id="range"),
-    ],
-)
-def test_square_products_preserve_specialized_indexes_and_coordinate_attrs(
-    index: pd.Index,
-) -> None:
-    """Square row/column axes preserve specialized indexes and coordinate attrs."""
-    covariance, basis_operator, h, _ = _problem()
-    h = h.drop_indexes("observation").drop_vars("observation")
-    h = h.assign_coords(xr.Coordinates.from_xindex(PandasIndex(index, "observation")))
-    h.coords["observation"].attrs["semantic_role"] = "measurement"
-
-    matrix = _project(covariance, basis_operator, h).native_observation_covariance
-
-    assert type(matrix.indexes["observation"]) is type(index)
-    assert type(matrix.indexes["observation_cov"]) is type(index)
-    assert matrix.indexes["observation"].equals(index)
-    assert matrix.indexes["observation_cov"].equals(index.rename("observation_cov"))
-    assert matrix.coords["observation"].attrs["semantic_role"] == "measurement"
-    assert matrix.coords["observation_cov"].attrs["semantic_role"] == "measurement"
-
-
 def test_product_kernel_avoids_throwaway_covariance_application(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -705,29 +574,6 @@ def test_product_kernel_avoids_throwaway_covariance_application(
     _project(covariance, basis_operator, h, observation_batch_size=2)
 
     assert calls == 3
-
-
-def test_each_dense_matrix_diagnostic_uses_one_eigendecomposition(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """State and observation covariance diagnostics each compute eigenvalues once."""
-    covariance, basis_operator, h, _ = _problem()
-    original_eigvalsh = np.linalg.eigvalsh
-    calls = 0
-
-    def counted_eigvalsh(matrix):
-        """Count symmetric eigensolver calls before delegating."""
-        nonlocal calls
-        calls += 1
-        return original_eigvalsh(matrix)
-
-    monkeypatch.setattr(np.linalg, "eigvalsh", counted_eigvalsh)
-
-    products = _project(covariance, basis_operator, h)
-
-    assert calls == 2
-    assert "minimum_eigenvalue" in products.state_covariance.attrs
-    assert "minimum_eigenvalue" in products.native_observation_covariance.attrs
 
 
 def test_projection_strategy_protocol_accepts_structural_implementations() -> None:
@@ -755,123 +601,6 @@ def test_projection_strategy_protocol_accepts_structural_implementations() -> No
     assert products.strategy == "delegating_strategy"
     xr.testing.assert_allclose(products.prolongation, expected.prolongation)
     xr.testing.assert_allclose(products.state_covariance, expected.state_covariance)
-
-
-def test_false_valued_structural_strategy_is_invoked() -> None:
-    """A valid strategy with false truth value does not trigger default fallback."""
-    covariance, basis_operator, h, _ = _problem()
-    invoked = False
-
-    class FalseValuedStrategy:
-        """Expose a false truth value while implementing the strategy protocol."""
-
-        def __bool__(self) -> bool:
-            """Return false without changing the object's strategy validity."""
-            return False
-
-        def projection(self, covariance, basis_prolongation, *, native_dims, state_dim):
-            """Delegate valid algebra and record that this strategy was selected."""
-            nonlocal invoked
-            invoked = True
-            valid = PreserveBucketProlongation().projection(
-                covariance,
-                basis_prolongation,
-                native_dims=native_dims,
-                state_dim=state_dim,
-            )
-            return RetainedProjection(valid.restriction, "false_valued")
-
-    products = _project(covariance, basis_operator, h, strategy=FalseValuedStrategy())
-
-    assert invoked
-    assert products.strategy == "false_valued"
-
-
-def test_custom_projection_rejects_conflicting_native_auxiliary_coordinates() -> None:
-    """Pi native semantic metadata must match the canonical native reference."""
-    covariance, basis_operator, h, _ = _problem()
-    h = h.assign_coords(cell_area=(("lat", "lon"), np.arange(6).reshape(3, 2)))
-
-    class ConflictingAuxiliaryStrategy:
-        """Return valid Pi values with contradictory semantic coordinates."""
-
-        def projection(self, covariance, basis_prolongation, *, native_dims, state_dim):
-            """Relabel one semantic auxiliary without changing numerical values."""
-            valid = PreserveBucketProlongation().projection(
-                covariance,
-                basis_prolongation,
-                native_dims=native_dims,
-                state_dim=state_dim,
-            )
-            restriction = valid.restriction.assign_coords(
-                cell_area=(("lat", "lon"), np.arange(6).reshape(3, 2) + 1)
-            )
-            return RetainedProjection(restriction, "conflicting_auxiliary")
-
-    with pytest.raises(ValueError, match="auxiliary|coordinate|group|cell_area"):
-        _project(covariance, basis_operator, h, strategy=ConflictingAuxiliaryStrategy())
-
-
-def test_projection_strategy_names_must_be_nonempty() -> None:
-    """Empty built-in and custom strategy identifiers are rejected."""
-    covariance, basis_operator, h, _ = _problem()
-
-    with pytest.raises(ValueError, match="non-empty"):
-        PreserveBucketProlongation(name="")
-
-    class EmptyNameStrategy:
-        """Delegate a valid projection but remove its stable identifier."""
-
-        def projection(self, covariance, basis_prolongation, *, native_dims, state_dim):
-            """Return a coherent projection with an invalid empty name."""
-            valid = PreserveBucketProlongation().projection(
-                covariance,
-                basis_prolongation,
-                native_dims=native_dims,
-                state_dim=state_dim,
-            )
-            return RetainedProjection(valid.restriction, "")
-
-    with pytest.raises(ValueError, match="non-empty"):
-        _project(covariance, basis_operator, h, strategy=EmptyNameStrategy())
-
-
-@pytest.mark.parametrize("invalid_result", [object(), RetainedProjection("not-an-array", "invalid")])
-def test_projection_strategy_rejects_malformed_result(invalid_result: object) -> None:
-    """Malformed extensions fail at the public strategy boundary with a clear error."""
-    covariance, basis_operator, h, _ = _problem()
-
-    class MalformedStrategy:
-        """Return one deliberately invalid projection result."""
-
-        def projection(self, covariance, basis_prolongation, *, native_dims, state_dim):
-            """Return the parameterized malformed result."""
-            return invalid_result
-
-    with pytest.raises(ValueError, match="RetainedProjection|xarray.DataArray"):
-        _project(covariance, basis_operator, h, strategy=MalformedStrategy())
-
-
-def test_projection_strategy_rejects_complex_restriction() -> None:
-    """Projection strategies use real covariance algebra and reject complex Pi."""
-    covariance, basis_operator, h, _ = _problem()
-
-    class ComplexStrategy:
-        """Add an imaginary component to an otherwise valid restriction."""
-
-        def projection(self, covariance, basis_prolongation, *, native_dims, state_dim):
-            """Return a deliberately complex restriction."""
-            valid = PreserveBucketProlongation().projection(
-                covariance,
-                basis_prolongation,
-                native_dims=native_dims,
-                state_dim=state_dim,
-            )
-            restriction = valid.restriction.astype(complex) + 1j
-            return RetainedProjection(restriction, "complex")
-
-    with pytest.raises(ValueError, match="finite real"):
-        _project(covariance, basis_operator, h, strategy=ComplexStrategy())
 
 
 @pytest.mark.parametrize("coordinate_change", ["mismatch", "reordered", "empty-intersection"])
@@ -902,7 +631,7 @@ def test_custom_projection_requires_exact_native_coordinates(
             restriction = valid.restriction.assign_coords(lat=invalid_latitude)
             return RetainedProjection(restriction, "relabeled")
 
-    with pytest.raises(ValueError, match=r"native coordinate 'lat'.*exactly match"):
+    with pytest.raises(ValueError, match=r"join='exact'|align"):
         _project(covariance, basis_operator, h, strategy=RelabelledStrategy())
 
 
@@ -924,10 +653,31 @@ def test_projection_strategy_must_return_full_rank_restriction() -> None:
         _project(covariance, basis_operator, h, strategy=SingularStrategy())
 
 
+def test_projection_strategy_restriction_must_be_real() -> None:
+    """A dynamic strategy cannot silently discard an imaginary component."""
+    covariance, basis_operator, h, _ = _problem()
+
+    class ComplexStrategy:
+        """Return a complex restriction at the dynamic strategy seam."""
+
+        def projection(self, covariance, basis_prolongation, *, native_dims, state_dim):
+            """Add an imaginary component to a valid restriction."""
+            valid = PreserveBucketProlongation().projection(
+                covariance,
+                basis_prolongation,
+                native_dims=native_dims,
+                state_dim=state_dim,
+            )
+            return RetainedProjection(valid.restriction.astype(complex) + 1j, "complex")
+
+    with pytest.raises(ValueError, match="finite real"):
+        _project(covariance, basis_operator, h, strategy=ComplexStrategy())
+
+
 def test_redundant_bucket_states_are_rejected() -> None:
     """Linearly dependent retained coordinates fail instead of being pseudoinverted."""
     covariance, basis_operator, _, _ = _problem()
-    prolongation = basis_operator.basis_matrix.compute()
+    prolongation = to_dense(basis_operator.basis_matrix).compute()
     redundant = xr.concat(
         [
             prolongation.sel(state=0),
@@ -945,32 +695,12 @@ def test_redundant_bucket_states_are_rejected() -> None:
         )
 
 
-@pytest.mark.parametrize(
-    ("transform", "message"),
-    [
-        pytest.param(
-            lambda h: h.assign_coords(lon=h.lon[::-1]),
-            "coordinate|align|longitude|lon",
-            id="misordered-native-coordinate",
-        ),
-        pytest.param(
-            lambda h: h.where(h.observation != "TAC-1"),
-            "finite|NaN",
-            id="non-finite-sensitivity",
-        ),
-        pytest.param(
-            lambda h: h.astype(complex) + 1j,
-            "finite real",
-            id="complex-sensitivity",
-        ),
-    ],
-)
-def test_products_reject_invalid_native_sensitivity(transform, message: str) -> None:
-    """Product construction rejects misaligned or non-finite native sensitivity."""
+def test_products_require_exact_native_sensitivity_alignment() -> None:
+    """Product construction does not silently intersect a different H grid."""
     covariance, basis_operator, h, _ = _problem()
 
-    with pytest.raises(ValueError, match=message):
-        _project(covariance, basis_operator, transform(h))
+    with pytest.raises(ValueError, match=r"join='exact'|align|lon"):
+        _project(covariance, basis_operator, h.assign_coords(lon=h.lon[::-1]))
 
 
 def test_class_blocked_products_match_dense_oracle() -> None:

--- a/tests/test_covariance_products.py
+++ b/tests/test_covariance_products.py
@@ -189,6 +189,11 @@ def test_products_match_dense_oracle_and_coherent_forward_model() -> None:
         "TAC-1",
         "RGL-1",
     ]
+    reciprocal_condition = products.state_covariance.attrs[
+        "estimated_reciprocal_condition_number"
+    ]
+    assert 0.0 < reciprocal_condition <= 1.0
+    assert products.state_covariance.attrs["condition_number_norm"] == "1"
 
 
 def test_covariance_natural_prolongation_is_the_bucket_prolongation() -> None:
@@ -685,6 +690,33 @@ def test_projection_strategy_must_return_full_rank_restriction() -> None:
 
     with pytest.raises(ValueError, match="empty retained state|positive definite|full rank"):
         _project(covariance, basis_operator, h, strategy=SingularStrategy())
+
+
+def test_nearly_redundant_projection_reports_unstable_retained_solve() -> None:
+    """A cheap retained-space condition estimate diagnoses near-duplicate states."""
+    covariance, basis_operator, h, _ = _problem()
+
+    class NearlyRedundantStrategy:
+        """Make two retained functionals numerically indistinguishable."""
+
+        def projection(self, covariance, basis_prolongation, *, native_dims, state_dim):
+            """Return a full-rank but ill-conditioned restriction."""
+            valid = PreserveBucketProlongation().projection(
+                covariance,
+                basis_prolongation,
+                native_dims=native_dims,
+                state_dim=state_dim,
+            )
+            first = valid.restriction.isel({state_dim: 0}, drop=True)
+            second = first + 1e-5 * valid.restriction.isel({state_dim: 1}, drop=True)
+            restriction = xr.concat(
+                [first, second],
+                dim=xr.IndexVariable(state_dim, valid.restriction[state_dim].values),
+            ).transpose(state_dim, *native_dims)
+            return RetainedProjection(restriction, "nearly_redundant")
+
+    with pytest.raises(ValueError, match="too ill-conditioned|non-redundant"):
+        _project(covariance, basis_operator, h, strategy=NearlyRedundantStrategy())
 
 
 def test_projection_strategy_restriction_must_be_real() -> None:

--- a/tests/test_covariance_products.py
+++ b/tests/test_covariance_products.py
@@ -555,6 +555,40 @@ def test_square_products_preserve_typed_row_and_column_indexes(multiindex: bool)
         assert matrix.coords["time_cov"].attrs["semantic_role"] == "sample_time"
 
 
+def test_retained_state_multiindex_survives_the_eager_boundary() -> None:
+    """Payload materialization preserves retained-state index structure."""
+    covariance, basis_operator, h, _ = _problem()
+    prolongation = basis_operator.native_prolongation(h, native_dims=covariance.native_dims)
+    state_index = pd.MultiIndex.from_tuples(
+        [("z-source", 7), ("a-source", 2)],
+        names=("source", "region"),
+    )
+    state_coordinates = {
+        str(name): coordinate
+        for name, coordinate in prolongation.coords.items()
+        if "state" not in coordinate.dims
+    }
+    prolongation = xr.DataArray(
+        prolongation.data,
+        dims=prolongation.dims,
+        coords=state_coordinates,
+        attrs=prolongation.attrs,
+    ).assign_coords(xr.Coordinates.from_pandas_multiindex(state_index, "state"))
+
+    products = project_native_covariance(
+        covariance=covariance,
+        basis_prolongation=prolongation,
+        state_dim="state",
+        native_sensitivity=h,
+        observation_dim="observation",
+    )
+
+    assert products.restriction.indexes["state"].equals(state_index)
+    assert products.prolongation.indexes["state"].equals(state_index)
+    assert products.state_covariance.indexes["state"].equals(state_index)
+    assert list(products.state_covariance.indexes["state_cov"]) == list(state_index)
+
+
 def test_product_kernel_avoids_throwaway_covariance_application(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_covariance_products.py
+++ b/tests/test_covariance_products.py
@@ -144,6 +144,18 @@ def test_retained_projection_public_contract_contains_only_pi_and_strategy() -> 
     )
 
 
+def test_array_product_handoffs_use_identity_equality() -> None:
+    """Array-bearing handoffs do not invoke ambiguous xarray value equality."""
+    covariance, basis_operator, h, _ = _problem()
+    products = _project(covariance, basis_operator, h)
+
+    assert products == products
+    assert products != _project(covariance, basis_operator, h)
+    projection = RetainedProjection(products.restriction, products.strategy)
+    assert projection == projection
+    assert projection != RetainedProjection(products.restriction, products.strategy)
+
+
 def test_products_match_dense_oracle_and_coherent_forward_model() -> None:
     """C_alpha, H_alpha, H B Pi.T, and H B H.T match dense coherent oracles."""
     covariance, basis_operator, h, dense_b = _problem()
@@ -822,6 +834,22 @@ def test_projection_strategy_names_must_be_nonempty() -> None:
 
     with pytest.raises(ValueError, match="non-empty"):
         _project(covariance, basis_operator, h, strategy=EmptyNameStrategy())
+
+
+@pytest.mark.parametrize("invalid_result", [object(), RetainedProjection("not-an-array", "invalid")])
+def test_projection_strategy_rejects_malformed_result(invalid_result: object) -> None:
+    """Malformed extensions fail at the public strategy boundary with a clear error."""
+    covariance, basis_operator, h, _ = _problem()
+
+    class MalformedStrategy:
+        """Return one deliberately invalid projection result."""
+
+        def projection(self, covariance, basis_prolongation, *, native_dims, state_dim):
+            """Return the parameterized malformed result."""
+            return invalid_result
+
+    with pytest.raises(ValueError, match="RetainedProjection|xarray.DataArray"):
+        _project(covariance, basis_operator, h, strategy=MalformedStrategy())
 
 
 def test_projection_strategy_rejects_complex_restriction() -> None:

--- a/tests/test_native_covariance.py
+++ b/tests/test_native_covariance.py
@@ -178,18 +178,13 @@ def test_default_configuration_round_trips_through_dataset() -> None:
         ),
         pytest.param(
             lambda rhs: rhs.drop_indexes("lon").drop_vars("lon"),
-            "coordinate|longitude|lon",
+            "lon",
             id="missing-coordinate",
-        ),
-        pytest.param(
-            lambda rhs: rhs.where(~((rhs.lat == 0.25) & (rhs.lon == 10.0))),
-            "finite|NaN",
-            id="non-finite-values",
         ),
     ],
 )
-def test_action_rejects_invalid_rhs_labels_and_values(bad_rhs, message: str) -> None:
-    """The action rejects ambiguous alignment and non-finite numerical inputs."""
+def test_action_requires_labelled_aligned_rhs(bad_rhs, message: str) -> None:
+    """The public action requires its configured labelled native grid."""
     latitude, longitude = _coordinates()
     covariance = _covariance()
     rhs = xr.DataArray(

--- a/tests/test_native_covariance_classes.py
+++ b/tests/test_native_covariance_classes.py
@@ -252,8 +252,9 @@ def test_covariance_round_trips_through_h5netcdf(
 
 def test_single_class_uses_unblocked_covariance(
     coordinates: tuple[xr.DataArray, xr.DataArray],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A single class is algebraically identical to the separable covariance."""
+    """A single class uses the allocation-free separable path."""
     latitude, longitude = coordinates
     labels = xr.DataArray(
         np.full((3, 2), "all"),
@@ -268,6 +269,11 @@ def test_single_class_uses_unblocked_covariance(
         coords={"lat": latitude, "lon": longitude},
     )
 
+    def reject_blocked_result_allocation(*args: object, **kwargs: object) -> None:
+        """Fail if apply enters the multi-class masked accumulation path."""
+        raise AssertionError("single-class covariance allocated a blocked result")
+
+    monkeypatch.setattr(native_covariance_module.np, "zeros_like", reject_blocked_result_allocation)
     xr.testing.assert_allclose(blocked.apply(rhs), unblocked.apply(rhs))
     xr.testing.assert_allclose(blocked.solve(rhs), unblocked.solve(rhs))
 

--- a/tests/test_serialization_codecs.py
+++ b/tests/test_serialization_codecs.py
@@ -215,7 +215,7 @@ def test_source_dispatch_requires_the_exact_configured_index(source_labels: list
     """Xarray exact alignment rejects reordered, missing, extra, duplicate, or mistyped labels."""
     covariance = _source_covariance()
 
-    with pytest.raises(ValueError, match="source labels/order do not match covariance configuration"):
+    with pytest.raises(ValueError, match=r"join='exact'|align|native_source"):
         covariance.apply(_source_rhs(source_labels))
 
 

--- a/tests/test_source_covariance.py
+++ b/tests/test_source_covariance.py
@@ -181,8 +181,17 @@ def test_action_rejects_numeric_source_label_matching_only_after_string_coercion
     numeric_named_covariance = IndependentSourceCovariance({"1": component})
     rhs = native_sensitivity.isel(native_source=[0]).assign_coords(native_source=[1])
 
-    with pytest.raises(ValueError, match="source labels/order"):
+    with pytest.raises(ValueError, match=r"join='exact'|align|native_source"):
         numeric_named_covariance.apply(rhs)
+
+
+def test_action_requires_an_indexed_source_coordinate() -> None:
+    """Equal-sized positional dimensions cannot stand in for source labels."""
+    covariance, native_sensitivity = _problem()
+    rhs = native_sensitivity.drop_indexes("native_source").drop_vars("native_source")
+
+    with pytest.raises(ValueError, match="indexed source coordinate"):
+        covariance.apply(rhs)
 
 
 @pytest.mark.parametrize("spatial_dim", ["lat", "lon"])


### PR DESCRIPTION
## Summary of changes

- simplify the new OPE-17 covariance-product path to transpose, exact-align, and jointly materialize labelled inputs once before evaluating the scientific equations
- trust locally constructed covariance products instead of repeatedly checking types, dimensions, finite values, identities, solve residuals, and derived unit strings
- retain checks only where they express an operational requirement or a genuine boundary: positive batching, Cholesky failure, exact indexed-grid alignment, diagonal roundoff policy, and finite-real custom strategy output
- use xarray's natural `join="exact"` errors instead of bespoke coordinate-comparison helpers
- add normative development guidance for validation boundaries, common xarray alignment/materialization patterns, and Pint-based unit normalization
- refocus tests on scientific oracles, alignment, lazy execution, extension seams, and numerical failures rather than corrupted package-created intermediates

This is the cleanup requested immediately after OPE-17, while the covariance API is new and has no model consumers. OPE-18 remains stacked on this draft.

## Developer impact

The main product kernel is substantially shorter and reads in scientific order. Ordinary Python type contracts are left to static checking. Independently sourced labelled arrays are canonicalized once, while package-created intermediates are trusted. The new guide records when an explicit check remains justified, including xarray's indexed-versus-unindexed caveat and the separation between Pint unit compatibility and xarray coordinate alignment.

## Validation

- Python 3.10 current-OpenGHG full suite: 1,329 passed, 12 skipped, 6 xfailed
- focused Python 3.10 covariance/serialization suite: 135 passed
- focused current-environment covariance suite: 70 passed
- Ruff: passed
- `git diff --check`: passed
- strict docs build renders the new page, but remains red on existing repository-wide autodoc warnings/errors unrelated to this change
- default `borrowed-types` remains red on the known NumPy 2.5 Mypy deprecation for `ndarray.resize` in unchanged `borrowed.py`

## Checklist

- [ ] Closes a GitHub issue — preparatory cleanup for Linear OPE-18
- [x] Tests added/refocused and passing
- [x] Documentation updated
- [x] CHANGELOG updated
- [x] No new requirements