### PR TITLE
Skip satellite BC scaling when max levels match

### DIFF
--- a/newsfragments/+.bugfix.md
+++ b/newsfragments/+.bugfix.md
@@ -1,0 +1,1 @@
+Do not scale satellite boundary-condition sensitivities when observation and footprint `max_level` values agree; retain the compatibility workaround only for missing or inconsistent vertical extents.

--- a/openghg_inversions/boundary_sensitivity.py
+++ b/openghg_inversions/boundary_sensitivity.py
@@ -109,42 +109,56 @@ def scale_satellite_boundary_sensitivity_to_column_signal(
     *,
     sites: Sequence[str],
     platform: Sequence[str | None],
+    observation_max_level: Sequence[int | None],
+    footprint_max_level: Sequence[int | None],
 ) -> xr.Dataset:
-    """Scale satellite boundary sensitivity into corrected-column space.
+    """Scale satellite boundary sensitivity only for inconsistent vertical extents.
 
     Args:
         inputs: Gathered inversion inputs containing ``H_bc`` and observation
             arrays. The dataset is borrowed and never mutated.
         sites: Site labels in the same order as ``platform``.
         platform: Platform values aligned to ``sites``.
+        observation_max_level: Column-processing levels aligned to ``sites``.
+        footprint_max_level: Footprint vertical extents aligned to ``sites``.
 
     Returns:
-        The unchanged borrowed dataset when scaling is inapplicable, otherwise
-        a shallow copy whose satellite ``H_bc`` rows are explicitly scaled and
-        carry transform provenance.
+        The unchanged borrowed dataset when scaling is inapplicable or the
+        observation and footprint levels match. Otherwise, a shallow copy
+        whose inconsistent satellite ``H_bc`` rows retain the legacy scaling
+        and carry transform provenance.
     """
     required = {"H_bc", "mf", "mf_prior_factor", "mf_prior_upper_level_factor", "site"}
     if not required <= set(inputs.variables):
         return inputs
-    satellite_sites = [
+    inconsistent_satellite_sites = [
         site
-        for site, value in zip(sites, platform, strict=True)
-        if value is not None and "satellite" in str(value).lower()
+        for site, value, obs_level, fp_level in zip(
+            sites,
+            platform,
+            observation_max_level,
+            footprint_max_level,
+            strict=True,
+        )
+        if value is not None
+        and "satellite" in str(value).lower()
+        and not (obs_level is not None and fp_level is not None and obs_level == fp_level)
     ]
-    if not satellite_sites:
+    if not inconsistent_satellite_sites:
         return inputs
-    satellite_mask = inputs["site"].astype(str).isin(satellite_sites)
+    satellite_mask = inputs["site"].astype(str).isin(inconsistent_satellite_sites)
     if not bool(satellite_mask.any()):
         return inputs
 
     raw_column = inputs["mf"] + inputs["mf_prior_factor"] + inputs["mf_prior_upper_level_factor"]
-    # Retain the released workaround until retrieval exposes the information
-    # needed for an exact corrected-column transform.
+    # Retain the released workaround only for footprints whose vertical extent
+    # is missing or inconsistent with the observation processing level.
     scale = xr.where(raw_column > 0, inputs["mf"] / raw_column, 1.0).clip(min=0.0, max=1.0)
     result = inputs.copy(deep=False)
     result["H_bc"] = inputs["H_bc"] * scale.where(satellite_mask, 1.0)
     result["H_bc"].attrs = dict(inputs["H_bc"].attrs)
     result["H_bc"].attrs["satellite_column_bc_scale"] = (
-        "Applied to satellite rows using mf / (mf + mf_prior_factor + mf_prior_upper_level_factor)."
+        "Applied to satellite rows with missing or inconsistent max_level metadata using "
+        "mf / (mf + mf_prior_factor + mf_prior_upper_level_factor)."
     )
     return result

--- a/openghg_inversions/hbmcmc/preparation.py
+++ b/openghg_inversions/hbmcmc/preparation.py
@@ -251,6 +251,8 @@ def prepare_fixedbasis_inversion_data(
         inv_inputs,
         sites=prepared_sites,
         platform=prepared_site_options.platform,
+        observation_max_level=prepared_site_options.max_level,
+        footprint_max_level=tuple(fp_data[site].attrs.get("max_level") for site in prepared_sites),
     )
     sigma_alignment = SigmaAlignment.from_frequency(
         inv_inputs["site_indicator"],

--- a/openghg_inversions/inversion_data/preparation.py
+++ b/openghg_inversions/inversion_data/preparation.py
@@ -1469,6 +1469,8 @@ def prepare_rhime_inputs(
         inv_inputs,
         sites=filtered_merged.sites,
         platform=filtered_merged.site_options.platform,
+        observation_max_level=filtered_merged.site_options.max_level,
+        footprint_max_level=tuple(fp_data[site].attrs.get("max_level") for site in filtered_merged.sites),
     )
     _warn_for_nan_inputs(inv_inputs, use_bc=use_bc)
     log_timing(

--- a/openghg_inversions/rhime/preparation.py
+++ b/openghg_inversions/rhime/preparation.py
@@ -213,8 +213,9 @@ def assemble_rhime_inputs(
     """Construct and validate durable, backend-neutral RHIME model inputs.
 
     The stage attaches domain metadata to shallow per-site copies, assembles
-    observation-aligned arrays, applies the satellite boundary-condition
-    scaling, and retains basis and site metadata. It also preserves the legacy
+    observation-aligned arrays, conditionally applies the legacy satellite
+    boundary scaling for inconsistent vertical extents, and retains basis and
+    site metadata. It also preserves the legacy
     construction of the minimum-error floor and boundary-condition temporal
     parameterization. Those are inverse-model settings, not properties of the
     acquired data; moving them to their model components is a later semantic
@@ -239,6 +240,8 @@ def assemble_rhime_inputs(
         inv_inputs,
         sites=merged.sites,
         platform=merged.platform,
+        observation_max_level=merged.site_options.max_level,
+        footprint_max_level=tuple(owned_site_data[site].attrs.get("max_level") for site in merged.sites),
     )
     inversion_preparation._warn_for_nan_inputs(inv_inputs, use_bc=data_args["use_bc"])
     basis_source = basis_functions.basis_artifact_source or "generated"

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -5312,14 +5312,15 @@ def test_fixedbasis_preparation_adds_anchored_legacy_sigma_index(
 def test_fixedbasis_preparation_uses_platform_for_sites_retained_after_filtering(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Satellite BC scaling receives platform metadata after a surface site is dropped."""
-    fp_data = {"OCO2-EASTASIA": _site_dataset([2.0])}
+    """Satellite BC scaling receives aligned level metadata after filtering."""
+    fp_data = {"OCO2-EASTASIA": _site_dataset([2.0]).assign_attrs(max_level=17)}
     merged = prep_module.RhimeMergedData(
         fp_all={"TAC": _site_dataset([]), **fp_data},
         site_options=_site_options(
             ["TAC", "OCO2-EASTASIA"],
             averaging_period=["1H", "1H"],
             platform=["surface", "satellite"],
+            max_level=[None, 17],
         ),
     )
     retained_options = merged.site_options.select_indices([1])
@@ -5366,23 +5367,30 @@ def test_fixedbasis_preparation_uses_platform_for_sites_retained_after_filtering
         use_bc=False,
     )
 
-    assert captured == {"sites": ["OCO2-EASTASIA"], "platform": ("satellite",)}
+    assert captured == {
+        "sites": ["OCO2-EASTASIA"],
+        "platform": ("satellite",),
+        "observation_max_level": (17,),
+        "footprint_max_level": (17,),
+    }
 
 
 def test_rhime_preparation_uses_platform_for_sites_retained_after_filtering(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """RHIME satellite BC scaling receives the filtered mixed-platform metadata."""
+    """RHIME satellite BC scaling receives filtered platform and level metadata."""
+    satellite_data = _site_dataset([2.0]).assign_attrs(max_level=17)
     merged = prep_module.RhimeMergedData(
-        fp_all={"TAC": _site_dataset([]), "OCO2-EASTASIA": _site_dataset([2.0])},
+        fp_all={"TAC": _site_dataset([]), "OCO2-EASTASIA": satellite_data},
         site_options=_site_options(
             ["TAC", "OCO2-EASTASIA"],
             averaging_period=["1H", "1H"],
             platform=["surface", "satellite"],
+            max_level=[None, 17],
         ),
     )
     filtered_merged = prep_module.RhimeMergedData(
-        fp_all={"OCO2-EASTASIA": _site_dataset([2.0])},
+        fp_all={"OCO2-EASTASIA": satellite_data},
         site_options=merged.site_options.select_indices([1]),
     )
     captured: dict[str, object] = {}
@@ -5393,7 +5401,7 @@ def test_rhime_preparation_uses_platform_for_sites_retained_after_filtering(
     monkeypatch.setattr(
         prep_module,
         "_rhime_site_data_from_basis_functions",
-        lambda **kwargs: {"OCO2-EASTASIA": _site_dataset([2.0])},
+        lambda **kwargs: {"OCO2-EASTASIA": satellite_data},
     )
     monkeypatch.setattr(
         prep_module,
@@ -5420,7 +5428,12 @@ def test_rhime_preparation_uses_platform_for_sites_retained_after_filtering(
         use_bc=False,
     )
 
-    assert captured == {"sites": ("OCO2-EASTASIA",), "platform": ("satellite",)}
+    assert captured == {
+        "sites": ("OCO2-EASTASIA",),
+        "platform": ("satellite",),
+        "observation_max_level": (17,),
+        "footprint_max_level": (17,),
+    }
 
 
 def test_prepare_rhime_inputs_uses_basis_sensitivity_without_legacy_side_channels(
@@ -6202,8 +6215,8 @@ def test_prepare_rhime_inputs_filters_sites_before_basis_generation(
     assert filtering_calls == 1
 
 
-def test_satellite_bc_sensitivity_is_scaled_to_corrected_column_signal() -> None:
-    """Satellite H_bc is reduced into the same OCO corrected-column space as mf."""
+def test_satellite_bc_sensitivity_is_scaled_for_inconsistent_max_levels() -> None:
+    """Satellite H_bc retains the legacy scaling when vertical extents differ."""
     inv_inputs = xr.Dataset(
         {
             "H_bc": (
@@ -6221,6 +6234,8 @@ def test_satellite_bc_sensitivity_is_scaled_to_corrected_column_signal() -> None
         inv_inputs,
         sites=["OCO2-EASTASIA"],
         platform=["satellite"],
+        observation_max_level=[3],
+        footprint_max_level=[17],
     )
 
     np.testing.assert_allclose(
@@ -6228,6 +6243,32 @@ def test_satellite_bc_sensitivity_is_scaled_to_corrected_column_signal() -> None
         np.array([[12.5, 50.0], [37.5, 100.0]]),
     )
     assert "satellite_column_bc_scale" in result["H_bc"].attrs
+
+
+def test_satellite_bc_sensitivity_is_not_scaled_for_matching_max_levels() -> None:
+    """Satellite H_bc is already in the corrected-column space when levels match."""
+    inv_inputs = xr.Dataset(
+        {
+            "H_bc": (
+                ("bc_region", "nmeasure"),
+                np.array([[100.0, 200.0], [300.0, 400.0]], dtype=float),
+            ),
+            "mf": ("nmeasure", np.array([50.0, 100.0], dtype=float)),
+            "mf_prior_factor": ("nmeasure", np.array([0.0, 0.0], dtype=float)),
+            "mf_prior_upper_level_factor": ("nmeasure", np.array([350.0, 300.0], dtype=float)),
+            "site": ("nmeasure", np.array(["GOSAT-BRAZIL", "GOSAT-BRAZIL"])),
+        }
+    )
+
+    result = prep_module._scale_satellite_bc_sensitivity_to_column_signal(
+        inv_inputs,
+        sites=["GOSAT-BRAZIL"],
+        platform=["satellite"],
+        observation_max_level=[17],
+        footprint_max_level=[17],
+    )
+
+    xr.testing.assert_identical(result, inv_inputs)
 
 
 def test_surface_bc_sensitivity_is_not_scaled_by_column_factors() -> None:
@@ -6249,6 +6290,8 @@ def test_surface_bc_sensitivity_is_not_scaled_by_column_factors() -> None:
         inv_inputs,
         sites=["TAC"],
         platform=[None],
+        observation_max_level=[None],
+        footprint_max_level=[None],
     )
 
     xr.testing.assert_identical(result["H_bc"], inv_inputs["H_bc"])


### PR DESCRIPTION
## Summary

- leave satellite boundary-condition sensitivities unscaled when observation and footprint `max_level` values match
- retain the compatibility scaling only when `max_level` metadata is missing or inconsistent
- pass aligned observation and footprint `max_level` metadata through RHIME and legacy preparation

## Tests

- `pytest -q tests/test_rhime.py -k 'satellite_bc_sensitivity or preparation_uses_platform_for_sites_retained_after_filtering or assemble_rhime_inputs_preserves_borrowed'`
- `pytest -q tests/test_boundary_sensitivity.py tests/test_full_inversion.py::test_full_satellite_inversion`
- `ruff check` on changed Python paths
- `git diff --check`