### PR TITLE
Consolidate linear PyMC components

### DIFF
--- a/docs/experimental/ramsden2022.rst
+++ b/docs/experimental/ramsden2022.rst
@@ -71,7 +71,7 @@ state coordinates.
      - Meaning
    * - ``H``
      - observation, state, source
-     - Labelled design matrix mapping scaling states into observation space.
+     - Labelled sensitivity matrix mapping scaling states into observation space.
    * - ``mf``
      - observation
      - Measured mole fraction in the channel's declared numeric units.
@@ -87,7 +87,7 @@ state coordinates.
      - Integer site index used to align site-level model error.
    * - ``H_bc``
      - observation, boundary state
-     - Boundary design; required when the channel enables boundary scaling.
+     - Boundary sensitivity; required when the channel enables boundary scaling.
 
 If state labels are positional numbers, retain and pass both
 :class:`~openghg_inversions.basis.basis_functions.BasisFunctions` objects.
@@ -100,12 +100,12 @@ Ratio contracts
 The model supports two explicit ratio conventions:
 
 Direct physical ratio
-   ``reference_ratio=None`` means the tracer design is ratio-free. The
+   ``reference_ratio=None`` means the tracer sensitivity is ratio-free. The
    sampled or fixed value is the dimensionless molar emission ratio, moles of
    tracer divided by moles of primary gas.
 
 Historical multiplier
-   A positive ``reference_ratio`` means the tracer design already contains
+   A positive ``reference_ratio`` means the tracer sensitivity already contains
    that ratio. The sampled or fixed value is a multiplier, and the model
    exposes
 
@@ -115,7 +115,7 @@ Historical multiplier
           R_{\mathrm{reference}} R_{\mathrm{multiplier}}.
 
 The independent ``tracer_design_reference_ratios`` mapping records what is
-already present in every tracer design. The builder rejects inconsistent
+already present in every tracer sensitivity. The builder rejects inconsistent
 declarations to prevent applying a ratio twice or omitting it.
 
 Units
@@ -123,8 +123,8 @@ Units
 
 The builder validates supported unit declarations by mole-fraction scale but
 does not convert numeric values. Observations, measurement errors, minimum
-errors, forward designs, and model-error prior values must already share each
-channel's declared scale.
+errors, forward sensitivities, and model-error prior values must already share
+each channel's declared scale.
 
 For the retained Ramsden case, methane values are numeric ``ppb`` and ethane
 values numeric ``ppt``. The paper prints the ethane model-error bounds as ppb,

--- a/docs/experimental/ramsden2022_validation.rst
+++ b/docs/experimental/ramsden2022_validation.rst
@@ -110,7 +110,7 @@ strict original-versus-modern comparison.
 
 The available current OpenGHG object store did not contain usable footprint
 and observation products for rebuilding this historical case. The validation
-therefore converted the retained designs into canonical prepared datasets
+therefore converted the retained sensitivities into canonical prepared datasets
 rather than rerunning modern retrieval and preparation.
 
 Sampling diagnostics

--- a/docs/usage/concrete_rhime_model.rst
+++ b/docs/usage/concrete_rhime_model.rst
@@ -165,13 +165,13 @@ The important default model-data and deterministic names are:
      - Role
      - Canonical input
    * - ``hx``
-     - Flux design data
+     - Flux sensitivity data
      - ``H``
    * - ``mu``
      - Flux contribution
      - ``hx @ x``
    * - ``hbc``
-     - Boundary design data
+     - Boundary sensitivity data
      - ``H_bc``
    * - ``mu_bc``
      - Boundary contribution
@@ -204,7 +204,7 @@ helpers:
 
    from openghg_inversions.models import (
        add_linear_component,
-       prepare_linear_design,
+       prepare_linear_sensitivity,
        registered_model,
    )
    from openghg_inversions.models.likelihoods import add_gaussian_observation_likelihood
@@ -231,12 +231,12 @@ helpers:
        frequency=None,
        per_site=True,
    )
-   flux_design = prepare_linear_design(inv_inputs["H"])
-   boundary_design = prepare_linear_design(inv_inputs["H_bc"])
+   flux_sensitivity = prepare_linear_sensitivity(inv_inputs["H"])
+   boundary_sensitivity = prepare_linear_sensitivity(inv_inputs["H_bc"])
 
    with registered_model() as model:
        flux = add_linear_component(
-           flux_design,
+           flux_sensitivity,
            data_name="hx",
            prior_args=x_prior,
            var_name="x",
@@ -244,7 +244,7 @@ helpers:
            output_dim="nmeasure",
        )
        boundary = add_linear_component(
-           boundary_design,
+           boundary_sensitivity,
            data_name="hbc",
            prior_args=bc_prior,
            var_name="bc",
@@ -282,12 +282,12 @@ model developer needs to change graph construction directly. It does not
 automatically participate in the complete ``run_rhime`` output pipeline; that
 pipeline still selects one of the built-in model builders.
 
-``prepare_linear_design`` is the single owning boundary for exact-zero column
-inspection. It removes those columns from the backend design while retaining
+``prepare_linear_sensitivity`` is the single owning boundary for exact-zero column
+inspection. It removes those columns from the backend sensitivity while retaining
 their full labelled-state mapping; ``state_activity=None`` therefore samples
 every retained state. An explicit ``StateActivity`` fixes or groups scientific
 states but cannot restore a structurally absent column. For shared or
-correlated states, use ``apply_linear_design`` to apply another prepared
+correlated states, use ``apply_linear_sensitivity`` to apply another prepared
 forward operator without constructing a second prior.
 
 Multisector model
@@ -303,7 +303,7 @@ state and forward contribution:
    \mu &= \sum_s \mu_s.
 
 If the normalized PyMC suffix for sector ``s`` is ``ff``, its variables are
-``x_ff`` and ``mu_ff`` and its design data is ``hx_ff``. Source values select
+``x_ff`` and ``mu_ff`` and its sensitivity data is ``hx_ff``. Source values select
 the corresponding ``H`` slices; sector names provide model identities. They
 are not required to be the same strings.
 

--- a/docs/usage/concrete_rhime_model.rst
+++ b/docs/usage/concrete_rhime_model.rst
@@ -204,6 +204,7 @@ helpers:
 
    from openghg_inversions.models import (
        add_linear_component,
+       prepare_linear_design,
        registered_model,
    )
    from openghg_inversions.models.likelihoods import add_gaussian_observation_likelihood
@@ -230,10 +231,12 @@ helpers:
        frequency=None,
        per_site=True,
    )
+   flux_design = prepare_linear_design(inv_inputs["H"])
+   boundary_design = prepare_linear_design(inv_inputs["H_bc"])
 
    with registered_model() as model:
        flux = add_linear_component(
-           inv_inputs["H"],
+           flux_design,
            data_name="hx",
            prior_args=x_prior,
            var_name="x",
@@ -241,7 +244,7 @@ helpers:
            output_dim="nmeasure",
        )
        boundary = add_linear_component(
-           inv_inputs["H_bc"],
+           boundary_design,
            data_name="hbc",
            prior_args=bc_prior,
            var_name="bc",
@@ -278,6 +281,14 @@ This example is deliberately concrete and editable. It is suitable when a
 model developer needs to change graph construction directly. It does not
 automatically participate in the complete ``run_rhime`` output pipeline; that
 pipeline still selects one of the built-in model builders.
+
+``prepare_linear_design`` is the single owning boundary for exact-zero column
+inspection. It removes those columns from the backend design while retaining
+their full labelled-state mapping; ``state_activity=None`` therefore samples
+every retained state. An explicit ``StateActivity`` fixes or groups scientific
+states but cannot restore a structurally absent column. For shared or
+correlated states, use ``apply_linear_design`` to apply another prepared
+forward operator without constructing a second prior.
 
 Multisector model
 -----------------

--- a/docs/usage/rhime.rst
+++ b/docs/usage/rhime.rst
@@ -697,7 +697,7 @@ work. Each ``SectorSpec.x_prior`` supports the same scalar, full-state array,
 and labelled ``DataArray`` parameter forms; labelled values must match the
 selected sector's state coordinate exactly.
 
-For low-level model construction, first inspect a labelled design with
+For low-level model construction, first inspect a labelled sensitivity matrix with
 ``detect_zero_sensitivity``, then combine the returned mask with a
 ``StateActivity`` using ``resolve_state_activity``. State-vector graph helpers
 consume the resulting ``ResolvedStateActivity``; they do not inspect ``H`` or
@@ -711,7 +711,11 @@ from supplying a standalone baseline time series, which belongs to a separate
 baseline component.
 
 The legacy single-sector ``inferpymc`` / ``fixedbasisMCMC`` compatibility path
-continues to sample its full flux state and does not gain multisector behavior.
+does not gain multisector behavior. It now removes exact-zero ``H`` columns in
+the same way as the standard model: observation-space predictions are unchanged,
+but formerly unidentified entries in the full posterior ``x`` are reconstructed
+at their fixed values instead of being prior draws. Derived flux products that
+use those entries may therefore differ from earlier releases.
 
 Correlated Positive Reduced States
 ----------------------------------

--- a/newsfragments/OPE-94.feature.md
+++ b/newsfragments/OPE-94.feature.md
@@ -1,0 +1,1 @@
+Use one prepared linear PyMC component path, removing exact-zero sensitivity columns before graph construction while retaining full labelled-state reconstruction.

--- a/openghg_inversions/experimental/ramsden2022/model.py
+++ b/openghg_inversions/experimental/ramsden2022/model.py
@@ -43,7 +43,11 @@ import xarray as xr
 
 from openghg_inversions.basis.basis_functions import BasisFunctions
 from openghg_inversions.inversion_inputs import DatetimeLike
-from openghg_inversions.models._flux import _select_sector_design, safe_pymc_name
+from openghg_inversions.models._flux import (
+    _namespace_sector_state_coords,
+    _select_sector_design,
+    safe_pymc_name,
+)
 from openghg_inversions.models.components import (
     add_linear_component,
     add_model_data,
@@ -696,7 +700,12 @@ def _namespace_retained_sensitivity(
     if retained_dim == prepared.state_dim:
         return prepared
     return PreparedLinearSensitivity(
-        sensitivity=prepared.sensitivity.rename({retained_dim: f"{retained_dim}_{suffix}"}),
+        sensitivity=_namespace_sector_state_coords(
+            prepared.sensitivity,
+            variable_suffix=suffix,
+            observation_dim=prepared.output_dim,
+            namespace_state_dim=True,
+        ),
         removed=prepared.removed,
         output_dim=prepared.output_dim,
     )

--- a/openghg_inversions/experimental/ramsden2022/model.py
+++ b/openghg_inversions/experimental/ramsden2022/model.py
@@ -19,9 +19,9 @@ model-error definition, ``sqrt(measurement_error**2 + sigma**2)``.
 
 Use :func:`build_ramsden_model` to construct the graph without sampling and
 :func:`run_ramsden_from_prepared_inputs` to sample it. Coupled primary/tracer
-designs must have exactly matching labelled state coordinates. A ratio may be
-applied directly to a ratio-free tracer design, or interpreted as a multiplier
-when the design already includes an explicit reference ratio. Boundary states
+sensitivities must have exactly matching labelled state coordinates. A ratio may
+be applied directly to a ratio-free tracer sensitivity, or interpreted as a
+multiplier when the sensitivity already includes an explicit reference ratio. Boundary states
 are optional and independent by gas. The caller is responsible for consistent
 units; this module performs no retrieval, conversion, or postprocessing.
 """
@@ -47,11 +47,14 @@ from openghg_inversions.models._flux import _select_sector_design, safe_pymc_nam
 from openghg_inversions.models.components import (
     add_linear_component,
     add_model_data,
-    apply_linear_design,
+    apply_linear_sensitivity,
 )
 from openghg_inversions.models.coords import add_coords, registered_model
 from openghg_inversions.models.priors import parse_prior
-from openghg_inversions.models.state_activity import PreparedLinearDesign, prepare_linear_design
+from openghg_inversions.models.state_activity import (
+    PreparedLinearSensitivity,
+    prepare_linear_sensitivity,
+)
 from openghg_inversions.rhime.sampling import RhimeSampler
 from openghg_inversions.sigma import SigmaAlignment
 
@@ -633,7 +636,7 @@ def _sum_terms(terms: list[TensorVariable], *, name: str, dim: str) -> TensorVar
 
 
 def _add_boundary_component(
-    prepared: PreparedLinearDesign | None,
+    prepared: PreparedLinearSensitivity | None,
     spec: RamsdenChannelSpec,
     *,
     suffix: str,
@@ -655,24 +658,48 @@ def _add_boundary_component(
     ).output
 
 
-def _prepare_boundary_design(
+def _prepare_boundary_sensitivity(
     data: xr.Dataset,
     spec: RamsdenChannelSpec,
     *,
     suffix: str,
-) -> PreparedLinearDesign | None:
-    """Prepare one optional namespaced channel boundary design."""
+) -> PreparedLinearSensitivity | None:
+    """Prepare one optional namespaced channel boundary sensitivity."""
     if not spec.use_bc:
         return None
     output_dim = f"nmeasure_{suffix}"
-    design = _rename_observation_axis(data["H_bc"], suffix)
-    state_renames = {str(dim): f"{dim}_{suffix}_bc" for dim in design.dims if str(dim) != output_dim}
+    sensitivity = _rename_observation_axis(data["H_bc"], suffix)
+    state_renames = {
+        str(dim): f"{dim}_{suffix}_bc"
+        for dim in sensitivity.dims
+        if str(dim) != output_dim
+    }
     if state_renames:
-        design = design.rename(state_renames)
-    state_dim = next(str(dim) for dim in design.dims if str(dim) != output_dim)
-    if state_dim not in design.coords:
-        design = design.assign_coords({state_dim: np.arange(design.sizes[state_dim])})
-    return prepare_linear_design(design, output_dim=output_dim)
+        sensitivity = sensitivity.rename(state_renames)
+    state_dim = next(str(dim) for dim in sensitivity.dims if str(dim) != output_dim)
+    if state_dim not in sensitivity.coords:
+        sensitivity = sensitivity.assign_coords(
+            {state_dim: np.arange(sensitivity.sizes[state_dim])}
+        )
+    return prepare_linear_sensitivity(sensitivity, output_dim=output_dim)
+
+
+def _namespace_retained_sensitivity(
+    prepared: PreparedLinearSensitivity,
+    *,
+    suffix: str,
+) -> PreparedLinearSensitivity:
+    """Namespace only a structurally retained backend state axis."""
+    retained_dim = next(
+        str(dim) for dim in prepared.sensitivity.dims if dim != prepared.output_dim
+    )
+    if retained_dim == prepared.state_dim:
+        return prepared
+    return PreparedLinearSensitivity(
+        sensitivity=prepared.sensitivity.rename({retained_dim: f"{retained_dim}_{suffix}"}),
+        removed=prepared.removed,
+        output_dim=prepared.output_dim,
+    )
 
 
 def _add_absolute_error_likelihood(
@@ -753,8 +780,8 @@ def build_ramsden_model(
             Observation coordinates may differ, but coupled sector state
             coordinates must match exactly.
         model_spec: Shared-state, ratio, likelihood, unit, and boundary
-            metadata. Direct ratios require ratio-free tracer designs;
-            reference-ratio mode requires tracer designs that already include
+            metadata. Direct ratios require ratio-free tracer sensitivities;
+            reference-ratio mode requires tracer sensitivities that already include
             the declared reference ratio.
 
     Returns:
@@ -774,7 +801,7 @@ def build_ramsden_model(
     _validate_model_spec(model_spec)
     _validate_channel_data(prepared_inputs.primary, model_spec.primary, label="primary")
     _validate_channel_data(prepared_inputs.tracer, model_spec.tracer, label="tracer")
-    sector_designs = [
+    sector_sensitivities = [
         (sector, _select_sector_designs(prepared_inputs, sector)) for sector in model_spec.sectors
     ]
 
@@ -782,29 +809,36 @@ def build_ramsden_model(
     tracer_suffix = _channel_suffix(model_spec.tracer)
     primary_dim = f"nmeasure_{primary_suffix}"
     tracer_dim = f"nmeasure_{tracer_suffix}"
-    prepared_terms = [
-        (
-            sector,
-            designs,
-            prepare_linear_design(
-                _rename_observation_axis(designs.primary, primary_suffix),
+    prepared_terms = []
+    for sector, sensitivities in sector_sensitivities:
+        variable_suffix = safe_pymc_name(sector.name)
+        primary_sensitivity = _namespace_retained_sensitivity(
+            prepare_linear_sensitivity(
+                _rename_observation_axis(sensitivities.primary, primary_suffix),
                 output_dim=primary_dim,
             ),
-            None
-            if designs.tracer is None
-            else prepare_linear_design(
-                _rename_observation_axis(designs.tracer, tracer_suffix),
-                output_dim=tracer_dim,
-            ),
+            suffix=f"{variable_suffix}_{primary_suffix}",
         )
-        for sector, designs in sector_designs
-    ]
-    primary_boundary = _prepare_boundary_design(
+        tracer_sensitivity = (
+            None
+            if sensitivities.tracer is None
+            else _namespace_retained_sensitivity(
+                prepare_linear_sensitivity(
+                    _rename_observation_axis(sensitivities.tracer, tracer_suffix),
+                    output_dim=tracer_dim,
+                ),
+                suffix=f"{variable_suffix}_{tracer_suffix}",
+            )
+        )
+        prepared_terms.append(
+            (sector, sensitivities, primary_sensitivity, tracer_sensitivity)
+        )
+    primary_boundary = _prepare_boundary_sensitivity(
         prepared_inputs.primary,
         model_spec.primary,
         suffix=primary_suffix,
     )
-    tracer_boundary = _prepare_boundary_design(
+    tracer_boundary = _prepare_boundary_sensitivity(
         prepared_inputs.tracer,
         model_spec.tracer,
         suffix=tracer_suffix,
@@ -814,34 +848,34 @@ def build_ramsden_model(
         primary_terms: list[TensorVariable] = []
         tracer_terms: list[TensorVariable] = []
 
-        for sector, designs, primary_design, tracer_design in prepared_terms:
+        for sector, sensitivities, primary_sensitivity, tracer_sensitivity in prepared_terms:
             variable_suffix = safe_pymc_name(sector.name)
-            add_coords(designs.primary.coords, model_dims=(designs.state_dim,))
+            add_coords(sensitivities.primary.coords, model_dims=(sensitivities.state_dim,))
             state = parse_prior(
                 f"x_{variable_suffix}",
                 sector.x_prior,
-                dims=designs.state_dim,
+                dims=sensitivities.state_dim,
             )
             primary_terms.append(
-                apply_linear_design(
-                    primary_design,
+                apply_linear_sensitivity(
+                    primary_sensitivity,
                     state,
                     data_name=f"hx_{variable_suffix}",
                     output_name=f"mu_{primary_suffix}_{variable_suffix}",
                 )
             )
 
-            if tracer_design is None:
+            if tracer_sensitivity is None:
                 continue
             ratio_factor, _ = _ratio_tensors(
                 sector,
                 state=state,
-                state_dim=designs.state_dim,
+                state_dim=sensitivities.state_dim,
                 variable_suffix=variable_suffix,
             )
             tracer_terms.append(
-                apply_linear_design(
-                    tracer_design,
+                apply_linear_sensitivity(
+                    tracer_sensitivity,
                     state * ratio_factor,
                     data_name=f"hx_{tracer_suffix}_{variable_suffix}",
                     output_name=f"mu_{tracer_suffix}_{variable_suffix}",

--- a/openghg_inversions/experimental/ramsden2022/model.py
+++ b/openghg_inversions/experimental/ramsden2022/model.py
@@ -44,9 +44,14 @@ import xarray as xr
 from openghg_inversions.basis.basis_functions import BasisFunctions
 from openghg_inversions.inversion_inputs import DatetimeLike
 from openghg_inversions.models._flux import _select_sector_design, safe_pymc_name
-from openghg_inversions.models.components import add_linear_component, add_model_data
+from openghg_inversions.models.components import (
+    add_linear_component,
+    add_model_data,
+    apply_linear_design,
+)
 from openghg_inversions.models.coords import add_coords, registered_model
 from openghg_inversions.models.priors import parse_prior
+from openghg_inversions.models.state_activity import PreparedLinearDesign, prepare_linear_design
 from openghg_inversions.rhime.sampling import RhimeSampler
 from openghg_inversions.sigma import SigmaAlignment
 
@@ -628,31 +633,46 @@ def _sum_terms(terms: list[TensorVariable], *, name: str, dim: str) -> TensorVar
 
 
 def _add_boundary_component(
-    data: xr.Dataset,
+    prepared: PreparedLinearDesign | None,
     spec: RamsdenChannelSpec,
     *,
     suffix: str,
 ) -> TensorVariable | None:
     """Add an independent optional boundary state for one channel."""
-    if not spec.use_bc:
+    if prepared is None:
         return None
 
     output_dim = f"nmeasure_{suffix}"
-    design = _rename_observation_axis(data["H_bc"], suffix)
-    state_renames = {str(dim): f"{dim}_{suffix}_bc" for dim in design.dims if str(dim) != output_dim}
-    if state_renames:
-        design = design.rename(state_renames)
     assert spec.bc_prior is not None
-    component = add_linear_component(
-        design,
+    return add_linear_component(
+        prepared,
         data_name=f"hbc_{suffix}",
         prior_args=dict(spec.bc_prior),
         var_name=f"bc_{suffix}",
         output_name=f"mu_bc_{suffix}",
         output_dim=output_dim,
         compute_deterministic=True,
-    )
-    return component.output
+    ).output
+
+
+def _prepare_boundary_design(
+    data: xr.Dataset,
+    spec: RamsdenChannelSpec,
+    *,
+    suffix: str,
+) -> PreparedLinearDesign | None:
+    """Prepare one optional namespaced channel boundary design."""
+    if not spec.use_bc:
+        return None
+    output_dim = f"nmeasure_{suffix}"
+    design = _rename_observation_axis(data["H_bc"], suffix)
+    state_renames = {str(dim): f"{dim}_{suffix}_bc" for dim in design.dims if str(dim) != output_dim}
+    if state_renames:
+        design = design.rename(state_renames)
+    state_dim = next(str(dim) for dim in design.dims if str(dim) != output_dim)
+    if state_dim not in design.coords:
+        design = design.assign_coords({state_dim: np.arange(design.sizes[state_dim])})
+    return prepare_linear_design(design, output_dim=output_dim)
 
 
 def _add_absolute_error_likelihood(
@@ -762,35 +782,57 @@ def build_ramsden_model(
     tracer_suffix = _channel_suffix(model_spec.tracer)
     primary_dim = f"nmeasure_{primary_suffix}"
     tracer_dim = f"nmeasure_{tracer_suffix}"
+    prepared_terms = [
+        (
+            sector,
+            designs,
+            prepare_linear_design(
+                _rename_observation_axis(designs.primary, primary_suffix),
+                output_dim=primary_dim,
+            ),
+            None
+            if designs.tracer is None
+            else prepare_linear_design(
+                _rename_observation_axis(designs.tracer, tracer_suffix),
+                output_dim=tracer_dim,
+            ),
+        )
+        for sector, designs in sector_designs
+    ]
+    primary_boundary = _prepare_boundary_design(
+        prepared_inputs.primary,
+        model_spec.primary,
+        suffix=primary_suffix,
+    )
+    tracer_boundary = _prepare_boundary_design(
+        prepared_inputs.tracer,
+        model_spec.tracer,
+        suffix=tracer_suffix,
+    )
 
     with registered_model() as model:
         primary_terms: list[TensorVariable] = []
         tracer_terms: list[TensorVariable] = []
 
-        for sector, designs in sector_designs:
+        for sector, designs, primary_design, tracer_design in prepared_terms:
             variable_suffix = safe_pymc_name(sector.name)
-            primary_design = _rename_observation_axis(designs.primary, primary_suffix)
-            primary_h = add_model_data(primary_design.transpose(primary_dim, ...), f"hx_{variable_suffix}")
+            add_coords(designs.primary.coords, model_dims=(designs.state_dim,))
             state = parse_prior(
                 f"x_{variable_suffix}",
                 sector.x_prior,
                 dims=designs.state_dim,
             )
             primary_terms.append(
-                pm.Deterministic(
-                    f"mu_{primary_suffix}_{variable_suffix}",
-                    pt.dot(primary_h, state),
-                    dims=primary_dim,
+                apply_linear_design(
+                    primary_design,
+                    state,
+                    data_name=f"hx_{variable_suffix}",
+                    output_name=f"mu_{primary_suffix}_{variable_suffix}",
                 )
             )
 
-            if designs.tracer is None:
+            if tracer_design is None:
                 continue
-            tracer_design = _rename_observation_axis(designs.tracer, tracer_suffix)
-            tracer_h = add_model_data(
-                tracer_design.transpose(tracer_dim, ...),
-                f"hx_{tracer_suffix}_{variable_suffix}",
-            )
             ratio_factor, _ = _ratio_tensors(
                 sector,
                 state=state,
@@ -798,22 +840,23 @@ def build_ramsden_model(
                 variable_suffix=variable_suffix,
             )
             tracer_terms.append(
-                pm.Deterministic(
-                    f"mu_{tracer_suffix}_{variable_suffix}",
-                    pt.dot(tracer_h, state * ratio_factor),
-                    dims=tracer_dim,
+                apply_linear_design(
+                    tracer_design,
+                    state * ratio_factor,
+                    data_name=f"hx_{tracer_suffix}_{variable_suffix}",
+                    output_name=f"mu_{tracer_suffix}_{variable_suffix}",
                 )
             )
 
         mu_primary = _sum_terms(primary_terms, name=f"mu_{primary_suffix}", dim=primary_dim)
         mu_tracer = _sum_terms(tracer_terms, name=f"mu_{tracer_suffix}", dim=tracer_dim)
         primary_bc = _add_boundary_component(
-            prepared_inputs.primary,
+            primary_boundary,
             model_spec.primary,
             suffix=primary_suffix,
         )
         tracer_bc = _add_boundary_component(
-            prepared_inputs.tracer,
+            tracer_boundary,
             model_spec.tracer,
             suffix=tracer_suffix,
         )

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -148,9 +148,16 @@ def build_inferpymc_model(
         inv_inputs["sigma_freq_index"],
         per_site=sigma_per_site,
     )
+    flux_sensitivity = inv_inputs["H"]
+    state_dims = [dim for dim in flux_sensitivity.dims if dim != "nmeasure"]
+    if len(state_dims) == 1 and state_dims[0] not in flux_sensitivity.coords:
+        state_dim = state_dims[0]
+        flux_sensitivity = flux_sensitivity.assign_coords(
+            {state_dim: np.arange(flux_sensitivity.sizes[state_dim])}
+        )
 
     return build_standard_rhime_model(
-        inv_inputs["H"],
+        flux_sensitivity,
         observations=inv_inputs["mf"],
         observation_error=inv_inputs["mf_error"],
         minimum_error=inv_inputs["min_error"],

--- a/openghg_inversions/hbmcmc/inversion_pymc.py
+++ b/openghg_inversions/hbmcmc/inversion_pymc.py
@@ -28,7 +28,6 @@ from openghg_inversions.rhime.standard import build_standard_rhime_model  # noqa
 from openghg_inversions.models.components import resolve_model_variable  # noqa: E402
 from openghg_inversions.models.coords import get_coord_registry, restore_inferencedata_coords  # noqa: E402
 from openghg_inversions.models.priors import PriorArgs  # noqa: E402
-from openghg_inversions.models.state_activity import StateActivity  # noqa: E402
 from openghg_inversions.inversion_inputs import _compact_integer_index  # noqa: E402
 from openghg_inversions.observation_error import resolve_aggregation_error  # noqa: E402
 from openghg_inversions.sigma import SigmaAlignment  # noqa: E402
@@ -170,9 +169,6 @@ def build_inferpymc_model(
         offset_args=offset_args,
         power=power,
         preserve_legacy_likelihood=True,
-        # Keep fixedbasisMCMC/inferpymc's legacy single-sector state graph.
-        # Modern RHIME model specs opt into exact-zero pruning separately.
-        state_activity=StateActivity(prune_zero=False),
     )
 
 

--- a/openghg_inversions/models/__init__.py
+++ b/openghg_inversions/models/__init__.py
@@ -1,6 +1,6 @@
 """Reusable model components, coordinates, priors, and state APIs.
 
-Linear design preparation removes structural zero columns once before graph
+Linear sensitivity preparation removes structural zero columns once before graph
 construction; state activity then controls scientific fixing among the full
 labelled state.
 
@@ -17,7 +17,7 @@ configure_pytensor()
 from openghg_inversions.models.components import (
     CorrelatedStateResult,
     LinearComponentResult,
-    apply_linear_design,
+    apply_linear_sensitivity,
     add_inferpymc_likelihood_component,
     add_linear_component,
     add_model_data,
@@ -36,12 +36,12 @@ from openghg_inversions.models.coords import (
 from openghg_inversions.models.priors import parse_prior
 from openghg_inversions.correlated_state import CorrelatedLognormalPrior
 from openghg_inversions.models.state_activity import (
-    PreparedLinearDesign,
+    PreparedLinearSensitivity,
     ResolvedStateActivity,
     StateActivity,
     active_prior_args,
     detect_zero_sensitivity,
-    prepare_linear_design,
+    prepare_linear_sensitivity,
     resolve_state_activity,
 )
 from openghg_inversions.observation_error import AggregationErrorMode
@@ -53,7 +53,7 @@ __all__ = [
     "LinearComponentResult",
     "AggregationErrorMode",
     "ResolvedStateActivity",
-    "PreparedLinearDesign",
+    "PreparedLinearSensitivity",
     "StateActivity",
     "add_coords",
     "attach_coord_registry",
@@ -64,12 +64,12 @@ __all__ = [
     "add_model_data",
     "add_correlated_lognormal_state",
     "add_linear_component",
-    "apply_linear_design",
+    "apply_linear_sensitivity",
     "add_sigma_component",
     "add_offset_component",
     "add_inferpymc_likelihood_component",
     "active_prior_args",
     "detect_zero_sensitivity",
-    "prepare_linear_design",
+    "prepare_linear_sensitivity",
     "resolve_state_activity",
 ]

--- a/openghg_inversions/models/__init__.py
+++ b/openghg_inversions/models/__init__.py
@@ -1,8 +1,8 @@
 """Reusable model components, coordinates, priors, and state APIs.
 
-State activity separates design inspection with ``detect_zero_sensitivity``,
-policy resolution with ``resolve_state_activity``, and graph construction in
-the component helpers.
+Linear design preparation removes structural zero columns once before graph
+construction; state activity then controls scientific fixing among the full
+labelled state.
 
 Importing this package configures PyTensor before re-exporting reusable model
 primitives. RHIME-specific recipes and contracts live in ``openghg_inversions.rhime``.
@@ -17,14 +17,13 @@ configure_pytensor()
 from openghg_inversions.models.components import (
     CorrelatedStateResult,
     LinearComponentResult,
-    StateLinearComponentResult,
+    apply_linear_design,
     add_inferpymc_likelihood_component,
     add_linear_component,
     add_model_data,
     add_offset_component,
     add_correlated_lognormal_state,
     add_sigma_component,
-    add_state_linear_component,
 )
 from openghg_inversions.models.coords import (
     CoordRegistry,
@@ -37,10 +36,12 @@ from openghg_inversions.models.coords import (
 from openghg_inversions.models.priors import parse_prior
 from openghg_inversions.correlated_state import CorrelatedLognormalPrior
 from openghg_inversions.models.state_activity import (
+    PreparedLinearDesign,
     ResolvedStateActivity,
     StateActivity,
     active_prior_args,
     detect_zero_sensitivity,
+    prepare_linear_design,
     resolve_state_activity,
 )
 from openghg_inversions.observation_error import AggregationErrorMode
@@ -49,8 +50,10 @@ __all__ = [
     "CoordRegistry",
     "CorrelatedLognormalPrior",
     "CorrelatedStateResult",
+    "LinearComponentResult",
     "AggregationErrorMode",
     "ResolvedStateActivity",
+    "PreparedLinearDesign",
     "StateActivity",
     "add_coords",
     "attach_coord_registry",
@@ -58,16 +61,15 @@ __all__ = [
     "registered_model",
     "restore_inferencedata_coords",
     "parse_prior",
-    "LinearComponentResult",
-    "StateLinearComponentResult",
     "add_model_data",
     "add_correlated_lognormal_state",
     "add_linear_component",
-    "add_state_linear_component",
+    "apply_linear_design",
     "add_sigma_component",
     "add_offset_component",
     "add_inferpymc_likelihood_component",
     "active_prior_args",
     "detect_zero_sensitivity",
+    "prepare_linear_design",
     "resolve_state_activity",
 ]

--- a/openghg_inversions/models/components.py
+++ b/openghg_inversions/models/components.py
@@ -1,14 +1,14 @@
 """Reusable PyMC model graph helpers.
 
 These helpers operate on the active PyMC model context and are designed to be
-xarray-first. They return PyTensor/PyMC tensors and should not implement their
-own coordinate sanitization policy; coordinate handling lives in
-``openghg_inversions.models.coords``.
+xarray-first. They return explicit component results or PyTensor/PyMC tensors
+and should not implement their own coordinate sanitization policy; coordinate
+handling lives in ``openghg_inversions.models.coords``.
 
 All component helpers operate inside an active PyMC model context.
 ``add_state_vector`` consumes an already resolved activity contract;
-``add_state_linear_component`` performs design inspection and policy resolution
-before constructing that graph.
+``add_linear_component`` consumes a design inspected by
+``prepare_linear_design`` before constructing that graph.
 
 Naming conventions:
 
@@ -40,10 +40,10 @@ from openghg_inversions.inversion_inputs import make_freq_indicator
 from openghg_inversions.models.coords import add_coords
 from openghg_inversions.models.priors import parse_prior
 from openghg_inversions.models.state_activity import (
+    PreparedLinearDesign,
     ResolvedStateActivity,
     StateActivity,
     active_prior_args,
-    detect_zero_sensitivity,
     resolve_state_activity,
 )
 from openghg_inversions.sigma import SigmaAlignment
@@ -51,11 +51,13 @@ from openghg_inversions.sigma import SigmaAlignment
 
 @dataclass
 class LinearComponentResult:
-    """Objects created by ``add_linear_component``."""
+    """Objects created by :func:`add_linear_component`."""
 
     data: TensorVariable
-    latent: TensorVariable
+    latent: TensorVariable | None
+    state: TensorVariable
     output: TensorVariable
+    activity: ResolvedStateActivity
 
 
 @dataclass
@@ -89,27 +91,6 @@ class CorrelatedStateResult:
     latent: TensorVariable
     state: TensorVariable
     prior: CorrelatedLognormalPrior
-
-
-@dataclass
-class StateLinearComponentResult:
-    """Objects created by ``add_state_linear_component``.
-
-    Attributes:
-        data: Full sensitivity matrix registered with PyMC.
-        latent: Effective active-state latent variable, or ``None`` when no
-            states are active.
-        state: Full ordered state vector. This is the ordinary user-facing
-            prior when all states are active and a deterministic otherwise.
-        output: Forward-model contribution from active and fixed states.
-        activity: Resolved state-activity contract in canonical state order.
-    """
-
-    data: TensorVariable
-    latent: TensorVariable | None
-    state: TensorVariable
-    output: TensorVariable
-    activity: ResolvedStateActivity
 
 
 def get_model_latent(variable: TensorVariable, base_name: str) -> TensorVariable:
@@ -229,19 +210,21 @@ def add_model_data(data: xr.DataArray, name: str | None = None) -> TensorVariabl
 
 
 def add_linear_component(
-    data: xr.DataArray,
+    prepared: PreparedLinearDesign,
     /,
     data_name: str,
     prior_args: dict,
     var_name: str,
     output_name: str,
+    state_activity: StateActivity | None = None,
     output_dim: str = "nmeasure",
     compute_deterministic: bool = True,
 ) -> LinearComponentResult:
-    """Add a linear latent component and its aligned forward-model contribution.
+    """Add one independent labelled linear component.
 
     Args:
-        data: Sensitivity matrix or other linear data term.
+        prepared: Retained design and full-state mapping produced by
+            :func:`prepare_linear_design`.
         data_name: Name used when registering the data as ``pm.Data``.
         prior_args: Prior specification for the latent random variable.
         var_name: Name for the latent random variable.
@@ -250,50 +233,53 @@ def add_linear_component(
         compute_deterministic: Whether to wrap the aligned output in
             ``pm.Deterministic``.
 
+        state_activity: Optional active/fixed policy over the full scientific
+            state. ``None`` samples every retained column.
+
     Returns:
-        A ``LinearComponentResult`` containing the registered data tensor, the
-        effective latent variable, and the aligned output tensor.
+        The registered design, effective latent, full state, aligned forward
+        contribution, and resolved activity.
     """
     output_dim = str(output_dim)
-    data = data.transpose(output_dim, ...)
-    h = add_model_data(data, data_name)
-    input_dims = tuple(str(dim) for dim in data.dims if dim != output_dim)
-    user_facing = parse_prior(var_name, prior_args, dims=input_dims)
-    latent = get_model_latent(user_facing, var_name)
-    output = pt.dot(h, user_facing)
-    if compute_deterministic:
-        output = pm.Deterministic(output_name, output, dims=output_dim)
-    return LinearComponentResult(data=h, latent=latent, output=output)
-
-
-def _with_legacy_all_active_coord(
-    data: xr.DataArray,
-    state_activity: StateActivity | None,
-    *,
-    output_dim: str,
-) -> xr.DataArray:
-    """Supply a positional state coordinate for the legacy all-active policy.
-
-    Args:
-        data: Candidate sensitivity matrix.
-        state_activity: Optional activity policy.
-        output_dim: Observation/output dimension name.
-
-    Returns:
-        ``data`` unchanged, or with positional labels for its sole state axis.
-    """
-    state_dims = [str(dim) for dim in data.dims if dim != output_dim]
-    legacy_all_active = (
-        state_activity is not None
-        and not state_activity.prune_zero
-        and not state_activity.fixed_groups
-        and isinstance(state_activity.active, (bool, np.bool_))
-        and bool(state_activity.active)
+    if output_dim != prepared.output_dim:
+        raise ValueError(
+            f"Prepared linear design owns output dimension {prepared.output_dim!r}, "
+            f"not {output_dim!r}."
+        )
+    activity = resolve_state_activity(prepared.removed, state_activity)
+    vector = add_state_vector(activity, prior_args=prior_args, var_name=var_name)
+    output = apply_linear_design(
+        prepared,
+        vector.state,
+        data_name=data_name,
+        output_name=output_name,
+        compute_deterministic=compute_deterministic,
     )
-    if legacy_all_active and len(state_dims) == 1 and state_dims[0] not in data.coords:
-        state_dim = state_dims[0]
-        return data.assign_coords({state_dim: np.arange(data.sizes[state_dim])})
-    return data
+    data = cast(TensorVariable, pm.modelcontext(None)[data_name])
+    return LinearComponentResult(
+        data=data,
+        latent=vector.latent,
+        state=vector.state,
+        output=output,
+        activity=vector.activity,
+    )
+
+
+def apply_linear_design(
+    prepared: PreparedLinearDesign,
+    state: TensorVariable,
+    /,
+    *,
+    data_name: str,
+    output_name: str,
+    compute_deterministic: bool = True,
+) -> TensorVariable:
+    """Apply a prepared design to an already-built full state vector."""
+    h = add_model_data(prepared.design, data_name)
+    output = pt.dot(h, state[prepared.retained_indices])
+    if compute_deterministic:
+        output = pm.Deterministic(output_name, output, dims=prepared.output_dim)
+    return cast(TensorVariable, output)
 
 
 def add_state_vector(
@@ -455,82 +441,6 @@ def add_correlated_lognormal_state(
         dims=state_dim,
     )
     return CorrelatedStateResult(latent=latent, state=state, prior=prior)
-
-
-def add_state_linear_component(
-    data: xr.DataArray,
-    /,
-    data_name: str,
-    prior_args: dict,
-    var_name: str,
-    output_name: str,
-    state_activity: StateActivity | None = None,
-    output_dim: str = "nmeasure",
-    compute_deterministic: bool = True,
-) -> StateLinearComponentResult:
-    """Add a linear component that samples only active labelled states.
-
-    The public ``var_name`` is always a full ordered vector. When every state
-    is active, it retains the ordinary prior graph produced by
-    ``add_linear_component``. Otherwise, active states are sampled in
-    ``{var_name}_active`` and restored with inactive fixed values into a full
-    deterministic state. The forward contribution is always ``H @ state``.
-
-    Args:
-        data: Finite sensitivity matrix containing ``output_dim`` and exactly
-            one other dimension with a unique labelled state coordinate. The
-            explicit legacy all-active policy may synthesize positional labels.
-        data_name: Name used when registering the full matrix as ``pm.Data``.
-        prior_args: Prior specification. Distribution parameters may be scalar,
-            full-state arrays, or labelled state ``DataArray`` objects.
-        var_name: Name of the full deterministic state vector.
-        output_name: Name for the aligned forward-model contribution.
-        state_activity: Optional active/fixed policy. The default prunes only
-            exactly-zero sensitivity columns and fixes them to one.
-        output_dim: Observation/output dimension name.
-        compute_deterministic: Whether to wrap the output in a named
-            ``pm.Deterministic``.
-
-    Returns:
-        Registered data, optional active latent, full state, output, and the
-        resolved activity contract.
-
-    Raises:
-        ValueError: If the sensitivity layout, state policy, labels, fixed
-            values, or state-valued prior parameters are invalid.
-
-    Notes:
-        This helper mutates the active ``pm.Model`` by registering coordinates,
-        the full design, state variables, and optionally the named output.
-    """
-    output_dim = str(output_dim)
-    data = _with_legacy_all_active_coord(
-        data.transpose(output_dim, ...),
-        state_activity,
-        output_dim=output_dim,
-    )
-    activity = resolve_state_activity(
-        detect_zero_sensitivity(data, output_dim=output_dim),
-        state_activity,
-    )
-    h_full = add_model_data(data, data_name)
-    vector = add_state_vector(
-        activity,
-        prior_args=prior_args,
-        var_name=var_name,
-    )
-
-    output = pt.dot(h_full, vector.state)
-    if compute_deterministic:
-        output = pm.Deterministic(output_name, output, dims=output_dim)
-
-    return StateLinearComponentResult(
-        data=h_full,
-        latent=vector.latent,
-        state=vector.state,
-        output=cast(TensorVariable, output),
-        activity=vector.activity,
-    )
 
 
 def add_sigma_component(

--- a/openghg_inversions/models/components.py
+++ b/openghg_inversions/models/components.py
@@ -7,8 +7,8 @@ handling lives in ``openghg_inversions.models.coords``.
 
 All component helpers operate inside an active PyMC model context.
 ``add_state_vector`` consumes an already resolved activity contract;
-``add_linear_component`` consumes a design inspected by
-``prepare_linear_design`` before constructing that graph.
+``add_linear_component`` consumes a sensitivity matrix inspected by
+``prepare_linear_sensitivity`` before constructing that graph.
 
 Naming conventions:
 
@@ -40,7 +40,7 @@ from openghg_inversions.inversion_inputs import make_freq_indicator
 from openghg_inversions.models.coords import add_coords
 from openghg_inversions.models.priors import parse_prior
 from openghg_inversions.models.state_activity import (
-    PreparedLinearDesign,
+    PreparedLinearSensitivity,
     ResolvedStateActivity,
     StateActivity,
     active_prior_args,
@@ -204,13 +204,14 @@ def add_model_data(data: xr.DataArray, name: str | None = None) -> TensorVariabl
     if name in model:
         return model[name]
 
-    dims = tuple(str(dim) for dim in data.dims)
-    add_coords(data.coords, model_dims=dims)
-    return cast(TensorVariable, pm.Data(name, data.values, dims=dims))
+    materialized = data.compute()
+    dims = tuple(str(dim) for dim in materialized.dims)
+    add_coords(materialized.coords, model_dims=dims)
+    return cast(TensorVariable, pm.Data(name, materialized.values, dims=dims))
 
 
 def add_linear_component(
-    prepared: PreparedLinearDesign,
+    prepared: PreparedLinearSensitivity,
     /,
     data_name: str,
     prior_args: dict,
@@ -223,8 +224,8 @@ def add_linear_component(
     """Add one independent labelled linear component.
 
     Args:
-        prepared: Retained design and full-state mapping produced by
-            :func:`prepare_linear_design`.
+        prepared: Retained sensitivity and full-state mapping produced by
+            :func:`prepare_linear_sensitivity`.
         data_name: Name used when registering the data as ``pm.Data``.
         prior_args: Prior specification for the latent random variable.
         var_name: Name for the latent random variable.
@@ -237,18 +238,18 @@ def add_linear_component(
             state. ``None`` samples every retained column.
 
     Returns:
-        The registered design, effective latent, full state, aligned forward
+        The registered sensitivity, effective latent, full state, aligned forward
         contribution, and resolved activity.
     """
     output_dim = str(output_dim)
     if output_dim != prepared.output_dim:
         raise ValueError(
-            f"Prepared linear design owns output dimension {prepared.output_dim!r}, "
+            f"Prepared linear sensitivity owns output dimension {prepared.output_dim!r}, "
             f"not {output_dim!r}."
         )
     activity = resolve_state_activity(prepared.removed, state_activity)
     vector = add_state_vector(activity, prior_args=prior_args, var_name=var_name)
-    output = apply_linear_design(
+    output = apply_linear_sensitivity(
         prepared,
         vector.state,
         data_name=data_name,
@@ -265,8 +266,8 @@ def add_linear_component(
     )
 
 
-def apply_linear_design(
-    prepared: PreparedLinearDesign,
+def apply_linear_sensitivity(
+    prepared: PreparedLinearSensitivity,
     state: TensorVariable,
     /,
     *,
@@ -274,8 +275,8 @@ def apply_linear_design(
     output_name: str,
     compute_deterministic: bool = True,
 ) -> TensorVariable:
-    """Apply a prepared design to an already-built full state vector."""
-    h = add_model_data(prepared.design, data_name)
+    """Apply a prepared sensitivity to an already-built full state vector."""
+    h = add_model_data(prepared.sensitivity, data_name)
     output = pt.dot(h, state[prepared.retained_indices])
     if compute_deterministic:
         output = pm.Deterministic(output_name, output, dims=prepared.output_dim)
@@ -313,7 +314,7 @@ def add_state_vector(
 
     Notes:
         This helper registers state variables and state coordinates, but it
-        does not inspect or register a linear design and does not construct a
+        does not inspect or register a sensitivity matrix and does not construct a
         forward-model output. The registered activity mask is immutable
         build-time metadata in semantic terms; changing it with ``pm.set_data``
         would not rebuild the latent state layout. Call this helper inside an

--- a/openghg_inversions/models/state_activity.py
+++ b/openghg_inversions/models/state_activity.py
@@ -11,7 +11,7 @@ Inactive states remain part of the public state vector and use labelled or
 scalar fixed values. The default fixed value is one, which preserves the prior
 forward-model contribution of a multiplicative flux-scaling state.
 
-``prepare_linear_design`` validates a linear design, removes exact-zero
+``prepare_linear_sensitivity`` validates a sensitivity matrix, removes exact-zero
 columns, and retains the full-state mapping. ``resolve_state_activity``
 combines that mapping with a policy to produce the canonical
 ``ResolvedStateActivity``;
@@ -54,7 +54,7 @@ class StateActivity:
         group_coord: Name of the state coordinate containing group labels.
     Explicit ``active`` masks and fixed groups are combined with structural
     zero-column removal using logical AND. Structural removal is owned by
-    linear-design preparation and cannot be disabled as an activity policy.
+    sensitivity preparation and cannot be disabled as an activity policy.
     """
 
     active: ActivityValue = True
@@ -64,10 +64,10 @@ class StateActivity:
 
 
 @dataclass(frozen=True)
-class PreparedLinearDesign:
-    """A retained linear design and its lossless full-state mapping."""
+class PreparedLinearSensitivity:
+    """A retained sensitivity matrix and its lossless full-state mapping."""
 
-    design: xr.DataArray
+    sensitivity: xr.DataArray
     removed: xr.DataArray
     output_dim: str
 
@@ -78,19 +78,19 @@ class PreparedLinearDesign:
 
     @property
     def retained_indices(self) -> np.ndarray:
-        """Return full-state positions retained by :attr:`design`."""
+        """Return full-state positions retained by :attr:`sensitivity`."""
         return np.flatnonzero(~_materialize_1d(self.removed, name="removed", dtype=bool))
 
 
-def prepare_linear_design(
+def prepare_linear_sensitivity(
     sensitivity: xr.DataArray,
     *,
     output_dim: str = "nmeasure",
-) -> PreparedLinearDesign:
+) -> PreparedLinearSensitivity:
     """Remove exact-zero columns once and retain their full-state mapping.
 
-    This is the eager inspection boundary for a labelled linear design. The
-    returned design keeps borrowed array data and contains only nonzero
+    This is the eager inspection boundary for a labelled sensitivity matrix. The
+    returned sensitivity keeps borrowed array data and contains only nonzero
     columns; ``removed`` retains the complete scientific state coordinate and
     auxiliary state metadata for reconstruction and provenance.
     """
@@ -99,18 +99,18 @@ def prepare_linear_design(
     removed = detect_zero_sensitivity(matrix, output_dim=output_dim)
     state_dim = str(removed.dims[0])
     retained_indices = np.flatnonzero(~removed.to_numpy())
-    design = matrix.isel({state_dim: retained_indices})
+    retained = matrix.isel({state_dim: retained_indices})
     if retained_indices.size != matrix.sizes[state_dim]:
-        design = design.rename({state_dim: f"{state_dim}_retained"})
+        retained = retained.rename({state_dim: f"{state_dim}_retained"})
         retained_dim = f"{state_dim}_retained"
         retained_auxiliary = {
             str(name): f"{name}_retained"
-            for name, coord in design.coords.items()
-            if name not in design.dims and retained_dim in coord.dims
+            for name, coord in retained.coords.items()
+            if name not in retained.dims and retained_dim in coord.dims
         }
-        design = design.rename(retained_auxiliary)
-    return PreparedLinearDesign(
-        design=design,
+        retained = retained.rename(retained_auxiliary)
+    return PreparedLinearSensitivity(
+        sensitivity=retained,
         removed=removed.rename("structurally_removed"),
         output_dim=output_dim,
     )
@@ -118,7 +118,7 @@ def prepare_linear_design(
 
 @dataclass(frozen=True)
 class ResolvedStateActivity:
-    """A state-activity policy aligned to one detected linear design.
+    """A state-activity policy aligned to one detected sensitivity matrix.
 
     Attributes:
         state_dim: Canonical state dimension name from the detection mask.
@@ -185,7 +185,7 @@ def detect_zero_sensitivity(
     """Return the labelled mask of exactly-zero sensitivity columns.
 
     Args:
-        sensitivity: Finite two-dimensional linear design containing
+        sensitivity: Finite two-dimensional sensitivity matrix containing
             ``output_dim`` and one uniquely labelled state dimension.
         output_dim: Name of the observation/output dimension.
 
@@ -431,7 +431,7 @@ def resolve_state_activity(
 
     Notes:
         Policy vectors are materialized during model construction. Use
-        ``detect_zero_sensitivity`` to validate and reduce a linear design
+        ``detect_zero_sensitivity`` to validate and reduce a sensitivity matrix
         before calling this function.
     """
     policy = policy or StateActivity()

--- a/openghg_inversions/models/state_activity.py
+++ b/openghg_inversions/models/state_activity.py
@@ -11,9 +11,10 @@ Inactive states remain part of the public state vector and use labelled or
 scalar fixed values. The default fixed value is one, which preserves the prior
 forward-model contribution of a multiplicative flux-scaling state.
 
-``detect_zero_sensitivity`` validates a linear design and reduces it to a
-labelled state mask. ``resolve_state_activity`` combines that mask with a
-policy to produce the canonical ``ResolvedStateActivity``;
+``prepare_linear_design`` validates a linear design, removes exact-zero
+columns, and retains the full-state mapping. ``resolve_state_activity``
+combines that mapping with a policy to produce the canonical
+``ResolvedStateActivity``;
 ``active_prior_args`` then aligns and subsets state-valued prior parameters.
 Finite checks, exact-zero reductions, and state-vector alignment are explicit
 eager-compute boundaries for lazy or Dask-backed inputs during model building.
@@ -51,20 +52,68 @@ class StateActivity:
         fixed_groups: ``basis_group`` labels to freeze. Group selection is by
             coordinate value, never by state-number ranges.
         group_coord: Name of the state coordinate containing group labels.
-        prune_zero: Whether states marked exactly zero by prior design
-            inspection are made inactive. No tolerance is applied; every
-            nonzero finite column remains active by default.
-
-    Explicit ``active`` masks, fixed groups, and exact-zero pruning are
-    combined with logical AND. This permits one policy to represent zero-H
-    pruning, frozen states, frozen groups, or an entirely frozen sector.
+    Explicit ``active`` masks and fixed groups are combined with structural
+    zero-column removal using logical AND. Structural removal is owned by
+    linear-design preparation and cannot be disabled as an activity policy.
     """
 
     active: ActivityValue = True
     fixed_value: FixedValue = 1.0
     fixed_groups: tuple[str, ...] = ()
     group_coord: str = "basis_group"
-    prune_zero: bool = True
+
+
+@dataclass(frozen=True)
+class PreparedLinearDesign:
+    """A retained linear design and its lossless full-state mapping."""
+
+    design: xr.DataArray
+    removed: xr.DataArray
+    output_dim: str
+
+    @property
+    def state_dim(self) -> str:
+        """Return the sole state dimension."""
+        return str(self.removed.dims[0])
+
+    @property
+    def retained_indices(self) -> np.ndarray:
+        """Return full-state positions retained by :attr:`design`."""
+        return np.flatnonzero(~_materialize_1d(self.removed, name="removed", dtype=bool))
+
+
+def prepare_linear_design(
+    sensitivity: xr.DataArray,
+    *,
+    output_dim: str = "nmeasure",
+) -> PreparedLinearDesign:
+    """Remove exact-zero columns once and retain their full-state mapping.
+
+    This is the eager inspection boundary for a labelled linear design. The
+    returned design keeps borrowed array data and contains only nonzero
+    columns; ``removed`` retains the complete scientific state coordinate and
+    auxiliary state metadata for reconstruction and provenance.
+    """
+    output_dim = str(output_dim)
+    matrix = sensitivity.transpose(output_dim, ...)
+    removed = detect_zero_sensitivity(matrix, output_dim=output_dim)
+    state_dim = str(removed.dims[0])
+    retained_indices = np.flatnonzero(~removed.to_numpy())
+    design = matrix.isel({state_dim: retained_indices})
+    if retained_indices.size != matrix.sizes[state_dim]:
+        design = design.rename({state_dim: f"{state_dim}_retained"})
+        retained_dim = f"{state_dim}_retained"
+        retained_auxiliary = {
+            str(name): f"{name}_retained"
+            for name, coord in design.coords.items()
+            if name not in design.dims and retained_dim in coord.dims
+        }
+        design = design.rename(retained_auxiliary)
+    return PreparedLinearDesign(
+        design=design,
+        removed=removed.rename("structurally_removed"),
+        output_dim=output_dim,
+    )
 
 
 @dataclass(frozen=True)
@@ -363,8 +412,8 @@ def resolve_state_activity(
             exactly-zero design columns. It must have a unique labelled state
             coordinate and may carry auxiliary state coordinates used by the
             policy.
-        policy: Optional activity policy. When omitted, exact-zero columns are
-            pruned and all other states are active with inactive value one.
+        policy: Optional activity policy. When omitted, every retained column
+            is active and structurally removed states use inactive value one.
 
     Returns:
         A policy aligned to the mask's canonical state coordinate.
@@ -406,9 +455,7 @@ def resolve_state_activity(
     )
     _require_finite(_materialize_1d(fixed_value, name="fixed_value"), name="fixed_value")
 
-    active = explicit_active
-    if policy.prune_zero:
-        active = active & ~zero_sensitivity
+    active = explicit_active & ~zero_sensitivity
 
     if policy.fixed_groups:
         if policy.group_coord not in zero_sensitivity.coords:

--- a/openghg_inversions/models/state_activity.py
+++ b/openghg_inversions/models/state_activity.py
@@ -216,10 +216,16 @@ def detect_zero_sensitivity(
         finite_mask = cast(xr.DataArray, np.isfinite(matrix))
     except TypeError as exc:
         raise ValueError("Sensitivity must contain numeric values.") from exc
-    if not bool(finite_mask.all().compute().item()):
+    inspection = xr.Dataset(
+        {
+            "all_finite": finite_mask.all(),
+            "zero_sensitivity": (matrix == 0).all(dim=output_dim),
+        }
+    ).compute()
+    if not bool(inspection["all_finite"].item()):
         raise ValueError("Sensitivity must contain only finite values.")
 
-    return (matrix == 0).all(dim=output_dim).compute().rename("zero_sensitivity")
+    return inspection["zero_sensitivity"]
 
 
 def _materialize_1d(

--- a/openghg_inversions/rhime/multisector.py
+++ b/openghg_inversions/rhime/multisector.py
@@ -18,7 +18,6 @@ from openghg_inversions.inversion_data import RhimeMergedData, RhimePreparedInpu
 from openghg_inversions.models.components import (
     add_linear_component,
     add_offset_component,
-    add_state_linear_component,
 )
 from openghg_inversions.models.coords import registered_model
 from openghg_inversions.models.pollution_event import build_pollution_event_gaussian_likelihood
@@ -29,9 +28,10 @@ from openghg_inversions.models._flux import (
     _select_sector_design,
 )
 from openghg_inversions.models.state_activity import (
+    PreparedLinearDesign,
     StateActivity,
     active_prior_args,
-    detect_zero_sensitivity,
+    prepare_linear_design,
     resolve_state_activity,
 )
 from openghg_inversions.observation_error import (
@@ -79,7 +79,7 @@ from .preparation import (
 from .sampling import RhimeSampler, sample_rhime_model
 
 
-_SectorComponent = tuple[SectorSpec, xr.DataArray, PriorArgs, StateActivity]
+_SectorComponent = tuple[SectorSpec, PreparedLinearDesign, PriorArgs, StateActivity]
 _MULTISECTOR_FLUX_INPUT_NAMES = ("H",)
 _MODEL_ERROR_ALIGNMENT_INPUT_NAMES = ("site_indicator",)
 _BASELINE_INPUT_NAMES = ("H_bc",)
@@ -248,28 +248,42 @@ def _prepare_multisector_flux_components(
             namespace_state_dim=False,
         )
         sector_policy = sector.state_activity if sector.state_activity is not None else state_activity
-        resolved_activity = resolve_state_activity(detect_zero_sensitivity(design), sector_policy)
+        prepared_design = prepare_linear_design(design)
+        resolved_activity = resolve_state_activity(prepared_design.removed, sector_policy)
         all_active = replace(
             resolved_activity,
             active=xr.ones_like(resolved_activity.active, dtype=bool),
         )
         prior = active_prior_args(dict(sector.x_prior), all_active)
         backend_design = _namespace_sector_state_coords(
-            design,
+            prepared_design.design,
             variable_suffix=sector.variable_suffix,
             namespace_state_dim=gathered_layout,
         )
-        backend_state_dim = next(str(dim) for dim in backend_design.dims if dim != "nmeasure")
         semantic_state_dim = resolved_activity.state_dim
+        backend_state_dim = (
+            f"{semantic_state_dim}_{sector.variable_suffix}"
+            if gathered_layout
+            else semantic_state_dim
+        )
         rename_state = (
             {semantic_state_dim: backend_state_dim} if semantic_state_dim != backend_state_dim else {}
+        )
+        backend_removed = _namespace_sector_state_coords(
+            prepared_design.removed,
+            variable_suffix=sector.variable_suffix,
+            namespace_state_dim=gathered_layout,
+        )
+        backend_prepared = PreparedLinearDesign(
+            design=backend_design,
+            removed=backend_removed,
+            output_dim=prepared_design.output_dim,
         )
         backend_activity = StateActivity(
             active=resolved_activity.active.rename(rename_state),
             fixed_value=resolved_activity.fixed_value.rename(rename_state),
-            prune_zero=False,
         )
-        components.append((sector, backend_design, prior, backend_activity))
+        components.append((sector, backend_prepared, prior, backend_activity))
     return tuple(components)
 
 
@@ -353,20 +367,26 @@ def build_multisector_rhime_model(
     bc_prior = dict(DEFAULT_BC_PRIOR if bc_prior is None else bc_prior)
     sigma_prior = dict(DEFAULT_SIGMA_PRIOR if sigma_prior is None else sigma_prior)
     offset_prior = dict(DEFAULT_OFFSET_PRIOR if offset_prior is None else offset_prior)
+    prepared_boundary = (
+        prepare_linear_design(boundary_sensitivity)
+        if use_bc and boundary_sensitivity is not None
+        else None
+    )
     with registered_model() as model:
         sector_outputs = []
         for sector, design, prior, sector_policy in sector_components:
-            linear_component = add_state_linear_component(
-                design,
-                data_name=f"hx_{sector.variable_suffix}",
-                prior_args=prior,
-                var_name=f"x_{sector.variable_suffix}",
-                output_name=f"mu_{sector.variable_suffix}",
-                output_dim="nmeasure",
-                compute_deterministic=True,
-                state_activity=sector_policy,
+            sector_outputs.append(
+                add_linear_component(
+                    design,
+                    data_name=f"hx_{sector.variable_suffix}",
+                    prior_args=prior,
+                    var_name=f"x_{sector.variable_suffix}",
+                    output_name=f"mu_{sector.variable_suffix}",
+                    output_dim="nmeasure",
+                    compute_deterministic=True,
+                    state_activity=sector_policy,
+                ).output
             )
-            sector_outputs.append(linear_component.output)
 
         pollution_mean = cast(Any, pt.stack(sector_outputs, axis=0)).sum(axis=0)
 
@@ -376,27 +396,17 @@ def build_multisector_rhime_model(
                 raise ValueError(
                     "Multisector baseline component requires `boundary_sensitivity` when `use_bc` is true."
                 )
-            if bc_state_activity is None:
-                boundary_mean = add_linear_component(
-                    boundary_sensitivity,
-                    data_name="hbc",
-                    prior_args=bc_prior,
-                    var_name="bc",
-                    output_name="mu_bc",
-                    output_dim="nmeasure",
-                    compute_deterministic=True,
-                ).output
-            else:
-                boundary_mean = add_state_linear_component(
-                    boundary_sensitivity,
-                    data_name="hbc",
-                    prior_args=bc_prior,
-                    var_name="bc",
-                    output_name="mu_bc",
-                    output_dim="nmeasure",
-                    compute_deterministic=True,
-                    state_activity=bc_state_activity,
-                ).output
+            assert prepared_boundary is not None
+            boundary_mean = add_linear_component(
+                prepared_boundary,
+                data_name="hbc",
+                prior_args=bc_prior,
+                var_name="bc",
+                output_name="mu_bc",
+                output_dim="nmeasure",
+                compute_deterministic=True,
+                state_activity=bc_state_activity,
+            ).output
 
         offset = None
         if add_offset:

--- a/openghg_inversions/rhime/multisector.py
+++ b/openghg_inversions/rhime/multisector.py
@@ -28,10 +28,10 @@ from openghg_inversions.models._flux import (
     _select_sector_design,
 )
 from openghg_inversions.models.state_activity import (
-    PreparedLinearDesign,
+    PreparedLinearSensitivity,
     StateActivity,
     active_prior_args,
-    prepare_linear_design,
+    prepare_linear_sensitivity,
     resolve_state_activity,
 )
 from openghg_inversions.observation_error import (
@@ -79,7 +79,7 @@ from .preparation import (
 from .sampling import RhimeSampler, sample_rhime_model
 
 
-_SectorComponent = tuple[SectorSpec, PreparedLinearDesign, PriorArgs, StateActivity]
+_SectorComponent = tuple[SectorSpec, PreparedLinearSensitivity, PriorArgs, StateActivity]
 _MULTISECTOR_FLUX_INPUT_NAMES = ("H",)
 _MODEL_ERROR_ALIGNMENT_INPUT_NAMES = ("site_indicator",)
 _BASELINE_INPUT_NAMES = ("H_bc",)
@@ -248,18 +248,20 @@ def _prepare_multisector_flux_components(
             namespace_state_dim=False,
         )
         sector_policy = sector.state_activity if sector.state_activity is not None else state_activity
-        prepared_design = prepare_linear_design(design)
-        resolved_activity = resolve_state_activity(prepared_design.removed, sector_policy)
+        prepared_sensitivity = prepare_linear_sensitivity(design)
+        resolved_activity = resolve_state_activity(prepared_sensitivity.removed, sector_policy)
         all_active = replace(
             resolved_activity,
             active=xr.ones_like(resolved_activity.active, dtype=bool),
         )
         prior = active_prior_args(dict(sector.x_prior), all_active)
         design_state_dim = next(
-            str(dim) for dim in prepared_design.design.dims if dim != prepared_design.output_dim
+            str(dim)
+            for dim in prepared_sensitivity.sensitivity.dims
+            if dim != prepared_sensitivity.output_dim
         )
         backend_design = _namespace_sector_state_coords(
-            prepared_design.design,
+            prepared_sensitivity.sensitivity,
             variable_suffix=sector.variable_suffix,
             namespace_state_dim=gathered_layout or design_state_dim != resolved_activity.state_dim,
         )
@@ -273,14 +275,14 @@ def _prepare_multisector_flux_components(
             {semantic_state_dim: backend_state_dim} if semantic_state_dim != backend_state_dim else {}
         )
         backend_removed = _namespace_sector_state_coords(
-            prepared_design.removed,
+            prepared_sensitivity.removed,
             variable_suffix=sector.variable_suffix,
             namespace_state_dim=gathered_layout,
         )
-        backend_prepared = PreparedLinearDesign(
-            design=backend_design,
+        backend_prepared = PreparedLinearSensitivity(
+            sensitivity=backend_design,
             removed=backend_removed,
-            output_dim=prepared_design.output_dim,
+            output_dim=prepared_sensitivity.output_dim,
         )
         backend_activity = StateActivity(
             active=resolved_activity.active.rename(rename_state),
@@ -371,7 +373,7 @@ def build_multisector_rhime_model(
     sigma_prior = dict(DEFAULT_SIGMA_PRIOR if sigma_prior is None else sigma_prior)
     offset_prior = dict(DEFAULT_OFFSET_PRIOR if offset_prior is None else offset_prior)
     prepared_boundary = (
-        prepare_linear_design(boundary_sensitivity)
+        prepare_linear_sensitivity(boundary_sensitivity)
         if use_bc and boundary_sensitivity is not None
         else None
     )

--- a/openghg_inversions/rhime/multisector.py
+++ b/openghg_inversions/rhime/multisector.py
@@ -255,10 +255,13 @@ def _prepare_multisector_flux_components(
             active=xr.ones_like(resolved_activity.active, dtype=bool),
         )
         prior = active_prior_args(dict(sector.x_prior), all_active)
+        design_state_dim = next(
+            str(dim) for dim in prepared_design.design.dims if dim != prepared_design.output_dim
+        )
         backend_design = _namespace_sector_state_coords(
             prepared_design.design,
             variable_suffix=sector.variable_suffix,
-            namespace_state_dim=gathered_layout,
+            namespace_state_dim=gathered_layout or design_state_dim != resolved_activity.state_dim,
         )
         semantic_state_dim = resolved_activity.state_dim
         backend_state_dim = (

--- a/openghg_inversions/rhime/standard.py
+++ b/openghg_inversions/rhime/standard.py
@@ -24,7 +24,7 @@ from openghg_inversions.models.components import (
 from openghg_inversions.models.coords import registered_model
 from openghg_inversions.models.pollution_event import build_pollution_event_gaussian_likelihood
 from openghg_inversions.models.priors import PriorArgs
-from openghg_inversions.models.state_activity import StateActivity, prepare_linear_design
+from openghg_inversions.models.state_activity import StateActivity, prepare_linear_sensitivity
 from openghg_inversions.observation_error import (
     AggregationError,
     OBSERVATION_ERROR_INPUT_NAMES,
@@ -236,9 +236,9 @@ def build_standard_rhime_model(
     sigma_prior = dict(DEFAULT_SIGMA_PRIOR if sigma_prior is None else sigma_prior)
     offset_prior = dict(DEFAULT_OFFSET_PRIOR if offset_prior is None else offset_prior)
 
-    prepared_flux = prepare_linear_design(flux_sensitivity)
+    prepared_flux = prepare_linear_sensitivity(flux_sensitivity)
     prepared_boundary = (
-        prepare_linear_design(boundary_sensitivity)
+        prepare_linear_sensitivity(boundary_sensitivity)
         if use_bc and boundary_sensitivity is not None
         else None
     )

--- a/openghg_inversions/rhime/standard.py
+++ b/openghg_inversions/rhime/standard.py
@@ -20,12 +20,11 @@ from openghg_inversions.inversion_data import RhimeMergedData, RhimePreparedInpu
 from openghg_inversions.models.components import (
     add_linear_component,
     add_offset_component,
-    add_state_linear_component,
 )
 from openghg_inversions.models.coords import registered_model
 from openghg_inversions.models.pollution_event import build_pollution_event_gaussian_likelihood
 from openghg_inversions.models.priors import PriorArgs
-from openghg_inversions.models.state_activity import StateActivity
+from openghg_inversions.models.state_activity import StateActivity, prepare_linear_design
 from openghg_inversions.observation_error import (
     AggregationError,
     OBSERVATION_ERROR_INPUT_NAMES,
@@ -237,9 +236,16 @@ def build_standard_rhime_model(
     sigma_prior = dict(DEFAULT_SIGMA_PRIOR if sigma_prior is None else sigma_prior)
     offset_prior = dict(DEFAULT_OFFSET_PRIOR if offset_prior is None else offset_prior)
 
+    prepared_flux = prepare_linear_design(flux_sensitivity)
+    prepared_boundary = (
+        prepare_linear_design(boundary_sensitivity)
+        if use_bc and boundary_sensitivity is not None
+        else None
+    )
+
     with registered_model() as model:
-        flux_component = add_state_linear_component(
-            flux_sensitivity,
+        flux_component = add_linear_component(
+            prepared_flux,
             data_name="hx",
             prior_args=x_prior,
             var_name="x",
@@ -256,27 +262,17 @@ def build_standard_rhime_model(
                 raise ValueError(
                     "Standard baseline component requires `boundary_sensitivity` when `use_bc` is true."
                 )
-            if bc_state_activity is None:
-                boundary_mean = add_linear_component(
-                    boundary_sensitivity,
-                    data_name="hbc",
-                    prior_args=bc_prior,
-                    var_name="bc",
-                    output_name="mu_bc",
-                    output_dim="nmeasure",
-                    compute_deterministic=True,
-                ).output
-            else:
-                boundary_mean = add_state_linear_component(
-                    boundary_sensitivity,
-                    data_name="hbc",
-                    prior_args=bc_prior,
-                    var_name="bc",
-                    output_name="mu_bc",
-                    output_dim="nmeasure",
-                    compute_deterministic=True,
-                    state_activity=bc_state_activity,
-                ).output
+            assert prepared_boundary is not None
+            boundary_mean = add_linear_component(
+                prepared_boundary,
+                data_name="hbc",
+                prior_args=bc_prior,
+                var_name="bc",
+                output_name="mu_bc",
+                output_dim="nmeasure",
+                compute_deterministic=True,
+                state_activity=bc_state_activity,
+            ).output
 
         offset = None
         if add_offset:

--- a/tests/experimental/test_ramsden2022.py
+++ b/tests/experimental/test_ramsden2022.py
@@ -156,6 +156,33 @@ def test_two_sector_equations_share_x_and_only_fossil_emits_tracer() -> None:
     assert "emission_ratio_biogenic" not in model.named_vars
 
 
+def test_differently_retained_channel_sensitivities_use_distinct_backend_axes() -> None:
+    """Shared states allow channel-specific exact-zero sensitivity columns."""
+    prepared = _prepared_inputs()
+    primary = prepared.primary.copy(deep=True)
+    tracer = prepared.tracer.copy(deep=True)
+    primary["H"].loc[{"source": "ff_ch4", "region": "west"}] = 0.0
+    tracer["H"].loc[{"source": "ff_c2h6", "region": "east"}] = 0.0
+    prepared = RamsdenPreparedInputs(
+        primary=primary,
+        tracer=tracer,
+        tracer_design_reference_ratios=prepared.tracer_design_reference_ratios,
+    )
+
+    model = build_ramsden_model(prepared, _model_spec())
+
+    assert model.named_vars_to_dims["hx_fossil"] == (
+        "nmeasure_ch4",
+        "region_retained_fossil_ch4",
+    )
+    assert model.named_vars_to_dims["hx_c2h6_fossil"] == (
+        "nmeasure_c2h6",
+        "region_retained_fossil_c2h6",
+    )
+    np.testing.assert_allclose(_initial_value(model, "mu_ch4_fossil"), [0.0, 6.0, 3.0])
+    np.testing.assert_allclose(_initial_value(model, "mu_c2h6_fossil"), [2.0, 0.0])
+
+
 def test_direct_and_reference_ratio_multiplier_contracts_are_equivalent() -> None:
     """A pre-scaled reference inventory and multiplier match a direct ratio."""
     direct = build_ramsden_model(_prepared_inputs(), _model_spec(fixed_ratio=0.2))

--- a/tests/experimental/test_ramsden2022.py
+++ b/tests/experimental/test_ramsden2022.py
@@ -17,6 +17,7 @@ from openghg_inversions.experimental.ramsden2022 import (
     build_ramsden_model,
     run_ramsden_from_prepared_inputs,
 )
+from openghg_inversions.models import get_coord_registry
 from openghg_inversions.rhime import RhimeSampler
 
 
@@ -159,8 +160,12 @@ def test_two_sector_equations_share_x_and_only_fossil_emits_tracer() -> None:
 def test_differently_retained_channel_sensitivities_use_distinct_backend_axes() -> None:
     """Shared states allow channel-specific exact-zero sensitivity columns."""
     prepared = _prepared_inputs()
-    primary = prepared.primary.copy(deep=True)
-    tracer = prepared.tracer.copy(deep=True)
+    primary = prepared.primary.copy(deep=True).assign_coords(
+        basis_group=("region", ["outer", "inner"])
+    )
+    tracer = prepared.tracer.copy(deep=True).assign_coords(
+        basis_group=("region", ["outer", "inner"])
+    )
     primary["H"].loc[{"source": "ff_ch4", "region": "west"}] = 0.0
     tracer["H"].loc[{"source": "ff_c2h6", "region": "east"}] = 0.0
     prepared = RamsdenPreparedInputs(
@@ -178,6 +183,14 @@ def test_differently_retained_channel_sensitivities_use_distinct_backend_axes() 
     assert model.named_vars_to_dims["hx_c2h6_fossil"] == (
         "nmeasure_c2h6",
         "region_retained_fossil_c2h6",
+    )
+    registry = get_coord_registry(model)
+    assert registry is not None
+    np.testing.assert_array_equal(
+        registry.auxiliary_coords["basis_group_retained_fossil_ch4"], ["inner"]
+    )
+    np.testing.assert_array_equal(
+        registry.auxiliary_coords["basis_group_retained_fossil_c2h6"], ["outer"]
     )
     np.testing.assert_allclose(_initial_value(model, "mu_ch4_fossil"), [0.0, 6.0, 3.0])
     np.testing.assert_allclose(_initial_value(model, "mu_c2h6_fossil"), [2.0, 0.0])

--- a/tests/models/test_components.py
+++ b/tests/models/test_components.py
@@ -15,7 +15,7 @@ from openghg_inversions.models.components import (
     resolve_model_variable,
 )
 from openghg_inversions.models.coords import CoordRegistry, attach_coord_registry
-from openghg_inversions.models.state_activity import prepare_linear_design
+from openghg_inversions.models.state_activity import prepare_linear_sensitivity
 from openghg_inversions.sigma import SigmaAlignment
 
 
@@ -96,7 +96,7 @@ def test_add_linear_component_creates_expected_named_vars() -> None:
     with pm.Model() as model:
         attach_coord_registry(model, CoordRegistry())
         result = add_linear_component(
-            prepare_linear_design(data),
+            prepare_linear_sensitivity(data),
             data_name="hx",
             prior_args={"pdf": "normal", "mu": 1.0, "sigma": 1.0},
             var_name="x",
@@ -123,7 +123,7 @@ def test_add_linear_component_returns_effective_reparameterised_latent() -> None
     with pm.Model() as model:
         attach_coord_registry(model, CoordRegistry())
         result = add_linear_component(
-            prepare_linear_design(data),
+            prepare_linear_sensitivity(data),
             data_name="hx",
             prior_args={"pdf": "lognormal", "mean": 1.5, "stdev": 0.2, "reparameterise": True},
             var_name="x",
@@ -147,7 +147,7 @@ def test_resolve_model_variable_prefers_latent() -> None:
     with pm.Model() as model:
         attach_coord_registry(model, CoordRegistry())
         add_linear_component(
-            prepare_linear_design(data),
+            prepare_linear_sensitivity(data),
             data_name="hx",
             prior_args={"pdf": "lognormal", "mean": 1.5, "stdev": 0.2, "reparameterise": True},
             var_name="x",

--- a/tests/models/test_components.py
+++ b/tests/models/test_components.py
@@ -15,6 +15,7 @@ from openghg_inversions.models.components import (
     resolve_model_variable,
 )
 from openghg_inversions.models.coords import CoordRegistry, attach_coord_registry
+from openghg_inversions.models.state_activity import prepare_linear_design
 from openghg_inversions.sigma import SigmaAlignment
 
 
@@ -95,17 +96,18 @@ def test_add_linear_component_creates_expected_named_vars() -> None:
     with pm.Model() as model:
         attach_coord_registry(model, CoordRegistry())
         result = add_linear_component(
-            data,
+            prepare_linear_design(data),
             data_name="hx",
             prior_args={"pdf": "normal", "mu": 1.0, "sigma": 1.0},
             var_name="x",
             output_name="mu",
         )
 
-    assert isinstance(result, LinearComponentResult)
     assert {"hx", "x", "mu"}.issubset(model.named_vars)
+    assert isinstance(result, LinearComponentResult)
     assert result.data is model.named_vars["hx"]
     assert result.latent is model.named_vars["x"]
+    assert result.state is model.named_vars["x"]
     assert result.output is model.named_vars["mu"]
 
 
@@ -121,7 +123,7 @@ def test_add_linear_component_returns_effective_reparameterised_latent() -> None
     with pm.Model() as model:
         attach_coord_registry(model, CoordRegistry())
         result = add_linear_component(
-            data,
+            prepare_linear_design(data),
             data_name="hx",
             prior_args={"pdf": "lognormal", "mean": 1.5, "stdev": 0.2, "reparameterise": True},
             var_name="x",
@@ -145,7 +147,7 @@ def test_resolve_model_variable_prefers_latent() -> None:
     with pm.Model() as model:
         attach_coord_registry(model, CoordRegistry())
         add_linear_component(
-            data,
+            prepare_linear_design(data),
             data_name="hx",
             prior_args={"pdf": "lognormal", "mean": 1.5, "stdev": 0.2, "reparameterise": True},
             var_name="x",

--- a/tests/models/test_state_activity.py
+++ b/tests/models/test_state_activity.py
@@ -180,7 +180,7 @@ def test_all_zero_linear_sensitivity_builds_zero_forward_and_full_fixed_state() 
     assert prepared.sensitivity.sizes["region_retained"] == 0
     assert model.free_RVs == []
     np.testing.assert_allclose(model.named_vars["x"].eval(), np.ones(4))
-    np.testing.assert_allclose(result.output.eval(), np.zeros(2))
+    np.testing.assert_allclose(result.output.eval(), np.zeros(2), atol=1e-12)
 
 
 def test_resolve_state_activity_combines_labels_groups_and_exact_zero() -> None:

--- a/tests/models/test_state_activity.py
+++ b/tests/models/test_state_activity.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any, cast
 
 import dask.array as da
+from dask.callbacks import Callback
 import numpy as np
 import pymc as pm
 import pytest
@@ -138,11 +139,26 @@ def test_prepare_linear_design_removes_columns_and_retains_full_mapping() -> Non
 
 
 def test_prepare_linear_design_keeps_retained_dask_payload_lazy() -> None:
-    """Preparation computes the structural mask without densifying retained data."""
-    prepared = prepare_linear_design(_sensitivity().chunk({"nmeasure": 1, "region": 2}))
+    """Inspect once, then keep retained data lazy until PyMC registration."""
+    executions: list[object] = []
+    callback = Callback(start=lambda graph: executions.append(graph))
+    with callback:
+        prepared = prepare_linear_design(_sensitivity().chunk({"nmeasure": 1, "region": 2}))
 
-    assert isinstance(prepared.design.data, da.Array)
-    assert not isinstance(prepared.removed.data, da.Array)
+        assert len(executions) == 1
+        assert isinstance(prepared.design.data, da.Array)
+        assert not isinstance(prepared.removed.data, da.Array)
+
+        with registered_model():
+            add_linear_component(
+                prepared,
+                data_name="hx",
+                prior_args={"pdf": "normal", "mu": 1.0, "sigma": 0.2},
+                var_name="x",
+                output_name="mu",
+            )
+
+        assert len(executions) > 1
 
 
 def test_all_zero_linear_design_builds_zero_forward_and_full_fixed_state() -> None:

--- a/tests/models/test_state_activity.py
+++ b/tests/models/test_state_activity.py
@@ -19,7 +19,7 @@ from openghg_inversions.models import (
     active_prior_args,
     attach_coord_registry,
     detect_zero_sensitivity,
-    prepare_linear_design,
+    prepare_linear_sensitivity,
     registered_model,
     resolve_state_activity,
 )
@@ -127,26 +127,28 @@ def test_detect_zero_sensitivity_accepts_a_named_output_dimension() -> None:
     assert zero_sensitivity.dims == ("region",)
 
 
-def test_prepare_linear_design_removes_columns_and_retains_full_mapping() -> None:
+def test_prepare_linear_sensitivity_removes_columns_and_retains_full_mapping() -> None:
     """Structural removal keeps a lossless labelled full-to-retained mapping."""
-    prepared = prepare_linear_design(_sensitivity())
+    prepared = prepare_linear_sensitivity(_sensitivity())
 
-    assert prepared.design.dims == ("nmeasure", "region_retained")
-    np.testing.assert_array_equal(prepared.design["region_retained"], ["inner-a", "outer-a", "inner-b"])
+    assert prepared.sensitivity.dims == ("nmeasure", "region_retained")
+    np.testing.assert_array_equal(
+        prepared.sensitivity["region_retained"], ["inner-a", "outer-a", "inner-b"]
+    )
     np.testing.assert_array_equal(prepared.removed, [False, True, False, False])
     np.testing.assert_array_equal(prepared.removed["basis_group"], ["inner", "inner", "outer", "inner"])
     np.testing.assert_array_equal(prepared.retained_indices, [0, 2, 3])
 
 
-def test_prepare_linear_design_keeps_retained_dask_payload_lazy() -> None:
+def test_prepare_linear_sensitivity_keeps_retained_dask_payload_lazy() -> None:
     """Inspect once, then keep retained data lazy until PyMC registration."""
     executions: list[object] = []
     callback = Callback(start=lambda graph: executions.append(graph))
     with callback:
-        prepared = prepare_linear_design(_sensitivity().chunk({"nmeasure": 1, "region": 2}))
+        prepared = prepare_linear_sensitivity(_sensitivity().chunk({"nmeasure": 1, "region": 2}))
 
         assert len(executions) == 1
-        assert isinstance(prepared.design.data, da.Array)
+        assert isinstance(prepared.sensitivity.data, da.Array)
         assert not isinstance(prepared.removed.data, da.Array)
 
         with registered_model():
@@ -158,13 +160,13 @@ def test_prepare_linear_design_keeps_retained_dask_payload_lazy() -> None:
                 output_name="mu",
             )
 
-        assert len(executions) > 1
+        assert len(executions) == 2
 
 
-def test_all_zero_linear_design_builds_zero_forward_and_full_fixed_state() -> None:
-    """An all-zero design has no latent variables and reconstructs the full state."""
+def test_all_zero_linear_sensitivity_builds_zero_forward_and_full_fixed_state() -> None:
+    """An all-zero sensitivity has no latent variables and reconstructs the full state."""
     h = xr.zeros_like(_sensitivity())
-    prepared = prepare_linear_design(h)
+    prepared = prepare_linear_sensitivity(h)
 
     with registered_model() as model:
         result = add_linear_component(
@@ -175,7 +177,7 @@ def test_all_zero_linear_design_builds_zero_forward_and_full_fixed_state() -> No
             output_name="mu",
         )
 
-    assert prepared.design.sizes["region_retained"] == 0
+    assert prepared.sensitivity.sizes["region_retained"] == 0
     assert model.free_RVs == []
     np.testing.assert_allclose(model.named_vars["x"].eval(), np.ones(4))
     np.testing.assert_allclose(result.output.eval(), np.zeros(2))
@@ -406,7 +408,7 @@ def test_state_linear_component_preserves_full_forward_identity() -> None:
     with pm.Model() as model:
         attach_coord_registry(model, registry)
         result = add_linear_component(
-            prepare_linear_design(h),
+            prepare_linear_sensitivity(h),
             data_name="hx",
             prior_args={"pdf": "normal", "mu": 2.0, "sigma": 0.1},
             var_name="x",
@@ -463,7 +465,7 @@ def test_linear_component_preserves_plain_graph_when_all_states_are_retained() -
     with pm.Model() as linear_model:
         attach_coord_registry(linear_model, CoordRegistry())
         result = add_linear_component(
-            prepare_linear_design(h),
+            prepare_linear_sensitivity(h),
             data_name="hx",
             prior_args=prior,
             var_name="x",
@@ -481,7 +483,7 @@ def test_state_linear_component_full_activity_preserves_reparameterised_names() 
     with pm.Model() as model:
         attach_coord_registry(model, CoordRegistry())
         result = add_linear_component(
-            prepare_linear_design(h),
+            prepare_linear_sensitivity(h),
             data_name="hx",
             prior_args={
                 "pdf": "lognormal",
@@ -510,7 +512,7 @@ def test_state_linear_component_restores_removed_states_in_canonical_order() -> 
     with pm.Model() as model:
         attach_coord_registry(model, CoordRegistry())
         result = add_linear_component(
-            prepare_linear_design(h),
+            prepare_linear_sensitivity(h),
             data_name="hx",
             prior_args={"pdf": "normal", "mu": 2.0, "sigma": 0.1},
             var_name="x",
@@ -544,7 +546,7 @@ def test_state_linear_component_supports_zero_active_states() -> None:
     with pm.Model() as model:
         attach_coord_registry(model, CoordRegistry())
         result = add_linear_component(
-            prepare_linear_design(h),
+            prepare_linear_sensitivity(h),
             data_name="hx",
             prior_args={"pdf": "normal", "mu": 1.0, "sigma": 1.0},
             var_name="x",

--- a/tests/models/test_state_activity.py
+++ b/tests/models/test_state_activity.py
@@ -16,9 +16,9 @@ from openghg_inversions.models import (
     CoordRegistry,
     StateActivity,
     active_prior_args,
-    add_state_linear_component,
     attach_coord_registry,
     detect_zero_sensitivity,
+    prepare_linear_design,
     registered_model,
     resolve_state_activity,
 )
@@ -124,6 +124,45 @@ def test_detect_zero_sensitivity_accepts_a_named_output_dimension() -> None:
 
     np.testing.assert_array_equal(zero_sensitivity, [False, True, False, False])
     assert zero_sensitivity.dims == ("region",)
+
+
+def test_prepare_linear_design_removes_columns_and_retains_full_mapping() -> None:
+    """Structural removal keeps a lossless labelled full-to-retained mapping."""
+    prepared = prepare_linear_design(_sensitivity())
+
+    assert prepared.design.dims == ("nmeasure", "region_retained")
+    np.testing.assert_array_equal(prepared.design["region_retained"], ["inner-a", "outer-a", "inner-b"])
+    np.testing.assert_array_equal(prepared.removed, [False, True, False, False])
+    np.testing.assert_array_equal(prepared.removed["basis_group"], ["inner", "inner", "outer", "inner"])
+    np.testing.assert_array_equal(prepared.retained_indices, [0, 2, 3])
+
+
+def test_prepare_linear_design_keeps_retained_dask_payload_lazy() -> None:
+    """Preparation computes the structural mask without densifying retained data."""
+    prepared = prepare_linear_design(_sensitivity().chunk({"nmeasure": 1, "region": 2}))
+
+    assert isinstance(prepared.design.data, da.Array)
+    assert not isinstance(prepared.removed.data, da.Array)
+
+
+def test_all_zero_linear_design_builds_zero_forward_and_full_fixed_state() -> None:
+    """An all-zero design has no latent variables and reconstructs the full state."""
+    h = xr.zeros_like(_sensitivity())
+    prepared = prepare_linear_design(h)
+
+    with registered_model() as model:
+        result = add_linear_component(
+            prepared,
+            data_name="hx",
+            prior_args={"pdf": "normal", "mu": 1.0, "sigma": 0.2},
+            var_name="x",
+            output_name="mu",
+        )
+
+    assert prepared.design.sizes["region_retained"] == 0
+    assert model.free_RVs == []
+    np.testing.assert_allclose(model.named_vars["x"].eval(), np.ones(4))
+    np.testing.assert_allclose(result.output.eval(), np.zeros(2))
 
 
 def test_resolve_state_activity_combines_labels_groups_and_exact_zero() -> None:
@@ -350,8 +389,8 @@ def test_state_linear_component_preserves_full_forward_identity() -> None:
     registry = CoordRegistry()
     with pm.Model() as model:
         attach_coord_registry(model, registry)
-        result = add_state_linear_component(
-            h,
+        result = add_linear_component(
+            prepare_linear_design(h),
             data_name="hx",
             prior_args={"pdf": "normal", "mu": 2.0, "sigma": 0.1},
             var_name="x",
@@ -362,12 +401,16 @@ def test_state_linear_component_preserves_full_forward_identity() -> None:
             ),
         )
 
+    activity = resolve_state_activity(detect_zero_sensitivity(h), StateActivity(
+        fixed_value=fixed_value,
+        fixed_groups=("outer",),
+    ))
     x_full, mu, x_active = pm.draw(
         [result.state, result.output, model.named_vars["x_active"]],
         random_seed=42,
     )
-    active = result.activity.active_indices
-    fixed = result.activity.fixed_indices
+    active = activity.active_indices
+    fixed = activity.fixed_indices
     expected_split = (
         h.values[:, active] @ x_active + h.values[:, fixed] @ fixed_value.sel(region=h.region).values[fixed]
     )
@@ -383,8 +426,7 @@ def test_state_linear_component_preserves_full_forward_identity() -> None:
 def test_add_state_vector_registers_full_state_coord_in_a_fresh_model() -> None:
     """Construct a state graph from a resolved contract and register its coordinate."""
     activity = resolve_state_activity(
-        detect_zero_sensitivity(_sensitivity()),
-        StateActivity(prune_zero=False),
+        xr.zeros_like(detect_zero_sensitivity(_sensitivity()), dtype=bool),
     )
     with registered_model() as model:
         result = add_state_vector(
@@ -397,35 +439,24 @@ def test_add_state_vector_registers_full_state_coord_in_a_fresh_model() -> None:
     assert model.coords["region"] == (0, 1, 2, 3)
 
 
-def test_state_linear_component_preserves_legacy_graph_when_all_states_are_active() -> None:
-    """Use the ordinary base prior graph when state pruning changes nothing."""
+def test_linear_component_preserves_plain_graph_when_all_states_are_retained() -> None:
+    """Use the ordinary base prior graph when preparation removes nothing."""
     h = _sensitivity().drop_sel(region="zero")
     prior = {"pdf": "normal", "mu": 1.0, "sigma": 0.2}
 
     with pm.Model() as linear_model:
         attach_coord_registry(linear_model, CoordRegistry())
-        linear_result = add_linear_component(
-            h,
+        result = add_linear_component(
+            prepare_linear_design(h),
             data_name="hx",
             prior_args=prior,
             var_name="x",
             output_name="mu",
         )
-    with pm.Model() as state_model:
-        attach_coord_registry(state_model, CoordRegistry())
-        state_result = add_state_linear_component(
-            h,
-            data_name="hx",
-            prior_args=prior,
-            var_name="x",
-            output_name="mu",
-        )
-
-    assert set(state_model.named_vars) == set(linear_model.named_vars) == {"hx", "x", "mu"}
-    assert [rv.name for rv in state_model.free_RVs] == [rv.name for rv in linear_model.free_RVs] == ["x"]
-    assert state_result.state is state_model.named_vars["x"]
-    assert state_result.latent is state_model.named_vars["x"]
-    assert linear_result.latent is linear_model.named_vars["x"]
+    assert set(linear_model.named_vars) == {"hx", "x", "mu"}
+    assert [rv.name for rv in linear_model.free_RVs] == ["x"]
+    assert result.state is linear_model.named_vars["x"]
+    assert result.output is linear_model.named_vars["mu"]
 
 
 def test_state_linear_component_full_activity_preserves_reparameterised_names() -> None:
@@ -433,8 +464,8 @@ def test_state_linear_component_full_activity_preserves_reparameterised_names() 
     h = _sensitivity().drop_sel(region="zero")
     with pm.Model() as model:
         attach_coord_registry(model, CoordRegistry())
-        result = add_state_linear_component(
-            h,
+        result = add_linear_component(
+            prepare_linear_design(h),
             data_name="hx",
             prior_args={
                 "pdf": "lognormal",
@@ -448,7 +479,7 @@ def test_state_linear_component_full_activity_preserves_reparameterised_names() 
 
     assert set(model.named_vars) == {"hx", "x_latent", "x", "mu"}
     assert [rv.name for rv in model.free_RVs] == ["x_latent"]
-    assert result.state is model.named_vars["x"]
+    assert result.output is model.named_vars["mu"]
     assert result.latent is model.named_vars["x_latent"]
 
 
@@ -462,8 +493,8 @@ def test_state_linear_component_restores_removed_states_in_canonical_order() -> 
     )
     with pm.Model() as model:
         attach_coord_registry(model, CoordRegistry())
-        result = add_state_linear_component(
-            h,
+        result = add_linear_component(
+            prepare_linear_design(h),
             data_name="hx",
             prior_args={"pdf": "normal", "mu": 2.0, "sigma": 0.1},
             var_name="x",
@@ -479,7 +510,11 @@ def test_state_linear_component_restores_removed_states_in_canonical_order() -> 
         random_seed=42,
     )
     restored = fixed.to_numpy().copy()
-    restored[result.activity.active_indices] = active_state
+    activity = resolve_state_activity(detect_zero_sensitivity(h), StateActivity(
+        active=np.array([True, False, True, False]),
+        fixed_value=fixed,
+    ))
+    restored[activity.active_indices] = active_state
 
     np.testing.assert_allclose(full_state, restored)
     np.testing.assert_allclose(output, h.to_numpy() @ restored)
@@ -492,8 +527,8 @@ def test_state_linear_component_supports_zero_active_states() -> None:
 
     with pm.Model() as model:
         attach_coord_registry(model, CoordRegistry())
-        result = add_state_linear_component(
-            h,
+        result = add_linear_component(
+            prepare_linear_design(h),
             data_name="hx",
             prior_args={"pdf": "normal", "mu": 1.0, "sigma": 1.0},
             var_name="x",
@@ -504,7 +539,6 @@ def test_state_linear_component_supports_zero_active_states() -> None:
     x_full, mu = pm.draw([result.state, result.output], random_seed=42)
     np.testing.assert_allclose(x_full, np.full(h.sizes["region"], 2.5))
     np.testing.assert_allclose(mu, h.values @ x_full)
-    assert result.latent is None
     assert "x_active" not in model.named_vars
     assert not any(rv.name and rv.name.startswith("x") for rv in model.free_RVs)
     assert resolve_model_variable(model, "x") is model.named_vars["x"]

--- a/tests/test_inferpymc.py
+++ b/tests/test_inferpymc.py
@@ -542,11 +542,11 @@ def test_build_inferpymc_model_contains_expected_variables(inv_inputs: xr.Datase
     assert expected_named_vars.issubset(model.named_vars)
 
 
-def test_build_inferpymc_model_keeps_zero_h_states_in_single_sector_graph(
+def test_build_inferpymc_model_prunes_zero_h_states_in_single_sector_graph(
     inv_inputs: xr.Dataset,
     model_args: dict,
 ) -> None:
-    """The legacy single-sector adapter does not adopt modern state pruning."""
+    """The legacy single-sector adapter uses the consolidated state pruning."""
     inputs = inv_inputs.copy()
     sensitivity = inputs["H"].copy()
     sensitivity[{"region": 0}] = 0.0
@@ -554,9 +554,11 @@ def test_build_inferpymc_model_keeps_zero_h_states_in_single_sector_graph(
 
     model = build_inferpymc_model(inputs, **model_args)
 
-    assert model.named_vars["x"] in model.free_RVs
+    assert model.named_vars["x_active"] in model.free_RVs
+    assert model.named_vars["x"] not in model.free_RVs
     assert model.named_vars_to_dims["x"] == ("region",)
-    assert "x_active" not in model.named_vars
+    assert model.named_vars_to_dims["x_active"] == ("region_x_active",)
+    assert not bool(model.named_vars["x_is_active"].eval()[0])
 
 
 def test_build_inferpymc_model_preserves_unlabelled_interpolated_prior(

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -1823,6 +1823,42 @@ def test_build_rhime_multisector_model_selects_sources_by_label(
     np.testing.assert_allclose(model["hx_ocean"].get_value(), expected_ocean.values)
 
 
+def test_multisector_model_namespaces_differently_retained_source_states(
+    multisector_inv_inputs: xr.Dataset,
+    builder_args: dict,
+) -> None:
+    """Source-specific zero columns get distinct retained backend dimensions."""
+    inputs = multisector_inv_inputs.copy(deep=True)
+    inputs["H"].loc[{"source": "total-ukghg-edgar7", "region": inputs.region[0]}] = 0.0
+    inputs["H"].loc[{"source": "sector-2", "region": inputs.region[1]}] = 0.0
+
+    model = build_rhime_multisector_model(
+        inputs,
+        sectors=(
+            _sector("FF", source="total-ukghg-edgar7", suffix="ff"),
+            _sector("ocean", source="sector-2", suffix="ocean"),
+        ),
+        **_multisector_args(builder_args),
+    )
+
+    assert model.named_vars_to_dims["hx_ff"] == ("nmeasure", "region_retained_ff")
+    assert model.named_vars_to_dims["hx_ocean"] == ("nmeasure", "region_retained_ocean")
+    np.testing.assert_allclose(
+        model["hx_ff"].get_value(),
+        inputs["H"]
+        .sel(source="total-ukghg-edgar7")
+        .isel(region=slice(1, None))
+        .transpose("nmeasure", "region"),
+    )
+    np.testing.assert_allclose(
+        model["hx_ocean"].get_value(),
+        inputs["H"]
+        .sel(source="sector-2")
+        .isel(region=[0, *range(2, inputs.sizes["region"])])
+        .transpose("nmeasure", "region"),
+    )
+
+
 def test_multisector_model_accepts_gathered_ragged_states(
     multisector_inv_inputs: xr.Dataset,
     builder_args: dict,
@@ -2275,10 +2311,10 @@ def test_bc_zero_columns_are_structurally_removed_by_default(
     assert list(registry.original_coords["bc_region_bc_active"]) == list(
         inv_inputs["H_bc"].indexes["bc_region"][1:]
     )
-    np.testing.assert_allclose(
-        model["mu_bc"].eval(),
-        model["hbc"].eval() @ model["bc"].eval()[1:],
-    )
+    actual, state = pm.draw([model["mu_bc"], model["bc"]], random_seed=417)
+    expected = model["hbc"].get_value() @ state[1:]
+    tolerance = 100 * max(np.finfo(actual.dtype).eps, np.finfo(expected.dtype).eps)
+    np.testing.assert_allclose(actual, expected, rtol=tolerance, atol=tolerance)
 
 
 

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -5085,7 +5085,7 @@ def test_prepared_multisector_runner_accepts_gathered_source_specific_basis_layo
 
 
 def test_multisector_runner_rejects_shared_basis_h_layout_mismatch() -> None:
-    """Retained shared-basis coordinates must match the prepared design state."""
+    """Retained shared-basis coordinates must match the prepared sensitivity state."""
     model_spec = RhimeModelSpec(
         species="ch4",
         domain="EUROPE",

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -2248,20 +2248,22 @@ def test_standard_model_supports_all_fixed_flux_and_bc(
     _assert_model_dot_matches_numpy(model, output_name="mu_bc", design_name="hbc", state_name="bc")
 
 
-def test_bc_activity_is_opt_in_and_restores_exact_zero_columns(
+def test_bc_zero_columns_are_structurally_removed_by_default(
     rhime_inv_inputs: xr.Dataset,
     builder_args: dict,
 ) -> None:
-    """Explicit BC activity prunes zero columns while omission keeps the old graph."""
+    """BC preparation always removes zero columns and reconstructs the full state."""
     inv_inputs = rhime_inv_inputs.copy(deep=True)
     first_region = inv_inputs["H_bc"].coords["bc_region"][0]
     inv_inputs["H_bc"].loc[{"bc_region": first_region}] = 0.0
     kwargs = {**builder_args, "no_model_error": True}
 
     default_model = build_rhime_model(inv_inputs, **kwargs)
-    assert default_model["bc"] in default_model.free_RVs
-    assert "bc_active" not in default_model.named_vars
-    assert "bc_is_active" not in default_model.named_vars
+    assert default_model["bc_active"] in default_model.free_RVs
+    assert default_model["bc"] not in default_model.free_RVs
+    assert not bool(default_model["bc_is_active"].eval()[0])
+    assert default_model["bc"].eval()[0] == 1.0
+    assert default_model["hbc"].eval().shape[1] == inv_inputs.sizes["bc_region"] - 1
 
     model = build_rhime_model(inv_inputs, bc_state_activity=StateActivity(), **kwargs)
     assert model["bc_active"] in model.free_RVs
@@ -2273,7 +2275,10 @@ def test_bc_activity_is_opt_in_and_restores_exact_zero_columns(
     assert list(registry.original_coords["bc_region_bc_active"]) == list(
         inv_inputs["H_bc"].indexes["bc_region"][1:]
     )
-    _assert_model_dot_matches_numpy(model, output_name="mu_bc", design_name="hbc", state_name="bc")
+    np.testing.assert_allclose(
+        model["mu_bc"].eval(),
+        model["hbc"].eval() @ model["bc"].eval()[1:],
+    )
 
 
 


### PR DESCRIPTION
* **Summary of changes**

Consolidates the plain and state-aware linear PyMC paths around one `add_linear_component(...)` API.

- Introduces `prepare_linear_sensitivity` as the owning boundary for exact-zero column removal while retaining the full labelled scientific-state mapping.
- Preserves the established `add_linear_component(...) -> LinearComponentResult` contract; the unified result exposes data, latent, state, output, and resolved activity.
- Adds `apply_linear_sensitivity` for shared or correlated states that need another prepared forward operator without another prior.
- Migrates standard, multisector, legacy, and Ramsden model construction to the consolidated path.
- Namespaces pruned Ramsden backend axes per sector and channel while preserving the shared scientific state dimension.
- Updates focused tests, documentation, and the OPE-94 Towncrier fragment.

Linear: [OPE-94](https://linear.app/openghg-inversions/issue/OPE-94/consolidate-plain-and-state-aware-linear-pymc-components)

* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx (No corresponding GitHub issue; tracked in Linear as OPE-94)
- [x] Tests added and passing
- [x] Documentation and tutorials updated/added
- [x] Added a Towncrier news fragment in `newsfragments/` for user-visible changes
- [x] No new requirements

**Validation**

- `uv run pytest tests/models/test_components.py tests/models/test_state_activity.py tests/experimental/test_ramsden2022.py tests/test_inferpymc.py tests/test_rhime.py -q -k 'state_activity or zero_columns or multisector_model or multisector_model_namespaces or inferpymc or ramsden'` — 89 passed
- Ruff on all changed Python files
- `git diff --check`
- SLURM tox job `18651421`: `py310-openghgCur`, `py310-openghgPrev`, and `py310-openghgDev` all passed