### PR TITLE
Add configurable additive-sigma Gaussian likelihood

### DIFF
--- a/docs/development/rhime_model_development.rst
+++ b/docs/development/rhime_model_development.rst
@@ -203,7 +203,8 @@ arrays together, and pass them to components as honest named arguments.
    * - ``min_error``
      - Reusable error-model product
      - Currently calculated by preparation
-     - Passed as ``minimum_error`` to the likelihood
+     - Passed as ``minimum_error`` to likelihoods which support the historical
+       total-error floor
    * - ``aggregation_error_covariance``, ``low_rank_factor``,
        ``diagonal_residual_variance``, ``aggregation_error_sd``
      - Optional reusable fixed-error products

--- a/docs/reference/openghg_inversions.models.additive_sigma.rst
+++ b/docs/reference/openghg_inversions.models.additive_sigma.rst
@@ -5,8 +5,8 @@ openghg\_inversions.models.additive\_sigma
 A model recipe supplies its completed forward-model mean explicitly; the
 likelihood then combines reported observation uncertainty, additive
 model-data-mismatch variance, and any selected fixed aggregation covariance.
-``build_additive_sigma_error`` remains available when a different observation
-distribution needs the same error construction.
+An optional prepared minimum error applies the historical floor on total
+marginal standard deviation.
 
 .. automodule:: openghg_inversions.models.additive_sigma
    :members:

--- a/docs/usage/customising_rhime.rst
+++ b/docs/usage/customising_rhime.rst
@@ -117,7 +117,9 @@ drop-in ordinary likelihood builder. It derives sigma alignment from the
 labelled observation ``site`` and ``time`` coordinates. Optional
 ``sigma_prior``, ``sigma_freq``, ``sigma_per_site``, ``sigma_freq_anchor``, and
 ``no_model_error`` settings belong to that component and can be supplied in
-``likelihood_kwargs``.
+``likelihood_kwargs``. This model adds absolute ``sigma**2`` directly to the
+independent variance. The prepared ``minimum_error`` retains its historical
+meaning as an optional floor on total standard deviation.
 
 Built-in aggregation covariance relies on the guarantees of its construction
 pipeline. A custom pipeline that assembles its own covariance may optionally

--- a/docs/usage/getting_started.rst
+++ b/docs/usage/getting_started.rst
@@ -379,7 +379,10 @@ The following file, ``my_hbmcmc_inputs.ini`` can be used to run an
 
    xprior   = {"pdf":"lognormal", "stdev":1}  ; lognormal with mean = 1, stdev = 1
    bcprior  = {"pdf":"truncatednormal", "mu":1.0, "sigma":0.02}  ; truncated normal with mean = 1, stdev 0.02
-   sigprior = {"pdf":"uniform", "lower":0.5, "upper":10}
+   sigprior = {"pdf":"halfnormal", "sigma":5.0}  ; additive sigma, in observation units
+   ; For the historical pollution-event likelihood instead, omit `likelihood`
+   ; below and use a dimensionless fractional prior such as:
+   ; sigprior = {"pdf":"uniform", "lower":0.0, "upper":0.2}
    ;add_offset = False
    ;offsetprior = {"pdf": "normal"}
    ;offset_args = {"drop_first": False}  ;; set to True if you want first site to have offset 0.0
@@ -413,6 +416,9 @@ The following file, ``my_hbmcmc_inputs.ini`` can be used to run an
    nchain = 4
 
    [MCMC.OPTIONS]
+   ; Select response-independent absolute model error. Omit this option to use
+   ; the historical pollution-event likelihood.
+   likelihood = "additive_sigma"
    ; averaging_error (bool): Add variability in averaging period to the measurement error (Note: currently this
    ;                         doesn't work correctly)
    ; min_error: numeric lower bound for model-measurement mismatch, or "residual"/"percentile"
@@ -438,12 +444,12 @@ The following file, ``my_hbmcmc_inputs.ini`` can be used to run an
    ; sampler_kwargs (dict): Kwargs to pass to the sampler (e.g. sampler_kwargs = {'target_accept': 0.99})
 
    averaging_error = True
-   min_error = "residual"
+   min_error = 0.0
    fix_basis_outer_regions = False
    use_bc = True
    nuts_sampler = "numpyro"
    save_trace = True
-   min_error_options = {"by_site": True}  ; mapping; only supported key is boolean by_site (residual only)
+   ;min_error_options = {"by_site": True}  ; mapping; only supported key is boolean by_site (residual only)
    pollution_events_from_obs = True
    no_model_error = False
    reparameterise_log_normal = False
@@ -460,6 +466,48 @@ The following file, ``my_hbmcmc_inputs.ini`` can be used to run an
 
    outputpath = '/user/work/ab12345/my_inversions'  ; (required)
    outputname = 'ch4_TAC_test'  ; (required)
+
+Additive-sigma likelihood
+-------------------------
+
+The ``run_hbmcmc.py`` INI route can select a response-independent additive
+Gaussian model-error term with::
+
+   [MCMC.PDF]
+   sigprior = {"pdf": "halfnormal", "sigma": 5.0}
+
+   [MCMC.BC_SPLIT]
+   sigma_freq = "monthly"
+   sigma_per_site = True
+
+   [MCMC.OPTIONS]
+   likelihood = "additive_sigma"
+   min_error = 0.0
+
+This gives the independent likelihood variance
+:math:`s_y^2 + \sigma_{site,period}^2`. It does not use the pollution
+enhancement and does not add aggregation error. ``min_error`` works as before
+as an optional floor on the total standard deviation; it defaults to ``0.0``.
+We recommend first trying the half-normal model with ``min_error = 0.0``.
+``aggregation_error_mode`` is unavailable for this ``run_hbmcmc.py`` option.
+
+A half-normal prior is the recommended starting family. Its ``sigma`` input is
+the half-normal *scale*, and
+
+.. math::
+
+   E[\sigma_{site,period}] = \sigma_{prior}\sqrt{2/\pi},
+   \qquad
+   \sigma_{prior} = E[\sigma_{site,period}]\sqrt{\pi/2}.
+
+Thus the scale which exactly matches a desired prior mean is about 1.25 times
+that mean. If the empirical "average model error" is only a rough upper
+starting point, choosing a somewhat smaller scale gives a correspondingly
+smaller prior mean. This scale is in the same physical units and on the same
+numerical scale as the observations (for example, ppt). It is not the
+dimensionless fractional ``sigma`` used by the pollution-event scaling
+options. Consequently, ``sigprior`` has different units and meaning depending
+on the selected likelihood.
 
 Description of HBMCMC output file
 ---------------------------------

--- a/docs/usage/getting_started.rst
+++ b/docs/usage/getting_started.rst
@@ -371,7 +371,8 @@ The following file, ``my_hbmcmc_inputs.ini`` can be used to run an
    ; Definitions of PDF shape and parameters for inputs
    ; - xprior (dict) - emissions
    ; - bcprior (dict) - boundary conditions
-   ; - sigprior (dict) - model error
+   ; - sigprior (dict) - historical fractional model error
+   ; - additive_sigma_prior (dict) - additive model error in observation units
 
    ; Each of these inputs should be dictionary with the name of probability distribution and shape parameters.
    ; See https://docs.pymc.io/api/distributions/continuous.html
@@ -379,10 +380,8 @@ The following file, ``my_hbmcmc_inputs.ini`` can be used to run an
 
    xprior   = {"pdf":"lognormal", "stdev":1}  ; lognormal with mean = 1, stdev = 1
    bcprior  = {"pdf":"truncatednormal", "mu":1.0, "sigma":0.02}  ; truncated normal with mean = 1, stdev 0.02
-   sigprior = {"pdf":"halfnormal", "sigma":5.0}  ; additive sigma, in observation units
-   ; For the historical pollution-event likelihood instead, omit `likelihood`
-   ; below and use a dimensionless fractional prior such as:
-   ; sigprior = {"pdf":"uniform", "lower":0.0, "upper":0.2}
+   sigprior = {"pdf":"uniform", "lower":0.0, "upper":0.2}
+   additive_sigma_prior = {"pdf":"halfnormal", "sigma":5.0}  ; observation units
    ;add_offset = False
    ;offsetprior = {"pdf": "normal"}
    ;offset_args = {"drop_first": False}  ;; set to True if you want first site to have offset 0.0
@@ -474,7 +473,7 @@ The ``run_hbmcmc.py`` INI route can select a response-independent additive
 Gaussian model-error term with::
 
    [MCMC.PDF]
-   sigprior = {"pdf": "halfnormal", "sigma": 5.0}
+   additive_sigma_prior = {"pdf": "halfnormal", "sigma": {"MHD": 5.0, "TAC": 2.0}}
 
    [MCMC.BC_SPLIT]
    sigma_freq = "monthly"
@@ -490,6 +489,11 @@ enhancement and does not add aggregation error. ``min_error`` works as before
 as an optional floor on the total standard deviation; it defaults to ``0.0``.
 We recommend first trying the half-normal model with ``min_error = 0.0``.
 ``aggregation_error_mode`` is unavailable for this ``run_hbmcmc.py`` option.
+``additive_sigma_prior`` takes precedence for this likelihood; when it is
+omitted, the compatibility entry point falls back to ``sigprior``. A mapping
+from site name to scale gives each retained site its own half-normal prior
+scale. Every retained site must be present; entries for sites removed during
+preparation are ignored. Site mappings require ``sigma_per_site = True``.
 
 A half-normal prior is the recommended starting family. Its ``sigma`` input is
 the half-normal *scale*, and
@@ -506,8 +510,9 @@ starting point, choosing a somewhat smaller scale gives a correspondingly
 smaller prior mean. This scale is in the same physical units and on the same
 numerical scale as the observations (for example, ppt). It is not the
 dimensionless fractional ``sigma`` used by the pollution-event scaling
-options. Consequently, ``sigprior`` has different units and meaning depending
-on the selected likelihood.
+options. ``additive_sigma_prior`` avoids overloading the historical,
+dimensionless ``sigprior``; the latter remains available as a compatibility
+fallback for additive-sigma configurations.
 
 Description of HBMCMC output file
 ---------------------------------

--- a/examples/rhime_cookiecutter/my_inversion/likelihoods.py
+++ b/examples/rhime_cookiecutter/my_inversion/likelihoods.py
@@ -1,12 +1,13 @@
 """Project-owned scientific variation for a cookiecutter-generated package."""
 
 import pymc as pm
+import pytensor.tensor as pt
 import xarray as xr
 from pytensor.tensor.variable import TensorVariable
 
-from openghg_inversions.models.additive_sigma import build_additive_sigma_error
 from openghg_inversions.observation_error import (
     AggregationError,
+    validate_observation_error_arrays,
 )
 
 
@@ -50,22 +51,42 @@ def likelihood_builder(
         raise ValueError("Student-t degrees of freedom must be positive.")
 
     del pollution_mean, pollution_event_baseline
-    state = build_additive_sigma_error(
-        observations=observations,
-        observation_error=observation_error,
-        minimum_error=minimum_error,
-        aggregation_error=aggregation_error,
-        sigma_alignment=None,
-        sigma_prior={},
-        no_model_error=True,
+    validate_observation_error_arrays(
+        observations,
+        observation_error,
+        minimum_error,
+        owner="Custom Student-t likelihood",
         output_dim=output_dim,
+    )
+    reported_error = pm.Data(
+        "error",
+        pm.floatX(observation_error.transpose(output_dim).compute().values),
+        dims=output_dim,
+    )
+    minimum_error_data = pm.Data(
+        "min_error",
+        pm.floatX(minimum_error.transpose(output_dim).compute().values),
+        dims=output_dim,
+    )
+    aggregation_variance = pm.Data(
+        "aggregation_error_marginal_variance",
+        pm.floatX(aggregation_error.marginal_variance),
+        dims=output_dim,
+    )
+    epsilon = pm.Deterministic(
+        "epsilon",
+        pt.maximum(
+            pt.sqrt(reported_error**2 + aggregation_variance),
+            minimum_error_data,
+        ),
+        dims=output_dim,
     )
     observed = pm.StudentT(
         "y",
         nu=degrees_of_freedom,
         mu=mean,
-        sigma=state.error_scale,
-        observed=state.observed,
+        sigma=epsilon,
+        observed=pm.floatX(observations.transpose(output_dim).compute().values),
         dims=output_dim,
     )
     return observed

--- a/examples/rhime_customisation/likelihoods.py
+++ b/examples/rhime_customisation/likelihoods.py
@@ -8,12 +8,13 @@ not build a model, retrieve data, sample, or write outputs.
 """
 
 import pymc as pm
+import pytensor.tensor as pt
 import xarray as xr
 from pytensor.tensor.variable import TensorVariable
 
-from openghg_inversions.models.additive_sigma import build_additive_sigma_error
 from openghg_inversions.observation_error import (
     AggregationError,
+    validate_observation_error_arrays,
 )
 
 
@@ -67,22 +68,42 @@ def likelihood_builder(
     if degrees_of_freedom <= 0:
         raise ValueError("Student-t degrees of freedom must be positive.")
     del pollution_mean, pollution_event_baseline
-    state = build_additive_sigma_error(
-        observations=observations,
-        observation_error=observation_error,
-        minimum_error=minimum_error,
-        aggregation_error=aggregation_error,
-        sigma_alignment=None,
-        sigma_prior={},
-        no_model_error=True,
+    validate_observation_error_arrays(
+        observations,
+        observation_error,
+        minimum_error,
+        owner="Custom Student-t likelihood",
         output_dim=output_dim,
+    )
+    reported_error = pm.Data(
+        "error",
+        pm.floatX(observation_error.transpose(output_dim).compute().values),
+        dims=output_dim,
+    )
+    minimum_error_data = pm.Data(
+        "min_error",
+        pm.floatX(minimum_error.transpose(output_dim).compute().values),
+        dims=output_dim,
+    )
+    aggregation_variance = pm.Data(
+        "aggregation_error_marginal_variance",
+        pm.floatX(aggregation_error.marginal_variance),
+        dims=output_dim,
+    )
+    epsilon = pm.Deterministic(
+        "epsilon",
+        pt.maximum(
+            pt.sqrt(reported_error**2 + aggregation_variance),
+            minimum_error_data,
+        ),
+        dims=output_dim,
     )
     observed = pm.StudentT(
         "y",
         nu=degrees_of_freedom,
         mu=mean,
-        sigma=state.error_scale,
-        observed=state.observed,
+        sigma=epsilon,
+        observed=pm.floatX(observations.transpose(output_dim).compute().values),
         dims=output_dim,
     )
     return observed

--- a/newsfragments/639.feature.md
+++ b/newsfragments/639.feature.md
@@ -1,0 +1,1 @@
+Add a reusable absolute additive-sigma Gaussian likelihood with an optional minimum-error floor, including an INI-selectable ``run_hbmcmc.py`` option for standard RHIME runs and fixed-error reuse by the CO2 and CO2/O2 recipes.

--- a/newsfragments/639.feature.md
+++ b/newsfragments/639.feature.md
@@ -1,1 +1,1 @@
-Add a reusable absolute additive-sigma Gaussian likelihood with an optional minimum-error floor, including an INI-selectable ``run_hbmcmc.py`` option for standard RHIME runs and fixed-error reuse by the CO2 and CO2/O2 recipes.
+Add a reusable absolute additive-sigma Gaussian likelihood with an optional minimum-error floor, including an INI-selectable ``run_hbmcmc.py`` option, labelled per-site prior scales, and fixed-error reuse by the CO2 and CO2/O2 recipes.

--- a/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template.ini
+++ b/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template.ini
@@ -150,7 +150,9 @@ mcmc_type = "fixed_basis"
 
 xprior = {"pdf" : "normal", "mu" : 1.0, "sigma" : 1}
 bcprior = {"pdf" : "normal", "mu" : 1.0, "sigma" : 0.5}
-sigprior = {"pdf" : "uniform", "lower" : 0.5, "upper" : 3}
+sigprior = {"pdf" : "uniform", "lower" : 0.0, "upper" : 0.2}  ; historical fractional sigma
+; With likelihood = "additive_sigma", prefer a half-normal in observation units:
+; sigprior = {"pdf" : "halfnormal", "sigma" : 1.0}
 add_offset = False
 ;offsetprior = {}
 ;offset_args = {"drop_first": False}  ;; set to True if you want first site to have offset 0.0
@@ -185,6 +187,11 @@ tune =    ; (required)
 nchain = 2
 
 [MCMC.OPTIONS]
+; likelihood (str/optional): Set to "additive_sigma" for absolute additive
+;                            Gaussian model error. With this option, prefer a
+;                            half-normal sigprior in observation units;
+;                            aggregation error is not applied. min_error works
+;                            as before; start with min_error = 0.0.
 ; averaging_error (bool): Add variability in averaging period to the measurement error (Note: currently this
 ;                         doesn't work correctly)
 ; min_error: numeric lower bound for model-measurement mismatch, or "residual"/"percentile"
@@ -210,6 +217,7 @@ nchain = 2
 ; sampler_kwargs (dict): Kwargs to pass to the sampler (e.g. sampler_kwargs = {'target_accept': 0.99})
 
 averaging_error = True
+; likelihood = "additive_sigma"
 min_error = "residual"
 ; min_error_options = {"by_site": True}  ; only affects min_error = "residual"
 fix_basis_outer_regions = False

--- a/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template.ini
+++ b/openghg_inversions/hbmcmc/config/openghg_hbmcmc_input_template.ini
@@ -152,7 +152,9 @@ xprior = {"pdf" : "normal", "mu" : 1.0, "sigma" : 1}
 bcprior = {"pdf" : "normal", "mu" : 1.0, "sigma" : 0.5}
 sigprior = {"pdf" : "uniform", "lower" : 0.0, "upper" : 0.2}  ; historical fractional sigma
 ; With likelihood = "additive_sigma", prefer a half-normal in observation units:
-; sigprior = {"pdf" : "halfnormal", "sigma" : 1.0}
+; additive_sigma_prior = {"pdf" : "halfnormal", "sigma" : 1.0}
+; Per-site scales use site names and require sigma_per_site = True:
+; additive_sigma_prior = {"pdf" : "halfnormal", "sigma" : {"MHD" : 5.0, "TAC" : 2.0}}
 add_offset = False
 ;offsetprior = {}
 ;offset_args = {"drop_first": False}  ;; set to True if you want first site to have offset 0.0
@@ -189,7 +191,8 @@ nchain = 2
 [MCMC.OPTIONS]
 ; likelihood (str/optional): Set to "additive_sigma" for absolute additive
 ;                            Gaussian model error. With this option, prefer a
-;                            half-normal sigprior in observation units;
+;                            half-normal additive_sigma_prior in observation
+;                            units; sigprior is accepted as a fallback;
 ;                            aggregation error is not applied. min_error works
 ;                            as before; start with min_error = 0.0.
 ; averaging_error (bool): Add variability in averaging period to the measurement error (Note: currently this

--- a/openghg_inversions/hbmcmc/run_hbmcmc.py
+++ b/openghg_inversions/hbmcmc/run_hbmcmc.py
@@ -270,6 +270,8 @@ def _select_additive_sigma_likelihood(
         for name in _ADDITIVE_SIGMA_OPTION_NAMES
         if name in rhime_params
     }
+    if options.get("sigma_freq") not in (None, "monthly"):
+        options.setdefault("sigma_freq_anchor", rhime_params["start_date"])
     resolved_prior = (
         rhime_params.get("sigma_prior", DEFAULT_ADDITIVE_SIGMA_PRIOR)
         if additive_sigma_prior is None

--- a/openghg_inversions/hbmcmc/run_hbmcmc.py
+++ b/openghg_inversions/hbmcmc/run_hbmcmc.py
@@ -45,6 +45,7 @@ from openghg_inversions.config import config
 from openghg_inversions.config.paths import Paths
 from openghg_inversions.hbmcmc.hbmcmc import _LEGACY_FIXEDBASIS_OUTPUT_FORMAT, fixedbasisMCMC
 from openghg_inversions.rhime import resolve_rhime_options, run_rhime
+from openghg_inversions.rhime.likelihoods import additive_sigma_likelihood_builder
 from openghg_inversions.rhime.params import normalise_rhime_params
 
 
@@ -60,6 +61,14 @@ _LEGACY_FIXEDBASIS_PARAM_NAMES = set(inspect.signature(fixedbasisMCMC).parameter
 _LEGACY_INFERPYMC_PARAM_NAMES = set(inspect.signature(inversion_pymc.inferpymc).parameters) - {"inv_inputs"}
 _LEGACY_FIXEDBASIS_EXTRA_PARAM_NAMES = {"flux_non_finite_check"}
 _LEGACY_FIXEDBASIS_OUTPUT_ALIASES = {"hbmcmc", "hbmcmc_postprocessing"}
+_ADDITIVE_SIGMA_LIKELIHOOD = "additive_sigma"
+_ADDITIVE_SIGMA_OPTION_NAMES = (
+    "sigma_prior",
+    "sigma_freq",
+    "sigma_per_site",
+    "sigma_freq_anchor",
+    "no_model_error",
+)
 
 
 def fixed_basis_expected_param() -> list[str]:
@@ -211,6 +220,7 @@ def fixedbasis_params_to_rhime(params: dict[str, Any]) -> dict[str, Any]:
     API performs its existing validation and spec construction.
     """
     translated = dict(params)
+    translated.pop("likelihood", None)
     mcmc_type = translated.pop("mcmc_type", "fixed_basis")
     if mcmc_type != "fixed_basis":
         raise ValueError(f"Unsupported run_hbmcmc mcmc_type {mcmc_type!r}; expected 'fixed_basis'.")
@@ -222,6 +232,37 @@ def fixedbasis_params_to_rhime(params: dict[str, Any]) -> dict[str, Any]:
     if "save_inversion_output" not in translated and translated["output_format"] != "inv_out":
         translated["save_inversion_output"] = False
     return normalise_rhime_params(translated)
+
+
+def _select_additive_sigma_likelihood(
+    raw_params: dict[str, Any],
+    rhime_params: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Return component options when an INI selects additive sigma.
+
+    This compatibility entry point owns the policy that additive sigma never
+    consumes aggregation error. The reusable component remains capable of
+    serving CO2-family recipes which do own fixed aggregation covariance.
+    """
+    likelihood = raw_params.get("likelihood")
+    if likelihood is None:
+        return None
+    if not isinstance(likelihood, str) or likelihood.strip().lower() != _ADDITIVE_SIGMA_LIKELIHOOD:
+        raise ValueError(
+            "run_hbmcmc supports only likelihood='additive_sigma'; omit `likelihood` "
+            "to retain the historical pollution-event likelihood."
+        )
+    if rhime_params.get("aggregation_error_mode", "none") != "none":
+        raise ValueError(
+            "run_hbmcmc additive_sigma does not support `aggregation_error_mode`; "
+            "remove it or set it to 'none'."
+        )
+    rhime_params["aggregation_error_mode"] = "none"
+    return {
+        name: rhime_params[name]
+        for name in _ADDITIVE_SIGMA_OPTION_NAMES
+        if name in rhime_params
+    }
 
 
 def validate_rhime_params(params: dict[str, Any]) -> None:
@@ -440,6 +481,7 @@ def main(argv: list[str] | None = None) -> None:
 
     with timed("run_hbmcmc.fixedbasis_to_rhime_translation"):
         rhime_params = fixedbasis_params_to_rhime(param)
+        additive_sigma_options = _select_additive_sigma_likelihood(param, rhime_params)
 
     with timed("run_hbmcmc.validation"):
         validate_rhime_params(rhime_params)
@@ -450,7 +492,15 @@ def main(argv: list[str] | None = None) -> None:
     with timed("run_hbmcmc.config_copy"):
         output.copy_config_file(str(config_file), param=param, **command_line_args)
 
-    run_rhime(preserve_legacy_likelihood=True, **rhime_params)
+    if additive_sigma_options is None:
+        run_rhime(preserve_legacy_likelihood=True, **rhime_params)
+    else:
+        run_rhime(
+            likelihood_builder=additive_sigma_likelihood_builder,
+            likelihood_kwargs=additive_sigma_options,
+            preserve_legacy_likelihood=False,
+            **rhime_params,
+        )
 
 
 if __name__ == "__main__":

--- a/openghg_inversions/hbmcmc/run_hbmcmc.py
+++ b/openghg_inversions/hbmcmc/run_hbmcmc.py
@@ -33,6 +33,7 @@ import inspect
 import json
 import sys
 import warnings
+from collections.abc import Mapping
 from pathlib import Path
 from shutil import copyfile
 from typing import Any
@@ -44,6 +45,7 @@ from openghg_inversions._timing import log_timing, timed, timer_seconds, timer_s
 from openghg_inversions.config import config
 from openghg_inversions.config.paths import Paths
 from openghg_inversions.hbmcmc.hbmcmc import _LEGACY_FIXEDBASIS_OUTPUT_FORMAT, fixedbasisMCMC
+from openghg_inversions.models.additive_sigma import DEFAULT_ADDITIVE_SIGMA_PRIOR
 from openghg_inversions.rhime import resolve_rhime_options, run_rhime
 from openghg_inversions.rhime.likelihoods import additive_sigma_likelihood_builder
 from openghg_inversions.rhime.params import normalise_rhime_params
@@ -62,6 +64,7 @@ _LEGACY_INFERPYMC_PARAM_NAMES = set(inspect.signature(inversion_pymc.inferpymc).
 _LEGACY_FIXEDBASIS_EXTRA_PARAM_NAMES = {"flux_non_finite_check"}
 _LEGACY_FIXEDBASIS_OUTPUT_ALIASES = {"hbmcmc", "hbmcmc_postprocessing"}
 _ADDITIVE_SIGMA_LIKELIHOOD = "additive_sigma"
+_ADDITIVE_SIGMA_PRIOR = "additive_sigma_prior"
 _ADDITIVE_SIGMA_OPTION_NAMES = (
     "sigma_prior",
     "sigma_freq",
@@ -221,6 +224,7 @@ def fixedbasis_params_to_rhime(params: dict[str, Any]) -> dict[str, Any]:
     """
     translated = dict(params)
     translated.pop("likelihood", None)
+    translated.pop(_ADDITIVE_SIGMA_PRIOR, None)
     mcmc_type = translated.pop("mcmc_type", "fixed_basis")
     if mcmc_type != "fixed_basis":
         raise ValueError(f"Unsupported run_hbmcmc mcmc_type {mcmc_type!r}; expected 'fixed_basis'.")
@@ -245,7 +249,10 @@ def _select_additive_sigma_likelihood(
     serving CO2-family recipes which do own fixed aggregation covariance.
     """
     likelihood = raw_params.get("likelihood")
+    additive_sigma_prior = raw_params.get(_ADDITIVE_SIGMA_PRIOR)
     if likelihood is None:
+        if additive_sigma_prior is not None:
+            raise ValueError("`additive_sigma_prior` requires likelihood='additive_sigma'.")
         return None
     if not isinstance(likelihood, str) or likelihood.strip().lower() != _ADDITIVE_SIGMA_LIKELIHOOD:
         raise ValueError(
@@ -258,11 +265,23 @@ def _select_additive_sigma_likelihood(
             "remove it or set it to 'none'."
         )
     rhime_params["aggregation_error_mode"] = "none"
-    return {
+    options = {
         name: rhime_params[name]
         for name in _ADDITIVE_SIGMA_OPTION_NAMES
         if name in rhime_params
     }
+    resolved_prior = (
+        rhime_params.get("sigma_prior", DEFAULT_ADDITIVE_SIGMA_PRIOR)
+        if additive_sigma_prior is None
+        else additive_sigma_prior
+    )
+    if not isinstance(resolved_prior, Mapping):
+        name = "sigma_prior" if additive_sigma_prior is None else _ADDITIVE_SIGMA_PRIOR
+        raise ValueError(f"`{name}` must be a mapping/dict.")
+    resolved_prior = dict(resolved_prior)
+    rhime_params["sigma_prior"] = resolved_prior
+    options["sigma_prior"] = resolved_prior
+    return options
 
 
 def validate_rhime_params(params: dict[str, Any]) -> None:

--- a/openghg_inversions/models/additive_sigma.py
+++ b/openghg_inversions/models/additive_sigma.py
@@ -9,16 +9,13 @@ component constructs the independent variance
 
    v = s_y^2 + s_{fixed}^2 + \sigma^2
 
-and applies ``min_error`` as a floor on the total marginal standard
-deviation. ``build_additive_sigma_error`` exposes the reusable error state;
-``add_additive_sigma_gaussian_likelihood`` combines that state with an
-explicitly supplied modelled concentration.
+An optional ``min_error`` applies the same floor on total marginal standard
+deviation as the historical likelihood.
 """
 
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass
 from typing import Any, cast
 
 import numpy as np
@@ -29,7 +26,6 @@ from pytensor.tensor.variable import TensorVariable
 
 from openghg_inversions.models.components import add_model_data, add_sigma_component
 from openghg_inversions.models.likelihoods import (
-    RegisteredAggregationError,
     add_aggregation_error_data,
     add_gaussian_observation_likelihood,
 )
@@ -41,57 +37,51 @@ from openghg_inversions.sigma import SigmaAlignment
 
 
 FIXED_MODEL_MISMATCH = "fixed_model_mismatch"
+DEFAULT_ADDITIVE_SIGMA_PRIOR = {"pdf": "halfnormal", "sigma": 1.0}
 
 
-@dataclass(frozen=True)
-class AdditiveSigmaErrorState:
-    """Terms required to construct an additive-sigma observation distribution."""
-
-    observed: TensorVariable
-    independent_variance: TensorVariable
-    aggregation_error: RegisteredAggregationError
-    error_scale: TensorVariable
-
-
-def build_additive_sigma_error(
+def add_additive_sigma_gaussian_likelihood(
     *,
     observations: xr.DataArray,
     observation_error: xr.DataArray,
-    minimum_error: xr.DataArray,
     aggregation_error: AggregationError,
+    mean: TensorVariable,
+    minimum_error: xr.DataArray | None = None,
     fixed_model_mismatch: xr.DataArray | None = None,
-    sigma_alignment: SigmaAlignment | None,
-    sigma_prior: Mapping[str, Any],
-    no_model_error: bool,
+    sigma_alignment: SigmaAlignment | None = None,
+    sigma_prior: Mapping[str, Any] | None = None,
     output_dim: str = "nmeasure",
-) -> AdditiveSigmaErrorState:
-    """Build observation-error terms with an additive mismatch scale.
+    observation_error_name: str = "error",
+) -> TensorVariable:
+    """Add a Gaussian likelihood with additive mismatch variance.
 
     ``fixed_model_mismatch`` is a known observation-aligned standard deviation.
     ``sigma`` is observation-aligned through ``sigma_alignment`` and enters as
-    a separate inferred variance term. When ``no_model_error`` is true, no
+    a separate inferred variance term. When no alignment is supplied, no
     ``sigma`` variable is constructed. Fixed diagonal, dense, or low-rank
-    aggregation error is included only when explicitly selected.
+    aggregation error is included only when explicitly selected. If supplied,
+    ``minimum_error`` floors the total marginal standard deviation.
 
     Args:
         observations: Observed mole fractions.
         observation_error: Reported observation-error standard deviations.
-        minimum_error: Minimum total-error standard deviations.
         aggregation_error: Validated fixed aggregation-error representation.
+        mean: Completed forward-model concentration aligned with
+            ``output_dim``.
+        minimum_error: Optional minimum total-error standard deviations.
         fixed_model_mismatch: Optional known model-data mismatch standard
             deviation, in the same units and observation order as
             ``observations``.
         sigma_alignment: Mapping from observations to mismatch-scale
-            parameters when model error is enabled.
+            parameters. Omit it for a fixed-error likelihood.
         sigma_prior: Prior arguments used to construct ``sigma`` when model
             error is enabled.
-        no_model_error: If true, omit ``sigma`` and use only reported and
-            selected aggregation errors.
         output_dim: Observation dimension used for named PyMC variables.
+        observation_error_name: PyMC data name for the reported error.
 
     Returns:
-        Labelled observed data, independent variance, fixed aggregation error,
-        and total marginal error scale.
+        The observed Gaussian variable, named ``y``. The total marginal error
+        scale is also recorded in the active model as ``epsilon``.
 
     Raises:
         ValueError: If the observation or aggregation-error inputs are
@@ -104,14 +94,12 @@ def build_additive_sigma_error(
         owner="Additive-sigma likelihood",
         output_dim=output_dim,
     )
-    if not no_model_error:
-        if sigma_alignment is None:
-            raise ValueError(
-                "Additive-sigma likelihood requires `sigma_alignment` when model error is enabled."
-            )
-    observed = add_model_data(observations.transpose(output_dim), "Y")
-    reported_error = add_model_data(observation_error.transpose(output_dim), "error")
-    minimum_error_data = add_model_data(minimum_error.transpose(output_dim), "min_error")
+    if sigma_alignment is not None and sigma_prior is None:
+        raise ValueError("Additive-sigma likelihood requires `sigma_prior` with `sigma_alignment`.")
+    reported_error = add_model_data(
+        observation_error.transpose(output_dim),
+        observation_error_name,
+    )
     registered_aggregation_error = add_aggregation_error_data(
         aggregation_error,
         observations,
@@ -135,101 +123,35 @@ def build_additive_sigma_error(
             FIXED_MODEL_MISMATCH,
         )
         independent_variance = independent_variance + fixed_mismatch_data**2
-    if not no_model_error:
-        assert sigma_alignment is not None
+    if sigma_alignment is not None:
+        assert sigma_prior is not None
         sigma = add_sigma_component(sigma_alignment, prior_args=dict(sigma_prior))
         independent_variance = independent_variance + sigma**2
 
     aggregation_marginal_variance = registered_aggregation_error.marginal_variance
-    floor_variance = cast(Any, pt.maximum)(
-        minimum_error_data**2 - independent_variance - aggregation_marginal_variance,
-        0.0,
-    )
-    independent_variance = independent_variance + floor_variance
-    error_scale = pm.Deterministic(
+    if minimum_error is not None:
+        minimum_error_data = add_model_data(minimum_error.transpose(output_dim), "min_error")
+        floor_variance = cast(Any, pt.maximum)(
+            minimum_error_data**2 - independent_variance - aggregation_marginal_variance,
+            0.0,
+        )
+        independent_variance = independent_variance + floor_variance
+    pm.Deterministic(
         "epsilon",
         pt.sqrt(independent_variance + aggregation_marginal_variance),
         dims=output_dim,
     )
-    return AdditiveSigmaErrorState(
-        observed=observed,
+    return add_gaussian_observation_likelihood(
+        observed=pm.floatX(observations.transpose(output_dim).compute().values),
+        mean=mean,
         independent_variance=independent_variance,
         aggregation_error=registered_aggregation_error,
-        error_scale=error_scale,
-    )
-
-
-def add_additive_sigma_gaussian_likelihood(
-    *,
-    observations: xr.DataArray,
-    observation_error: xr.DataArray,
-    minimum_error: xr.DataArray,
-    aggregation_error: AggregationError,
-    fixed_model_mismatch: xr.DataArray | None = None,
-    mean: TensorVariable,
-    sigma_alignment: SigmaAlignment | None,
-    sigma_prior: Mapping[str, Any],
-    no_model_error: bool,
-    output_dim: str = "nmeasure",
-) -> TensorVariable:
-    """Add a Gaussian likelihood with additive mismatch variance.
-
-    This is the complete, opt-in observation model associated with
-    :func:`build_additive_sigma_error`. The supplied ``mean`` is the completed
-    forward-model concentration, including every pollution and baseline term
-    selected by the calling model recipe. Model-data mismatch contributes
-    ``sigma**2`` to the reported observation-error variance; it is not scaled
-    by the pollution enhancement.
-
-    Args:
-        observations: Observed mole fractions.
-        observation_error: Reported observation-error standard deviations.
-        minimum_error: Minimum total-error standard deviations.
-        aggregation_error: Validated fixed aggregation-error representation.
-        fixed_model_mismatch: Optional known model-data mismatch standard
-            deviation, in the same units and observation order as
-            ``observations``.
-        mean: Completed forward-model concentration aligned with
-            ``output_dim``.
-        sigma_alignment: Mapping from observations to mismatch-scale
-            parameters when model error is enabled.
-        sigma_prior: Prior arguments used to construct ``sigma`` when model
-            error is enabled.
-        no_model_error: If true, omit ``sigma`` and use only reported and
-            selected aggregation errors.
-        output_dim: Observation dimension used for named PyMC variables.
-
-    Returns:
-        The observed Gaussian variable, named ``y``. The total marginal error
-        scale is also recorded in the active model as ``epsilon``.
-
-    Raises:
-        ValueError: If the observation or aggregation-error inputs are
-            inconsistent with ``output_dim``.
-    """
-    state = build_additive_sigma_error(
-        observations=observations,
-        observation_error=observation_error,
-        minimum_error=minimum_error,
-        aggregation_error=aggregation_error,
-        fixed_model_mismatch=fixed_model_mismatch,
-        sigma_alignment=sigma_alignment,
-        sigma_prior=sigma_prior,
-        no_model_error=no_model_error,
-        output_dim=output_dim,
-    )
-    return add_gaussian_observation_likelihood(
-        observed=state.observed,
-        mean=mean,
-        independent_variance=state.independent_variance,
-        aggregation_error=state.aggregation_error,
         output_dim=output_dim,
     )
 
 
 __all__ = [
+    "DEFAULT_ADDITIVE_SIGMA_PRIOR",
     "FIXED_MODEL_MISMATCH",
-    "AdditiveSigmaErrorState",
     "add_additive_sigma_gaussian_likelihood",
-    "build_additive_sigma_error",
 ]

--- a/openghg_inversions/observation_error.py
+++ b/openghg_inversions/observation_error.py
@@ -188,7 +188,7 @@ def _validate_vector(
 def validate_observation_error_arrays(
     observations: xr.DataArray,
     observation_error: xr.DataArray,
-    minimum_error: xr.DataArray,
+    minimum_error: xr.DataArray | None,
     *,
     owner: str,
     output_dim: str = "nmeasure",
@@ -198,7 +198,7 @@ def validate_observation_error_arrays(
     Args:
         observations: Observed mole fractions.
         observation_error: Reported observation-error standard deviations.
-        minimum_error: Minimum total-error standard deviations.
+        minimum_error: Optional minimum total-error standard deviations.
         owner: Name of the likelihood/error component consuming the arrays.
         output_dim: Required observation dimension.
 
@@ -213,10 +213,10 @@ def validate_observation_error_arrays(
         )
     _numeric_finite("observations", observations, owner=f"{owner} input")
     nmeasure = observations.sizes[output_dim]
-    for name, array in (
-        ("observation_error", observation_error),
-        ("minimum_error", minimum_error),
-    ):
+    arrays = [("observation_error", observation_error)]
+    if minimum_error is not None:
+        arrays.append(("minimum_error", minimum_error))
+    for name, array in arrays:
         if array.dims != (output_dim,):
             raise ValueError(
                 f"{owner} input {name!r} must have dims "

--- a/openghg_inversions/rhime/co2/co2_model.py
+++ b/openghg_inversions/rhime/co2/co2_model.py
@@ -12,7 +12,10 @@ import pymc as pm
 import xarray as xr
 
 from openghg_inversions.correlated_state import CorrelatedLognormalPrior
-from openghg_inversions.models.additive_sigma import add_additive_sigma_gaussian_likelihood
+from openghg_inversions.models.additive_sigma import (
+    DEFAULT_ADDITIVE_SIGMA_PRIOR,
+    add_additive_sigma_gaussian_likelihood,
+)
 from openghg_inversions.models.components import (
     add_coherent_affine_component,
     add_correlated_lognormal_state_with_activity,
@@ -28,7 +31,7 @@ from openghg_inversions.models.state_activity import (
     resolve_state_activity,
 )
 from openghg_inversions.observation_error import AggregationError
-from openghg_inversions.rhime.specs import DEFAULT_BC_PRIOR, DEFAULT_SIGMA_PRIOR
+from openghg_inversions.rhime.specs import DEFAULT_BC_PRIOR
 from openghg_inversions.sigma import SigmaAlignment
 
 from .outer_regions import (
@@ -147,7 +150,7 @@ def build_co2_model(
         ValueError: If shared preparation, prior construction, or registered
             coordinate alignment fails.
     """
-    sigma_prior = dict(DEFAULT_SIGMA_PRIOR if sigma_prior is None else sigma_prior)
+    sigma_prior = dict(DEFAULT_ADDITIVE_SIGMA_PRIOR if sigma_prior is None else sigma_prior)
     bc_prior = dict(DEFAULT_BC_PRIOR if bc_prior is None else bc_prior)
     fixed_mismatch = _fixed_mismatch_array(observations, fixed_model_mismatch)
     prepared_flux = prepare_linear_sensitivity(flux_sensitivity, output_dim="nmeasure")
@@ -217,9 +220,8 @@ def build_co2_model(
             aggregation_error=aggregation_error,
             fixed_model_mismatch=fixed_mismatch,
             mean=modelled_mean,
-            sigma_alignment=sigma_alignment,
-            sigma_prior=sigma_prior,
-            no_model_error=no_model_error,
+            sigma_alignment=None if no_model_error else sigma_alignment,
+            sigma_prior=None if no_model_error else sigma_prior,
             output_dim="nmeasure",
         )
     return model

--- a/openghg_inversions/rhime/co2/co2_model.py
+++ b/openghg_inversions/rhime/co2/co2_model.py
@@ -81,7 +81,6 @@ def build_co2_model(
     boundary_sensitivity: xr.DataArray | None = None,
     bc_prior: PriorArgs | None = None,
     bc_state_activity: StateActivity | None = None,
-    no_model_error: bool = False,
 ) -> pm.Model:
     """Build the CO2 coherent-reduction model from explicit scientific arrays.
 
@@ -140,7 +139,6 @@ def build_co2_model(
         bc_prior: Optional prior arguments for boundary-condition scaling.
         bc_state_activity: Optional labelled activity policy for boundary
             states.
-        no_model_error: If true, omit inferred additive model error.
 
     Returns:
         A registered PyMC model containing the complete affine concentration
@@ -150,7 +148,10 @@ def build_co2_model(
         ValueError: If shared preparation, prior construction, or registered
             coordinate alignment fails.
     """
-    sigma_prior = dict(DEFAULT_ADDITIVE_SIGMA_PRIOR if sigma_prior is None else sigma_prior)
+    if sigma_alignment is not None:
+        sigma_prior = dict(DEFAULT_ADDITIVE_SIGMA_PRIOR if sigma_prior is None else sigma_prior)
+    else:
+        sigma_prior = None
     bc_prior = dict(DEFAULT_BC_PRIOR if bc_prior is None else bc_prior)
     fixed_mismatch = _fixed_mismatch_array(observations, fixed_model_mismatch)
     prepared_flux = prepare_linear_sensitivity(flux_sensitivity, output_dim="nmeasure")
@@ -220,8 +221,8 @@ def build_co2_model(
             aggregation_error=aggregation_error,
             fixed_model_mismatch=fixed_mismatch,
             mean=modelled_mean,
-            sigma_alignment=None if no_model_error else sigma_alignment,
-            sigma_prior=None if no_model_error else sigma_prior,
+            sigma_alignment=sigma_alignment,
+            sigma_prior=sigma_prior,
             output_dim="nmeasure",
         )
     return model

--- a/openghg_inversions/rhime/co2/co2_o2_model.py
+++ b/openghg_inversions/rhime/co2/co2_o2_model.py
@@ -13,15 +13,11 @@ from openghg_inversions.models import (
     add_coherent_affine_component,
     add_correlated_lognormal_state_with_activity,
     add_linked_linear_component,
-    add_model_data,
     prepare_linear_sensitivity,
     registered_model,
     resolve_state_activity,
 )
-from openghg_inversions.models.likelihoods import (
-    add_aggregation_error_data,
-    add_gaussian_observation_likelihood,
-)
+from openghg_inversions.models.additive_sigma import add_additive_sigma_gaussian_likelihood
 from openghg_inversions.observation_error import AggregationError
 
 
@@ -125,23 +121,14 @@ def _add_co2_o2_fixed_error_likelihood(
     aggregation_error: AggregationError,
     output_dim: str,
 ) -> None:
-    """Add the registered joint fixed-error likelihood for both species."""
-    observed = add_model_data(observations, "observed_concentration")
-    fixed_error = add_model_data(
-        independent_error_sd,
-        "fixed_independent_error_sd",
-    )
-    registered_aggregation_error = add_aggregation_error_data(
-        aggregation_error,
-        observations,
-        output_dim=output_dim,
-    )
-    add_gaussian_observation_likelihood(
-        observed=observed,
+    """Add the reusable fixed-error form of the additive-sigma likelihood."""
+    add_additive_sigma_gaussian_likelihood(
+        observations=observations,
+        observation_error=independent_error_sd,
         mean=modelled_concentration,
-        independent_variance=fixed_error**2,
-        aggregation_error=registered_aggregation_error,
+        aggregation_error=aggregation_error,
         output_dim=output_dim,
+        observation_error_name="fixed_independent_error_sd",
     )
 
 

--- a/openghg_inversions/rhime/co2/co2_o2_model.py
+++ b/openghg_inversions/rhime/co2/co2_o2_model.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import pymc as pm
 import xarray as xr
-from pytensor.tensor.variable import TensorVariable
 
 from openghg_inversions.array_ops import concat_gather_data_arrays
 from openghg_inversions.correlated_state import CorrelatedLognormalPrior
@@ -112,26 +111,6 @@ def evaluate_co2_o2_prior_forward_mean(
     )
 
 
-def _add_co2_o2_fixed_error_likelihood(
-    observations: xr.DataArray,
-    modelled_concentration: TensorVariable,
-    /,
-    *,
-    independent_error_sd: xr.DataArray,
-    aggregation_error: AggregationError,
-    output_dim: str,
-) -> None:
-    """Add the reusable fixed-error form of the additive-sigma likelihood."""
-    add_additive_sigma_gaussian_likelihood(
-        observations=observations,
-        observation_error=independent_error_sd,
-        mean=modelled_concentration,
-        aggregation_error=aggregation_error,
-        output_dim=output_dim,
-        observation_error_name="fixed_independent_error_sd",
-    )
-
-
 def build_co2_o2_model(
     *,
     observations: xr.DataArray,
@@ -227,11 +206,12 @@ def build_co2_o2_model(
             output_name="modelled_concentration",
         )
 
-        _add_co2_o2_fixed_error_likelihood(
-            observations,
-            modelled,
-            independent_error_sd=independent_error_sd,
+        add_additive_sigma_gaussian_likelihood(
+            observations=observations,
+            observation_error=independent_error_sd,
+            mean=modelled,
             aggregation_error=aggregation_error,
             output_dim=output_dim,
+            observation_error_name="fixed_independent_error_sd",
         )
     return model

--- a/openghg_inversions/rhime/co2/co2_runner.py
+++ b/openghg_inversions/rhime/co2/co2_runner.py
@@ -52,7 +52,6 @@ def _annotate_co2_trace(
     # PyMC data names differ from prepared-array role names. Keep those
     # concrete scientific identities visible on stored constants too.
     concrete_roles = {
-        "Y": ["observation"],
         "error": ["observation_error"],
         "min_error": ["minimum_error"],
         "fixed_model_mismatch": ["fixed_model_mismatch"],
@@ -76,7 +75,6 @@ def _annotate_co2_trace(
         roles_by_variable[name].extend(scientific_roles)
 
     concentration_variables = {
-        "Y",
         "error",
         "min_error",
         "fixed_model_mismatch",
@@ -246,7 +244,7 @@ def run_rhime_co2(
     built = RhimeModelBuildResult(
         model=model,
         variable_roles={
-            "observation": "mf",
+            "observation": "y",
             "observation_error": "mf_error",
             "minimum_error": "min_error",
             "concentration": "y",

--- a/openghg_inversions/rhime/co2/co2_runner.py
+++ b/openghg_inversions/rhime/co2/co2_runner.py
@@ -217,7 +217,10 @@ def run_rhime_co2(
         derive_sigma_alignment=not no_model_error and sigma_alignment is None,
     )
     model_inputs = materialize_pymc_inputs(prepared, variable_names=names)
-    if not no_model_error and sigma_alignment is None:
+    if no_model_error:
+        sigma_alignment = None
+        sigma_prior = None
+    elif sigma_alignment is None:
         sigma_alignment = SigmaAlignment.from_frequency(model_inputs["site_indicator"])
     aggregation_error = resolve_aggregation_error(
         model_inputs,
@@ -239,7 +242,6 @@ def run_rhime_co2(
         sigma_prior=sigma_prior,
         fixed_model_mismatch=prepared_mismatch,
         state_activity=_state_activity_from_inputs(model_inputs),
-        no_model_error=no_model_error,
     )
     built = RhimeModelBuildResult(
         model=model,

--- a/openghg_inversions/rhime/likelihoods.py
+++ b/openghg_inversions/rhime/likelihoods.py
@@ -10,13 +10,11 @@ from pytensor.tensor.variable import TensorVariable
 
 from openghg_inversions.inversion_inputs import DatetimeLike, make_site_indicator
 from openghg_inversions.models.additive_sigma import (
+    DEFAULT_ADDITIVE_SIGMA_PRIOR,
     add_additive_sigma_gaussian_likelihood,
 )
 from openghg_inversions.observation_error import AggregationError
 from openghg_inversions.sigma import SigmaAlignment
-
-from .specs import DEFAULT_SIGMA_PRIOR
-
 
 def additive_sigma_likelihood_builder(
     *,
@@ -89,10 +87,13 @@ def additive_sigma_likelihood_builder(
         aggregation_error=aggregation_error,
         mean=mean,
         sigma_alignment=sigma_alignment,
-        sigma_prior=dict(DEFAULT_SIGMA_PRIOR if sigma_prior is None else sigma_prior),
-        no_model_error=no_model_error,
+        sigma_prior=(
+            None
+            if no_model_error
+            else dict(DEFAULT_ADDITIVE_SIGMA_PRIOR if sigma_prior is None else sigma_prior)
+        ),
         output_dim=output_dim,
     )
 
 
-__all__ = ["additive_sigma_likelihood_builder"]
+__all__ = ["DEFAULT_ADDITIVE_SIGMA_PRIOR", "additive_sigma_likelihood_builder"]

--- a/openghg_inversions/rhime/likelihoods.py
+++ b/openghg_inversions/rhime/likelihoods.py
@@ -3,18 +3,50 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from numbers import Real
 from typing import Any
 
+import numpy as np
 import xarray as xr
 from pytensor.tensor.variable import TensorVariable
 
-from openghg_inversions.inversion_inputs import DatetimeLike, make_site_indicator
+from openghg_inversions.inversion_inputs import DatetimeLike, make_site_indicator, make_site_names
 from openghg_inversions.models.additive_sigma import (
     DEFAULT_ADDITIVE_SIGMA_PRIOR,
     add_additive_sigma_gaussian_likelihood,
 )
 from openghg_inversions.observation_error import AggregationError
 from openghg_inversions.sigma import SigmaAlignment
+
+
+def _resolve_site_sigma_prior(
+    sigma_prior: Mapping[str, Any],
+    site: xr.DataArray,
+    *,
+    per_site: bool,
+) -> dict[str, Any]:
+    """Align an optional site-keyed ``sigma`` parameter to latent site order."""
+    resolved = dict(sigma_prior)
+    sigma = resolved.get("sigma")
+    if not isinstance(sigma, Mapping):
+        return resolved
+    if not per_site:
+        raise ValueError("A site-keyed sigma prior requires `sigma_per_site=True`.")
+
+    site_names = [str(value) for value in make_site_names(site).values]
+    missing = [name for name in site_names if name not in sigma]
+    if missing:
+        raise ValueError(f"Site-keyed sigma prior is missing retained site(s): {missing!r}.")
+
+    values = [sigma[name] for name in site_names]
+    if any(isinstance(value, bool) or not isinstance(value, Real) for value in values):
+        raise ValueError("Site-keyed sigma prior values must be finite positive numbers.")
+    scales = np.asarray(values, dtype=float)
+    if np.any(~np.isfinite(scales)) or np.any(scales <= 0):
+        raise ValueError("Site-keyed sigma prior values must be finite positive numbers.")
+    resolved["sigma"] = scales[:, None]
+    return resolved
+
 
 def additive_sigma_likelihood_builder(
     *,
@@ -51,7 +83,9 @@ def additive_sigma_likelihood_builder(
         pollution_event_baseline: Baseline used by pollution-event-scaled
             likelihoods, unused by additive mismatch variance.
         output_dim: Observation dimension used for named PyMC variables.
-        sigma_prior: Optional prior arguments used to construct ``sigma``.
+        sigma_prior: Optional prior arguments used to construct ``sigma``. The
+            distribution's ``sigma`` parameter may map site names to scales
+            when ``sigma_per_site`` is true.
         sigma_freq: Optional frequency for sigma periods.
         sigma_per_site: Whether sigma varies independently by site.
         sigma_freq_anchor: Optional anchor for fixed-duration sigma periods.
@@ -80,6 +114,13 @@ def additive_sigma_likelihood_builder(
             per_site=sigma_per_site,
             anchor_time=sigma_freq_anchor,
         )
+    resolved_sigma_prior = None
+    if not no_model_error:
+        resolved_sigma_prior = _resolve_site_sigma_prior(
+            DEFAULT_ADDITIVE_SIGMA_PRIOR if sigma_prior is None else sigma_prior,
+            site,
+            per_site=sigma_per_site,
+        )
     return add_additive_sigma_gaussian_likelihood(
         observations=observations,
         observation_error=observation_error,
@@ -87,11 +128,7 @@ def additive_sigma_likelihood_builder(
         aggregation_error=aggregation_error,
         mean=mean,
         sigma_alignment=sigma_alignment,
-        sigma_prior=(
-            None
-            if no_model_error
-            else dict(DEFAULT_ADDITIVE_SIGMA_PRIOR if sigma_prior is None else sigma_prior)
-        ),
+        sigma_prior=resolved_sigma_prior,
         output_dim=output_dim,
     )
 

--- a/tests/models/test_likelihoods.py
+++ b/tests/models/test_likelihoods.py
@@ -6,10 +6,7 @@ import pytest
 import xarray as xr
 from scipy.stats import multivariate_normal
 
-from openghg_inversions.models.additive_sigma import (
-    add_additive_sigma_gaussian_likelihood,
-    build_additive_sigma_error,
-)
+from openghg_inversions.models.additive_sigma import add_additive_sigma_gaussian_likelihood
 from openghg_inversions.models.coords import registered_model
 from openghg_inversions.models.likelihoods import (
     add_aggregation_error_data,
@@ -295,9 +292,9 @@ def test_pollution_event_validation_names_malformed_input_and_owner() -> None:
 
 
 def test_additive_sigma_validation_names_malformed_input_and_owner() -> None:
-    """Malformed minimum error fails before the additive component builds."""
+    """Malformed reported error fails before the additive component builds."""
     data = _base_data()
-    malformed_minimum = data["min_error"].rename(nmeasure="sample")
+    malformed_error = data["mf_error"].rename(nmeasure="sample")
     sigma_alignment = SigmaAlignment.from_frequency(
         data["site_indicator"], frequency=None, per_site=False
     )
@@ -305,16 +302,15 @@ def test_additive_sigma_validation_names_malformed_input_and_owner() -> None:
     with registered_model(coords={"nmeasure": np.arange(3)}):
         with pytest.raises(
             ValueError,
-            match="Additive-sigma likelihood input 'minimum_error'.*dims",
+            match="Additive-sigma likelihood input 'observation_error'.*dims",
         ):
-            build_additive_sigma_error(
+            add_additive_sigma_gaussian_likelihood(
                 observations=data["mf"],
-                observation_error=data["mf_error"],
-                minimum_error=malformed_minimum,
+                observation_error=malformed_error,
                 aggregation_error=resolve_aggregation_error(data, "none"),
+                mean=pm.math.constant(np.ones(3)),
                 sigma_alignment=sigma_alignment,
                 sigma_prior={"pdf": "uniform", "lower": 0.1, "upper": 1.0},
-                no_model_error=False,
             )
 
 
@@ -350,19 +346,18 @@ def test_likelihoods_reject_reordered_observation_error_coordinates(
                     no_model_error=False,
                 )
             else:
-                build_additive_sigma_error(
+                add_additive_sigma_gaussian_likelihood(
                     observations=data["mf"],
                     observation_error=reordered_error,
-                    minimum_error=data["min_error"],
                     aggregation_error=resolve_aggregation_error(data, "none"),
+                    mean=pm.math.constant(np.ones(3)),
                     sigma_alignment=sigma_alignment,
                     sigma_prior={"pdf": "uniform", "lower": 0.1, "upper": 1.0},
-                    no_model_error=False,
                 )
 
 
-def test_additive_sigma_error_adds_mismatch_variance_and_applies_marginal_floor() -> None:
-    """The reusable additive component follows its variance equation."""
+def test_additive_sigma_likelihood_applies_minimum_error_floor() -> None:
+    """The complete additive likelihood floors total marginal error."""
     data = _base_data()
     data["min_error"] = ("nmeasure", np.array([0.0, 1.0, 0.0]))
     data["aggregation_error_sd"] = ("nmeasure", np.array([0.1, 0.2, 0.3]))
@@ -370,14 +365,14 @@ def test_additive_sigma_error_adds_mismatch_variance_and_applies_marginal_floor(
         data["site_indicator"], frequency=None, per_site=False
     )
     with registered_model(coords={"nmeasure": np.arange(3)}) as model:
-        state = build_additive_sigma_error(
+        add_additive_sigma_gaussian_likelihood(
             observations=data["mf"],
             observation_error=data["mf_error"],
             minimum_error=data["min_error"],
             aggregation_error=resolve_aggregation_error(data, "diagonal"),
+            mean=pm.math.constant(np.ones(3)),
             sigma_alignment=sigma_alignment,
             sigma_prior={"pdf": "uniform", "lower": 0.5, "upper": 0.500001},
-            no_model_error=False,
         )
 
     sigma = np.asarray(model.named_vars["sigma"].eval()).item()
@@ -387,28 +382,24 @@ def test_additive_sigma_error_adds_mismatch_variance_and_applies_marginal_floor(
         + data["aggregation_error_sd"].values ** 2
     )
     expected_scale = np.maximum(unconstrained_scale, data["min_error"].values)
-    np.testing.assert_allclose(state.error_scale.eval(), expected_scale)
+    np.testing.assert_allclose(model["epsilon"].eval(), expected_scale)
 
 
-def test_additive_sigma_error_omits_sigma_when_model_error_is_disabled() -> None:
-    """The modern no-mismatch form has no disconnected sigma variable."""
+def test_additive_sigma_likelihood_omits_optional_sigma_and_minimum_error() -> None:
+    """The fixed-error form has no disconnected optional variables."""
     data = _base_data()
-    sigma_alignment = SigmaAlignment.from_frequency(
-        data["site_indicator"], frequency=None, per_site=False
-    )
     with registered_model(coords={"nmeasure": np.arange(3)}) as model:
-        state = build_additive_sigma_error(
+        add_additive_sigma_gaussian_likelihood(
             observations=data["mf"],
             observation_error=data["mf_error"],
-            minimum_error=data["min_error"],
             aggregation_error=resolve_aggregation_error(data, "none"),
-            sigma_alignment=sigma_alignment,
-            sigma_prior={"pdf": "uniform", "lower": 0.1, "upper": 1.0},
-            no_model_error=True,
+            mean=pm.math.constant(np.ones(3)),
         )
 
     assert "sigma" not in model.named_vars
-    np.testing.assert_allclose(state.error_scale.eval(), data["mf_error"].values)
+    assert "min_error" not in model.named_vars
+    assert "Y" not in model.named_vars
+    np.testing.assert_allclose(model["epsilon"].eval(), data["mf_error"].values)
 
 
 def test_additive_sigma_gaussian_likelihood_uses_completed_mean() -> None:
@@ -429,7 +420,6 @@ def test_additive_sigma_gaussian_likelihood_uses_completed_mean() -> None:
             mean=mean,
             sigma_alignment=sigma_alignment,
             sigma_prior={"pdf": "uniform", "lower": 0.2, "upper": 0.200001},
-            no_model_error=False,
         )
 
     assert likelihood is model.named_vars["y"]

--- a/tests/models/test_likelihoods.py
+++ b/tests/models/test_likelihoods.py
@@ -14,7 +14,10 @@ from openghg_inversions.models.likelihoods import (
 )
 from openghg_inversions.models.pollution_event import build_pollution_event_error
 from openghg_inversions.observation_error import resolve_aggregation_error
-from openghg_inversions.rhime.likelihoods import additive_sigma_likelihood_builder
+from openghg_inversions.rhime.likelihoods import (
+    _resolve_site_sigma_prior,
+    additive_sigma_likelihood_builder,
+)
 from openghg_inversions.sigma import SigmaAlignment
 
 
@@ -459,6 +462,40 @@ def test_rhime_additive_sigma_adapter_accepts_pollution_event_inputs() -> None:
 
     assert likelihood is model.named_vars["y"]
     np.testing.assert_allclose(model.named_vars["y"].owner.inputs[-2].eval(), np.ones(3))
+
+
+def test_rhime_additive_sigma_adapter_aligns_site_prior_scales() -> None:
+    site = xr.DataArray(["TAC", "MHD", "TAC"], dims="nmeasure")
+
+    resolved = _resolve_site_sigma_prior(
+        {
+            "pdf": "halfnormal",
+            "sigma": {"MHD": 5.0, "unused": 9.0, "TAC": 2.0},
+        },
+        site,
+        per_site=True,
+    )
+
+    assert resolved["pdf"] == "halfnormal"
+    np.testing.assert_array_equal(resolved["sigma"], [[2.0], [5.0]])
+
+
+def test_rhime_additive_sigma_adapter_rejects_incomplete_site_prior_scales() -> None:
+    site = xr.DataArray(["MHD", "TAC"], dims="nmeasure")
+
+    with pytest.raises(ValueError, match="missing retained site.*TAC"):
+        _resolve_site_sigma_prior(
+            {"pdf": "halfnormal", "sigma": {"MHD": 5.0}},
+            site,
+            per_site=True,
+        )
+
+    with pytest.raises(ValueError, match="sigma_per_site=True"):
+        _resolve_site_sigma_prior(
+            {"pdf": "halfnormal", "sigma": {"MHD": 5.0, "TAC": 2.0}},
+            site,
+            per_site=False,
+        )
 
 
 def test_observation_derived_pollution_event_subtracts_complete_baseline() -> None:

--- a/tests/test_co2_outer_regions.py
+++ b/tests/test_co2_outer_regions.py
@@ -400,7 +400,6 @@ def test_co2_model_composes_sampled_boundary_and_each_outer_mode() -> None:
             aggregation_error=aggregation_error,
             outer_treatment=treatment,
             boundary_sensitivity=boundary_h,
-            no_model_error=True,
         )
 
     fixed = build("fixed")
@@ -540,7 +539,6 @@ def test_inner_and_outer_state_auxiliary_coords_are_namespaced() -> None:
         minimum_error=error,
         aggregation_error=aggregation_error,
         outer_treatment=treatment,
-        no_model_error=True,
     )
     registry = get_coord_registry(model)
 

--- a/tests/test_co2_rhime.py
+++ b/tests/test_co2_rhime.py
@@ -94,7 +94,6 @@ def _build_model(inputs: xr.Dataset, **kwargs: Any) -> pm.Model:
         observation_error=inputs["mf_error"],
         minimum_error=inputs["min_error"],
         aggregation_error=resolve_aggregation_error(inputs, "dense"),
-        no_model_error=True,
         **kwargs,
     )
 
@@ -252,6 +251,7 @@ def test_public_co2_runner_persists_fixed_mismatch_manifest(
         no_model_error=True,
     )
 
+    assert "sigma" not in sampled_models[0].named_vars
     np.testing.assert_allclose(sampled_models[0]["fixed_model_mismatch"].eval(), 1.0)
     roles = json.loads(result.attrs["rhime_variable_roles"])
     metadata = json.loads(result.attrs["rhime_model_metadata"])

--- a/tests/test_co2_rhime.py
+++ b/tests/test_co2_rhime.py
@@ -109,10 +109,9 @@ def test_co2_model_exposes_affine_correlated_dense_covariance_graph() -> None:
         "co2_flux_contribution",
         "fixed_prior_contribution",
         "modelled_concentration",
-        "Y",
         "error",
-        "fixed_model_mismatch",
         "min_error",
+        "fixed_model_mismatch",
         "epsilon",
         "y",
     } <= set(model.named_vars)

--- a/tests/test_rhime.py
+++ b/tests/test_rhime.py
@@ -50,7 +50,6 @@ from openghg_inversions.inversion_data import RhimeMergedData, RhimePreparedInpu
 from openghg_inversions.inversion_inputs import make_inv_inputs
 from openghg_inversions.models import StateActivity
 from openghg_inversions.models._flux import safe_pymc_name
-from openghg_inversions.models.additive_sigma import build_additive_sigma_error
 from openghg_inversions.observation_error import AggregationError, resolve_aggregation_error
 from openghg_inversions.postprocessing._basis_products import (
     BASIS_ARTIFACT_PATH_OUTPUT_ATTR,
@@ -3581,21 +3580,11 @@ def test_run_rhime_rejects_noncanonical_custom_likelihood_before_sampling(
 
     def noncanonical_likelihood(**kwargs: Any) -> Any:
         """Build an intentionally noncanonical likelihood variable."""
-        state = build_additive_sigma_error(
-            observations=kwargs["observations"],
-            observation_error=kwargs["observation_error"],
-            minimum_error=kwargs["minimum_error"],
-            aggregation_error=kwargs["aggregation_error"],
-            sigma_alignment=None,
-            sigma_prior={},
-            no_model_error=True,
-            output_dim=kwargs["output_dim"],
-        )
         return pm.Normal(
             "sampling_only_y",
             mu=kwargs["mean"],
-            sigma=state.error_scale,
-            observed=state.observed,
+            sigma=kwargs["observation_error"].values,
+            observed=kwargs["observations"].values,
             dims=kwargs["output_dim"],
         )
 

--- a/tests/test_run_hbmcmc_shim.py
+++ b/tests/test_run_hbmcmc_shim.py
@@ -111,6 +111,58 @@ def test_additive_sigma_selection_forces_no_aggregation_error(tmp_path: Path) ->
     }
 
 
+def test_additive_sigma_prior_takes_precedence_over_sigprior(tmp_path: Path) -> None:
+    config_file = tmp_path / "hbmcmc.ini"
+    _fixedbasis_config(config_file)
+    params = run_hbmcmc.hbmcmc_extract_param(str(config_file), print_param=False)
+    params["likelihood"] = "additive_sigma"
+    params["additive_sigma_prior"] = {
+        "pdf": "halfnormal",
+        "sigma": {"MHD": 5.0, "TAC": 2.0},
+    }
+
+    translated = run_hbmcmc.fixedbasis_params_to_rhime(params)
+    options = run_hbmcmc._select_additive_sigma_likelihood(params, translated)
+
+    assert "additive_sigma_prior" not in translated
+    assert translated["sigma_prior"] == {
+        "pdf": "halfnormal",
+        "sigma": {"MHD": 5.0, "TAC": 2.0},
+    }
+    assert options == {
+        "sigma_prior": {
+            "pdf": "halfnormal",
+            "sigma": {"MHD": 5.0, "TAC": 2.0},
+        }
+    }
+
+
+def test_additive_sigma_selection_defaults_to_half_normal(tmp_path: Path) -> None:
+    config_file = tmp_path / "hbmcmc.ini"
+    _fixedbasis_config(config_file)
+    params = run_hbmcmc.hbmcmc_extract_param(str(config_file), print_param=False)
+    params["likelihood"] = "additive_sigma"
+    del params["sigprior"]
+
+    translated = run_hbmcmc.fixedbasis_params_to_rhime(params)
+    options = run_hbmcmc._select_additive_sigma_likelihood(params, translated)
+
+    assert translated["sigma_prior"] == run_hbmcmc.DEFAULT_ADDITIVE_SIGMA_PRIOR
+    assert options == {"sigma_prior": run_hbmcmc.DEFAULT_ADDITIVE_SIGMA_PRIOR}
+
+
+def test_additive_sigma_prior_requires_additive_likelihood(tmp_path: Path) -> None:
+    config_file = tmp_path / "hbmcmc.ini"
+    _fixedbasis_config(config_file)
+    params = run_hbmcmc.hbmcmc_extract_param(str(config_file), print_param=False)
+    params["additive_sigma_prior"] = {"pdf": "halfnormal", "sigma": 5.0}
+
+    translated = run_hbmcmc.fixedbasis_params_to_rhime(params)
+
+    with pytest.raises(ValueError, match="requires likelihood='additive_sigma'"):
+        run_hbmcmc._select_additive_sigma_likelihood(params, translated)
+
+
 def test_additive_sigma_selection_rejects_aggregation_error(tmp_path: Path) -> None:
     config_file = tmp_path / "hbmcmc.ini"
     _fixedbasis_config(config_file)
@@ -270,7 +322,12 @@ def test_run_hbmcmc_main_selects_additive_sigma_from_ini(
     config_file = tmp_path / "hbmcmc.ini"
     _fixedbasis_config(config_file)
     config_file.write_text(
-        config_file.read_text(encoding="utf-8").replace(
+        config_file.read_text(encoding="utf-8")
+        .replace(
+            "[MCMC.PDF]",
+            '[MCMC.PDF]\nadditive_sigma_prior = {"pdf": "halfnormal", "sigma": {"TAC": 2.0}}',
+        )
+        .replace(
             "[MCMC.OPTIONS]",
             '[MCMC.OPTIONS]\nlikelihood = "additive_sigma"',
         ),
@@ -285,8 +342,9 @@ def test_run_hbmcmc_main_selects_additive_sigma_from_ini(
 
     assert seen["likelihood_builder"] is run_hbmcmc.additive_sigma_likelihood_builder
     assert seen["likelihood_kwargs"] == {
-        "sigma_prior": {"pdf": "uniform", "lower": 0.1, "upper": 10.0},
+        "sigma_prior": {"pdf": "halfnormal", "sigma": {"TAC": 2.0}},
     }
+    assert seen["sigma_prior"] == {"pdf": "halfnormal", "sigma": {"TAC": 2.0}}
     assert seen["aggregation_error_mode"] == "none"
     assert seen["preserve_legacy_likelihood"] is False
 

--- a/tests/test_run_hbmcmc_shim.py
+++ b/tests/test_run_hbmcmc_shim.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+import numpy as np
 import pytest
+import xarray as xr
 
 import openghg_inversions.hbmcmc.run_hbmcmc as run_hbmcmc
+from openghg_inversions.sigma import SigmaAlignment
 
 
 def _fixedbasis_config(path: Path) -> None:
@@ -109,6 +112,35 @@ def test_additive_sigma_selection_forces_no_aggregation_error(tmp_path: Path) ->
         "sigma_prior": {"pdf": "halfnormal", "sigma": 5.0},
         "sigma_freq": "monthly",
     }
+
+
+def test_additive_sigma_fixed_periods_keep_inversion_start_anchor(tmp_path: Path) -> None:
+    config_file = tmp_path / "hbmcmc.ini"
+    _fixedbasis_config(config_file)
+    params = run_hbmcmc.hbmcmc_extract_param(str(config_file), print_param=False)
+    params.update(likelihood="additive_sigma", sigma_freq="8D")
+
+    translated = run_hbmcmc.fixedbasis_params_to_rhime(params)
+    options = run_hbmcmc._select_additive_sigma_likelihood(params, translated)
+    site_index = xr.DataArray(
+        [0, 0],
+        dims="nmeasure",
+        coords={
+            "time": (
+                "nmeasure",
+                np.array(["2019-01-10", "2019-01-17"], dtype="datetime64[ns]"),
+            )
+        },
+    )
+    alignment = SigmaAlignment.from_frequency(
+        site_index,
+        frequency=options["sigma_freq"],
+        per_site=False,
+        anchor_time=options["sigma_freq_anchor"],
+    )
+
+    assert options["sigma_freq_anchor"] == "2019-01-01"
+    np.testing.assert_array_equal(alignment.period_index, [0, 1])
 
 
 def test_additive_sigma_prior_takes_precedence_over_sigprior(tmp_path: Path) -> None:

--- a/tests/test_run_hbmcmc_shim.py
+++ b/tests/test_run_hbmcmc_shim.py
@@ -91,6 +91,38 @@ def test_fixedbasis_default_does_not_opt_into_aggregation_error(tmp_path: Path) 
     assert setup.run_spec.model.aggregation_error_mode == "none"
 
 
+def test_additive_sigma_selection_forces_no_aggregation_error(tmp_path: Path) -> None:
+    """The compatibility entry point owns the no-aggregation policy."""
+    config_file = tmp_path / "hbmcmc.ini"
+    _fixedbasis_config(config_file)
+    params = run_hbmcmc.hbmcmc_extract_param(str(config_file), print_param=False)
+    params["likelihood"] = "additive_sigma"
+    params["sigprior"] = {"pdf": "halfnormal", "sigma": 5.0}
+    params["sigma_freq"] = "monthly"
+
+    translated = run_hbmcmc.fixedbasis_params_to_rhime(params)
+    options = run_hbmcmc._select_additive_sigma_likelihood(params, translated)
+
+    assert "likelihood" not in translated
+    assert translated["aggregation_error_mode"] == "none"
+    assert options == {
+        "sigma_prior": {"pdf": "halfnormal", "sigma": 5.0},
+        "sigma_freq": "monthly",
+    }
+
+
+def test_additive_sigma_selection_rejects_aggregation_error(tmp_path: Path) -> None:
+    config_file = tmp_path / "hbmcmc.ini"
+    _fixedbasis_config(config_file)
+    params = run_hbmcmc.hbmcmc_extract_param(str(config_file), print_param=False)
+    params.update(likelihood="additive_sigma", aggregation_error_mode="dense")
+
+    translated = run_hbmcmc.fixedbasis_params_to_rhime(params)
+
+    with pytest.raises(ValueError, match="does not support.*aggregation_error_mode"):
+        run_hbmcmc._select_additive_sigma_likelihood(params, translated)
+
+
 def test_fixedbasis_params_to_rhime_translates_reparameterise_log_normal(tmp_path: Path) -> None:
     """Legacy lognormal translation warns visibly and updates both priors."""
     config_file = tmp_path / "hbmcmc.ini"
@@ -229,6 +261,34 @@ def test_run_hbmcmc_main_routes_to_run_rhime(monkeypatch: pytest.MonkeyPatch, tm
     assert seen["run_rhime_kwargs"]["output_format"] == "legacy"
     assert seen["run_rhime_kwargs"]["output_filename_convention"] == "legacy"
     assert seen["run_rhime_kwargs"]["preserve_legacy_likelihood"] is True
+
+
+def test_run_hbmcmc_main_selects_additive_sigma_from_ini(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    config_file = tmp_path / "hbmcmc.ini"
+    _fixedbasis_config(config_file)
+    config_file.write_text(
+        config_file.read_text(encoding="utf-8").replace(
+            "[MCMC.OPTIONS]",
+            '[MCMC.OPTIONS]\nlikelihood = "additive_sigma"',
+        ),
+        encoding="utf-8",
+    )
+    seen: dict[str, Any] = {}
+
+    monkeypatch.setattr(run_hbmcmc.output, "copy_config_file", lambda *args, **kwargs: None)
+    monkeypatch.setattr(run_hbmcmc, "run_rhime", lambda **kwargs: seen.update(kwargs))
+
+    run_hbmcmc.main(["-c", str(config_file)])
+
+    assert seen["likelihood_builder"] is run_hbmcmc.additive_sigma_likelihood_builder
+    assert seen["likelihood_kwargs"] == {
+        "sigma_prior": {"pdf": "uniform", "lower": 0.1, "upper": 10.0},
+    }
+    assert seen["aggregation_error_mode"] == "none"
+    assert seen["preserve_legacy_likelihood"] is False
 
 
 def test_run_hbmcmc_legacy_fixedbasis_parser_is_explicit(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary of changes

- add one complete reusable additive-sigma Gaussian likelihood whose independent variance is `observation_error**2 + fixed_model_mismatch**2 + sigma**2`
- retain `min_error` as an optional floor on total marginal standard deviation; the standard configuration defaults it to `0.0`
- use `SigmaAlignment | None` as the complete component's inferred-sigma switch, with a HalfNormal prior as the installed adapter's default
- avoid a separate error-state constructor and store observations only under the canonical observed variable `y`
- reuse the likelihood in the CO2 and CO2/O2 recipes introduced by #635 while preserving their structured aggregation covariance
- let `run_hbmcmc.py` select the likelihood with `likelihood = "additive_sigma"`, explicitly forcing aggregation error off
- add the preferred `additive_sigma_prior` INI key, with `sigprior` as a compatibility fallback
- accept labelled HalfNormal scales such as `{"MHD": 5.0, "TAC": 2.0}` and align them to retained sites independently of dictionary order
- document the recommended HalfNormal-without-floor starting point and `E[sigma] = prior_scale * sqrt(2 / pi)`

This addresses the additive-likelihood replacement investigated in #637 and is related to #639. Unlike #639's original wording, this version deliberately retains the optional minimum-error floor following user feedback.

## Please check if the PR fulfills these requirements

- [x] Rebased onto the CO2-family changes from #635
- [x] Tests added and passing
- [x] Documentation and tutorials updated/added
- [x] Added a Towncrier news fragment in `newsfragments/` for user-visible changes
- [x] No new requirements

## Validation

- `uv run pytest tests/test_run_hbmcmc_shim.py tests/models/test_likelihoods.py` — 47 passed
- broader RHIME, shim, likelihood, and CO2 selection — 315 passed; three unrelated environment/data-stack failures (`h5netcdf` dimension-scale read and two OpenGHG `long_name` expectations)
- Ruff on all changed Python paths — passed
- `git diff --check` — passed
- BP1 `ch4_hbmcmc_additive_sigma_2sites` against commit `93f7e0b29e08fd9a09b6bf169f84948ada61be8f` — SLURM job `18693385`, exit 0, run status `OK`, convergence output `Passed`, one divergence
  - HalfNormal prior scale: 5.0 ppb; `min_error = 0.0`
  - posterior sigma MHD: mean 4.76 ppb, median 4.75 ppb, 5–95% interval 4.21–5.36 ppb
  - posterior sigma TAC: mean 1.35 ppb, median 1.28 ppb, 5–95% interval 0.10–2.84 ppb
- direct fixed-seed CH4 prototype against commit `2636fd87ffead0a6f90e9937acfec1db74c21b3d` reconstructed the 260-observation/259-state model from the completed real-data run without using the test_inversions registry:
  - default diagonal NumPyro: zero divergences, 186 mean steps, max R-hat 1.020, minimum bulk ESS 393
  - dense mass: zero divergences but every draw hit depth 10 (1,023 steps), 6x slower, max R-hat 1.035, minimum bulk ESS 106
  - diagonal `target_accept=0.75`: clean convergence but 222 mean steps, so it does not shorten trajectories
  - diagonal `target_accept=0.70`: 148 mean steps but max R-hat 1.193 and minimum bulk ESS 14; `0.60` produced 52 divergences
  - conclusion: retain NumPyro's default diagonal sampler; the long trajectories reflect the sharp, correlated flux/BC posterior rather than an additive-sigma implementation defect
