### PR TITLE
[OPE-83] Relocate fixed-basis preparation under hbmcmc

### DIFF
--- a/docs/reference/openghg_inversions.hbmcmc.preparation.rst
+++ b/docs/reference/openghg_inversions.hbmcmc.preparation.rst
@@ -1,0 +1,7 @@
+openghg\_inversions.hbmcmc.preparation
+=======================================
+
+.. automodule:: openghg_inversions.hbmcmc.preparation
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/reference/openghg_inversions.hbmcmc.rst
+++ b/docs/reference/openghg_inversions.hbmcmc.rst
@@ -18,4 +18,5 @@ openghg\_inversions.hbmcmc
    openghg_inversions.hbmcmc.inversion_pymc
    openghg_inversions.hbmcmc.inversionsetup
    openghg_inversions.hbmcmc.post_process_inputs
+   openghg_inversions.hbmcmc.preparation
    openghg_inversions.hbmcmc.run_hbmcmc

--- a/newsfragments/OPE-83.misc.md
+++ b/newsfragments/OPE-83.misc.md
@@ -1,0 +1,1 @@
+Move the temporary fixed-basis preparation contract under ``hbmcmc`` while preserving deprecated compatibility imports from ``inversion_data``.

--- a/openghg_inversions/hbmcmc/hbmcmc.py
+++ b/openghg_inversions/hbmcmc/hbmcmc.py
@@ -40,7 +40,10 @@ import xarray as xr
 
 import openghg_inversions.hbmcmc.inversion_pymc as mcmc
 from openghg_inversions.basis.basis_functions import BasisFunctions
-from openghg_inversions.inversion_data import FixedBasisPreparedData, prepare_fixedbasis_inversion_data
+from openghg_inversions.hbmcmc.preparation import (
+    FixedBasisPreparedData,
+    prepare_fixedbasis_inversion_data,
+)
 from openghg_inversions.inversion_data._site_options import (
     expand_site_option,
     is_column_observation,

--- a/openghg_inversions/hbmcmc/preparation.py
+++ b/openghg_inversions/hbmcmc/preparation.py
@@ -1,0 +1,273 @@
+"""Prepare data for the temporary legacy ``fixedbasisMCMC`` workflow.
+
+This module owns the fixed-basis compatibility contract.  It composes shared
+retrieval, filtering, basis, and labelled-array mechanics from
+``openghg_inversions.inversion_data.preparation`` without making that legacy
+orchestration part of the modern RHIME preparation surface.
+
+New workflows should use the named stages in
+``openghg_inversions.rhime.preparation``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal, cast
+
+import xarray as xr
+
+from openghg_inversions.basis import basis_functions_wrapper
+from openghg_inversions.basis.basis_functions import BasisFunctions
+from openghg_inversions.flux_sanitization import FluxNonFiniteCheck
+from openghg_inversions.inversion_data.preparation import (
+    MinErrorConfig,
+    SiteInletOption,
+    SiteIntegerOption,
+    SiteStringOption,
+    _apply_filters_and_drop_empty_sites,
+    _bc_basis_directory_arg,
+    _make_inv_inputs,
+    _prepare_merged_data,
+    _scale_satellite_bc_sensitivity_to_column_signal,
+    _select_fp_all_sites,
+    _set_domain_attrs,
+    _warn_for_nan_inputs,
+)
+from openghg_inversions.model_error import normalise_min_error_options
+from openghg_inversions.sigma import SigmaAlignment
+
+__all__ = ["FixedBasisPreparedData", "prepare_fixedbasis_inversion_data"]
+
+
+@dataclass
+class FixedBasisPreparedData:
+    """Data prepared for the legacy fixed-basis runner.
+
+    Args:
+        fp_all: Raw merged-data container returned by data gathering or reload.
+        fp_data: Forward-model data after basis functions and filters.
+        inv_inputs: Canonical inversion inputs consumed by the legacy model.
+        sites: Retained site names after data gathering and filtering.
+        averaging_period: Averaging periods aligned to retained sites.
+        basis_objects: Basis objects returned by ``basis_functions_wrapper``.
+        basis_artifact_source: Source of the flux basis artifact.
+        basis_artifact_path: Path to the flux basis artifact, when loaded or saved.
+        is_column: Whether any retained observation is a column observation.
+    """
+
+    fp_all: dict
+    fp_data: dict | None = None
+    inv_inputs: xr.Dataset | None = None
+    sites: list[str] = field(default_factory=list)
+    averaging_period: list[str | None] = field(default_factory=list)
+    basis_objects: dict[str, BasisFunctions] = field(default_factory=dict)
+    basis_artifact_source: str = "generated"
+    basis_artifact_path: str | None = None
+    is_column: bool = False
+
+
+def prepare_fixedbasis_inversion_data(
+    *,
+    species: str,
+    sites: list[str],
+    domain: str,
+    averaging_period: SiteStringOption,
+    start_date: str,
+    end_date: str,
+    output_name: str,
+    flux_sources: list[str] | None,
+    split_by_sectors: bool = False,
+    bc_store: str = "user",
+    obs_store: str = "user",
+    footprint_store: str = "user",
+    emissions_store: str = "user",
+    met_model: SiteStringOption = None,
+    fp_model: str | None = None,
+    fp_height: SiteStringOption = None,
+    fp_species: str | None = None,
+    inlet: SiteInletOption = None,
+    instrument: SiteStringOption = None,
+    max_level: SiteIntegerOption = None,
+    calibration_scale: str | None = None,
+    obs_data_level: SiteStringOption = None,
+    platform: SiteStringOption = None,
+    use_tracer: bool = False,
+    use_bc: bool = True,
+    fp_basis_case: str | None = None,
+    basis_directory: str | None = None,
+    bc_basis_case: str = "NESW",
+    bc_basis_directory: str | Path | None = None,
+    country_directory: str | None = None,
+    bc_input: str | None = None,
+    basis_algorithm: str = "weighted",
+    nbasis: int = 100,
+    filters: Any = None,
+    fix_basis_outer_regions: bool = False,
+    averaging_error: bool = True,
+    bc_freq: str | None = None,
+    sigma_freq: str | None = None,
+    reload_merged_data: bool = False,
+    save_merged_data: bool = False,
+    merged_data_dir: str | None = None,
+    merged_data_name: str | None = None,
+    basis_output_path: str | None = None,
+    min_error: MinErrorConfig = 0.0,
+    calculate_min_error: Literal["percentile", "residual"] | None = None,
+    min_error_options: Mapping[str, Any] | None = None,
+    return_basis_objects: bool = False,
+    merged_data_only: bool = False,
+    flux_non_finite_check: FluxNonFiniteCheck = "lazy",
+) -> FixedBasisPreparedData:
+    """Prepare data for legacy ``fixedbasisMCMC`` and its output adapters.
+
+    This adapter preserves the fixed-basis inversion-input contract. Unless
+    ``merged_data_only`` is true, the returned ``inv_inputs`` includes
+    ``sigma_freq_index(nmeasure)`` derived from ``sigma_freq`` and anchored to
+    ``start_date``. Modern RHIME preparation intentionally omits this
+    component-specific variable.
+
+    Args:
+        sites: Requested observation site names. At least one unique site is
+            required.
+        averaging_period: Observation averaging period, either scalar or
+            aligned to ``sites``.
+        inlet: Inlet selector, either scalar or aligned to ``sites``. Entries
+            may be strings, legacy ``slice`` selectors, or ``None``.
+        fp_height: Footprint inlet height, either scalar or aligned to ``sites``.
+        instrument: Observation instrument, either scalar or aligned to ``sites``.
+        platform: Observation platform, either scalar or aligned to ``sites``.
+        obs_data_level: Observation data level, either scalar or aligned to ``sites``.
+        met_model: Footprint meteorological model, either scalar or aligned to ``sites``.
+        max_level: Maximum column level, either scalar or aligned to ``sites``.
+            Entries must be integers or ``None``.
+        min_error: Numeric minimum error or ``"residual"``/``"percentile"``
+            calculation method.
+        calculate_min_error: Deprecated calculation-method spelling.
+        min_error_options: Calculated minimum-error options. The only supported
+            key is boolean ``by_site``.
+
+    Returns:
+        Prepared legacy data, including forward-model inputs and optional basis
+        objects. When ``merged_data_only`` is true, only merged data and
+        retained site metadata are populated.
+
+    Raises:
+        ValueError: If site options are empty, duplicated, misaligned, or have
+            invalid types, or if minimum-error options are invalid.
+
+    Warns:
+        FutureWarning: If deprecated ``calculate_min_error`` is supplied.
+    """
+    min_error_options = normalise_min_error_options(min_error_options)
+    merged = _prepare_merged_data(
+        species=species,
+        sites=sites,
+        domain=domain,
+        averaging_period=averaging_period,
+        start_date=start_date,
+        end_date=end_date,
+        output_name=output_name,
+        flux_sources=flux_sources,
+        split_by_sectors=split_by_sectors,
+        bc_store=bc_store,
+        obs_store=obs_store,
+        footprint_store=footprint_store,
+        emissions_store=emissions_store,
+        met_model=met_model,
+        fp_model=fp_model,
+        fp_height=fp_height,
+        fp_species=fp_species,
+        inlet=inlet,
+        instrument=instrument,
+        max_level=max_level,
+        calibration_scale=calibration_scale,
+        obs_data_level=obs_data_level,
+        platform=platform,
+        use_tracer=use_tracer,
+        use_bc=use_bc,
+        bc_input=bc_input,
+        averaging_error=averaging_error,
+        reload_merged_data=reload_merged_data,
+        save_merged_data=save_merged_data,
+        merged_data_dir=merged_data_dir,
+        merged_data_name=merged_data_name,
+        flux_non_finite_check=flux_non_finite_check,
+    )
+
+    if merged_data_only:
+        return FixedBasisPreparedData(
+            fp_all=merged.fp_all,
+            sites=list(merged.sites),
+            averaging_period=list(merged.averaging_period),
+            is_column=merged.site_options.is_column,
+        )
+
+    basis_result = basis_functions_wrapper(
+        basis_algorithm=basis_algorithm,
+        nbasis=nbasis,
+        fp_basis_case=fp_basis_case,
+        bc_basis_case=bc_basis_case,
+        basis_directory=basis_directory,
+        bc_basis_directory=_bc_basis_directory_arg(bc_basis_directory),
+        country_directory=country_directory,
+        fp_all=merged.fp_all,
+        use_bc=use_bc,
+        species=species,
+        domain=domain,
+        start_date=start_date,
+        fix_outer_regions=fix_basis_outer_regions,
+        emissions_name=flux_sources,
+        outputname=output_name,
+        output_path=basis_output_path,
+        return_basis_objects=True,
+    )
+    fp_data, fixedbasis_basis_objects = cast(tuple[dict, dict[str, BasisFunctions]], basis_result)
+    emissions_basis = fixedbasis_basis_objects["emissions"]
+    basis_source = emissions_basis.basis_artifact_source or "generated"
+    basis_path = getattr(emissions_basis, "basis_artifact_path", None)
+    basis_objects = fixedbasis_basis_objects if return_basis_objects else {}
+
+    fp_data, prepared_site_options = _apply_filters_and_drop_empty_sites(
+        fp_data=fp_data,
+        site_options=merged.site_options,
+        filters=filters,
+    )
+    prepared_sites = list(prepared_site_options.sites)
+    prepared_averaging_period = list(prepared_site_options.averaging_period)
+    _set_domain_attrs(fp_data, prepared_sites, domain)
+
+    inv_inputs = _make_inv_inputs(
+        fp_data=fp_data,
+        sites=prepared_sites,
+        start_date=start_date,
+        bc_freq=bc_freq,
+        min_error=min_error,
+        calculate_min_error=calculate_min_error,
+        min_error_per_site=min_error_options["by_site"],
+    )
+    inv_inputs = _scale_satellite_bc_sensitivity_to_column_signal(
+        inv_inputs,
+        sites=prepared_sites,
+        platform=prepared_site_options.platform,
+    )
+    sigma_alignment = SigmaAlignment.from_frequency(
+        inv_inputs["site_indicator"],
+        frequency=sigma_freq,
+        anchor_time=start_date,
+    )
+    inv_inputs["sigma_freq_index"] = sigma_alignment.period_index.rename("sigma_freq_index")
+    _warn_for_nan_inputs(inv_inputs, use_bc=use_bc)
+
+    return FixedBasisPreparedData(
+        fp_all=_select_fp_all_sites(merged.fp_all, prepared_sites),
+        fp_data=fp_data,
+        inv_inputs=inv_inputs,
+        basis_objects=basis_objects,
+        basis_artifact_source=basis_source,
+        basis_artifact_path=basis_path,
+        sites=prepared_sites,
+        averaging_period=prepared_averaging_period,
+        is_column=prepared_site_options.is_column,
+    )

--- a/openghg_inversions/inversion_data/__init__.py
+++ b/openghg_inversions/inversion_data/__init__.py
@@ -1,9 +1,10 @@
+import warnings
+from typing import Any
+
 from .get_data import data_processing_surface_notracer
 from .preparation import (
-    FixedBasisPreparedData,
     RhimeMergedData,
     RhimePreparedInputs,
-    prepare_fixedbasis_inversion_data,
     prepare_rhime_inputs,
 )
 from .serialise import load_merged_data, _save_merged_data
@@ -20,3 +21,19 @@ __all__ = [
     "prepare_rhime_inputs",
     "prepare_rhime_inputs_from_xarray",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Provide warning-emitting aliases for former fixed-basis exports."""
+    if name not in {"FixedBasisPreparedData", "prepare_fixedbasis_inversion_data"}:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    warnings.warn(
+        f"{__name__}.{name} has moved to openghg_inversions.hbmcmc.preparation; "
+        "the old import path is deprecated.",
+        FutureWarning,
+        stacklevel=2,
+    )
+    from openghg_inversions.hbmcmc import preparation as fixedbasis_preparation
+
+    return getattr(fixedbasis_preparation, name)

--- a/openghg_inversions/inversion_data/preparation.py
+++ b/openghg_inversions/inversion_data/preparation.py
@@ -1,10 +1,10 @@
-"""Prepare inversion data for modern RHIME and legacy fixedbasis runners.
+"""Shared mechanics and durable data contracts for inversion preparation.
 
 ``prepare_rhime_inputs`` returns backend-neutral observations, sensitivities,
 basis metadata, and site metadata; component-specific model arrays are
-intentionally absent. ``prepare_fixedbasis_inversion_data`` is a compatibility
-adapter that retains the input variables required by ``fixedbasisMCMC``,
-including its sigma-period index.
+intentionally absent. The temporary legacy fixed-basis orchestration is owned
+by :mod:`openghg_inversions.hbmcmc.preparation` and composes the lower-level
+retrieval, filtering, basis, and array helpers retained here.
 
 ``RhimePreparedInputs`` validates the relationships between these labeled
 arrays when it is constructed. When the retained basis-functions object
@@ -14,15 +14,15 @@ objects without that hook are retained unchanged.
 
 Preparation can read OpenGHG object stores or local merged-data artifacts,
 write merged-data and basis artifacts, emit warnings and progress messages,
-and record timing information. Neither public entry point constructs a PyMC
-model.
+and record timing information. These backend-neutral preparation functions do
+not construct a PyMC model.
 """
 
 from __future__ import annotations
 
 import warnings
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from numbers import Integral
 from pathlib import Path
 from typing import Any, Literal, cast
@@ -33,7 +33,7 @@ import xarray as xr
 from typing_extensions import Self
 
 from openghg_inversions._timing import log_timing, timed, timer_seconds, timer_start
-from openghg_inversions.basis import basis_functions_wrapper, make_basis_functions
+from openghg_inversions.basis import make_basis_functions
 from openghg_inversions.basis._helpers import bc_sensitivity
 from openghg_inversions.basis.basis_functions import (
     BASIS_ARTIFACT_PATH_ATTR,
@@ -56,7 +56,6 @@ from openghg_inversions.serialization import (
     open_datatree_loaded,
     save_datatree,
 )
-from openghg_inversions.sigma import SigmaAlignment
 
 MinErrorConfig = Literal["percentile", "residual"] | dict[str, float] | None | int | float
 RHIME_PREPARED_INPUTS_SCHEMA = "openghg_inversions.rhime_prepared_inputs"
@@ -65,34 +64,6 @@ _SITE_AVERAGING_PERIOD = "averaging_period"
 SiteStringOption = Sequence[str | None] | str | None
 SiteInletOption = Sequence[str | slice | None] | str | None
 SiteIntegerOption = Sequence[int | None] | int | None
-
-
-@dataclass
-class FixedBasisPreparedData:
-    """Data prepared for the legacy fixedbasis runner.
-
-    Args:
-        fp_all: Raw merged-data container returned by data gathering or reload.
-        fp_data: Forward-model data after basis functions and filters.
-        inv_inputs: Canonical inversion inputs consumed by model builders.
-        sites: Retained site names after data gathering and filtering.
-        averaging_period: Averaging periods aligned to retained sites.
-        basis_objects: Basis objects returned by ``basis_functions_wrapper``.
-        basis_artifact_source: Source of the flux basis artifact.
-        basis_artifact_path: Path to the flux basis artifact, when loaded or saved.
-        is_column: Whether any retained observation is a column observation.
-    """
-
-    fp_all: dict
-    fp_data: dict | None = None
-    inv_inputs: xr.Dataset | None = None
-    sites: list[str] = field(default_factory=list)
-    averaging_period: list[str | None] = field(default_factory=list)
-    basis_objects: dict[str, BasisFunctions] = field(default_factory=dict)
-    basis_artifact_source: str = "generated"
-    basis_artifact_path: str | None = None
-    is_column: bool = False
-
 
 @dataclass(frozen=True, init=False)
 class RhimePreparedInputs:
@@ -1359,217 +1330,6 @@ def _filter_merged_inversion_data(
     return RhimeMergedData(fp_all=fp_all, site_options=site_options)
 
 
-def prepare_fixedbasis_inversion_data(
-    *,
-    species: str,
-    sites: list[str],
-    domain: str,
-    averaging_period: SiteStringOption,
-    start_date: str,
-    end_date: str,
-    output_name: str,
-    flux_sources: list[str] | None,
-    split_by_sectors: bool = False,
-    bc_store: str = "user",
-    obs_store: str = "user",
-    footprint_store: str = "user",
-    emissions_store: str = "user",
-    met_model: SiteStringOption = None,
-    fp_model: str | None = None,
-    fp_height: SiteStringOption = None,
-    fp_species: str | None = None,
-    inlet: SiteInletOption = None,
-    instrument: SiteStringOption = None,
-    max_level: SiteIntegerOption = None,
-    calibration_scale: str | None = None,
-    obs_data_level: SiteStringOption = None,
-    platform: SiteStringOption = None,
-    use_tracer: bool = False,
-    use_bc: bool = True,
-    fp_basis_case: str | None = None,
-    basis_directory: str | None = None,
-    bc_basis_case: str = "NESW",
-    bc_basis_directory: str | Path | None = None,
-    country_directory: str | None = None,
-    bc_input: str | None = None,
-    basis_algorithm: str = "weighted",
-    nbasis: int = 100,
-    filters: Any = None,
-    fix_basis_outer_regions: bool = False,
-    averaging_error: bool = True,
-    bc_freq: str | None = None,
-    sigma_freq: str | None = None,
-    reload_merged_data: bool = False,
-    save_merged_data: bool = False,
-    merged_data_dir: str | None = None,
-    merged_data_name: str | None = None,
-    basis_output_path: str | None = None,
-    min_error: MinErrorConfig = 0.0,
-    calculate_min_error: Literal["percentile", "residual"] | None = None,
-    min_error_options: Mapping[str, Any] | None = None,
-    return_basis_objects: bool = False,
-    merged_data_only: bool = False,
-    flux_non_finite_check: FluxNonFiniteCheck = "lazy",
-) -> FixedBasisPreparedData:
-    """Prepare data for legacy ``fixedbasisMCMC`` and its output adapters.
-
-    This adapter preserves the fixed-basis inversion-input contract. Unless
-    ``merged_data_only`` is true, the returned ``inv_inputs`` includes
-    ``sigma_freq_index(nmeasure)`` derived from ``sigma_freq`` and anchored to
-    ``start_date``. Modern RHIME preparation intentionally omits this
-    component-specific variable.
-
-    Args:
-        sites: Requested observation site names. At least one unique site is
-            required.
-        averaging_period: Observation averaging period, either scalar or
-            aligned to ``sites``.
-        inlet: Inlet selector, either scalar or aligned to ``sites``. Entries
-            may be strings, legacy ``slice`` selectors, or ``None``.
-        fp_height: Footprint inlet height, either scalar or aligned to
-            ``sites``.
-        instrument: Observation instrument, either scalar or aligned to
-            ``sites``.
-        platform: Observation platform, either scalar or aligned to ``sites``.
-        obs_data_level: Observation data level, either scalar or aligned to
-            ``sites``.
-        met_model: Footprint meteorological model, either scalar or aligned to
-            ``sites``.
-        max_level: Maximum column level, either scalar or aligned to ``sites``.
-            Entries must be integers or ``None``.
-        min_error: Numeric minimum error or ``"residual"``/``"percentile"``
-            calculation method.
-        calculate_min_error: Deprecated calculation-method spelling.
-        min_error_options: Calculated minimum-error options. The only supported
-            key is boolean ``by_site``.
-
-    Returns:
-        Prepared legacy data, including forward-model inputs and optional basis
-        objects. When ``merged_data_only`` is true, only merged data and
-        retained site metadata are populated.
-
-    Raises:
-        ValueError: If site options are empty, duplicated, misaligned, or have
-            invalid types, or if minimum-error options are invalid.
-
-    Warns:
-        FutureWarning: If deprecated ``calculate_min_error`` is supplied.
-    """
-    min_error_options = normalise_min_error_options(min_error_options)
-    merged = _prepare_merged_data(
-        species=species,
-        sites=sites,
-        domain=domain,
-        averaging_period=averaging_period,
-        start_date=start_date,
-        end_date=end_date,
-        output_name=output_name,
-        flux_sources=flux_sources,
-        split_by_sectors=split_by_sectors,
-        bc_store=bc_store,
-        obs_store=obs_store,
-        footprint_store=footprint_store,
-        emissions_store=emissions_store,
-        met_model=met_model,
-        fp_model=fp_model,
-        fp_height=fp_height,
-        fp_species=fp_species,
-        inlet=inlet,
-        instrument=instrument,
-        max_level=max_level,
-        calibration_scale=calibration_scale,
-        obs_data_level=obs_data_level,
-        platform=platform,
-        use_tracer=use_tracer,
-        use_bc=use_bc,
-        bc_input=bc_input,
-        averaging_error=averaging_error,
-        reload_merged_data=reload_merged_data,
-        save_merged_data=save_merged_data,
-        merged_data_dir=merged_data_dir,
-        merged_data_name=merged_data_name,
-        flux_non_finite_check=flux_non_finite_check,
-    )
-
-    if merged_data_only:
-        return FixedBasisPreparedData(
-            fp_all=merged.fp_all,
-            sites=list(merged.sites),
-            averaging_period=list(merged.averaging_period),
-            is_column=merged.site_options.is_column,
-        )
-
-    bc_basis_directory_arg = _bc_basis_directory_arg(bc_basis_directory)
-
-    basis_result = basis_functions_wrapper(
-        basis_algorithm=basis_algorithm,
-        nbasis=nbasis,
-        fp_basis_case=fp_basis_case,
-        bc_basis_case=bc_basis_case,
-        basis_directory=basis_directory,
-        bc_basis_directory=bc_basis_directory_arg,
-        country_directory=country_directory,
-        fp_all=merged.fp_all,
-        use_bc=use_bc,
-        species=species,
-        domain=domain,
-        start_date=start_date,
-        fix_outer_regions=fix_basis_outer_regions,
-        emissions_name=flux_sources,
-        outputname=output_name,
-        output_path=basis_output_path,
-        return_basis_objects=True,
-    )
-    fp_data, fixedbasis_basis_objects = cast(tuple[dict, dict[str, BasisFunctions]], basis_result)
-    emissions_basis = fixedbasis_basis_objects["emissions"]
-    basis_source = emissions_basis.basis_artifact_source or "generated"
-    basis_path = getattr(emissions_basis, "basis_artifact_path", None)
-    basis_objects = fixedbasis_basis_objects if return_basis_objects else {}
-
-    fp_data, prepared_site_options = _apply_filters_and_drop_empty_sites(
-        fp_data=fp_data,
-        site_options=merged.site_options,
-        filters=filters,
-    )
-    prepared_sites = list(prepared_site_options.sites)
-    prepared_averaging_period = list(prepared_site_options.averaging_period)
-    _set_domain_attrs(fp_data, prepared_sites, domain)
-
-    inv_inputs = _make_inv_inputs(
-        fp_data=fp_data,
-        sites=prepared_sites,
-        start_date=start_date,
-        bc_freq=bc_freq,
-        min_error=min_error,
-        calculate_min_error=calculate_min_error,
-        min_error_per_site=min_error_options["by_site"],
-    )
-    inv_inputs = _scale_satellite_bc_sensitivity_to_column_signal(
-        inv_inputs,
-        sites=prepared_sites,
-        platform=prepared_site_options.platform,
-    )
-    sigma_alignment = SigmaAlignment.from_frequency(
-        inv_inputs["site_indicator"],
-        frequency=sigma_freq,
-        anchor_time=start_date,
-    )
-    inv_inputs["sigma_freq_index"] = sigma_alignment.period_index.rename("sigma_freq_index")
-    _warn_for_nan_inputs(inv_inputs, use_bc=use_bc)
-
-    return FixedBasisPreparedData(
-        fp_all=_select_fp_all_sites(merged.fp_all, prepared_sites),
-        fp_data=fp_data,
-        inv_inputs=inv_inputs,
-        basis_objects=basis_objects,
-        basis_artifact_source=basis_source,
-        basis_artifact_path=basis_path,
-        sites=prepared_sites,
-        averaging_period=prepared_averaging_period,
-        is_column=prepared_site_options.is_column,
-    )
-
-
 def prepare_rhime_inputs(
     *,
     species: str,
@@ -1780,3 +1540,19 @@ def prepare_rhime_inputs(
             averaging_period=filtered_merged.averaging_period,
         ),
     )
+
+
+def __getattr__(name: str) -> Any:
+    """Provide warning-emitting aliases for the former fixed-basis location."""
+    if name not in {"FixedBasisPreparedData", "prepare_fixedbasis_inversion_data"}:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    warnings.warn(
+        f"{__name__}.{name} has moved to openghg_inversions.hbmcmc.preparation; "
+        "the old import path is deprecated.",
+        FutureWarning,
+        stacklevel=2,
+    )
+    from openghg_inversions.hbmcmc import preparation as fixedbasis_preparation
+
+    return getattr(fixedbasis_preparation, name)

--- a/tests/test_hbmcmc_preparation.py
+++ b/tests/test_hbmcmc_preparation.py
@@ -1,0 +1,55 @@
+"""Ownership and compatibility tests for legacy fixed-basis preparation."""
+
+from pathlib import Path
+
+import pytest
+
+import openghg_inversions.hbmcmc.hbmcmc as hbmcmc
+import openghg_inversions.inversion_data as inversion_data
+import openghg_inversions.inversion_data.preparation as shared_preparation
+from openghg_inversions.hbmcmc.preparation import (
+    FixedBasisPreparedData,
+    prepare_fixedbasis_inversion_data,
+)
+
+
+@pytest.mark.parametrize(
+    ("module", "name", "canonical"),
+    [
+        (inversion_data, "FixedBasisPreparedData", FixedBasisPreparedData),
+        (inversion_data, "prepare_fixedbasis_inversion_data", prepare_fixedbasis_inversion_data),
+        (shared_preparation, "FixedBasisPreparedData", FixedBasisPreparedData),
+        (
+            shared_preparation,
+            "prepare_fixedbasis_inversion_data",
+            prepare_fixedbasis_inversion_data,
+        ),
+    ],
+)
+def test_former_fixedbasis_imports_warn_and_resolve_to_hbmcmc(module, name, canonical) -> None:
+    """Former import locations remain aliases during the compatibility period."""
+    with pytest.warns(FutureWarning, match="has moved to openghg_inversions.hbmcmc.preparation"):
+        alias = getattr(module, name)
+
+    assert alias is canonical
+
+
+def test_fixedbasis_preparation_contract_is_owned_by_hbmcmc() -> None:
+    """The runner and contract resolve to the compatibility-owned module."""
+    assert FixedBasisPreparedData.__module__ == "openghg_inversions.hbmcmc.preparation"
+    assert prepare_fixedbasis_inversion_data.__module__ == "openghg_inversions.hbmcmc.preparation"
+    assert hbmcmc.FixedBasisPreparedData is FixedBasisPreparedData
+    assert hbmcmc.prepare_fixedbasis_inversion_data is prepare_fixedbasis_inversion_data
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    ["rhime/standard.py", "rhime/multisector.py", "rhime/preparation.py"],
+)
+def test_modern_rhime_modules_do_not_depend_on_fixedbasis_preparation(relative_path: str) -> None:
+    """Modern recipes and preparation do not import the legacy contract."""
+    package_root = Path(__file__).parents[1] / "openghg_inversions"
+    source = (package_root / relative_path).read_text()
+
+    assert "FixedBasisPreparedData" not in source
+    assert "prepare_fixedbasis_inversion_data" not in source

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -20,6 +20,7 @@ from dask.callbacks import Callback
 
 from examples.rhime_customisation import likelihoods as example_likelihoods
 import openghg_inversions.hbmcmc.inversion_pymc as legacy_mcmc
+import openghg_inversions.hbmcmc.preparation as fixedbasis_preparation
 import openghg_inversions.inversion_data.preparation as prep_module
 import openghg_inversions.models as models
 import openghg_inversions.postprocessing.inversion_output as inversion_output_module
@@ -4642,21 +4643,25 @@ def test_fixedbasis_preparation_adds_anchored_legacy_sigma_index(
     )
     basis_functions = _fake_basis_functions()
 
-    monkeypatch.setattr(prep_module, "_prepare_merged_data", lambda **kwargs: merged)
+    monkeypatch.setattr(fixedbasis_preparation, "_prepare_merged_data", lambda **kwargs: merged)
     monkeypatch.setattr(
-        prep_module,
+        fixedbasis_preparation,
         "basis_functions_wrapper",
         lambda **kwargs: (fp_data, {"emissions": basis_functions}),
     )
     monkeypatch.setattr(
-        prep_module,
+        fixedbasis_preparation,
         "_apply_filters_and_drop_empty_sites",
         lambda **kwargs: (fp_data, _site_options(["TAC"], averaging_period=["1H"])),
     )
-    monkeypatch.setattr(prep_module, "_set_domain_attrs", lambda *args, **kwargs: None)
-    monkeypatch.setattr(prep_module, "_make_inv_inputs", lambda **kwargs: inv_inputs.copy())
+    monkeypatch.setattr(fixedbasis_preparation, "_set_domain_attrs", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        fixedbasis_preparation,
+        "_make_inv_inputs",
+        lambda **kwargs: inv_inputs.copy(),
+    )
 
-    prepared = prep_module.prepare_fixedbasis_inversion_data(
+    prepared = fixedbasis_preparation.prepare_fixedbasis_inversion_data(
         species="ch4",
         sites=["TAC"],
         domain="EUROPE",
@@ -4689,20 +4694,20 @@ def test_fixedbasis_preparation_uses_platform_for_sites_retained_after_filtering
     retained_options = merged.site_options.select_indices([1])
     captured: dict[str, object] = {}
 
-    monkeypatch.setattr(prep_module, "_prepare_merged_data", lambda **kwargs: merged)
+    monkeypatch.setattr(fixedbasis_preparation, "_prepare_merged_data", lambda **kwargs: merged)
     monkeypatch.setattr(
-        prep_module,
+        fixedbasis_preparation,
         "basis_functions_wrapper",
         lambda **kwargs: (fp_data, {"emissions": _fake_basis_functions()}),
     )
     monkeypatch.setattr(
-        prep_module,
+        fixedbasis_preparation,
         "_apply_filters_and_drop_empty_sites",
         lambda **kwargs: (fp_data, retained_options),
     )
-    monkeypatch.setattr(prep_module, "_set_domain_attrs", lambda *args, **kwargs: None)
+    monkeypatch.setattr(fixedbasis_preparation, "_set_domain_attrs", lambda *args, **kwargs: None)
     monkeypatch.setattr(
-        prep_module,
+        fixedbasis_preparation,
         "_make_inv_inputs",
         lambda **kwargs: _minimal_prepared_inv_inputs(sites=("OCO2-EASTASIA",)),
     )
@@ -4711,9 +4716,13 @@ def test_fixedbasis_preparation_uses_platform_for_sites_retained_after_filtering
         captured.update(kwargs)
         return inv_inputs
 
-    monkeypatch.setattr(prep_module, "_scale_satellite_bc_sensitivity_to_column_signal", capture_scaling)
+    monkeypatch.setattr(
+        fixedbasis_preparation,
+        "_scale_satellite_bc_sensitivity_to_column_signal",
+        capture_scaling,
+    )
 
-    prep_module.prepare_fixedbasis_inversion_data(
+    fixedbasis_preparation.prepare_fixedbasis_inversion_data(
         species="co2",
         sites=["TAC", "OCO2-EASTASIA"],
         domain="EASTASIA",


### PR DESCRIPTION
## Summary

- move `FixedBasisPreparedData` and `prepare_fixedbasis_inversion_data` into the legacy-owned `openghg_inversions.hbmcmc.preparation` module
- retain shared retrieval, filtering, basis, and labelled-array mechanics under `inversion_data`
- preserve both former import paths as warning-emitting compatibility aliases
- document and test that modern standard and multisector RHIME modules do not depend on the fixed-basis contract

## Why

`fixedbasisMCMC` is a time-limited compatibility workflow. Keeping its prepared-data contract beside modern backend-neutral preparation obscured ownership and made the modern RHIME surface appear coupled to legacy orchestration.

## Validation

- `uv run pytest tests/test_hbmcmc_preparation.py` — 8 passed
- focused fixed-basis preparation tests in `tests/test_rhime.py` — 2 passed
- fixed-basis runner handoff and exact legacy output contract tests in `tests/test_postprocessing.py` — 2 passed
- `uv run ruff check` on changed Python paths — passed
- `git diff --check` — passed

The full `tests/test_postprocessing.py` run reached 66 passed and one environment-dependent HDF5 trace-reopen failure (`H5DSget_num_scales`), which the independent test audit also reproduced on the baseline.