### PR TITLE
Test PARIS covariance file merging

### DIFF
--- a/newsfragments/630.bugfix.md
+++ b/newsfragments/630.bugfix.md
@@ -1,0 +1,1 @@
+Latest multisector PARIS covariance outputs can now be combined across time without duplicate dimension names.

--- a/tests/postprocessing/test_make_paris_outputs.py
+++ b/tests/postprocessing/test_make_paris_outputs.py
@@ -107,7 +107,7 @@ def test_latest_paris_flux_output_processes_multisector_sectors(
     fake_multisector_basis_functions_matching_country_grid: Callable[..., BasisFunctions],
     multisector_postprocessing_inv_out: Callable[..., InversionOutput],
 ) -> None:
-    """Latest multisector PARIS output projects countries before population covariance."""
+    """Latest multisector PARIS output projects countries and combines cleanly across time."""
     inv_out = multisector_postprocessing_inv_out(
         fake_multisector_basis_functions_matching_country_grid(
             europe_country_file,
@@ -291,6 +291,7 @@ def test_latest_paris_flux_output_processes_multisector_sectors(
     assert _flux_nonfinite_metadata(flux_outputs).policy == NONFINITE_POLICY_ZERO_FILL
 
     flux_file = tmp_path / "latest_multisector_flux.nc"
+    shifted_flux_file = tmp_path / "latest_multisector_flux_shifted.nc"
     flux_outputs.to_netcdf(flux_file)
     with xr.open_dataset(flux_file) as reloaded_flux:
         assert tuple(reloaded_flux.sector.values) == ("ff", "ocean")
@@ -317,6 +318,13 @@ def test_latest_paris_flux_output_processes_multisector_sectors(
         assert reloaded_flux.attrs["Conventions"] == "CF-1.8"
         assert "conventions" not in reloaded_flux.attrs
         _assert_latest_flux_dimension_order(reloaded_flux)
+        shifted_flux = reloaded_flux.assign_coords(time=reloaded_flux.time + np.timedelta64(1, "D"))
+        shifted_flux["time_bnds"] = shifted_flux.time_bnds + np.timedelta64(1, "D")
+        shifted_flux.to_netcdf(shifted_flux_file)
+    with xr.open_mfdataset([flux_file, shifted_flux_file], combine="by_coords") as combined_flux:
+        assert combined_flux.sizes["time"] == 2
+        for variable_name, expected_dims in covariance_dims.items():
+            assert combined_flux[variable_name].dims == expected_dims
     with xr.open_dataset(flux_file, decode_cf=False) as raw_flux:
         assert raw_flux.attrs["Conventions"] == "CF-1.8"
         assert "conventions" not in raw_flux.attrs


### PR DESCRIPTION
* **Summary of changes**

Adds a regression test that writes two time-distinct latest-template multisector PARIS flux files and combines them with `xarray.open_mfdataset`. The test locks in distinct `country_2` and `sector_2` covariance axes for total, per-sector, and cross-sector covariance variables. Adds the issue-specific Towncrier bugfix fragment.

The production dimension fix was already merged in #597; this PR directly covers the downstream merge failure reported in #630.

* **Please check if the PR fulfills these requirements**

- [x] Closes #630
- [x] Tests added and passing
- [ ] Documentation and tutorials updated/added (not needed; regression-only follow-up)
- [x] Added a Towncrier news fragment in `newsfragments/`
- [ ] Added any new requirements to `requirements.txt` (none needed)

Checks:

- `uv run pytest tests/postprocessing/test_make_paris_outputs.py` (8 passed)
- `uv run ruff check tests/postprocessing/test_make_paris_outputs.py`
- `uv run ruff format --check tests/postprocessing/test_make_paris_outputs.py`
- `git diff --check`

Closes #630