### PR TITLE
Preserve legacy options in MCMC.TYPE

### DIFF
--- a/openghg_inversions/hbmcmc/run_hbmcmc.py
+++ b/openghg_inversions/hbmcmc/run_hbmcmc.py
@@ -323,10 +323,8 @@ def hbmcmc_extract_param(
         if key in expected_param and value is not None:
             expected_param.remove(key)
 
-    mcmc_type_section = "MCMC.TYPE"
-    param = config.extract_params(
-        config_file, expected_param=expected_param, ignore_sections=[mcmc_type_section]
-    )
+    param = config.extract_params(config_file, expected_param=expected_param)
+    param.pop("mcmc_type", None)
 
     # Command line values added to param (or supersede inputs from the config
     # file)

--- a/tests/test_run_hbmcmc_shim.py
+++ b/tests/test_run_hbmcmc_shim.py
@@ -24,6 +24,7 @@ emissions_name = ["total-ukghg-edgar7"]
 
 [MCMC.TYPE]
 mcmc_type = "fixed_basis"
+nuts_sampler = "numpyro"
 
 [MCMC.PDF]
 xprior = {"pdf": "normal", "mu": 1.0, "sigma": 1.0}
@@ -68,6 +69,7 @@ def test_fixedbasis_params_to_rhime_translates_legacy_names(tmp_path: Path) -> N
     assert translated["chains"] == 3
     assert translated["progressbar"] is True
     assert translated["sample_kwargs"] == {"target_accept": 0.9}
+    assert translated["nuts_sampler"] == "numpyro"
     assert translated["output_format"] == "legacy"
     assert translated["output_filename_convention"] == "legacy"
     assert translated["save_inversion_output"] is False
@@ -210,6 +212,7 @@ def test_run_hbmcmc_main_routes_to_run_rhime(monkeypatch: pytest.MonkeyPatch, tm
     assert seen["run_rhime_kwargs"]["end_date"] == "2020-02-01"
     assert seen["run_rhime_kwargs"]["output_path"] == str(output_path)
     assert seen["run_rhime_kwargs"]["chains"] == 2
+    assert seen["run_rhime_kwargs"]["nuts_sampler"] == "numpyro"
     assert seen["run_rhime_kwargs"]["output_format"] == "legacy"
     assert seen["run_rhime_kwargs"]["output_filename_convention"] == "legacy"
 
@@ -269,6 +272,7 @@ def test_run_hbmcmc_legacy_fixedbasis_preserves_raw_params_and_selects_true_lega
     assert fixedbasis_kwargs["nchain"] == 3
     assert fixedbasis_kwargs["emissions_name"] == ["total-ukghg-edgar7"]
     assert fixedbasis_kwargs["sampler_kwargs"] == {"target_accept": 0.9}
+    assert fixedbasis_kwargs["nuts_sampler"] == "numpyro"
     assert fixedbasis_kwargs["outputpath"] == "out"
     assert fixedbasis_kwargs["outputname"] == "legacy_run"
     assert fixedbasis_kwargs["output_format"] == run_hbmcmc._LEGACY_FIXEDBASIS_OUTPUT_FORMAT


### PR DESCRIPTION
* **Summary of changes**

Restore the historical section-agnostic behavior of `run_hbmcmc.py` while keeping `mcmc_type` as a routing-only option.

The parser previously excluded the entire `[MCMC.TYPE]` section after reading `mcmc_type`. That silently dropped any other valid legacy option placed there, including `nuts_sampler = "numpyro"`, and caused sampling to fall back to native PyMC.

This change parses all sections and removes only `mcmc_type` before forwarding parameters. Regression assertions cover both the RHIME compatibility route and the explicit legacy fixedbasis route.

Related to #608.

* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [x] Tests added and passing
- [ ] Documentation and tutorials updated/added
- [ ] Added an entry to the `CHANGELOG.md` file
- [ ] Added any new requirements to `requirements.txt`

Validation:

- `uv run pytest tests/test_run_hbmcmc_shim.py` (19 passed)
- `uv run ruff check openghg_inversions/hbmcmc/run_hbmcmc.py tests/test_run_hbmcmc_shim.py`
- `git diff --check`