### PR TITLE
OPE-48: Validate coordinate registry for sampling-only models

### DIFF
--- a/openghg_inversions/rhime/builders.py
+++ b/openghg_inversions/rhime/builders.py
@@ -164,17 +164,17 @@ def validate_model_build_result(
         ValueError: If the requested output is unsupported or a declared
             variable role refers to an absent variable.
     """
-    output_format = context.run_spec.output.output_format
-    if output_format == "none":
-        return
-
-    result.validate_requested_output(output_format)
-
     if get_coord_registry(result.model) is None:
         raise ValueError(
             "A custom RHIME model must carry a `CoordRegistry`; construct it "
             "with `registered_model()`."
         )
+
+    output_format = context.run_spec.output.output_format
+    if output_format == "none":
+        return
+
+    result.validate_requested_output(output_format)
 
     available_names = set(result.model.named_vars) | set(context.prepared_inputs.inv_inputs.variables)
     missing = {role: name for role, name in result.variable_roles.items() if name not in available_names}

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -3340,7 +3340,7 @@ def test_complete_model_builder_owns_lazy_aggregation_error_inputs(
             context.prepared_inputs.inv_inputs["aggregation_error_covariance"].data,
             da.Array,
         )
-        with pm.Model() as model:
+        with models.registered_model() as model:
             pm.Normal("custom_y")
         return RhimeModelBuildResult(
             model=model,


### PR DESCRIPTION
## Summary

- enforce the existing `registered_model()` invariant before the `output_format="none"` early return
- restore the existing sampling-only regression test on current `devel`
- keep output-format validation unchanged for output-producing runs

## Why

Current `devel` independently fails `test_complete_model_validation_requires_coord_registry[False]`: an unregistered custom `pm.Model()` is accepted when sampling without postprocessing. This also makes otherwise unrelated stacked PRs fail all dependency-matrix CI jobs.

## Validation

- focused invariant and custom-builder tests — **3 passed**
- focused Ruff — passed
- `git diff --check` — passed

Exact base: `1d69ecd69e3d4b6a4abe0544a7e98842321a7c01`
Exact head: `64d82284585d5550c336cbb0d44b7256280f698f`

## Checklist

- [x] Existing regression test covers the fix
- [x] No new dependency
- [x] No scientific/model-policy change

Linear: OPE-48