### PR TITLE
OPE-77: Add the linked CO₂/O₂ model handoff

### DIFF
--- a/newsfragments/OPE-77.feature.md
+++ b/newsfragments/OPE-77.feature.md
@@ -1,0 +1,1 @@
+Add an explicit labelled linked CO2/O2 preparation, model, and sampling seam with shared land states, tracer-specific ocean states, and a joint aggregation-error covariance.

--- a/openghg_inversions/rhime/co2/__init__.py
+++ b/openghg_inversions/rhime/co2/__init__.py
@@ -1,11 +1,22 @@
-"""CO2-only RHIME recipe."""
+"""Public CO2-family RHIME recipes."""
 
 from .model import build_co2_rhime_model, co2_prior_forward_mean
 from .runner import co2_model_input_names, run_rhime_co2
+from .linked_model import (
+    build_linked_co2_o2_model,
+    linked_co2_o2_prior_forward_mean,
+)
+from .linked_preparation import Co2O2PreparedInputs, prepare_linked_co2_o2_inputs
+from .linked_runner import run_rhime_co2_o2
 
 __all__ = [
+    "Co2O2PreparedInputs",
     "build_co2_rhime_model",
+    "build_linked_co2_o2_model",
     "co2_model_input_names",
     "co2_prior_forward_mean",
+    "linked_co2_o2_prior_forward_mean",
+    "prepare_linked_co2_o2_inputs",
     "run_rhime_co2",
+    "run_rhime_co2_o2",
 ]

--- a/openghg_inversions/rhime/co2/linked_model.py
+++ b/openghg_inversions/rhime/co2/linked_model.py
@@ -1,0 +1,264 @@
+"""Explicit PyMC graph for the linked CO2/O2 recipe."""
+
+from __future__ import annotations
+
+import numpy as np
+import pymc as pm
+import pytensor.tensor as pt
+import xarray as xr
+
+from openghg_inversions.correlated_state import CorrelatedLognormalPrior
+from openghg_inversions.models import (
+    ResolvedStateActivity,
+    StateActivity,
+    add_correlated_lognormal_state_with_activity,
+    add_model_data,
+    detect_zero_sensitivity,
+    registered_model,
+    resolve_state_activity,
+)
+from openghg_inversions.models.likelihoods import (
+    add_aggregation_error_data,
+    add_gaussian_observation_likelihood,
+)
+from openghg_inversions.observation_error import (
+    AggregationError,
+    validate_aggregation_error_alignment,
+    validate_observation_alignment,
+)
+
+
+def _validate_linked_arrays(
+    *,
+    observations: xr.DataArray,
+    prior_forward_mean: xr.DataArray,
+    effective_observation_operator: xr.DataArray,
+    independent_error_sd: xr.DataArray,
+    aggregation_error: AggregationError,
+    retained_prior: CorrelatedLognormalPrior,
+    output_dim: str,
+    covariance_dim: str,
+) -> xr.DataArray:
+    """Validate explicit scientific arrays at the linked-model boundary."""
+    owner = "Linked CO2/O2 model"
+    if observations.dims != (output_dim,):
+        raise ValueError(f"{owner} observations must have dims ({output_dim!r},).")
+    if output_dim not in observations.indexes or not observations.indexes[output_dim].is_unique:
+        raise ValueError(f"{owner} observations require unique {output_dim!r} labels.")
+    observation_values = np.asarray(observations.values)
+    if not np.issubdtype(observation_values.dtype, np.number) or not np.isfinite(observation_values).all():
+        raise ValueError(f"{owner} observations must be finite and numeric.")
+
+    if prior_forward_mean.dims != (output_dim,):
+        raise ValueError(f"{owner} prior forward mean must have dims ({output_dim!r},).")
+    prior_forward_values = np.asarray(prior_forward_mean.values)
+    if (
+        not np.issubdtype(prior_forward_values.dtype, np.number)
+        or not np.isfinite(prior_forward_values).all()
+    ):
+        raise ValueError(f"{owner} prior forward mean must be finite and numeric.")
+    validate_observation_alignment(
+        observations,
+        prior_forward_mean,
+        input_name="prior_forward_mean",
+        owner=owner,
+        output_dim=output_dim,
+    )
+    state_dim = retained_prior.state_dim
+    if effective_observation_operator.dims != (output_dim, state_dim):
+        raise ValueError(f"{owner} effective operator must have dims {(output_dim, state_dim)!r}.")
+    validate_observation_alignment(
+        observations,
+        effective_observation_operator,
+        input_name="effective_observation_operator",
+        owner=owner,
+        output_dim=output_dim,
+    )
+    if not effective_observation_operator.get_index(state_dim).equals(
+        retained_prior.mean.get_index(state_dim)
+    ):
+        raise ValueError(f"{owner} operator state labels must match the retained prior.")
+    operator_values = np.asarray(effective_observation_operator.values)
+    if not np.issubdtype(operator_values.dtype, np.number) or not np.isfinite(operator_values).all():
+        raise ValueError(f"{owner} effective operator must be finite and numeric.")
+    mean = retained_prior.mean
+    if any(name not in mean.coords for name in ("source", "tracer_scope")):
+        raise ValueError(f"{owner} retained states require source and tracer_scope coordinates.")
+    state_roles = {
+        (str(source).lower(), str(scope).lower())
+        for source, scope in zip(mean["source"].values, mean["tracer_scope"].values, strict=True)
+    }
+    if state_roles != {
+        ("gpp", "shared"),
+        ("ter", "shared"),
+        ("ff", "shared"),
+        ("ocean", "co2"),
+        ("ocean", "o2"),
+    }:
+        raise ValueError(f"{owner} states must be shared GPP/TER/FF and tracer-specific CO2/O2 ocean states.")
+
+    if independent_error_sd.dims != (output_dim,):
+        raise ValueError(f"{owner} independent error must have dims ({output_dim!r},).")
+    validate_observation_alignment(
+        observations,
+        independent_error_sd,
+        input_name="independent_error_sd",
+        owner=owner,
+        output_dim=output_dim,
+    )
+    if "observation_units" not in observations.coords or "observation_units" not in (
+        independent_error_sd.coords
+    ):
+        raise ValueError(f"{owner} observations and independent error require observation_units.")
+    if not np.array_equal(
+        observations["observation_units"].values,
+        independent_error_sd["observation_units"].values,
+    ):
+        raise ValueError(f"{owner} independent-error units must match the observations.")
+    error_values = np.asarray(independent_error_sd.values)
+    if (
+        not np.issubdtype(error_values.dtype, np.number)
+        or not np.isfinite(error_values).all()
+        or (error_values <= 0).any()
+    ):
+        raise ValueError(f"{owner} independent error must be finite and positive.")
+
+    if aggregation_error.covariance is not None:
+        validate_observation_alignment(
+            observations,
+            aggregation_error.covariance,
+            input_name="aggregation_error_covariance",
+            owner=owner,
+            output_dim=output_dim,
+        )
+    validate_aggregation_error_alignment(
+        observations,
+        aggregation_error,
+        owner=owner,
+        output_dim=output_dim,
+        covariance_dim=covariance_dim,
+    )
+    return independent_error_sd.rename("fixed_independent_error_sd")
+
+
+def _resolve_activity(
+    effective_observation_operator: xr.DataArray,
+    state_activity: StateActivity | None,
+    *,
+    output_dim: str,
+) -> ResolvedStateActivity:
+    """Align an optional active/fixed policy with the joint operator."""
+    return resolve_state_activity(
+        detect_zero_sensitivity(
+            effective_observation_operator,
+            output_dim=output_dim,
+        ),
+        state_activity,
+    )
+
+
+def linked_co2_o2_prior_forward_mean(
+    *,
+    prior_forward_mean: xr.DataArray,
+    effective_observation_operator: xr.DataArray,
+    retained_prior: CorrelatedLognormalPrior,
+    state_activity: StateActivity | None = None,
+    output_dim: str = "observation",
+) -> xr.DataArray:
+    """Return the deterministic prior concentration after exact state fixing."""
+    activity = _resolve_activity(
+        effective_observation_operator,
+        state_activity,
+        output_dim=output_dim,
+    )
+    prior_state = xr.where(
+        activity.active,
+        retained_prior.mean,
+        activity.fixed_value,
+    )
+    adjustment = xr.dot(
+        effective_observation_operator,
+        prior_state - retained_prior.mean,
+        dim=retained_prior.state_dim,
+    )
+    return (prior_forward_mean + adjustment).rename("prior_forward_concentration")
+
+
+def build_linked_co2_o2_model(
+    *,
+    observations: xr.DataArray,
+    prior_forward_mean: xr.DataArray,
+    effective_observation_operator: xr.DataArray,
+    aggregation_error: AggregationError,
+    retained_prior: CorrelatedLognormalPrior,
+    independent_error_sd: xr.DataArray,
+    state_activity: StateActivity | None = None,
+    output_dim: str = "observation",
+    covariance_dim: str = "observation_cov",
+) -> pm.Model:
+    """Build one affine linked signal and fixed-error joint likelihood.
+
+    All scientific inputs are explicit labelled values. The UOB prototype
+    supplies one ppm as ``independent_error_sd`` for each channel; this builder
+    does not encode that run policy and does not infer a mismatch amplitude.
+    """
+    independent_error = _validate_linked_arrays(
+        observations=observations,
+        prior_forward_mean=prior_forward_mean,
+        effective_observation_operator=effective_observation_operator,
+        independent_error_sd=independent_error_sd,
+        aggregation_error=aggregation_error,
+        retained_prior=retained_prior,
+        output_dim=output_dim,
+        covariance_dim=covariance_dim,
+    )
+    activity = _resolve_activity(
+        effective_observation_operator,
+        state_activity,
+        output_dim=output_dim,
+    )
+    prior_state = xr.where(
+        activity.active,
+        retained_prior.mean,
+        activity.fixed_value,
+    ).rename("prior_flux_scaling")
+    activity_prior_forward = linked_co2_o2_prior_forward_mean(
+        prior_forward_mean=prior_forward_mean,
+        effective_observation_operator=effective_observation_operator,
+        retained_prior=retained_prior,
+        state_activity=state_activity,
+        output_dim=output_dim,
+    )
+
+    with registered_model() as model:
+        state = add_correlated_lognormal_state_with_activity(
+            activity,
+            retained_prior,
+            var_name="flux_scaling",
+        ).state
+        operator = add_model_data(
+            effective_observation_operator,
+            "effective_observation_operator",
+        )
+        prior_state_data = add_model_data(prior_state)
+        prior_forward_data = add_model_data(activity_prior_forward)
+        modelled = pm.Deterministic(
+            "modelled_concentration",
+            prior_forward_data + pt.dot(operator, state - prior_state_data),
+            dims=output_dim,
+        )
+        observed = add_model_data(observations, "observed_concentration")
+        fixed_error = add_model_data(independent_error)
+        registered_aggregation_error = add_aggregation_error_data(
+            aggregation_error,
+            observations,
+            output_dim=output_dim,
+        )
+        add_gaussian_observation_likelihood(
+            observed=observed,
+            mean=modelled,
+            independent_variance=fixed_error**2,
+            aggregation_error=registered_aggregation_error,
+            output_dim=output_dim,
+        )
+    return model

--- a/openghg_inversions/rhime/co2/linked_preparation.py
+++ b/openghg_inversions/rhime/co2/linked_preparation.py
@@ -1,0 +1,277 @@
+"""Labelled scientific inputs for the linked CO2/O2 recipe.
+
+CO2 and O2 keep distinct, potentially unequal observation axes at this public
+boundary. They are stacked only after their labels, state meanings, covariance
+blocks, and units have been checked.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+import json
+from typing import Any
+
+import numpy as np
+import xarray as xr
+
+from openghg_inversions.correlated_state import CorrelatedLognormalPrior
+from openghg_inversions.observation_error import (
+    AGGREGATION_ERROR_COVARIANCE,
+    AggregationError,
+    resolve_aggregation_error,
+)
+
+
+@dataclass(frozen=True, slots=True, eq=False)
+class Co2O2PreparedInputs:
+    """Backend-neutral joint inputs with shared land and split-ocean states."""
+
+    observations: xr.DataArray
+    prior_forward_mean: xr.DataArray
+    effective_observation_operator: xr.DataArray
+    aggregation_error: AggregationError
+    retained_prior: CorrelatedLognormalPrior
+    co2_observation_dim: str
+    o2_observation_dim: str
+    provenance: Mapping[str, Any] = field(default_factory=dict)
+
+
+def _axis(array: xr.DataArray, name: str) -> str:
+    if array.ndim != 1:
+        raise ValueError(f"{name} must be one-dimensional; got {array.dims!r}.")
+    dim = str(array.dims[0])
+    if dim not in array.indexes or not array.indexes[dim].is_unique:
+        raise ValueError(f"{name} requires unique labels on {dim!r}.")
+    return dim
+
+
+def _same_axis(reference: xr.DataArray, candidate: xr.DataArray, name: str) -> None:
+    dim = str(reference.dims[0])
+    if candidate.dims != (dim,) or not candidate.indexes[dim].equals(reference.indexes[dim]):
+        raise ValueError(f"{name} labels must exactly match its observations.")
+
+
+def _state(prior: CorrelatedLognormalPrior) -> tuple[xr.DataArray, str]:
+    mean = prior.mean
+    state_dim = prior.state_dim
+    if any(name not in mean.coords for name in ("source", "tracer_scope")):
+        raise ValueError("Retained states require source and tracer_scope coordinates.")
+    pairs = {
+        (str(source).lower(), str(scope).lower())
+        for source, scope in zip(mean["source"].values, mean["tracer_scope"].values, strict=True)
+    }
+    required = {
+        ("gpp", "shared"),
+        ("ter", "shared"),
+        ("ff", "shared"),
+        ("ocean", "co2"),
+        ("ocean", "o2"),
+    }
+    if pairs != required:
+        raise ValueError(
+            "Retained states must contain only shared GPP/TER/FF and tracer-specific CO2/O2 ocean states."
+        )
+    return mean, state_dim
+
+
+def _operator(
+    value: xr.DataArray,
+    observation: xr.DataArray,
+    state_mean: xr.DataArray,
+    name: str,
+) -> None:
+    observation_dim = str(observation.dims[0])
+    state_dim = str(state_mean.dims[0])
+    if value.dims != (observation_dim, state_dim):
+        raise ValueError(f"{name} operator must have dimensions {(observation_dim, state_dim)!r}.")
+    if not value.indexes[observation_dim].equals(observation.indexes[observation_dim]):
+        raise ValueError(f"{name} operator rows do not match its observations.")
+    if not value.indexes[state_dim].equals(state_mean.indexes[state_dim]):
+        raise ValueError(f"{name} operator state labels do not match the retained prior.")
+
+
+def _covariance(
+    value: xr.DataArray,
+    row: xr.DataArray,
+    column: xr.DataArray,
+    name: str,
+) -> np.ndarray:
+    row_dim = str(row.dims[0])
+    column_dim = str(column.dims[0])
+    if value.ndim != 2 or value.dims[0] != row_dim or value.shape != (row.size, column.size):
+        raise ValueError(f"{name} shape or row dimension does not match its observation axes.")
+    value_column_dim = str(value.dims[1])
+    if not value.indexes[row_dim].equals(row.indexes[row_dim]):
+        raise ValueError(f"{name} row labels do not match its observations.")
+    if not value.indexes[value_column_dim].equals(column.indexes[column_dim]):
+        raise ValueError(f"{name} column labels do not match its observations.")
+    result = np.asarray(value.values, dtype=np.float64)
+    if not np.isfinite(result).all():
+        raise ValueError(f"{name} contains non-finite values.")
+    return result
+
+
+def _stack(
+    co2: xr.DataArray,
+    o2: xr.DataArray,
+    *,
+    co2_units: str,
+    o2_units: str,
+    name: str,
+) -> xr.DataArray:
+    nco2, no2 = co2.size, o2.size
+    coords: dict[str, object] = {
+        "observation": np.arange(nco2 + no2),
+        "tracer": ("observation", np.repeat(("co2", "o2"), (nco2, no2))),
+        "within_tracer_observation": (
+            "observation",
+            [str(label) for label in (*co2.indexes[co2.dims[0]], *o2.indexes[o2.dims[0]])],
+        ),
+        "observation_units": (
+            "observation",
+            np.repeat((co2_units, o2_units), (nco2, no2)),
+        ),
+    }
+    for coordinate_name in ("site", "time"):
+        if coordinate_name not in co2.coords or coordinate_name not in o2.coords:
+            continue
+        co2_coordinate = co2.coords[coordinate_name]
+        o2_coordinate = o2.coords[coordinate_name]
+        if co2_coordinate.dims == co2.dims and o2_coordinate.dims == o2.dims:
+            coords[coordinate_name] = (
+                "observation",
+                np.concatenate((co2_coordinate.values, o2_coordinate.values)),
+            )
+    return xr.DataArray(
+        np.concatenate((co2.values, o2.values)),
+        dims=("observation",),
+        coords=coords,
+        name=name,
+        attrs={"units": "mixed; see observation_units coordinate"},
+    )
+
+
+def prepare_linked_co2_o2_inputs(
+    *,
+    co2_observations: xr.DataArray,
+    o2_observations: xr.DataArray,
+    co2_prior_forward_mean: xr.DataArray,
+    o2_prior_forward_mean: xr.DataArray,
+    co2_operator: xr.DataArray,
+    o2_operator: xr.DataArray,
+    co2_aggregation_covariance: xr.DataArray,
+    co2_o2_aggregation_covariance: xr.DataArray,
+    o2_aggregation_covariance: xr.DataArray,
+    retained_prior: CorrelatedLognormalPrior,
+    co2_units: str,
+    o2_units: str,
+    provenance: Mapping[str, Any] | None = None,
+) -> Co2O2PreparedInputs:
+    """Validate separate tracer inputs and form one labelled joint likelihood."""
+    if not co2_units.strip() or not o2_units.strip():
+        raise ValueError("CO2 and O2 channel units must be non-empty.")
+    try:
+        prepared_provenance = json.loads(json.dumps(dict(provenance or {})))
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Linked CO2/O2 provenance must be JSON serializable.") from exc
+
+    co2_dim = _axis(co2_observations, "CO2 observations")
+    o2_dim = _axis(o2_observations, "O2 observations")
+    if co2_dim == o2_dim:
+        raise ValueError("CO2 and O2 require distinct pre-stacking dimension names.")
+    _same_axis(co2_observations, co2_prior_forward_mean, "CO2 prior forward mean")
+    _same_axis(o2_observations, o2_prior_forward_mean, "O2 prior forward mean")
+    state_mean, state_dim = _state(retained_prior)
+    _operator(co2_operator, co2_observations, state_mean, "CO2")
+    _operator(o2_operator, o2_observations, state_mean, "O2")
+
+    co2_covariance = _covariance(
+        co2_aggregation_covariance,
+        co2_observations,
+        co2_observations,
+        "CO2 covariance",
+    )
+    cross_covariance = _covariance(
+        co2_o2_aggregation_covariance,
+        co2_observations,
+        o2_observations,
+        "CO2/O2 cross-covariance",
+    )
+    o2_covariance = _covariance(
+        o2_aggregation_covariance,
+        o2_observations,
+        o2_observations,
+        "O2 covariance",
+    )
+    joint_covariance = np.block([[co2_covariance, cross_covariance], [cross_covariance.T, o2_covariance]])
+
+    observations = _stack(
+        co2_observations,
+        o2_observations,
+        co2_units=co2_units,
+        o2_units=o2_units,
+        name="observed_concentration",
+    )
+    prior_forward = _stack(
+        co2_prior_forward_mean,
+        o2_prior_forward_mean,
+        co2_units=co2_units,
+        o2_units=o2_units,
+        name="prior_forward_concentration",
+    )
+    operator = xr.DataArray(
+        np.concatenate((co2_operator.values, o2_operator.values), axis=0),
+        dims=("observation", state_dim),
+        coords={"observation": observations["observation"], state_dim: state_mean[state_dim]},
+        name="effective_observation_operator",
+        attrs={"units": "observation_units per dimensionless flux scale"},
+    )
+    operator_coords: dict[str, xr.DataArray] = {
+        "tracer": observations["tracer"],
+        "observation_units": observations["observation_units"],
+    }
+    for coordinate_name in ("source", "tracer_scope"):
+        # MultiIndex state levels are already part of the index. Reassigning
+        # only some levels would corrupt that index in modern xarray.
+        if coordinate_name not in operator.coords:
+            operator_coords[coordinate_name] = state_mean[coordinate_name]
+    operator = operator.assign_coords(operator_coords)
+    covariance = xr.DataArray(
+        joint_covariance,
+        dims=("observation", "observation_cov"),
+        coords={
+            "observation": observations["observation"],
+            "observation_cov": observations["observation"].values,
+            "tracer": observations["tracer"],
+            "tracer_cov": ("observation_cov", observations["tracer"].values),
+            "observation_units": observations["observation_units"],
+            "observation_units_cov": (
+                "observation_cov",
+                observations["observation_units"].values,
+            ),
+        },
+        name=AGGREGATION_ERROR_COVARIANCE,
+        attrs={"units": "observation_units * observation_units_cov"},
+    )
+    aggregation_error = resolve_aggregation_error(
+        xr.Dataset(
+            {
+                observations.name: observations,
+                AGGREGATION_ERROR_COVARIANCE: covariance,
+            }
+        ),
+        "dense",
+        output_dim="observation",
+        covariance_dim="observation_cov",
+    )
+    return Co2O2PreparedInputs(
+        observations=observations,
+        prior_forward_mean=prior_forward,
+        effective_observation_operator=operator,
+        aggregation_error=aggregation_error,
+        retained_prior=retained_prior,
+        co2_observation_dim=co2_dim,
+        o2_observation_dim=o2_dim,
+        provenance=prepared_provenance,
+    )

--- a/openghg_inversions/rhime/co2/linked_runner.py
+++ b/openghg_inversions/rhime/co2/linked_runner.py
@@ -1,0 +1,138 @@
+"""Sampling seam for validated linked CO2/O2 scientific inputs."""
+
+from __future__ import annotations
+
+import json
+
+import arviz as az
+import xarray as xr
+
+from openghg_inversions.models import StateActivity
+from openghg_inversions.rhime.builders import RhimeModelBuildResult
+from openghg_inversions.rhime.sampling import RhimeSampler, sample_rhime_model
+
+from .linked_model import build_linked_co2_o2_model
+from .linked_preparation import Co2O2PreparedInputs
+
+
+_LINKED_VARIABLE_ROLES = {
+    "observation": "observed_concentration",
+    "concentration": "modelled_concentration",
+    "modelled_concentration": "modelled_concentration",
+    "pollution_concentration": "modelled_concentration",
+    "flux_scale": "flux_scaling",
+    "flux_scaling": "flux_scaling",
+    "emissions_sensitivity": "effective_observation_operator",
+    "prior_forward_concentration": "prior_forward_concentration",
+    "independent_error": "fixed_independent_error_sd",
+}
+
+
+def _default_linked_sampler() -> RhimeSampler:
+    """Return the sampler settings used by the accepted UOB prototype."""
+    return RhimeSampler(
+        nuts_sampler="numpyro",
+        sample_kwargs={"target_accept": 0.95},
+    )
+
+
+def _linked_metadata(prepared: Co2O2PreparedInputs) -> dict[str, object]:
+    """Return JSON-safe scientific identity for the sampled result."""
+    channel_units = {
+        tracer: str(
+            prepared.observations["observation_units"]
+            .where(prepared.observations["tracer"] == tracer, drop=True)
+            .values[0]
+        )
+        for tracer in ("co2", "o2")
+    }
+    return {
+        "recipe": "co2_o2",
+        "prior": "correlated arithmetic-moment lognormal",
+        "likelihood": "joint Gaussian with fixed independent channel error",
+        "independent_error": "fixed labelled standard deviation supplied by caller",
+        "observation_units": channel_units,
+        "provenance": dict(prepared.provenance),
+    }
+
+
+def _annotate_linked_trace(
+    trace: az.InferenceData,
+    *,
+    built: RhimeModelBuildResult,
+) -> az.InferenceData:
+    """Persist scientific roles, units, and provenance after coord restoration."""
+    trace.attrs["rhime_recipe"] = "co2_o2"
+    trace.attrs["rhime_variable_roles"] = json.dumps(
+        dict(built.variable_roles),
+        sort_keys=True,
+    )
+    trace.attrs["rhime_model_metadata"] = json.dumps(dict(built.metadata), sort_keys=True)
+    roles_by_variable: dict[str, list[str]] = {}
+    for role, variable in built.variable_roles.items():
+        roles_by_variable.setdefault(variable, []).append(role)
+
+    concentration_variables = {
+        "observed_concentration",
+        "modelled_concentration",
+        "prior_forward_concentration",
+        "fixed_independent_error_sd",
+    }
+    state_variables = {
+        "flux_scaling",
+        "prior_flux_scaling",
+        "flux_scaling_fixed_value",
+    }
+    for group_name in trace.groups():
+        group = getattr(trace, group_name)
+        for variable, roles in roles_by_variable.items():
+            if variable in group:
+                group[variable].attrs["rhime_scientific_roles"] = json.dumps(sorted(roles))
+        for variable in concentration_variables & set(group.variables):
+            group[variable].attrs["units"] = "mixed; see observation_units coordinate"
+        for variable in state_variables & set(group.variables):
+            group[variable].attrs["units"] = "dimensionless flux scale"
+        if "effective_observation_operator" in group:
+            group["effective_observation_operator"].attrs["units"] = (
+                "observation_units per dimensionless flux scale"
+            )
+        if "aggregation_error_covariance" in group:
+            group["aggregation_error_covariance"].attrs["units"] = "observation_units * observation_units_cov"
+        group.attrs["rhime_recipe"] = "co2_o2"
+        setattr(trace, group_name, group)
+    return trace
+
+
+def run_rhime_co2_o2(
+    *,
+    prepared_inputs: Co2O2PreparedInputs,
+    independent_error_sd: xr.DataArray,
+    state_activity: StateActivity | None = None,
+    sampler: RhimeSampler | None = None,
+) -> az.InferenceData:
+    """Build and sample the linked model from validated scientific inputs.
+
+    The fixed independent channel error is required and remains labelled. Run
+    policy, such as the UOB prototype's one ppm value for both channels, belongs
+    to the caller rather than the model API.
+    """
+    prepared = prepared_inputs
+    model = build_linked_co2_o2_model(
+        observations=prepared.observations,
+        prior_forward_mean=prepared.prior_forward_mean,
+        effective_observation_operator=prepared.effective_observation_operator,
+        aggregation_error=prepared.aggregation_error,
+        retained_prior=prepared.retained_prior,
+        independent_error_sd=independent_error_sd,
+        state_activity=state_activity,
+    )
+    built = RhimeModelBuildResult(
+        model=model,
+        variable_roles=_LINKED_VARIABLE_ROLES,
+        metadata=_linked_metadata(prepared),
+    )
+    trace = sample_rhime_model(
+        built,
+        _default_linked_sampler() if sampler is None else sampler,
+    )
+    return _annotate_linked_trace(trace, built=built)

--- a/openghg_inversions/rhime/config/co2_o2.ini
+++ b/openghg_inversions/rhime/config/co2_o2.ini
@@ -1,0 +1,25 @@
+; Documentation for the linked UOB CO2/O2 replay contract. The current RHIME
+; config resolver does not yet consume these linked-channel sections; callers
+; must prepare labelled inputs and pass the fixed error arrays explicitly.
+
+[co2_o2]
+recipe = linked_co2_o2
+shared_flux_sources = GPP, TER, FF
+tracer_specific_flux_sources = co2:ocean, o2:ocean
+aggregation_error = joint_dense_covariance
+infer_mismatch_amplitude = false
+
+[co2_observations]
+units = ppm
+fixed_independent_error_sd = 1.0
+fixed_independent_error_sd_units = ppm
+
+[o2_observations]
+; The 14 August 2026 prototype represents this linked channel in ppm.
+units = ppm
+fixed_independent_error_sd = 1.0
+fixed_independent_error_sd_units = ppm
+
+[sampling]
+nuts_sampler = numpyro
+target_accept = 0.95

--- a/tests/test_rhime_co2_o2_linked.py
+++ b/tests/test_rhime_co2_o2_linked.py
@@ -1,0 +1,386 @@
+"""Focused contracts for linked CO2/O2 preparation, modelling, and sampling."""
+
+from __future__ import annotations
+
+import configparser
+import json
+from pathlib import Path
+
+import arviz as az
+import numpy as np
+import pandas as pd
+import pymc as pm
+import pytest
+import xarray as xr
+
+from openghg_inversions.correlated_state import CorrelatedLognormalPrior
+from openghg_inversions.models import (
+    StateActivity,
+    get_coord_registry,
+    restore_inferencedata_coords,
+)
+from openghg_inversions.rhime.co2 import (
+    build_linked_co2_o2_model,
+    linked_co2_o2_prior_forward_mean,
+    prepare_linked_co2_o2_inputs,
+    run_rhime_co2_o2,
+)
+from openghg_inversions.rhime.sampling import RhimeSampler
+
+
+def _inputs(*, gathered_state: bool = False) -> dict[str, object]:
+    labels: list[str] | pd.MultiIndex
+    if gathered_state:
+        labels = pd.MultiIndex.from_tuples(
+            [
+                ("GPP", "shared", 1),
+                ("TER", "shared", 1),
+                ("FF", "shared", 1),
+                ("ocean", "co2", 1),
+                ("ocean", "o2", 1),
+            ],
+            names=("source", "tracer_scope", "region_in_source"),
+        )
+        state_coords = xr.Coordinates.from_pandas_multiindex(labels, "state")
+    else:
+        labels = ["gpp:1", "ter:1", "ff:1", "co2-ocean:1", "o2-ocean:1"]
+        state_coords = {
+            "state": labels,
+            "source": ("state", ["GPP", "TER", "FF", "ocean", "ocean"]),
+            "tracer_scope": ("state", ["shared", "shared", "shared", "co2", "o2"]),
+        }
+    mean = xr.DataArray(
+        np.ones(5),
+        dims=("state",),
+        coords=state_coords,
+        name="retained_prior_mean",
+        attrs={"units": "dimensionless flux scale"},
+    )
+    covariance = np.diag([0.01, 0.02, 0.03, 0.04, 0.05])
+    co2 = xr.DataArray([2.0, 3.0], dims="co2_measure", coords={"co2_measure": ["c1", "c2"]})
+    o2 = xr.DataArray(
+        [-4.0, -5.0, -6.0],
+        dims="o2_measure",
+        coords={"o2_measure": ["o1", "o2", "o3"]},
+    )
+    return {
+        "co2_observations": co2,
+        "o2_observations": o2,
+        "co2_prior_forward_mean": co2 - 0.25,
+        "o2_prior_forward_mean": o2 + 0.5,
+        "co2_operator": xr.DataArray(
+            [[1, 2, 3, 4, 0], [0.5, 1, 1.5, 2, 0]],
+            dims=("co2_measure", "state"),
+            coords={"co2_measure": co2["co2_measure"], "state": mean["state"]},
+        ),
+        "o2_operator": xr.DataArray(
+            [[-1, -2, -3, 0, 5], [-0.5, -1, -1.5, 0, 2.5], [-0.2, -0.4, -0.6, 0, 1]],
+            dims=("o2_measure", "state"),
+            coords={"o2_measure": o2["o2_measure"], "state": mean["state"]},
+        ),
+        "co2_aggregation_covariance": xr.DataArray(
+            [[1, 0.2], [0.2, 1.5]],
+            dims=("co2_measure", "co2_measure_cov"),
+            coords={"co2_measure": co2["co2_measure"], "co2_measure_cov": ["c1", "c2"]},
+        ),
+        "co2_o2_aggregation_covariance": xr.DataArray(
+            [[-0.1, -0.05, -0.02], [-0.08, -0.04, -0.01]],
+            dims=("co2_measure", "o2_measure"),
+            coords={"co2_measure": co2["co2_measure"], "o2_measure": o2["o2_measure"]},
+        ),
+        "o2_aggregation_covariance": xr.DataArray(
+            np.diag([2, 2.5, 3]),
+            dims=("o2_measure", "o2_measure_cov"),
+            coords={"o2_measure": o2["o2_measure"], "o2_measure_cov": ["o1", "o2", "o3"]},
+        ),
+        "retained_prior": CorrelatedLognormalPrior(mean, covariance),
+        "co2_units": "ppm",
+        "o2_units": "per meg",
+        "provenance": {"verification_games_issue": "OPE-77", "fixture": "linked"},
+    }
+
+
+def _independent_error(prepared, value: float = 0.1) -> xr.DataArray:
+    return xr.DataArray(
+        np.full(prepared.observations.size, value),
+        dims=("observation",),
+        coords={
+            "observation": prepared.observations["observation"],
+            "observation_units": prepared.observations["observation_units"],
+        },
+        name="fixed_independent_error_sd",
+    )
+
+
+def _build(prepared, *, state_activity: StateActivity | None = None):
+    return build_linked_co2_o2_model(
+        observations=prepared.observations,
+        prior_forward_mean=prepared.prior_forward_mean,
+        effective_observation_operator=prepared.effective_observation_operator,
+        aggregation_error=prepared.aggregation_error,
+        retained_prior=prepared.retained_prior,
+        independent_error_sd=_independent_error(prepared),
+        state_activity=state_activity,
+    )
+
+
+def test_stacks_unequal_axes_cross_covariance_and_units() -> None:
+    inputs = _inputs()
+    prepared = prepare_linked_co2_o2_inputs(**inputs)
+
+    assert prepared.observations["tracer"].values.tolist() == ["co2", "co2", "o2", "o2", "o2"]
+    assert prepared.observations["observation_units"].values.tolist() == [
+        "ppm",
+        "ppm",
+        "per meg",
+        "per meg",
+        "per meg",
+    ]
+    assert prepared.aggregation_error.mode == "dense"
+    covariance = prepared.aggregation_error.covariance
+    assert covariance is not None
+    np.testing.assert_allclose(covariance.values[:2, 2:], inputs["co2_o2_aggregation_covariance"])
+    np.testing.assert_allclose(covariance.values[2:, :2], inputs["co2_o2_aggregation_covariance"].T)
+    assert prepared.effective_observation_operator["tracer_scope"].values.tolist() == [
+        "shared",
+        "shared",
+        "shared",
+        "co2",
+        "o2",
+    ]
+
+
+def test_rejects_a_shared_ocean_state() -> None:
+    inputs = _inputs()
+    prior = inputs["retained_prior"]
+    mean = prior.mean.assign_coords(tracer_scope=("state", ["shared", "shared", "shared", "shared", "o2"]))
+    inputs["retained_prior"] = CorrelatedLognormalPrior(mean, prior.arithmetic_covariance)
+    with pytest.raises(ValueError, match="tracer-specific"):
+        prepare_linked_co2_o2_inputs(**inputs)
+
+
+def test_model_uses_registered_explicit_arrays_and_joint_covariance() -> None:
+    prepared = prepare_linked_co2_o2_inputs(**_inputs())
+    model = _build(prepared)
+
+    assert get_coord_registry(model) is not None
+    scaling, modelled = pm.draw(
+        [model["flux_scaling"], model["modelled_concentration"]],
+        draws=2,
+        random_seed=4,
+    )
+    expected = prepared.prior_forward_mean.values + np.einsum(
+        "os,ds->do",
+        prepared.effective_observation_operator.values,
+        scaling - prepared.retained_prior.mean.values,
+    )
+    np.testing.assert_allclose(modelled, expected)
+    covariance = prepared.aggregation_error.covariance
+    assert covariance is not None
+    np.testing.assert_allclose(model["aggregation_error_covariance"].eval(), covariance)
+
+
+def test_fixed_state_changes_prior_closure_and_is_not_sampled() -> None:
+    prepared = prepare_linked_co2_o2_inputs(**_inputs())
+    state_dim = prepared.retained_prior.state_dim
+    activity = StateActivity(
+        active=xr.DataArray(
+            [True, True, False, True, True],
+            dims=state_dim,
+            coords={state_dim: prepared.retained_prior.mean[state_dim]},
+        ),
+        fixed_value=xr.DataArray(
+            [1.0, 1.0, 0.75, 1.0, 1.0],
+            dims=state_dim,
+            coords={state_dim: prepared.retained_prior.mean[state_dim]},
+        ),
+        prune_zero=False,
+    )
+    expected_prior = prepared.prior_forward_mean - 0.25 * (
+        prepared.effective_observation_operator.isel({state_dim: 2}, drop=True)
+    )
+    xr.testing.assert_allclose(
+        linked_co2_o2_prior_forward_mean(
+            prior_forward_mean=prepared.prior_forward_mean,
+            effective_observation_operator=prepared.effective_observation_operator,
+            retained_prior=prepared.retained_prior,
+            state_activity=activity,
+        ),
+        expected_prior.rename("prior_forward_concentration"),
+    )
+
+    model = _build(prepared, state_activity=activity)
+    scaling, modelled = pm.draw(
+        [model["flux_scaling"], model["modelled_concentration"]],
+        draws=2,
+        random_seed=8,
+    )
+    np.testing.assert_allclose(scaling[:, 2], 0.75)
+    expected_modelled = prepared.prior_forward_mean.values + np.einsum(
+        "os,ds->do",
+        prepared.effective_observation_operator.values,
+        scaling - prepared.retained_prior.mean.values,
+    )
+    np.testing.assert_allclose(modelled, expected_modelled)
+
+
+def test_partial_gathered_state_restores_full_multiindex() -> None:
+    prepared = prepare_linked_co2_o2_inputs(**_inputs(gathered_state=True))
+    state_dim = prepared.retained_prior.state_dim
+    activity = StateActivity(
+        active=xr.DataArray(
+            [True, True, False, True, True],
+            dims=state_dim,
+            coords={state_dim: prepared.retained_prior.mean[state_dim]},
+        ),
+        fixed_value=0.75,
+        prune_zero=False,
+    )
+    model = _build(prepared, state_activity=activity)
+    with model:
+        trace = pm.sample_prior_predictive(draws=2, random_seed=42)
+    registry = get_coord_registry(model)
+    assert registry is not None
+    restored = restore_inferencedata_coords(trace, registry)
+
+    assert restored.prior.indexes[state_dim].equals(prepared.retained_prior.mean.indexes[state_dim])
+    assert restored.prior["source"].values.tolist() == ["GPP", "TER", "FF", "ocean", "ocean"]
+    np.testing.assert_allclose(restored.prior["flux_scaling"].isel({state_dim: 2}), 0.75)
+
+
+def _two_site_week_inputs() -> dict[str, object]:
+    inputs = _inputs()
+    sites = np.repeat(["TAC", "MHD"], 7)
+    times = np.tile(np.arange("2021-07-12", "2021-07-19", dtype="datetime64[D]"), 2)
+    nmeasure = sites.size
+    co2_labels = [f"co2:{site}:{time}" for site, time in zip(sites, times, strict=True)]
+    o2_labels = [f"o2:{site}:{time}" for site, time in zip(sites, times, strict=True)]
+    co2 = xr.DataArray(
+        np.linspace(-4.0, -3.0, nmeasure),
+        dims="co2_measure",
+        coords={
+            "co2_measure": co2_labels,
+            "site": ("co2_measure", sites),
+            "time": ("co2_measure", times),
+        },
+    )
+    o2 = xr.DataArray(
+        np.linspace(5.0, 6.0, nmeasure),
+        dims="o2_measure",
+        coords={
+            "o2_measure": o2_labels,
+            "site": ("o2_measure", sites),
+            "time": ("o2_measure", times),
+        },
+    )
+    state_labels = inputs["retained_prior"].mean["state"]
+    inputs.update(
+        {
+            "co2_observations": co2,
+            "o2_observations": o2,
+            "co2_prior_forward_mean": co2.copy(),
+            "o2_prior_forward_mean": o2.copy(),
+            "co2_operator": xr.DataArray(
+                np.tile([[-0.4, 0.3, 0.2, -0.1, 0.0]], (nmeasure, 1)),
+                dims=("co2_measure", "state"),
+                coords={"co2_measure": co2["co2_measure"], "state": state_labels},
+            ),
+            "o2_operator": xr.DataArray(
+                np.tile([[0.5, -0.4, -0.3, 0.0, 0.2]], (nmeasure, 1)),
+                dims=("o2_measure", "state"),
+                coords={"o2_measure": o2["o2_measure"], "state": state_labels},
+            ),
+            "co2_aggregation_covariance": xr.DataArray(
+                np.eye(nmeasure) * 0.2,
+                dims=("co2_measure", "co2_measure_cov"),
+                coords={"co2_measure": co2["co2_measure"], "co2_measure_cov": co2_labels},
+            ),
+            "co2_o2_aggregation_covariance": xr.DataArray(
+                np.eye(nmeasure) * 0.01,
+                dims=("co2_measure", "o2_measure"),
+                coords={"co2_measure": co2["co2_measure"], "o2_measure": o2["o2_measure"]},
+            ),
+            "o2_aggregation_covariance": xr.DataArray(
+                np.eye(nmeasure) * 0.3,
+                dims=("o2_measure", "o2_measure_cov"),
+                coords={"o2_measure": o2["o2_measure"], "o2_measure_cov": o2_labels},
+            ),
+            "co2_units": "ppm",
+            "o2_units": "ppm",
+            "provenance": {
+                "verification_games_issue": "OPE-77",
+                "period": "2021-07-12/2021-07-19",
+                "sites": ["TAC", "MHD"],
+            },
+        }
+    )
+    return inputs
+
+
+def test_two_site_week_runner_persists_labels_roles_units_and_provenance(tmp_path: Path) -> None:
+    prepared = prepare_linked_co2_o2_inputs(**_two_site_week_inputs())
+    state_dim = prepared.retained_prior.state_dim
+    activity = StateActivity(
+        active=xr.DataArray(
+            [True, True, False, True, True],
+            dims=state_dim,
+            coords={state_dim: prepared.retained_prior.mean[state_dim]},
+        ),
+        fixed_value=xr.DataArray(
+            [1.0, 1.0, 0.75, 1.0, 1.0],
+            dims=state_dim,
+            coords={state_dim: prepared.retained_prior.mean[state_dim]},
+        ),
+        prune_zero=False,
+    )
+    trace = run_rhime_co2_o2(
+        prepared_inputs=prepared,
+        independent_error_sd=_independent_error(prepared, value=1.0),
+        state_activity=activity,
+        sampler=RhimeSampler(
+            draws=2,
+            tune=2,
+            chains=1,
+            nuts_sampler="pymc",
+            sample_kwargs={"random_seed": 19, "compute_convergence_checks": False},
+            sample_prior_predictive=False,
+            sample_posterior_predictive=False,
+        ),
+    )
+
+    assert trace.posterior.sizes["observation"] == 28
+    assert set(trace.posterior["site"].values) == {"TAC", "MHD"}
+    assert np.unique(trace.posterior["time"]).size == 7
+    roles = json.loads(trace.attrs["rhime_variable_roles"])
+    metadata = json.loads(trace.attrs["rhime_model_metadata"])
+    assert roles["flux_scaling"] == "flux_scaling"
+    assert metadata["provenance"]["sites"] == ["TAC", "MHD"]
+    assert trace.posterior["flux_scaling"].attrs["units"] == "dimensionless flux scale"
+    assert json.loads(trace.posterior["flux_scaling"].attrs["rhime_scientific_roles"]) == [
+        "flux_scale",
+        "flux_scaling",
+    ]
+    np.testing.assert_allclose(trace.posterior["flux_scaling"].sel(state="ff:1"), 0.75)
+    assert trace.posterior["source"].values.tolist() == ["GPP", "TER", "FF", "ocean", "ocean"]
+    assert trace.constant_data["fixed_independent_error_sd"].values.tolist() == [1.0] * 28
+
+    path = tmp_path / "linked_trace.nc"
+    az.to_netcdf(trace, path)
+    reloaded = az.from_netcdf(path)
+    assert json.loads(reloaded.attrs["rhime_model_metadata"])["provenance"]["period"] == (
+        "2021-07-12/2021-07-19"
+    )
+    assert reloaded.posterior["observation_units"].values.tolist() == ["ppm"] * 28
+    assert reloaded.constant_data["fixed_independent_error_sd"].attrs["units"] == (
+        "mixed; see observation_units coordinate"
+    )
+
+
+def test_linked_config_documents_fixed_errors_and_no_inferred_mismatch() -> None:
+    config = configparser.ConfigParser()
+    config.read(Path(__file__).parents[1] / "openghg_inversions" / "rhime" / "config" / "co2_o2.ini")
+    assert config["co2_o2"]["infer_mismatch_amplitude"] == "false"
+    assert config["co2_observations"]["fixed_independent_error_sd"] == "1.0"
+    assert config["o2_observations"]["fixed_independent_error_sd"] == "1.0"
+    assert config["sampling"]["nuts_sampler"] == "numpyro"
+    assert config["sampling"]["target_accept"] == "0.95"


### PR DESCRIPTION
## Stack

- #616 — explicit scientific inputs and enforced coordinate registry
- #617 — activity-aware correlated state plus concrete CO₂ recipe
- This PR — linked CO₂/O₂ preparation, model, runner, config, and tests
- VG consumer/acceptance: openghg/verification-games#44

## Summary

- preserve separate, potentially unequal CO₂ and O₂ observation axes until validated joint preparation
- require shared GPP/TER/FF states and tracer-specific CO₂/O₂ ocean states
- assemble four labelled aggregation-covariance blocks, including the CO₂–O₂ cross block
- carry tracer, site, time, source role, state, row-unit, and covariance-column-unit metadata
- build from explicit arrays, `CorrelatedLognormalPrior`, `AggregationError`, and `registered_model()`
- reuse #617's activity-aware component so inactive states stay visible and fixed exactly
- require labelled fixed independent error rather than silently inferring mismatch
- persist roles, units, coordinates, and preparation provenance in InferenceData/NetCDF

## Scientific model

```text
x_active ~ correlated arithmetic-moment LogNormal
x = restore_active_and_exact_fixed_values(x_active)
mu = prior_forward + H_alpha @ (x - prior_state)
R = A_joint + diag(independent_error_sd²)
(co2, o2) ~ MVN(mu, R)
```

The UOB prototype config documents fixed 1 ppm per channel, no inferred mismatch, NumPyro, and `target_accept=0.95`. The public resolver does not yet consume those linked-channel sections.

## Validation

OGI:

- linked suite plus amended CO₂ config regression: 8 passed
- shared activity regressions: passed
- two-site/seven-day runner + NetCDF test and real partial gathered MultiIndex regression
- Ruff lint/format and `git diff --check`: passed

Real VG acceptance against this exact head:

- UOB BASE + ATEN, MHD/TAC, 12–18 July 2021; 70 rows/tracer/scenario
- all 365 public states retained: 282 active, 83 fixed exactly
- design, active prior covariance, and full cross-tracer aggregation covariance differences: 0
- prior-forward max difference: `8.88e-16 ppm`
- 1000 tune + 1000 draws, four NumPyro chains: zero divergences
- max R-hat 1.00/1.01; min bulk ESS 4680/3752
- roles, row/covariance units, labels, preparation provenance, and exact inactive values survive OGI save/load
- VG PR #44 exact head `a9b6bd647fb0fd97d85f5374344591559fd87ec1`

## Visible follow-ups

- linked config needs a public resolver
- O₂/N₂ per-meg transformation and normalized-evidence semantics remain OPE-86
- serializer should encode ordinary tuple-valued internal active-state coordinates
- active prior moments should not require dummy positive full-vector moments for fixed zero states
- runtime OGI revision should be trace-root provenance rather than sidecar-only
- no WUR/fixed-OU, posterior predictive, flux reconstruction, or result-catalog acceptance yet

Linear: OPE-77