### PR TITLE
OPE-92 Consolidate minimum-error preparation

### DIFF
--- a/newsfragments/OPE-92.feature.md
+++ b/newsfragments/OPE-92.feature.md
@@ -1,0 +1,1 @@
+Consolidate minimum-error preparation, validation, alignment, and provenance in a typed ``MinimumError`` value.

--- a/openghg_inversions/inversion_inputs.py
+++ b/openghg_inversions/inversion_inputs.py
@@ -8,7 +8,6 @@ explicit empty selection is an error.
 """
 
 import datetime as dt
-import numbers
 from collections.abc import Iterable
 from typing import Any, Literal
 
@@ -18,12 +17,8 @@ import xarray as xr
 
 from openghg_inversions.array_ops import concat_gather_datasets, get_xr_dummies
 from openghg_inversions.model_error import (
+    MinimumError,
     normalise_min_error_options as normalise_min_error_options,  # noqa: PLC0414
-)
-from openghg_inversions.model_error import (
-    percentile_error_method,
-    residual_error_method,
-    xr_setup_min_error,
 )
 
 DatetimeLike = str | dt.datetime | np.datetime64 | pd.Timestamp
@@ -159,61 +154,14 @@ def add_min_error(
     min_error: str | dict[str, float] | int | float = 0.0,
     min_error_per_site: bool = True,
 ) -> xr.Dataset:
-    """Add min_error to combined Dataset."""
-    min_error_data: xr.DataArray | float | np.ndarray
-
-    def site_names_for_min_error() -> list[str]:
-        if "site_names" in ds:
-            return [str(site) for site in ds.site_names.values]
-        if "site" in ds:
-            return [str(site) for site in make_site_names(ds.site).values]
-        return [site for site in fp_data if not site.startswith(".")]
-
-    def site_indicator_for_min_error() -> xr.DataArray:
-        if "site_indicator" in ds:
-            return ds.site_indicator
-        if "site" in ds:
-            return xr_unique_inv(ds.site, sort=False).rename("site_indicator")
-        raise ValueError("Per-site min_error values require site_indicator or site data.")
-
-    def fp_data_for_ds_sites() -> dict[str, Any]:
-        return {site: fp_data[site] for site in site_names_for_min_error()}
-
-    if isinstance(min_error, numbers.Real) and not isinstance(min_error, bool):
-        min_error_data = float(min_error) * xr.ones_like(ds.mf)
-    elif isinstance(min_error, np.ndarray) and min_error.ndim == 0:
-        min_error_data = min_error * xr.ones_like(ds.mf)
-    elif isinstance(min_error, dict):
-        fp_data_for_sites = fp_data_for_ds_sites()
-        sites = list(fp_data_for_sites)
-        missing_sites = [site for site in sites if site not in min_error]
-        if missing_sites:
-            raise ValueError(f"min_error mapping is missing values for site(s): {missing_sites}")
-        err_per_site = np.array([min_error[site] for site in sites])
-        min_error_data = xr_setup_min_error(err_per_site, site_indicator_for_min_error())
-    elif min_error == "residual":
-        fp_data_for_sites = fp_data_for_ds_sites()
-        res_err = residual_error_method(fp_data_for_sites, by_site=min_error_per_site)
-        if min_error_per_site:
-            min_error_data = xr_setup_min_error(res_err, site_indicator_for_min_error())
-        else:
-            min_error_data = res_err
-    elif min_error == "percentile":
-        fp_data_for_sites = fp_data_for_ds_sites()
-        perc_err = percentile_error_method(fp_data_for_sites)
-        min_error_data = xr_setup_min_error(perc_err, site_indicator_for_min_error())
-    else:
-        raise ValueError(f"Option '{min_error}' is not valid.")
-
-    if not isinstance(min_error_data, xr.DataArray):
-        min_error_data = xr.full_like(ds.mf, min_error_data).rename("min_error")
-    elif "nmeasure" not in min_error_data.dims:
-        min_error_data = xr.full_like(ds.mf, min_error_data.values).rename("min_error")
-    else:
-        min_error_data = min_error_data.rename("min_error")
-
-    assert isinstance(min_error_data, xr.DataArray)
-    ds["min_error"] = xr.DataArray(min_error_data.data, dims=("nmeasure",), name="min_error")
+    """Add a prepared, observation-aligned minimum error to a dataset."""
+    prepared = MinimumError.prepare(ds, fp_data, min_error, by_site=min_error_per_site)
+    ds["min_error"] = xr.DataArray(
+        prepared.values.data,
+        dims=prepared.values.dims,
+        name="min_error",
+        attrs=prepared.values.attrs,
+    )
     return ds
 
 

--- a/openghg_inversions/model_error.py
+++ b/openghg_inversions/model_error.py
@@ -9,9 +9,9 @@ import numpy as np
 import xarray as xr
 
 
-@dataclass(frozen=True, init=False)
+@dataclass(frozen=True, eq=False, slots=True)
 class MinimumError:
-    """Validated, observation-aligned minimum model error.
+    """Observation-aligned minimum model error.
 
     Attributes:
         values: Minimum error labelled by observation.
@@ -24,26 +24,6 @@ class MinimumError:
     method: str
     by_site: bool
     sites: tuple[str, ...]
-
-    def __init__(self) -> None:
-        """Reject construction outside :meth:`prepare`."""
-        raise TypeError("Use MinimumError.prepare() to construct a validated value.")
-
-    @classmethod
-    def _from_validated(
-        cls,
-        values: xr.DataArray,
-        method: str,
-        by_site: bool,
-        sites: tuple[str, ...],
-    ) -> "MinimumError":
-        """Construct an instance after :meth:`prepare` validates its fields."""
-        result = object.__new__(cls)
-        object.__setattr__(result, "values", values)
-        object.__setattr__(result, "method", method)
-        object.__setattr__(result, "by_site", by_site)
-        object.__setattr__(result, "sites", sites)
-        return result
 
     @classmethod
     def prepare(
@@ -75,14 +55,8 @@ class MinimumError:
         if not isinstance(by_site, bool):
             raise ValueError(f"Minimum-error 'by_site' must be a boolean, got {type(by_site).__name__}.")
 
-        site_coord = observations.coords.get("site")
-        sites = (
-            tuple(dict.fromkeys(str(value) for value in site_coord.values))
-            if site_coord is not None
-            else ()
-        )
-        selected = {site: fp_data[site] for site in sites if site in fp_data}
-        missing_data = [site for site in sites if site not in selected]
+        site_coord: xr.DataArray | None = None
+        sites: tuple[str, ...] = ()
         method: str
         varies_by_site = False
 
@@ -93,6 +67,10 @@ class MinimumError:
             source = value
             method = "scalar"
         elif isinstance(value, Mapping):
+            site_coord = observations.coords.get("site")
+            if site_coord is None:
+                raise ValueError("Per-site min_error values require a labelled site coordinate.")
+            sites = tuple(dict.fromkeys(str(site) for site in site_coord.values))
             missing = [site for site in sites if site not in value]
             if missing:
                 raise ValueError(f"min_error mapping is missing values for site(s): {missing}")
@@ -100,6 +78,12 @@ class MinimumError:
             method = "per_site"
             varies_by_site = True
         elif value in ("residual", "percentile"):
+            site_coord = observations.coords.get("site")
+            if site_coord is None:
+                raise ValueError("Calculated min_error values require a labelled site coordinate.")
+            sites = tuple(dict.fromkeys(str(site) for site in site_coord.values))
+            selected = {site: fp_data[site] for site in sites if site in fp_data}
+            missing_data = [site for site in sites if site not in selected]
             if missing_data:
                 raise ValueError(f"Minimum-error calculation is missing fp_data for site(s): {missing_data}")
             method = value
@@ -132,13 +116,14 @@ class MinimumError:
                 raise ValueError("A non-site minimum error must contain exactly one value.")
             data = xr.full_like(observations.mf, float(source.reshape(-1)[0]), dtype=float)
 
-        data = data.rename("min_error").assign_attrs(
-            units=observations.mf.attrs.get("units", ""),
-            minimum_error_method=method,
-            minimum_error_by_site=int(varies_by_site),
-            minimum_error_sites=",".join(sites),
-        )
-        return cls._from_validated(data, method, varies_by_site, sites)
+        data = data.rename("min_error")
+        data.attrs = {
+            "units": observations.mf.attrs.get("units", ""),
+            "minimum_error_method": method,
+            "minimum_error_by_site": int(varies_by_site),
+            "minimum_error_sites": ",".join(sites),
+        }
+        return cls(data, method, varies_by_site, sites)
 
 
 def normalise_min_error_options(options: Mapping[str, Any] | None) -> dict[str, bool]:

--- a/openghg_inversions/model_error.py
+++ b/openghg_inversions/model_error.py
@@ -1,10 +1,124 @@
 """Normalize, calculate, and align minimum model-error values."""
 
+import numbers
 from collections.abc import Mapping
+from dataclasses import dataclass
 from typing import Any
 
 import numpy as np
 import xarray as xr
+
+
+@dataclass(frozen=True)
+class MinimumError:
+    """Validated, observation-aligned minimum model error.
+
+    Attributes:
+        values: Minimum error labelled by observation.
+        method: Source form used to obtain the values.
+        by_site: Whether the source values varied by site.
+        sites: Site order used for per-site alignment.
+    """
+
+    values: xr.DataArray
+    method: str
+    by_site: bool
+    sites: tuple[str, ...]
+
+    @classmethod
+    def prepare(
+        cls,
+        observations: xr.Dataset,
+        fp_data: Mapping[str, xr.Dataset],
+        value: str | Mapping[str, float] | int | float = 0.0,
+        *,
+        by_site: bool = True,
+    ) -> "MinimumError":
+        """Prepare minimum error from a scalar, site mapping, or named method.
+
+        Args:
+            observations: Gathered observations containing ``mf`` and a labelled
+                ``site`` coordinate for per-site values.
+            fp_data: Per-site scientific datasets used by calculated methods.
+            value: Scalar, per-site mapping, ``"residual"``, or ``"percentile"``.
+            by_site: Whether residual values are calculated separately by site.
+
+        Returns:
+            A validated, observation-aligned minimum error value.
+
+        Raises:
+            ValueError: If the configuration, site labels, or resulting values
+                are invalid.
+        """
+        if "mf" not in observations:
+            raise ValueError("Minimum-error preparation requires an 'mf' observation array.")
+        if not isinstance(by_site, bool):
+            raise ValueError(f"Minimum-error 'by_site' must be a boolean, got {type(by_site).__name__}.")
+
+        site_coord = observations.coords.get("site")
+        sites = (
+            tuple(dict.fromkeys(str(value) for value in site_coord.values))
+            if site_coord is not None
+            else ()
+        )
+        selected = {site: fp_data[site] for site in sites if site in fp_data}
+        missing_data = [site for site in sites if site not in selected]
+        method: str
+        varies_by_site = False
+
+        if isinstance(value, numbers.Real) and not isinstance(value, bool):
+            source = np.asarray(float(value))
+            method = "scalar"
+        elif isinstance(value, np.ndarray) and value.ndim == 0:
+            source = value
+            method = "scalar"
+        elif isinstance(value, Mapping):
+            missing = [site for site in sites if site not in value]
+            if missing:
+                raise ValueError(f"min_error mapping is missing values for site(s): {missing}")
+            source = np.asarray([value[site] for site in sites], dtype=float)
+            method = "per_site"
+            varies_by_site = True
+        elif value in ("residual", "percentile"):
+            if missing_data:
+                raise ValueError(f"Minimum-error calculation is missing fp_data for site(s): {missing_data}")
+            method = value
+            varies_by_site = value == "percentile" or by_site
+            source = (
+                residual_error_method(selected, by_site=by_site)
+                if value == "residual"
+                else percentile_error_method(selected)
+            )
+        else:
+            raise ValueError(f"Option '{value}' is not valid.")
+
+        source = np.asarray(source, dtype=float)
+        if not np.isfinite(source).all() or (source < 0).any():
+            raise ValueError("Minimum-error values must be finite and non-negative.")
+
+        if varies_by_site:
+            if site_coord is None:
+                raise ValueError("Per-site min_error values require a labelled site coordinate.")
+            if source.ndim > 1 or source.size != len(sites):
+                raise ValueError(f"Minimum error has {source.size} site values; expected {len(sites)}.")
+            per_site = xr.DataArray(
+                source.reshape(-1),
+                coords={"site": np.asarray(sites)},
+                dims="site",
+            )
+            data = per_site.sel(site=site_coord)
+        else:
+            if source.size != 1:
+                raise ValueError("A non-site minimum error must contain exactly one value.")
+            data = xr.full_like(observations.mf, float(source.reshape(-1)[0]))
+
+        data = data.rename("min_error").assign_attrs(
+            units=observations.mf.attrs.get("units", ""),
+            minimum_error_method=method,
+            minimum_error_by_site=varies_by_site,
+            minimum_error_sites=",".join(sites),
+        )
+        return cls(values=data, method=method, by_site=varies_by_site, sites=sites)
 
 
 def normalise_min_error_options(options: Mapping[str, Any] | None) -> dict[str, bool]:
@@ -153,24 +267,3 @@ def percentile_error_method(ds_dict: dict[str, xr.Dataset]) -> np.ndarray:
     res_err = (monthly_50pc - monthly_5pc).groupby("site").mean(dim="time")
 
     return res_err.values
-
-
-def setup_min_error(min_error: np.ndarray, siteindicator: np.ndarray) -> np.ndarray:
-    """Align min error vector with obs vector.
-
-    Given min_error vector with same length as number of sites, create a vector
-    aligned with obs stacked by site.
-    """
-    # catch zero dimensional case (e.g. one site)
-    if min_error.ndim == 0:
-        return min_error * np.ones_like(siteindicator, dtype=float)
-
-    # need the same number of min_error values as distinct values in siteindicator
-    assert np.max(siteindicator) == len(min_error) - 1
-
-    return min_error[siteindicator.astype(int)]
-
-
-def xr_setup_min_error(min_error: np.ndarray, siteindicator: xr.DataArray) -> xr.DataArray:
-    """Align min error vector with obs vector."""
-    return xr.apply_ufunc(lambda x: setup_min_error(min_error, x), siteindicator)

--- a/openghg_inversions/model_error.py
+++ b/openghg_inversions/model_error.py
@@ -115,7 +115,7 @@ class MinimumError:
         data = data.rename("min_error").assign_attrs(
             units=observations.mf.attrs.get("units", ""),
             minimum_error_method=method,
-            minimum_error_by_site=varies_by_site,
+            minimum_error_by_site=int(varies_by_site),
             minimum_error_sites=",".join(sites),
         )
         return cls(values=data, method=method, by_site=varies_by_site, sites=sites)

--- a/openghg_inversions/model_error.py
+++ b/openghg_inversions/model_error.py
@@ -9,7 +9,7 @@ import numpy as np
 import xarray as xr
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, init=False)
 class MinimumError:
     """Validated, observation-aligned minimum model error.
 
@@ -24,6 +24,26 @@ class MinimumError:
     method: str
     by_site: bool
     sites: tuple[str, ...]
+
+    def __init__(self) -> None:
+        """Reject construction outside :meth:`prepare`."""
+        raise TypeError("Use MinimumError.prepare() to construct a validated value.")
+
+    @classmethod
+    def _from_validated(
+        cls,
+        values: xr.DataArray,
+        method: str,
+        by_site: bool,
+        sites: tuple[str, ...],
+    ) -> "MinimumError":
+        """Construct an instance after :meth:`prepare` validates its fields."""
+        result = object.__new__(cls)
+        object.__setattr__(result, "values", values)
+        object.__setattr__(result, "method", method)
+        object.__setattr__(result, "by_site", by_site)
+        object.__setattr__(result, "sites", sites)
+        return result
 
     @classmethod
     def prepare(
@@ -110,7 +130,7 @@ class MinimumError:
         else:
             if source.size != 1:
                 raise ValueError("A non-site minimum error must contain exactly one value.")
-            data = xr.full_like(observations.mf, float(source.reshape(-1)[0]))
+            data = xr.full_like(observations.mf, float(source.reshape(-1)[0]), dtype=float)
 
         data = data.rename("min_error").assign_attrs(
             units=observations.mf.attrs.get("units", ""),
@@ -118,7 +138,7 @@ class MinimumError:
             minimum_error_by_site=int(varies_by_site),
             minimum_error_sites=",".join(sites),
         )
-        return cls(values=data, method=method, by_site=varies_by_site, sites=sites)
+        return cls._from_validated(data, method, varies_by_site, sites)
 
 
 def normalise_min_error_options(options: Mapping[str, Any] | None) -> dict[str, bool]:

--- a/tests/test_inversion_inputs.py
+++ b/tests/test_inversion_inputs.py
@@ -19,6 +19,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 from dask import array as da
+from dask.callbacks import Callback
 
 from openghg_inversions.inversion_inputs import (
     add_min_error,
@@ -596,16 +597,25 @@ def test_minimum_error_rejects_invalid_values(value: float):
 
 def test_scalar_minimum_error_preserves_lazy_borrowed_observations():
     mf = xr.DataArray(da.from_array(np.ones(3, dtype=int), chunks=2), dims="nmeasure")
-    observations = xr.Dataset({"mf": mf})
+    site = xr.DataArray(
+        da.from_array(np.array(["AAA", "AAA", "BBB"]), chunks=2),
+        dims="nmeasure",
+    )
+    observations = xr.Dataset({"mf": mf}, coords={"site": site})
+    observations.mf.attrs = {"units": "ppb", "standard_name": "mole_fraction", "calibration": "X"}
+    executed_tasks = []
 
-    result = MinimumError.prepare(observations, {}, 0.5)
+    with Callback(pretask=lambda *args: executed_tasks.append(args[0])):
+        result = MinimumError.prepare(observations, {}, 0.5)
 
+    assert executed_tasks == []
     assert result.values.variable._data is not observations.mf.variable._data
     assert hasattr(result.values.data, "chunks")
     assert np.issubdtype(result.values.dtype, np.floating)
+    assert result.values.attrs == {
+        "units": "ppb",
+        "minimum_error_method": "scalar",
+        "minimum_error_by_site": 0,
+        "minimum_error_sites": "",
+    }
     np.testing.assert_allclose(result.values.compute(), 0.5)
-
-
-def test_minimum_error_requires_preparation():
-    with pytest.raises(TypeError, match=r"MinimumError\.prepare"):
-        MinimumError()

--- a/tests/test_inversion_inputs.py
+++ b/tests/test_inversion_inputs.py
@@ -565,7 +565,7 @@ def test_make_inv_inputs_residual_min_error_can_be_site_specific():
     np.testing.assert_allclose(result.min_error.values, expected)
 
 
-def test_minimum_error_uses_declared_site_order_and_records_provenance():
+def test_minimum_error_uses_declared_site_order_and_records_provenance(tmp_path: Path):
     """Per-site values follow labels rather than mapping or alphabetical order."""
     observations = xr.Dataset(
         {"mf": ("nmeasure", [1.0, 2.0, 3.0])},
@@ -580,9 +580,10 @@ def test_minimum_error_uses_declared_site_order_and_records_provenance():
     assert result.values.attrs == {
         "units": "ppb",
         "minimum_error_method": "per_site",
-        "minimum_error_by_site": True,
+        "minimum_error_by_site": 1,
         "minimum_error_sites": "BBB,AAA",
     }
+    result.values.to_netcdf(tmp_path / "minimum_error.nc")
 
 
 @pytest.mark.parametrize("value", [-1.0, np.inf, np.nan])

--- a/tests/test_inversion_inputs.py
+++ b/tests/test_inversion_inputs.py
@@ -18,6 +18,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
+from dask import array as da
 
 from openghg_inversions.inversion_inputs import (
     add_min_error,
@@ -25,6 +26,7 @@ from openghg_inversions.inversion_inputs import (
     concat_gather_datasets,
     make_inv_inputs,
 )
+from openghg_inversions.model_error import MinimumError
 from openghg_inversions.sigma import SigmaAlignment
 
 
@@ -561,3 +563,42 @@ def test_make_inv_inputs_residual_min_error_can_be_site_specific():
 
     expected = np.where(result.site_indicator.values == 0, 1.0, 2.0)
     np.testing.assert_allclose(result.min_error.values, expected)
+
+
+def test_minimum_error_uses_declared_site_order_and_records_provenance():
+    """Per-site values follow labels rather than mapping or alphabetical order."""
+    observations = xr.Dataset(
+        {"mf": ("nmeasure", [1.0, 2.0, 3.0])},
+        coords={"site": ("nmeasure", ["BBB", "AAA", "BBB"])},
+    )
+    observations.mf.attrs["units"] = "ppb"
+
+    result = MinimumError.prepare(observations, {}, {"AAA": 1.0, "BBB": 2.0})
+
+    np.testing.assert_allclose(result.values, [2.0, 1.0, 2.0])
+    assert result.sites == ("BBB", "AAA")
+    assert result.values.attrs == {
+        "units": "ppb",
+        "minimum_error_method": "per_site",
+        "minimum_error_by_site": True,
+        "minimum_error_sites": "BBB,AAA",
+    }
+
+
+@pytest.mark.parametrize("value", [-1.0, np.inf, np.nan])
+def test_minimum_error_rejects_invalid_values(value: float):
+    observations = xr.Dataset({"mf": ("nmeasure", [1.0])})
+
+    with pytest.raises(ValueError, match="finite and non-negative"):
+        MinimumError.prepare(observations, {}, value)
+
+
+def test_scalar_minimum_error_preserves_lazy_borrowed_observations():
+    mf = xr.DataArray(da.from_array(np.ones(3), chunks=2), dims="nmeasure")
+    observations = xr.Dataset({"mf": mf})
+
+    result = MinimumError.prepare(observations, {}, 0.5)
+
+    assert result.values.variable._data is not observations.mf.variable._data
+    assert hasattr(result.values.data, "chunks")
+    np.testing.assert_allclose(result.values.compute(), 0.5)

--- a/tests/test_inversion_inputs.py
+++ b/tests/test_inversion_inputs.py
@@ -595,11 +595,17 @@ def test_minimum_error_rejects_invalid_values(value: float):
 
 
 def test_scalar_minimum_error_preserves_lazy_borrowed_observations():
-    mf = xr.DataArray(da.from_array(np.ones(3), chunks=2), dims="nmeasure")
+    mf = xr.DataArray(da.from_array(np.ones(3, dtype=int), chunks=2), dims="nmeasure")
     observations = xr.Dataset({"mf": mf})
 
     result = MinimumError.prepare(observations, {}, 0.5)
 
     assert result.values.variable._data is not observations.mf.variable._data
     assert hasattr(result.values.data, "chunks")
+    assert np.issubdtype(result.values.dtype, np.floating)
     np.testing.assert_allclose(result.values.compute(), 0.5)
+
+
+def test_minimum_error_requires_preparation():
+    with pytest.raises(TypeError, match=r"MinimumError\.prepare"):
+        MinimumError()


### PR DESCRIPTION
* **Summary of changes**

Consolidate scalar, per-site, residual, and percentile minimum-error preparation in a typed `MinimumError` value.

- align per-site values through the labelled observation `site` coordinate
- validate finite, non-negative values and record method/site/unit provenance
- preserve resolved `xr.DataArray` inputs for RHIME/PyMC and analytic consumers
- remove superseded minimum-error alignment helpers

Linear: [OPE-92](https://linear.app/openghg-inversions/issue/OPE-92/consolidate-minimum-error-preparation-in-a-typed-minimumerror-value)

* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx — N/A; tracked in Linear as OPE-92
- [x] Tests added and passing
- [ ] Documentation and tutorials updated/added — not required; public API docstrings added
- [x] Added a Towncrier news fragment in `newsfragments/`
- [ ] Added any new requirements to `requirements.txt` — no new requirements

Checks:
- `uv run pytest tests/test_inversion_inputs.py -q`: 22 passed, 1 deselected
- targeted RHIME/xarray/fixed-basis minimum-error tests: 7 passed, 363 deselected
- `uv run ruff check openghg_inversions/model_error.py openghg_inversions/inversion_inputs.py tests/test_inversion_inputs.py`
- `git diff --check`
- Slurm Mypy job 18645378 reached the existing repository baseline: 197 errors in 56 files; no errors in the new `model_error.py`.