### PR TITLE
Document uncertain cross-channel couplings

### DIFF
--- a/docs/plans/rhime_model_family_expansion.md
+++ b/docs/plans/rhime_model_family_expansion.md
@@ -209,6 +209,32 @@ y_obs = multivariate_normal(
 )
 ```
 
+### Fixed and uncertain cross-channel couplings
+
+A fixed oxidative ratio or other cross-channel coupling is a labelled
+scientific input. Its contract must state its units, direction, sign,
+coordinate scope, alignment, and provenance. A prepared operator may embed a
+fixed coupling, but its metadata and the consuming recipe must say so
+explicitly to prevent the coupling from being applied twice or omitted.
+
+An uncertain coupling is an explicit sampled parameter in the concrete model
+recipe, not metadata attached to a fixed operator. For example, a latent
+O2-per-CO2 ratio requires a ratio-free O2 operator and a visible graph of the
+form:
+
+```text
+oxidative_ratio = positive_parameter(...)
+o2_contribution = H_o2_ratio_free @ (-oxidative_ratio * x_shared)
+```
+
+This is bilinear in the ratio and shared flux state. Preparation must therefore
+not silently reuse an operator or aggregation covariance derived for a fixed
+ratio. Any covariance held fixed under the uncertain coupling must have a
+scientific justification and be recorded as an approximation. Configuration
+may offer a recipe-owned choice between a fixed value and a prior
+specification; this does not require a generic parameter graph or nested-prior
+language.
+
 Keep the first model literal and local: shared sources and tracer-specific
 sources should be plainly visible rather than normalized through a generic
 multigas schema. A `Co2O2PreparedInputs`-style handoff is justified because it

--- a/docs/usage/concrete_rhime_model.rst
+++ b/docs/usage/concrete_rhime_model.rst
@@ -525,8 +525,10 @@ sector roles use keys such as ``flux_scale:FF`` and
 ``pm.Model``; the corresponding ``*_model_result`` wrappers add the runner and
 output metadata contract.
 
-The more general semantic model and observation-channel representation remains
-tracked in `issue #528 <https://github.com/openghg/openghg_inversions/issues/528>`_.
+Structurally distinct observation-channel models belong in readable named
+recipes with concrete builders. The active design guidance is
+:doc:`../development/rhime_model_development`; the retired semantic-model work
+in issue #528 remains research evidence rather than production architecture.
 
 Customization boundaries
 ------------------------

--- a/newsfragments/+.doc.md
+++ b/newsfragments/+.doc.md
@@ -1,0 +1,1 @@
+Preserve fixed and uncertain cross-channel coupling guidance in the active RHIME model-family plan and remove a stale semantic-model roadmap reference.


### PR DESCRIPTION
## Summary
- preserve fixed and latent cross-channel coupling guidance in the active RHIME model-family plan
- clarify the ratio-free operator and covariance implications of latent ratios
- remove the stale semantic-model roadmap reference

## Validation
- git diff --cached --check