### PR TITLE
Respect explicit PyTensor process precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ## Code changes
 
+- Made PyTensor precision ownership explicit at process startup. Fresh
+  OpenGHG Inversions PyMC processes retain the memory-conscious float32
+  default, while explicit `PYTENSOR_FLAGS` precision and already-initialized
+  PyTensor or PyMC runtimes are left unchanged. Future component-level
+  mixed-precision accumulation work is tracked in
+  [#607](https://github.com/openghg/openghg_inversions/issues/607).
+
 - Moved RHIME retrieval, filtering, basis, sensitivity, labelled assembly, and
   PyMC materialization into a cohesive preparation module while keeping their
   scientific order visible in the runners. `run_rhime` and

--- a/docs/usage/concrete_rhime_model.rst
+++ b/docs/usage/concrete_rhime_model.rst
@@ -75,6 +75,27 @@ Source/design resolution and the boundary, offset, error, and likelihood
 components remain shared. This keeps parity meaningful and avoids independent
 copies silently drifting while compiler extensions are developed.
 
+PyTensor precision at process startup
+-------------------------------------
+
+A fresh OpenGHG Inversions PyMC or RHIME process defaults PyTensor to
+``float32``. This keeps float32 footprint sensitivities from being promoted
+when observations or errors arrive from preparation as float64. Because
+PyTensor configuration is process-wide, graph precision is not a
+``RhimeModelSpec`` option and must be selected before importing PyTensor,
+PyMC, or OpenGHG Inversions.
+
+Set PyTensor's native environment flag to opt into a float64 graph::
+
+   PYTENSOR_FLAGS="floatX=float64,warn_float64=ignore" python inversion.py
+
+An explicitly configured or already-imported PyTensor runtime is never
+overwritten. In a notebook, set the environment flag before library imports
+and restart the kernel when changing precision. Storage precision, graph
+precision, and numerically sensitive accumulation precision are separate
+concerns; components may promote specific calculations without requiring the
+whole graph or prepared-data cache to use float64.
+
 Standard single-flux model
 --------------------------
 

--- a/docs/usage/concrete_rhime_model.rst
+++ b/docs/usage/concrete_rhime_model.rst
@@ -75,27 +75,6 @@ Source/design resolution and the boundary, offset, error, and likelihood
 components remain shared. This keeps parity meaningful and avoids independent
 copies silently drifting while compiler extensions are developed.
 
-PyTensor precision at process startup
--------------------------------------
-
-A fresh OpenGHG Inversions PyMC or RHIME process defaults PyTensor to
-``float32``. This keeps float32 footprint sensitivities from being promoted
-when observations or errors arrive from preparation as float64. Because
-PyTensor configuration is process-wide, graph precision is not a
-``RhimeModelSpec`` option and must be selected before importing PyTensor,
-PyMC, or OpenGHG Inversions.
-
-Set PyTensor's native environment flag to opt into a float64 graph::
-
-   PYTENSOR_FLAGS="floatX=float64,warn_float64=ignore" python inversion.py
-
-An explicitly configured or already-imported PyTensor runtime is never
-overwritten. In a notebook, set the environment flag before library imports
-and restart the kernel when changing precision. Storage precision, graph
-precision, and numerically sensitive accumulation precision are separate
-concerns; components may promote specific calculations without requiring the
-whole graph or prepared-data cache to use float64.
-
 Standard single-flux model
 --------------------------
 

--- a/docs/usage/rhime.rst
+++ b/docs/usage/rhime.rst
@@ -43,6 +43,27 @@ Terminology
 ``emissions_name``
    Legacy compatibility spelling accepted only when ``flux_sources`` is absent.
 
+Configuring PyTensor precision
+------------------------------
+
+A fresh OpenGHG Inversions PyMC or RHIME process defaults PyTensor to
+``float32``. This keeps float32 footprint sensitivities from being promoted
+when observations or errors arrive from preparation as float64. Because
+PyTensor configuration is process-wide, graph precision is not a
+``RhimeModelSpec`` option and must be selected before importing PyTensor,
+PyMC, or OpenGHG Inversions.
+
+Set PyTensor's native environment flag to opt into a float64 graph::
+
+   PYTENSOR_FLAGS="floatX=float64,warn_float64=ignore" python inversion.py
+
+An explicitly configured or already-imported PyTensor runtime is never
+overwritten. In a notebook, set the environment flag before library imports
+and restart the kernel when changing precision. Storage precision, graph
+precision, and numerically sensitive accumulation precision are separate
+concerns; components may promote specific calculations without requiring the
+whole graph or prepared-data cache to use float64.
+
 Python API
 ----------
 

--- a/openghg_inversions/_pymc_config.py
+++ b/openghg_inversions/_pymc_config.py
@@ -2,13 +2,35 @@
 
 from __future__ import annotations
 
+import os
+import sys
 from typing import Any, cast
 
 
+def _pytensor_flag_is_explicit(name: str) -> bool:
+    """Return whether the process supplied one named ``PYTENSOR_FLAGS`` value."""
+    for setting in os.environ.get("PYTENSOR_FLAGS", "").split(","):
+        key, separator, _ = setting.partition("=")
+        if separator and key.strip() == name:
+            return True
+    return False
+
+
 def configure_pytensor() -> None:
-    """Apply OpenGHG Inversions PyTensor defaults before importing PyMC."""
+    """Apply memory-conscious defaults only to a fresh PyTensor runtime.
+
+    Process owners can select another graph precision with ``PYTENSOR_FLAGS``
+    before importing PyTensor, PyMC, or OpenGHG Inversions. An already-imported
+    runtime is left untouched because changing process-wide tensor defaults
+    after graph libraries have initialized is ambiguous and unsafe.
+    """
+    pytensor_was_loaded = "pytensor" in sys.modules
     import pytensor
 
     config = cast(Any, pytensor).config
-    config.floatX = "float32"
-    config.warn_float64 = "warn"
+    if pytensor_was_loaded:
+        return
+    if not _pytensor_flag_is_explicit("floatX"):
+        config.floatX = "float32"
+    if config.floatX == "float32" and not _pytensor_flag_is_explicit("warn_float64"):
+        config.warn_float64 = "warn"

--- a/tests/test_pymc_config.py
+++ b/tests/test_pymc_config.py
@@ -2,29 +2,76 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 
 
-def test_rhime_import_configures_pytensor_float32_before_pymc() -> None:
-    """Importing RHIME applies the same float32 PyTensor default as legacy fixedbasis."""
+def _probe_pytensor_config(code: str, *, flags: str | None = None) -> dict[str, str]:
+    """Inspect PyTensor configuration in an isolated Python process."""
+    env = os.environ.copy()
+    retained_flags = [
+        setting
+        for setting in env.get("PYTENSOR_FLAGS", "").split(",")
+        if setting and setting.partition("=")[0].strip() not in {"floatX", "warn_float64"}
+    ]
+    if flags is not None:
+        retained_flags.extend(flags.split(","))
+    if retained_flags:
+        env["PYTENSOR_FLAGS"] = ",".join(retained_flags)
+    else:
+        env.pop("PYTENSOR_FLAGS", None)
     completed = subprocess.run(
         [
             sys.executable,
             "-c",
-            (
-                "import pytensor; "
-                "print('before=' + pytensor.config.floatX); "
-                "import openghg_inversions.rhime; "
-                "print('after=' + pytensor.config.floatX); "
-                "print('warn=' + pytensor.config.warn_float64)"
-            ),
+            code,
         ],
         check=True,
         capture_output=True,
+        env=env,
         text=True,
     )
+    return dict(line.split("=", 1) for line in completed.stdout.strip().splitlines())
 
-    values = dict(line.split("=", 1) for line in completed.stdout.strip().splitlines())
-    assert values["after"] == "float32"
+
+def test_fresh_rhime_import_defaults_pytensor_to_float32() -> None:
+    """A fresh RHIME process uses the memory-conscious graph default."""
+    values = _probe_pytensor_config(
+        "import openghg_inversions.rhime; "
+        "import pytensor; "
+        "print('floatX=' + pytensor.config.floatX); "
+        "print('warn=' + pytensor.config.warn_float64)"
+    )
+
+    assert values["floatX"] == "float32"
     assert values["warn"] == "warn"
+
+
+def test_rhime_import_honours_explicit_pytensor_float64() -> None:
+    """A process-level PyTensor precision selection overrides the default."""
+    values = _probe_pytensor_config(
+        "import openghg_inversions.rhime; "
+        "import pytensor; "
+        "print('floatX=' + pytensor.config.floatX); "
+        "print('warn=' + pytensor.config.warn_float64)",
+        flags="floatX=float64,warn_float64=ignore",
+    )
+
+    assert values["floatX"] == "float64"
+    assert values["warn"] == "ignore"
+
+
+def test_rhime_import_does_not_mutate_initialized_pytensor() -> None:
+    """Notebook and host-process owners retain an initialized runtime."""
+    values = _probe_pytensor_config(
+        "import pytensor; "
+        "pytensor.config.floatX = 'float64'; "
+        "pytensor.config.warn_float64 = 'ignore'; "
+        "import openghg_inversions.rhime; "
+        "print('floatX=' + pytensor.config.floatX); "
+        "print('warn=' + pytensor.config.warn_float64)"
+    )
+
+    assert values["floatX"] == "float64"
+    assert values["warn"] == "ignore"


### PR DESCRIPTION
## Summary of changes

- retain the memory-conscious PyTensor float32 default only when OpenGHG Inversions owns a fresh process runtime
- honor explicit `PYTENSOR_FLAGS` selections such as `floatX=float64`
- leave already-imported PyTensor/PyMC runtimes unchanged, making notebook and host-process ownership predictable
- document the process-startup requirement and add isolated subprocess tests for all three cases

This separates process-wide precision policy from the RHIME ownership work in PR #606. Component-level mixed-precision accumulation, numerical evidence, provenance, and launcher ergonomics remain tracked in #607.

## Why

Float32 model inputs avoid promoting stored float32 footprints when observations or errors arrive as float64, which can substantially increase inversion memory. Some CO₂ and verification-games calculations require wider accumulation. A process-wide float64 mode remains available, while future work can promote only scientifically sensitive operations.

## Please check if the PR fulfills these requirements

- [x] Tests added and passing
- [x] Documentation updated
- [x] Added an entry to `CHANGELOG.md`
- [x] No new requirements

## Validation

- `tests/test_pymc_config.py` — 3 passed in an isolated existing environment
- Ruff passed for the changed Python paths
- `git diff --check` passed

Related: #607, #606.