### PR TITLE
Add labelled fixed-OU mismatch covariance

### DIFF
--- a/docs/usage/customising_rhime.rst
+++ b/docs/usage/customising_rhime.rst
@@ -121,6 +121,33 @@ labelled observation ``site`` and ``time`` coordinates. Optional
 independent variance. The prepared ``minimum_error`` retains its historical
 meaning as an optional floor on total standard deviation.
 
+The installed ``rhime.likelihoods.fixed_ou_likelihood_builder`` adds a fixed-
+timescale, within-site Ornstein--Uhlenbeck mismatch covariance. For example::
+
+   from openghg_inversions.rhime import fixed_ou_likelihood_builder, run_rhime
+
+   result = run_rhime(
+       ...,
+       likelihood_builder=fixed_ou_likelihood_builder,
+       likelihood_kwargs={
+           "tau_hours": 5.0,
+           "site_amplitude_prior": {"pdf": "halfnormal", "sigma": 0.75},
+       },
+   )
+
+``tau_hours`` may instead be an exact mapping from retained site labels to
+fixed positive timescales. Pass ``fixed_site_amplitudes`` as a scalar or exact
+site mapping to use known amplitudes instead of the inferred prior. Amplitudes
+have the observation units and tau has units of hours. Observation rows may be
+interleaved or nonmonotonic in time; the component preserves their order and
+sets cross-site OU covariance exactly to zero.
+
+The component applies ``min_error`` to the fixed aggregation-plus-reported-
+error marginal before adding OU variance. It evaluates low-rank aggregation
+covariance with the fixed-OU generalized-eigen and Woodbury method, without
+forming a dense observation covariance. Sampled tau and the cached blocked
+sampler are separate extensions.
+
 Built-in aggregation covariance relies on the guarantees of its construction
 pipeline. A custom pipeline that assembles its own covariance may optionally
 call

--- a/newsfragments/OPE-22.feature.md
+++ b/newsfragments/OPE-22.feature.md
@@ -1,0 +1,1 @@
+Add a labelled fixed-timescale, within-site Ornstein--Uhlenbeck mismatch likelihood with fixed or inferred site amplitudes and low-rank Woodbury evaluation.

--- a/openghg_inversions/models/fixed_ou.py
+++ b/openghg_inversions/models/fixed_ou.py
@@ -1,0 +1,513 @@
+"""Fixed within-site OU covariance under a diagonal-plus-low-rank base."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+import math
+from typing import Any, cast
+
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
+import pymc as pm
+import pytensor.tensor as pt
+from pytensor.gradient import DisconnectedType, grad_not_implemented
+from pytensor.graph.basic import Apply, Variable
+from pytensor.graph.op import Op
+from pytensor.tensor.variable import TensorVariable
+from scipy.linalg import cho_solve, eigh, solve_triangular
+from scipy.sparse import csr_matrix
+
+
+FloatArray = NDArray[np.float64]
+IntArray = NDArray[np.int64]
+_HOURS_PER_NANOSECOND = 1.0 / 3.6e12
+
+
+@dataclass(frozen=True)
+class FixedOuSiteBlock:
+    """Precomputed generalized eigenbasis for one site's fixed OU template."""
+
+    site: int
+    observation_indices: IntArray
+    mode_slice: slice
+    correlation: FloatArray
+    correlation_cholesky: FloatArray
+    transform: FloatArray
+
+
+@dataclass(frozen=True)
+class FixedOuLikelihoodEvaluation:
+    """One exact likelihood value and its physical-space gradients."""
+
+    log_likelihood: float
+    gradient_residual: FloatArray
+    gradient_site_amplitude: FloatArray
+
+
+def _rejection_gradient_amplitude(amplitude: FloatArray) -> FloatArray:
+    """Return a transform-safe gradient for an invalid scale proposal."""
+    gradient = np.full(amplitude.shape, -1.0, dtype=np.float64)
+    finite_large = np.isfinite(amplitude) & (amplitude > 1.0)
+    gradient[finite_large] = -np.reciprocal(amplitude[finite_large])
+    return gradient
+
+
+class _FixedOuLogpOp(Op):
+    """Instance-local PyTensor bridge to one prepared NumPy/SciPy target."""
+
+    def __init__(self, target: FixedOuLowRank) -> None:
+        self.target = target
+
+    def make_node(self, residual: Any, site_amplitude: Any) -> Apply:
+        residual_variable = pt.as_tensor_variable(residual)
+        amplitude_variable = pt.as_tensor_variable(site_amplitude)
+        if residual_variable.ndim != 1:
+            raise TypeError("residual must be a one-dimensional PyTensor variable.")
+        if amplitude_variable.ndim != 1:
+            raise TypeError("site_amplitude must be a one-dimensional PyTensor variable.")
+        return Apply(
+            self,
+            [residual_variable, amplitude_variable],
+            [pt.dscalar(), pt.dvector(), pt.dvector()],
+        )
+
+    def perform(
+        self,
+        node: Apply,
+        inputs: list[NDArray[Any]],
+        output_storage: list[list[NDArray[Any] | None]],
+    ) -> None:
+        del node
+        evaluation = self.target.evaluate(inputs[0], inputs[1])
+        output_storage[0][0] = np.asarray(evaluation.log_likelihood, dtype=np.float64)
+        output_storage[1][0] = np.asarray(evaluation.gradient_residual, dtype=np.float64)
+        output_storage[2][0] = np.asarray(
+            evaluation.gradient_site_amplitude, dtype=np.float64
+        )
+
+    def L_op(
+        self,
+        inputs: list[Variable],
+        outputs: list[Variable],
+        output_grads: list[Variable],
+    ) -> list[Variable]:
+        """Reuse analytic outputs when differentiating the likelihood value."""
+        if not isinstance(output_grads[1].type, DisconnectedType) or not isinstance(
+            output_grads[2].type, DisconnectedType
+        ):
+            return [
+                grad_not_implemented(self, 0, inputs[0]),
+                grad_not_implemented(self, 1, inputs[1]),
+            ]
+        return [output_grads[0] * outputs[1], output_grads[0] * outputs[2]]
+
+    def infer_shape(
+        self,
+        fgraph: Any,
+        node: Apply,
+        input_shapes: list[tuple[Any, ...]],
+    ) -> list[tuple[Any, ...]]:
+        del fgraph, node
+        return [(), input_shapes[0], input_shapes[1]]
+
+
+@dataclass(frozen=True)
+class FixedOuLowRank:
+    """Exact fixed-OU target with a diagonal-plus-low-rank fixed covariance.
+
+    The eager constructor precomputes one generalized eigenbasis per site.
+    :meth:`logp` then evaluates changing site amplitudes through an ``r x r``
+    Woodbury system, where ``r`` is the aggregation-covariance rank.
+    """
+
+    factor: FloatArray
+    diagonal_variance: FloatArray
+    observation_time_hours: FloatArray
+    site_index: IntArray
+    site_labels: tuple[str, ...]
+    tau_hours_by_site: FloatArray
+    site_blocks: tuple[FixedOuSiteBlock, ...]
+    mode_eigenvalues: FloatArray
+    mode_site_index: IntArray
+    transformed_factor: FloatArray
+    mode_transform: csr_matrix
+    base_logdet: float
+    _logp_op: _FixedOuLogpOp = field(init=False, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "_logp_op", _FixedOuLogpOp(self))
+
+    @property
+    def n_observation(self) -> int:
+        """Number of observation rows."""
+        return int(self.diagonal_variance.size)
+
+    @property
+    def n_site(self) -> int:
+        """Number of independently scaled sites."""
+        return int(self.tau_hours_by_site.size)
+
+    @property
+    def rank(self) -> int:
+        """Rank of the fixed coherent covariance factor."""
+        return int(self.factor.shape[1])
+
+    def logp(
+        self,
+        value: TensorVariable,
+        mean: TensorVariable,
+        site_amplitude: TensorVariable,
+    ) -> TensorVariable:
+        """Return the normalized Gaussian log density as a differentiable Op."""
+        residual = pt.cast(value - mean, "float64")
+        amplitude = pt.cast(pt.atleast_1d(site_amplitude), "float64")
+        return cast(TensorVariable, self._logp_op(residual, amplitude)[0])
+
+    def evaluate(
+        self,
+        residual: ArrayLike,
+        site_amplitude: ArrayLike | float,
+    ) -> FixedOuLikelihoodEvaluation:
+        """Evaluate the exact log density and analytic physical gradients."""
+        residual_value = np.asarray(residual, dtype=np.float64)
+        amplitude = np.atleast_1d(np.asarray(site_amplitude, dtype=np.float64))
+        if residual_value.shape != (self.n_observation,):
+            raise ValueError(
+                f"residual has shape {residual_value.shape}, "
+                f"expected {(self.n_observation,)}."
+            )
+        if amplitude.shape != (self.n_site,):
+            raise ValueError(
+                f"site_amplitude has shape {amplitude.shape}, expected {(self.n_site,)}."
+            )
+        with np.errstate(over="ignore", invalid="ignore"):
+            amplitude_squared = np.square(amplitude)
+        invalid_amplitude = bool(
+            not np.isfinite(amplitude).all()
+            or np.any(amplitude < 0.0)
+            or not np.isfinite(amplitude_squared).all()
+        )
+        if invalid_amplitude:
+            return FixedOuLikelihoodEvaluation(
+                log_likelihood=-np.inf,
+                gradient_residual=np.zeros(self.n_observation, dtype=np.float64),
+                gradient_site_amplitude=_rejection_gradient_amplitude(amplitude),
+            )
+        if not np.isfinite(residual_value).all():
+            gradient_residual = np.zeros(self.n_observation, dtype=np.float64)
+            infinite = np.isinf(residual_value)
+            gradient_residual[infinite] = -np.sign(residual_value[infinite])
+            return FixedOuLikelihoodEvaluation(
+                log_likelihood=-np.inf,
+                gradient_residual=gradient_residual,
+                gradient_site_amplitude=np.zeros(self.n_site, dtype=np.float64),
+            )
+
+        mode_variance = self.mode_eigenvalues + amplitude_squared[self.mode_site_index]
+        if not np.isfinite(mode_variance).all() or np.any(mode_variance <= 0.0):
+            return FixedOuLikelihoodEvaluation(
+                log_likelihood=-np.inf,
+                gradient_residual=np.zeros(self.n_observation, dtype=np.float64),
+                gradient_site_amplitude=_rejection_gradient_amplitude(amplitude),
+            )
+        weights = np.reciprocal(mode_variance)
+        transformed_residual = cast(FloatArray, self.mode_transform @ residual_value)
+        square_root_weights = np.sqrt(weights)
+        whitened_residual = transformed_residual * square_root_weights
+
+        if self.rank:
+            whitened_factor = self.transformed_factor * square_root_weights[:, None]
+            core = np.eye(self.rank, dtype=np.float64) + (
+                whitened_factor.T @ whitened_factor
+            )
+            core = (core + core.T) * 0.5
+            cholesky = np.linalg.cholesky(core)
+            projected = whitened_factor.T @ whitened_residual
+            latent_mode = cho_solve((cholesky, True), projected, check_finite=False)
+            conditional_whitened = whitened_residual - whitened_factor @ latent_mode
+            quadratic = float(
+                conditional_whitened @ conditional_whitened
+                + latent_mode @ latent_mode
+            )
+            logdet_core = float(2.0 * np.log(np.diag(cholesky)).sum())
+            conditional_residual = (
+                transformed_residual - self.transformed_factor @ latent_mode
+            )
+            transformed = solve_triangular(
+                cholesky,
+                self.transformed_factor.T,
+                lower=True,
+                check_finite=False,
+            )
+            leverage = np.square(transformed).sum(axis=0)
+        else:
+            quadratic = float(whitened_residual @ whitened_residual)
+            logdet_core = 0.0
+            conditional_residual = transformed_residual
+            leverage = np.zeros(self.n_observation, dtype=np.float64)
+
+        logdet = self.base_logdet + float(np.log(mode_variance).sum()) + logdet_core
+        log_likelihood = -0.5 * (
+            self.n_observation * math.log(2.0 * math.pi) + logdet + quadratic
+        )
+        mode_score = (
+            np.square(weights) * (np.square(conditional_residual) + leverage) - weights
+        )
+        gradient_amplitude = amplitude * np.bincount(
+            self.mode_site_index,
+            weights=mode_score,
+            minlength=self.n_site,
+        )
+        solved_transformed = weights * conditional_residual
+        gradient_residual = -(self.mode_transform.T @ solved_transformed)
+        return FixedOuLikelihoodEvaluation(
+            log_likelihood=float(log_likelihood),
+            gradient_residual=cast(FloatArray, np.asarray(gradient_residual)),
+            gradient_site_amplitude=cast(FloatArray, gradient_amplitude),
+        )
+
+    def marginal_variance(self, site_amplitude: TensorVariable) -> TensorVariable:
+        """Return the observation-aligned covariance diagonal."""
+        amplitude = pt.atleast_1d(site_amplitude)
+        site_index = pt.as_tensor_variable(self.site_index)
+        return (
+            pm.floatX(self.diagonal_variance)
+            + pm.floatX(np.square(self.factor).sum(axis=1))
+            + pt.square(amplitude[site_index])
+        )
+
+    def covariance_dense(self, site_amplitude: ArrayLike | float) -> FloatArray:
+        """Materialize the represented covariance for small reference checks."""
+        amplitude = _site_values(site_amplitude, self.n_site, "site_amplitude", positive=False)
+        covariance = self.factor @ self.factor.T + np.diag(self.diagonal_variance)
+        for block in self.site_blocks:
+            indices = block.observation_indices
+            covariance[np.ix_(indices, indices)] += (
+                amplitude[block.site] ** 2 * block.correlation
+            )
+        return cast(FloatArray, (covariance + covariance.T) * 0.5)
+
+    def random(
+        self,
+        mean: np.ndarray,
+        site_amplitude: np.ndarray,
+        rng: np.random.Generator | None = None,
+        size: int | Sequence[int] | None = None,
+    ) -> np.ndarray:
+        """Draw from the represented Gaussian for ``pm.CustomDist``."""
+        rng = np.random.default_rng() if rng is None else rng
+        sample_shape = () if size is None else (size,) if isinstance(size, int) else tuple(size)
+        amplitude = _site_values(site_amplitude, self.n_site, "site_amplitude", positive=False)
+        result = np.broadcast_to(np.asarray(mean), (*sample_shape, self.n_observation)).copy()
+        if self.rank:
+            factor_noise = rng.normal(size=(*sample_shape, self.rank))
+            result += np.einsum("...r,nr->...n", factor_noise, self.factor)
+        result += rng.normal(size=result.shape) * np.sqrt(self.diagonal_variance)
+        for block in self.site_blocks:
+            site_noise = rng.normal(size=(*sample_shape, block.observation_indices.size))
+            result[..., block.observation_indices] += amplitude[block.site] * (
+                site_noise @ block.correlation_cholesky.T
+            )
+        return result
+
+
+def prepare_fixed_ou_low_rank(
+    factor: ArrayLike,
+    diagonal_variance: ArrayLike,
+    observation_times: ArrayLike,
+    site_index: ArrayLike,
+    tau_hours: ArrayLike | float | Mapping[str, float],
+    *,
+    site_labels: Sequence[str] | None = None,
+) -> FixedOuLowRank:
+    """Precompute a fixed within-site OU target at an explicit eager boundary.
+
+    Observation rows may be interleaved and their times need not be sorted.
+    ``site_index`` must use contiguous integer identifiers from zero. A mapping
+    of tau values is accepted only with matching, ordered ``site_labels``.
+    """
+    diagonal = _vector(diagonal_variance, "diagonal_variance")
+    n_observation = diagonal.size
+    if n_observation == 0:
+        raise ValueError("At least one observation is required.")
+    if np.any(diagonal < 0.0):
+        raise ValueError("diagonal_variance must contain non-negative values.")
+    factor_value = _matrix(factor, "factor")
+    if factor_value.shape[0] != n_observation:
+        raise ValueError("factor must have one row per observation.")
+    time_hours = _time_hours(observation_times)
+    if time_hours.shape != (n_observation,):
+        raise ValueError("observation_times must have one value per observation.")
+    group_index = _group_index(site_index, n_observation)
+    n_site = int(group_index.max()) + 1
+    labels = _site_labels(site_labels, n_site)
+    tau_by_site = _tau_values(tau_hours, labels)
+
+    blocks: list[FixedOuSiteBlock] = []
+    eigenvalues: list[FloatArray] = []
+    mode_sites: list[IntArray] = []
+    transform_rows: list[IntArray] = []
+    transform_columns: list[IntArray] = []
+    transform_values: list[FloatArray] = []
+    transformed_factor = np.empty_like(factor_value)
+    mode_start = 0
+    base_logdet = 0.0
+    for site in range(n_site):
+        indices = np.flatnonzero(group_index == site).astype(np.int64)
+        times = time_hours[indices]
+        if np.unique(times).size != times.size:
+            raise ValueError(
+                f"Observation times must be unique within site {labels[site]!r}."
+            )
+        lag_hours = np.abs(times[:, None] - times[None, :])
+        correlation = np.exp(-lag_hours / tau_by_site[site])
+        correlation = cast(FloatArray, (correlation + correlation.T) * 0.5)
+        try:
+            correlation_cholesky = np.linalg.cholesky(correlation)
+        except np.linalg.LinAlgError as error:
+            raise ValueError(
+                f"OU correlation template for site {labels[site]!r} must be positive definite."
+            ) from error
+        base_logdet += float(2.0 * np.log(np.diag(correlation_cholesky)).sum())
+
+        values, vectors = eigh(
+            np.diag(diagonal[indices]), correlation, check_finite=False
+        )
+        scale = max(1.0, float(np.max(np.abs(values))))
+        if values[0] < -1.0e-10 * scale:
+            raise np.linalg.LinAlgError(
+                f"OU template for site {labels[site]!r} is not positive semidefinite."
+            )
+        values = cast(FloatArray, np.maximum(values, 0.0))
+        transform = cast(FloatArray, vectors.T)
+        mode_stop = mode_start + indices.size
+        transformed_factor[mode_start:mode_stop] = transform @ factor_value[indices]
+        transform_rows.append(
+            np.repeat(np.arange(mode_start, mode_stop, dtype=np.int64), indices.size)
+        )
+        transform_columns.append(np.tile(indices, indices.size))
+        transform_values.append(transform.ravel())
+        blocks.append(
+            FixedOuSiteBlock(
+                site=site,
+                observation_indices=indices,
+                mode_slice=slice(mode_start, mode_stop),
+                correlation=correlation,
+                correlation_cholesky=cast(FloatArray, correlation_cholesky),
+                transform=transform,
+            )
+        )
+        eigenvalues.append(values)
+        mode_sites.append(np.full(indices.size, site, dtype=np.int64))
+        mode_start = mode_stop
+
+    return FixedOuLowRank(
+        factor=factor_value,
+        diagonal_variance=diagonal,
+        observation_time_hours=time_hours,
+        site_index=group_index,
+        site_labels=labels,
+        tau_hours_by_site=tau_by_site,
+        site_blocks=tuple(blocks),
+        mode_eigenvalues=cast(FloatArray, np.concatenate(eigenvalues)),
+        mode_site_index=cast(IntArray, np.concatenate(mode_sites)),
+        transformed_factor=cast(FloatArray, transformed_factor),
+        mode_transform=csr_matrix(
+            (
+                np.concatenate(transform_values),
+                (np.concatenate(transform_rows), np.concatenate(transform_columns)),
+            ),
+            shape=(n_observation, n_observation),
+        ),
+        base_logdet=base_logdet,
+    )
+
+
+def _time_hours(value: ArrayLike) -> FloatArray:
+    array = np.asarray(value)
+    if array.ndim != 1:
+        raise ValueError(f"observation_times must be one-dimensional, got {array.shape}.")
+    if np.issubdtype(array.dtype, np.datetime64):
+        nanoseconds = array.astype("datetime64[ns]").astype(np.int64)
+        if np.any(nanoseconds == np.iinfo(np.int64).min):
+            raise ValueError("observation_times must not contain NaT.")
+        hours = (nanoseconds - nanoseconds.min()).astype(np.float64)
+        hours *= _HOURS_PER_NANOSECOND
+    else:
+        hours = np.asarray(value, dtype=np.float64)
+    if not np.isfinite(hours).all():
+        raise ValueError("observation_times must contain only finite values.")
+    return cast(FloatArray, hours.copy())
+
+
+def _vector(value: ArrayLike, name: str) -> FloatArray:
+    array = np.asarray(value, dtype=np.float64)
+    if array.ndim != 1:
+        raise ValueError(f"{name} must be one-dimensional, got shape {array.shape}.")
+    if not np.isfinite(array).all():
+        raise ValueError(f"{name} must contain only finite values.")
+    return cast(FloatArray, array.copy())
+
+
+def _matrix(value: ArrayLike, name: str) -> FloatArray:
+    array = np.asarray(value, dtype=np.float64)
+    if array.ndim != 2:
+        raise ValueError(f"{name} must be two-dimensional, got shape {array.shape}.")
+    if not np.isfinite(array).all():
+        raise ValueError(f"{name} must contain only finite values.")
+    return cast(FloatArray, array.copy())
+
+
+def _group_index(value: ArrayLike, n_observation: int) -> IntArray:
+    array = np.asarray(value)
+    if array.shape != (n_observation,):
+        raise ValueError(
+            f"site_index has shape {array.shape}, expected {(n_observation,)}."
+        )
+    if not np.issubdtype(array.dtype, np.integer):
+        raise ValueError("site_index must contain integer identifiers.")
+    index = np.asarray(array, dtype=np.int64)
+    if np.any(index < 0):
+        raise ValueError("site_index must be non-negative.")
+    expected = np.arange(int(index.max()) + 1, dtype=np.int64)
+    if not np.array_equal(np.unique(index), expected):
+        raise ValueError("site_index identifiers must be contiguous from zero.")
+    return cast(IntArray, index.copy())
+
+
+def _site_labels(labels: Sequence[str] | None, n_site: int) -> tuple[str, ...]:
+    result = tuple(str(site) for site in (range(n_site) if labels is None else labels))
+    if len(result) != n_site or len(set(result)) != n_site:
+        raise ValueError("site_labels must contain one unique label per site.")
+    return result
+
+
+def _tau_values(
+    tau_hours: ArrayLike | float | Mapping[str, float], labels: tuple[str, ...]
+) -> FloatArray:
+    if isinstance(tau_hours, Mapping):
+        if set(tau_hours) != set(labels):
+            raise ValueError("tau_hours mapping keys must exactly match site_labels.")
+        value: ArrayLike | float = [tau_hours[label] for label in labels]
+    else:
+        value = tau_hours
+    return _site_values(value, len(labels), "tau_hours", positive=True)
+
+
+def _site_values(
+    value: ArrayLike | float,
+    n_site: int,
+    name: str,
+    *,
+    positive: bool,
+) -> FloatArray:
+    values = np.asarray(value, dtype=np.float64)
+    if values.ndim == 0:
+        values = np.full(n_site, values.item(), dtype=np.float64)
+    elif values.shape != (n_site,):
+        raise ValueError(f"{name} must be scalar or have shape {(n_site,)}, got {values.shape}.")
+    if not np.isfinite(values).all() or np.any(values <= 0.0 if positive else values < 0.0):
+        qualifier = "strictly positive" if positive else "non-negative"
+        raise ValueError(f"{name} must contain finite, {qualifier} values.")
+    return cast(FloatArray, values.copy())

--- a/openghg_inversions/rhime/__init__.py
+++ b/openghg_inversions/rhime/__init__.py
@@ -27,6 +27,7 @@ from .builders import (
 )
 from .co2 import build_co2_model, co2_model_input_names, run_rhime_co2
 from .materialization import materialize_pymc_inputs
+from .likelihoods import fixed_ou_likelihood_builder
 from .params import params_from_config, resolve_flux_sources, resolve_rhime_options
 from .preparation import (
     assemble_rhime_inputs,
@@ -76,6 +77,7 @@ __all__ = [
     "build_standard_rhime_model",
     "build_standard_rhime_model_result",
     "filter_rhime_observations",
+    "fixed_ou_likelihood_builder",
     "make_multisector_rhime_result",
     "make_multisector_rhime_outputs",
     "make_standard_rhime_result",

--- a/openghg_inversions/rhime/likelihoods.py
+++ b/openghg_inversions/rhime/likelihoods.py
@@ -4,18 +4,32 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from numbers import Real
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
+import pymc as pm
+import pytensor.tensor as pt
 import xarray as xr
 from pytensor.tensor.variable import TensorVariable
 
-from openghg_inversions.inversion_inputs import DatetimeLike, make_site_indicator, make_site_names
+from openghg_inversions.inversion_inputs import (
+    DatetimeLike,
+    make_site_indicator,
+    make_site_names,
+)
+from openghg_inversions.models.components import add_model_data
+from openghg_inversions.models.coords import add_coords
 from openghg_inversions.models.additive_sigma import (
     DEFAULT_ADDITIVE_SIGMA_PRIOR,
     add_additive_sigma_gaussian_likelihood,
 )
-from openghg_inversions.observation_error import AggregationError
+from openghg_inversions.models.fixed_ou import prepare_fixed_ou_low_rank
+from openghg_inversions.models.likelihoods import add_aggregation_error_data
+from openghg_inversions.models.priors import parse_prior
+from openghg_inversions.observation_error import (
+    AggregationError,
+    validate_observation_error_arrays,
+)
 from openghg_inversions.sigma import SigmaAlignment
 
 
@@ -46,6 +60,61 @@ def _resolve_site_sigma_prior(
         raise ValueError("Site-keyed sigma prior values must be finite positive numbers.")
     resolved["sigma"] = scales[:, None]
     return resolved
+
+
+DEFAULT_OU_SITE_AMPLITUDE_PRIOR: dict[str, Any] = {
+    "pdf": "halfnormal",
+    "sigma": 0.75,
+}
+
+
+def _aggregation_low_rank_factor(
+    aggregation_error: AggregationError,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return an exact factor-plus-diagonal representation of aggregation error."""
+    n_observation = aggregation_error.marginal_variance.size
+    if aggregation_error.mode == "dense":
+        assert aggregation_error.covariance is not None
+        covariance = np.asarray(aggregation_error.covariance.values, dtype=float)
+        eigenvalues, eigenvectors = np.linalg.eigh((covariance + covariance.T) * 0.5)
+        tolerance = 1.0e-10 * max(1.0, float(np.max(np.abs(eigenvalues))))
+        if eigenvalues[0] < -tolerance:
+            raise ValueError("Dense aggregation covariance must be positive semidefinite.")
+        positive = eigenvalues > 0.0
+        factor = eigenvectors[:, positive] * np.sqrt(np.maximum(eigenvalues[positive], 0.0))
+        return factor, np.zeros(n_observation)
+    if aggregation_error.mode == "low_rank":
+        assert aggregation_error.factor is not None
+        assert aggregation_error.diagonal_variance is not None
+        return (
+            np.asarray(aggregation_error.factor.values, dtype=float),
+            np.asarray(aggregation_error.diagonal_variance.values, dtype=float),
+        )
+    if aggregation_error.mode == "diagonal":
+        assert aggregation_error.diagonal_variance is not None
+        return (
+            np.empty((n_observation, 0)),
+            np.asarray(aggregation_error.diagonal_variance.values, dtype=float),
+        )
+    return np.empty((n_observation, 0)), np.zeros(n_observation)
+
+
+def _fixed_site_amplitudes(
+    value: float | Mapping[str, float],
+    site_labels: tuple[str, ...],
+) -> np.ndarray:
+    """Resolve a scalar or exact labelled fixed-amplitude mapping."""
+    if isinstance(value, Mapping):
+        if set(value) != set(site_labels):
+            raise ValueError(
+                "`fixed_site_amplitudes` mapping keys must exactly match the observation sites."
+            )
+        amplitudes = np.asarray([value[site] for site in site_labels], dtype=float)
+    else:
+        amplitudes = np.full(len(site_labels), value, dtype=float)
+    if not np.isfinite(amplitudes).all() or (amplitudes < 0.0).any():
+        raise ValueError("`fixed_site_amplitudes` must contain finite, non-negative values.")
+    return amplitudes
 
 
 def additive_sigma_likelihood_builder(
@@ -133,4 +202,174 @@ def additive_sigma_likelihood_builder(
     )
 
 
-__all__ = ["DEFAULT_ADDITIVE_SIGMA_PRIOR", "additive_sigma_likelihood_builder"]
+def fixed_ou_likelihood_builder(
+    *,
+    observations: xr.DataArray,
+    observation_error: xr.DataArray,
+    minimum_error: xr.DataArray,
+    aggregation_error: AggregationError,
+    mean: TensorVariable,
+    pollution_mean: TensorVariable,
+    pollution_event_baseline: TensorVariable | None,
+    output_dim: str,
+    tau_hours: float | Mapping[str, float],
+    fixed_site_amplitudes: float | Mapping[str, float] | None = None,
+    site_amplitude_prior: Mapping[str, Any] | None = None,
+) -> TensorVariable:
+    """Add labelled fixed-tau within-site OU model-data mismatch.
+
+    The complete covariance is the selected fixed aggregation covariance,
+    reported observation-error variance, and one OU block per site. The
+    ``minimum_error`` floor is applied to the fixed aggregation-plus-reported
+    marginal before OU variance is added. Consequently OU variance can only
+    increase the final marginal above that floor.
+
+    ``tau_hours`` and fixed amplitudes may be scalar or exact mappings keyed by
+    the observation sites. When amplitudes are inferred, their default prior
+    is an independent ``HalfNormal(sigma=0.75)`` in observation units.
+
+    Args:
+        observations: Observed mole fractions carrying aligned ``site`` and
+            ``time`` coordinates.
+        observation_error: Reported observation-error standard deviations.
+        minimum_error: Minimum fixed-base marginal standard deviations.
+        aggregation_error: Validated fixed aggregation-error representation.
+        mean: Completed forward-model concentration.
+        pollution_mean: Modelled pollution contribution, unused by this
+            additive covariance component.
+        pollution_event_baseline: Baseline used by pollution-event likelihoods,
+            unused by this additive covariance component.
+        output_dim: Observation dimension used for named PyMC variables.
+        tau_hours: Fixed positive OU correlation time in hours, globally or by
+            exact site-label mapping.
+        fixed_site_amplitudes: Optional known non-negative OU standard
+            deviations in observation units, globally or by site.
+        site_amplitude_prior: Optional positive-support PyMC prior arguments
+            for inferred site amplitudes. Mutually exclusive with fixed values.
+
+    Returns:
+        The observed Gaussian variable named ``y``. The component also creates
+        canonical ``epsilon`` and labelled ``ou_site_amplitude`` variables.
+
+    Raises:
+        ValueError: If labels, configuration, or covariance inputs are invalid.
+    """
+    del pollution_mean, pollution_event_baseline
+    if fixed_site_amplitudes is not None and site_amplitude_prior is not None:
+        raise ValueError(
+            "Pass either `fixed_site_amplitudes` or `site_amplitude_prior`, not both."
+        )
+    validate_observation_error_arrays(
+        observations,
+        observation_error,
+        minimum_error,
+        owner="Fixed-OU likelihood",
+        output_dim=output_dim,
+    )
+    site = observations.coords.get("site")
+    time = observations.coords.get("time")
+    if site is None or site.dims != (output_dim,):
+        raise ValueError(
+            "The fixed-OU likelihood requires an observation-aligned 'site' coordinate."
+        )
+    if time is None or time.dims != (output_dim,):
+        raise ValueError(
+            "The fixed-OU likelihood requires an observation-aligned 'time' coordinate."
+        )
+
+    site_index = make_site_indicator(site)
+    site_codes = np.asarray(site_index.values, dtype=np.int64)
+    site_values = np.asarray(site.values)
+    site_labels = tuple(
+        str(site_values[np.flatnonzero(site_codes == index)[0]])
+        for index in range(int(site_codes.max()) + 1)
+    )
+    add_coords({"ou_site": np.asarray(site_labels, dtype=object)})
+
+    # Register the original labelled fixed inputs before crossing the eager
+    # fixed-OU precomputation boundary.
+    observed = add_model_data(observations.transpose(output_dim), "Y")
+    add_model_data(observation_error.transpose(output_dim), "error")
+    add_model_data(minimum_error.transpose(output_dim), "min_error")
+    add_aggregation_error_data(aggregation_error, observations, output_dim=output_dim)
+    add_model_data(site_index.rename("ou_site_index"), "ou_site_index")
+
+    observation_variance = np.square(np.asarray(observation_error.values, dtype=float))
+    minimum_variance = np.square(np.asarray(minimum_error.values, dtype=float))
+    fixed_marginal = observation_variance + aggregation_error.marginal_variance
+    floor_variance = np.maximum(minimum_variance - fixed_marginal, 0.0)
+    factor, aggregation_diagonal = _aggregation_low_rank_factor(aggregation_error)
+    prepared = prepare_fixed_ou_low_rank(
+        factor,
+        observation_variance + aggregation_diagonal + floor_variance,
+        np.asarray(time.values),
+        site_codes,
+        tau_hours,
+        site_labels=site_labels,
+    )
+    add_model_data(
+        xr.DataArray(
+            prepared.tau_hours_by_site,
+            dims=("ou_site",),
+            coords={"ou_site": np.asarray(site_labels, dtype=object)},
+            name="ou_tau_hours",
+        )
+    )
+
+    if fixed_site_amplitudes is None:
+        amplitude = parse_prior(
+            "ou_site_amplitude",
+            dict(
+                DEFAULT_OU_SITE_AMPLITUDE_PRIOR
+                if site_amplitude_prior is None
+                else site_amplitude_prior
+            ),
+            dims="ou_site",
+        )
+    else:
+        fixed_amplitude_values = _fixed_site_amplitudes(
+            fixed_site_amplitudes, site_labels
+        )
+        mode_variance = prepared.mode_eigenvalues + np.square(
+            fixed_amplitude_values[prepared.mode_site_index]
+        )
+        if np.any(mode_variance <= 0.0):
+            raise ValueError(
+                "Fixed OU amplitudes and the fixed base must produce a positive-definite "
+                "complete observation covariance."
+            )
+        amplitude = add_model_data(
+            xr.DataArray(
+                fixed_amplitude_values,
+                dims=("ou_site",),
+                coords={"ou_site": np.asarray(site_labels, dtype=object)},
+                name="ou_site_amplitude",
+            )
+        )
+
+    pm.Deterministic(
+        "epsilon",
+        pt.sqrt(prepared.marginal_variance(amplitude)),
+        dims=output_dim,
+    )
+    return cast(
+        TensorVariable,
+        pm.CustomDist(
+            "y",
+            mean,
+            amplitude,
+            logp=prepared.logp,
+            random=prepared.random,
+            signature="(n),(s)->(n)",
+            observed=observed,
+            dims=output_dim,
+        ),
+    )
+
+
+__all__ = [
+    "DEFAULT_ADDITIVE_SIGMA_PRIOR",
+    "DEFAULT_OU_SITE_AMPLITUDE_PRIOR",
+    "additive_sigma_likelihood_builder",
+    "fixed_ou_likelihood_builder",
+]

--- a/openghg_inversions/rhime/multisector.py
+++ b/openghg_inversions/rhime/multisector.py
@@ -66,7 +66,7 @@ from .builders import (
     validate_model_build_result,
 )
 from .materialization import materialize_pymc_inputs
-from .outputs import RhimeResult, make_multisector_rhime_outputs
+from .outputs import RhimeResult, annotate_likelihood_trace, make_multisector_rhime_outputs
 from .params import params_from_config, resolve_rhime_options
 from .preparation import (
     assemble_rhime_inputs,
@@ -653,6 +653,12 @@ def make_multisector_rhime_result(
     if likelihood_builder is not None:
         identity = callable_metadata(likelihood_builder)
         result.output_metadata["likelihood_builder"] = identity
+        annotate_likelihood_trace(
+            result.idata,
+            builder_identity=identity,
+            likelihood_kwargs=likelihood_kwargs,
+            concentration_units=prepared.inv_inputs["mf"].attrs.get("units"),
+        )
     if likelihood_kwargs is not None:
         result.output_metadata["likelihood_kwargs"] = likelihood_kwargs
     return result

--- a/openghg_inversions/rhime/outputs.py
+++ b/openghg_inversions/rhime/outputs.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import asdict, dataclass, field
+import json
 from pathlib import Path
 from typing import Any, cast
 
@@ -43,6 +45,44 @@ class RhimeResult:
     inv_out: InversionOutput | None = None
     sampler: RhimeSampler = field(default_factory=RhimeSampler)
     model_build_result: RhimeModelBuildResult | None = None
+
+
+def annotate_likelihood_trace(
+    idata: az.InferenceData,
+    *,
+    builder_identity: dict[str, str],
+    likelihood_kwargs: Mapping[str, Any] | None,
+    concentration_units: str | None,
+) -> None:
+    """Persist installed likelihood identity and fixed-OU variable metadata."""
+    idata.attrs["rhime_likelihood_builder"] = json.dumps(builder_identity, sort_keys=True)
+    idata.attrs["rhime_likelihood_kwargs"] = json.dumps(
+        dict(likelihood_kwargs or {}), sort_keys=True
+    )
+    is_fixed_ou = builder_identity.get("qualname", "").endswith(
+        "fixed_ou_likelihood_builder"
+    )
+    if is_fixed_ou:
+        idata.attrs["rhime_mismatch_component"] = "fixed_within_site_ou"
+    for group_name in idata.groups():
+        group = getattr(idata, group_name)
+        if not isinstance(group, xr.Dataset):
+            continue
+        if "ou_tau_hours" in group:
+            group["ou_tau_hours"].attrs["units"] = "h"
+            group["ou_tau_hours"].attrs["rhime_scientific_role"] = (
+                "fixed_within_site_ou_correlation_time"
+            )
+        if "ou_site_amplitude" in group:
+            if concentration_units is not None:
+                group["ou_site_amplitude"].attrs["units"] = concentration_units
+            group["ou_site_amplitude"].attrs["rhime_scientific_role"] = (
+                "within_site_ou_mismatch_amplitude"
+            )
+        if is_fixed_ou and concentration_units is not None:
+            for name in ("epsilon", "y"):
+                if name in group:
+                    group[name].attrs["units"] = concentration_units
 
 
 def _structured_metadata(value: Any) -> Any:

--- a/openghg_inversions/rhime/standard.py
+++ b/openghg_inversions/rhime/standard.py
@@ -48,7 +48,7 @@ from .builders import (
     validate_model_build_result,
 )
 from .materialization import materialize_pymc_inputs
-from .outputs import RhimeResult, make_standard_rhime_outputs
+from .outputs import RhimeResult, annotate_likelihood_trace, make_standard_rhime_outputs
 from .params import params_from_config, resolve_rhime_options
 from .preparation import (
     assemble_rhime_inputs,
@@ -464,6 +464,12 @@ def make_standard_rhime_result(
     if likelihood_builder is not None:
         identity = callable_metadata(likelihood_builder)
         result.output_metadata["likelihood_builder"] = identity
+        annotate_likelihood_trace(
+            result.idata,
+            builder_identity=identity,
+            likelihood_kwargs=likelihood_kwargs,
+            concentration_units=prepared.inv_inputs["mf"].attrs.get("units"),
+        )
     if likelihood_kwargs is not None:
         result.output_metadata["likelihood_kwargs"] = likelihood_kwargs
     return result

--- a/tests/models/test_fixed_ou.py
+++ b/tests/models/test_fixed_ou.py
@@ -1,0 +1,380 @@
+import numpy as np
+import pymc as pm
+import pytensor
+import pytensor.tensor as pt
+import pytest
+from scipy.stats import multivariate_normal
+
+from openghg_inversions.models.fixed_ou import prepare_fixed_ou_low_rank
+
+
+def _prepared(*, rank: int = 2):
+    factor = np.array(
+        [
+            [0.30, 0.00],
+            [0.10, 0.20],
+            [0.00, 0.25],
+            [0.15, 0.10],
+            [0.05, 0.00],
+        ]
+    )[:, :rank]
+    diagonal = np.array([0.00, 0.20, 0.10, 0.00, 0.15])
+    times = np.array(
+        [
+            "2021-01-01T06:00",
+            "2021-01-01T03:00",
+            "2021-01-01T00:00",
+            "2021-01-01T09:00",
+            "2021-01-01T12:00",
+        ],
+        dtype="datetime64[m]",
+    )
+    sites = np.array([0, 1, 0, 1, 0])
+    prepared = prepare_fixed_ou_low_rank(
+        factor,
+        diagonal,
+        times,
+        sites,
+        {"MHD": 4.0, "TAC": 8.0},
+        site_labels=("MHD", "TAC"),
+    )
+    return prepared, factor, diagonal, times, sites
+
+
+def _direct_covariance(
+    factor: np.ndarray,
+    diagonal: np.ndarray,
+    times: np.ndarray,
+    sites: np.ndarray,
+    amplitude: np.ndarray,
+) -> np.ndarray:
+    hours = times.astype("datetime64[m]").astype(np.int64) / 60.0
+    tau = np.array([4.0, 8.0])
+    lag = np.abs(hours[:, None] - hours[None, :])
+    correlation = np.exp(-lag / tau[sites, None])
+    correlation[sites[:, None] != sites[None, :]] = 0.0
+    return (
+        factor @ factor.T
+        + np.diag(diagonal)
+        + amplitude[sites, None] * amplitude[sites[None, :]] * correlation
+    )
+
+
+def test_covariance_preserves_interleaved_rows_and_labelled_tau() -> None:
+    prepared, factor, diagonal, times, sites = _prepared()
+    amplitude = np.array([0.7, 1.2])
+
+    expected = _direct_covariance(factor, diagonal, times, sites, amplitude)
+
+    np.testing.assert_allclose(prepared.covariance_dense(amplitude), expected)
+    assert prepared.site_labels == ("MHD", "TAC")
+    np.testing.assert_allclose(prepared.tau_hours_by_site, [4.0, 8.0])
+    ou_covariance = expected - factor @ factor.T - np.diag(diagonal)
+    assert ou_covariance[0, 1] == 0.0
+
+
+@pytest.mark.parametrize("rank", [0, 2])
+def test_pytensor_logp_matches_dense_oracle_with_zero_diagonal_tail(rank: int) -> None:
+    prepared, factor, diagonal, times, sites = _prepared(rank=rank)
+    observed = np.array([0.5, -0.1, 0.2, 0.7, -0.4])
+    mean = np.array([0.1, 0.0, 0.3, 0.2, -0.2])
+    amplitude = np.array([0.7, 1.2])
+    value_symbol = pt.dvector("value")
+    mean_symbol = pt.dvector("mean")
+    amplitude_symbol = pt.dvector("amplitude")
+    compiled = pytensor.function(
+        [value_symbol, mean_symbol, amplitude_symbol],
+        prepared.logp(value_symbol, mean_symbol, amplitude_symbol),
+    )
+
+    covariance = _direct_covariance(factor, diagonal, times, sites, amplitude)
+    expected = multivariate_normal.logpdf(observed, mean=mean, cov=covariance)
+
+    assert float(compiled(observed, mean, amplitude)) == pytest.approx(expected, rel=1e-10)
+
+
+def test_logp_is_differentiable_for_inferred_site_amplitudes() -> None:
+    prepared, factor, diagonal, times, sites = _prepared()
+    observed = np.array([0.5, -0.1, 0.2, 0.7, -0.4])
+    mean = np.array([0.1, 0.0, 0.3, 0.2, -0.2])
+    amplitude = np.array([0.7, 1.2])
+    amplitude_symbol = pt.dvector("amplitude")
+    logp = prepared.logp(pt.as_tensor(observed), pt.as_tensor(mean), amplitude_symbol)
+    gradient = pytensor.function([amplitude_symbol], pt.grad(logp, amplitude_symbol))
+
+    step = 1.0e-5
+    expected = np.empty(2)
+    for site in range(2):
+        upper = amplitude.copy()
+        lower = amplitude.copy()
+        upper[site] += step
+        lower[site] -= step
+        expected[site] = (
+            multivariate_normal.logpdf(
+                observed,
+                mean=mean,
+                cov=_direct_covariance(factor, diagonal, times, sites, upper),
+            )
+            - multivariate_normal.logpdf(
+                observed,
+                mean=mean,
+                cov=_direct_covariance(factor, diagonal, times, sites, lower),
+            )
+        ) / (2.0 * step)
+
+    np.testing.assert_allclose(gradient(amplitude), expected, rtol=1e-5)
+
+
+def test_analytic_value_mean_and_amplitude_gradients_match_dense_finite_difference() -> None:
+    prepared, factor, diagonal, times, sites = _prepared()
+    observed = np.array([0.5, -0.1, 0.2, 0.7, -0.4])
+    mean = np.array([0.1, 0.0, 0.3, 0.2, -0.2])
+    amplitude = np.array([0.7, 1.2])
+    value_symbol = pt.dvector("value")
+    mean_symbol = pt.dvector("mean")
+    amplitude_symbol = pt.dvector("amplitude")
+    logp = prepared.logp(value_symbol, mean_symbol, amplitude_symbol)
+    compiled = pytensor.function(
+        [value_symbol, mean_symbol, amplitude_symbol],
+        [
+            logp,
+            pt.grad(logp, value_symbol),
+            pt.grad(logp, mean_symbol),
+            pt.grad(logp, amplitude_symbol),
+        ],
+    )
+    _, value_gradient, mean_gradient, amplitude_gradient = compiled(
+        observed, mean, amplitude
+    )
+
+    def dense_logp(value: np.ndarray, location: np.ndarray, scale: np.ndarray) -> float:
+        return float(
+            multivariate_normal.logpdf(
+                value,
+                mean=location,
+                cov=_direct_covariance(factor, diagonal, times, sites, scale),
+            )
+        )
+
+    step = 1.0e-6
+    expected_value = np.empty(observed.size)
+    expected_mean = np.empty(mean.size)
+    expected_amplitude = np.empty(amplitude.size)
+    for index in range(observed.size):
+        direction = np.zeros(observed.size)
+        direction[index] = step
+        expected_value[index] = (
+            dense_logp(observed + direction, mean, amplitude)
+            - dense_logp(observed - direction, mean, amplitude)
+        ) / (2.0 * step)
+        expected_mean[index] = (
+            dense_logp(observed, mean + direction, amplitude)
+            - dense_logp(observed, mean - direction, amplitude)
+        ) / (2.0 * step)
+    for index in range(amplitude.size):
+        direction = np.zeros(amplitude.size)
+        direction[index] = step
+        expected_amplitude[index] = (
+            dense_logp(observed, mean, amplitude + direction)
+            - dense_logp(observed, mean, amplitude - direction)
+        ) / (2.0 * step)
+
+    evaluation = prepared.evaluate(observed - mean, amplitude)
+    np.testing.assert_allclose(value_gradient, expected_value, rtol=2e-8, atol=2e-8)
+    np.testing.assert_allclose(mean_gradient, expected_mean, rtol=2e-8, atol=2e-8)
+    np.testing.assert_allclose(
+        amplitude_gradient, expected_amplitude, rtol=2e-8, atol=2e-8
+    )
+    np.testing.assert_allclose(evaluation.gradient_residual, expected_value, rtol=2e-8)
+    np.testing.assert_allclose(
+        evaluation.gradient_site_amplitude, expected_amplitude, rtol=2e-8
+    )
+
+
+def test_logp_matches_frozen_verification_games_fixture() -> None:
+    """Match verification-games ``_inputs()`` and its fixed-OU evaluator."""
+    observed = np.array([1.2, -0.4, 0.5, 1.6, -0.2, 0.8])
+    fixed = np.array([0.1, -0.1, 0.2, 0.3, -0.2, 0.0])
+    design = np.array(
+        [
+            [0.2, -0.1],
+            [0.3, 0.4],
+            [-0.5, 0.2],
+            [0.1, 0.6],
+            [0.4, -0.2],
+            [-0.1, 0.3],
+        ]
+    )
+    factor = np.array(
+        [
+            [0.8, -0.2],
+            [0.3, 0.5],
+            [-0.1, 0.7],
+            [0.6, 0.1],
+            [0.2, -0.4],
+            [0.1, 0.2],
+        ]
+    )
+    prepared = prepare_fixed_ou_low_rank(
+        factor,
+        np.array([0.16, 0.25, 0.09, 0.36, 0.20, 0.11]),
+        np.array([0.0, 0.25, 1.5, 2.0, 7.0, 8.5]),
+        np.array([0, 1, 0, 1, 0, 1]),
+        5.5,
+    )
+    state = np.array([0.3, -0.7])
+    amplitude = np.array([0.23, 0.41])
+    expression = prepared.logp(
+        pt.as_tensor(observed),
+        pt.as_tensor(fixed + design @ state),
+        pt.as_tensor(amplitude),
+    )
+
+    # Frozen from FixedOuCachedMarginalQuadraticTarget.log_likelihood.
+    assert float(expression.eval()) == pytest.approx(-7.781189009752531, rel=2e-12)
+
+
+def test_singular_zero_amplitude_returns_negative_infinity_without_jitter() -> None:
+    prepared = prepare_fixed_ou_low_rank(
+        np.empty((2, 0)),
+        np.zeros(2),
+        np.array([0.0, 1.0]),
+        np.zeros(2, dtype=int),
+        5.0,
+    )
+    expression = prepared.logp(
+        pt.as_tensor(np.zeros(2)),
+        pt.as_tensor(np.zeros(2)),
+        pt.as_tensor(np.array([0.0])),
+    )
+
+    assert float(expression.eval()) == -np.inf
+
+
+def test_overflowing_log_amplitude_rejects_without_nan_gradient() -> None:
+    prepared, *_ = _prepared()
+    log_amplitude = pt.dvector("log_amplitude")
+    amplitude = pt.exp(log_amplitude)
+    logp = prepared.logp(
+        pt.as_tensor(np.zeros(prepared.n_observation)),
+        pt.as_tensor(np.zeros(prepared.n_observation)),
+        amplitude,
+    )
+    compiled = pytensor.function(
+        [log_amplitude],
+        [logp, pt.grad(logp, log_amplitude)],
+    )
+
+    with np.errstate(over="ignore", invalid="ignore"):
+        value, gradient = compiled(np.full(prepared.n_site, 1_000.0))
+
+    assert float(value) == -np.inf
+    assert not np.isnan(gradient).any()
+
+
+def test_custom_dist_supports_fixed_and_inferred_amplitudes() -> None:
+    prepared, *_ = _prepared()
+    observed = np.array([0.5, -0.1, 0.2, 0.7, -0.4])
+
+    with pm.Model(coords={"observation": np.arange(5), "site": prepared.site_labels}) as model:
+        amplitude = pm.HalfNormal("ou_site_amplitude", 1.0, dims="site")
+        pm.CustomDist(
+            "y",
+            np.zeros(5),
+            amplitude,
+            logp=prepared.logp,
+            random=prepared.random,
+            signature="(n),(s)->(n)",
+            observed=observed,
+            dims="observation",
+        )
+
+    assert np.isfinite(model.compile_logp()(model.initial_point()))
+    with model:
+        predictive = pm.sample_prior_predictive(draws=2, var_names=["y"])
+    assert predictive.prior_predictive["y"].shape == (1, 2, 5)
+
+
+def test_marginal_variance_includes_all_three_components_once() -> None:
+    prepared, factor, diagonal, *_ = _prepared()
+    amplitude = pt.dvector("amplitude")
+    compiled = pytensor.function([amplitude], prepared.marginal_variance(amplitude))
+
+    expected = diagonal + np.square(factor).sum(axis=1) + np.square([0.7, 1.2])[prepared.site_index]
+
+    np.testing.assert_allclose(compiled([0.7, 1.2]), expected)
+
+
+def test_random_draws_reproduce_dense_covariance() -> None:
+    prepared, *_ = _prepared()
+    amplitude = np.array([0.7, 1.2])
+    draws = prepared.random(
+        np.zeros(prepared.n_observation),
+        amplitude,
+        rng=np.random.default_rng(4),
+        size=40_000,
+    )
+
+    np.testing.assert_allclose(
+        np.cov(draws, rowvar=False),
+        prepared.covariance_dense(amplitude),
+        rtol=0.04,
+        atol=0.015,
+    )
+
+
+def test_duplicate_times_within_site_are_rejected_without_jitter() -> None:
+    with pytest.raises(ValueError, match="unique within site 'MHD'"):
+        prepare_fixed_ou_low_rank(
+            np.empty((3, 0)),
+            np.zeros(3),
+            np.array([0.0, 1.0, 0.0]),
+            np.array([0, 1, 0]),
+            5.0,
+            site_labels=("MHD", "TAC"),
+        )
+
+
+def test_labelled_tau_requires_exact_site_coverage() -> None:
+    with pytest.raises(ValueError, match="exactly match site_labels"):
+        prepare_fixed_ou_low_rank(
+            np.empty((2, 0)),
+            np.ones(2),
+            np.array([0.0, 1.0]),
+            np.array([0, 1]),
+            {"MHD": 5.0},
+            site_labels=("MHD", "TAC"),
+        )
+
+
+@pytest.mark.parametrize("tau_hours", [0.0, -1.0, np.inf, np.nan])
+def test_tau_must_be_finite_and_strictly_positive(tau_hours: float) -> None:
+    with pytest.raises(ValueError, match="finite, strictly positive"):
+        prepare_fixed_ou_low_rank(
+            np.empty((2, 0)),
+            np.ones(2),
+            np.array([0.0, 1.0]),
+            np.array([0, 1]),
+            tau_hours,
+            site_labels=("MHD", "TAC"),
+        )
+
+
+def test_small_tau_reproduces_iid_site_amplitudes() -> None:
+    prepared, factor, diagonal, *_ = _prepared()
+    iid = prepare_fixed_ou_low_rank(
+        factor,
+        diagonal,
+        prepared.observation_time_hours,
+        prepared.site_index,
+        1.0e-12,
+        site_labels=prepared.site_labels,
+    )
+    amplitude = np.array([0.7, 1.2])
+    expected = (
+        factor @ factor.T
+        + np.diag(diagonal)
+        + np.diag(np.square(amplitude[prepared.site_index]))
+    )
+
+    np.testing.assert_allclose(iid.covariance_dense(amplitude), expected, atol=0.0)

--- a/tests/models/test_fixed_ou_rhime.py
+++ b/tests/models/test_fixed_ou_rhime.py
@@ -1,0 +1,358 @@
+"""RHIME integration tests for the fixed within-site OU likelihood."""
+
+from __future__ import annotations
+
+import json
+
+import arviz as az
+import numpy as np
+import pymc as pm
+import pytest
+import xarray as xr
+from scipy.stats import multivariate_normal
+
+from openghg_inversions.models.coords import get_coord_registry, registered_model
+from openghg_inversions.observation_error import resolve_aggregation_error
+from openghg_inversions.rhime.likelihoods import fixed_ou_likelihood_builder
+from openghg_inversions.rhime.multisector import build_multisector_rhime_model
+from openghg_inversions.rhime.outputs import annotate_likelihood_trace
+from openghg_inversions.rhime.specs import SectorSpec
+from openghg_inversions.rhime.standard import build_standard_rhime_model
+
+
+def _ou_inputs(*, low_rank: bool = True, zero_base: bool = False) -> xr.Dataset:
+    nmeasure = 4
+    data = xr.Dataset(
+        {
+            "mf": ("nmeasure", [1.0, 2.0, 3.0, 4.0]),
+            "mf_error": (
+                "nmeasure",
+                np.zeros(nmeasure) if zero_base else np.full(nmeasure, 0.2),
+            ),
+            "min_error": ("nmeasure", [0.5, 0.0, 0.0, 0.0]),
+        },
+        coords={
+            "nmeasure": np.arange(nmeasure),
+            "site": ("nmeasure", ["MHD", "TAC", "MHD", "TAC"]),
+            "time": (
+                "nmeasure",
+                np.array(
+                    [
+                        "2020-01-01T00",
+                        "2020-01-01T00",
+                        "2020-01-01T01",
+                        "2020-01-01T02",
+                    ],
+                    dtype="datetime64[h]",
+                ),
+            ),
+        },
+    )
+    data["mf"].attrs["units"] = "ppm"
+    if low_rank:
+        data["low_rank_factor"] = (
+            ("nmeasure", "aggregation_rank"),
+            [[0.1], [0.2], [0.1], [0.2]],
+        )
+        data["diagonal_residual_variance"] = (
+            "nmeasure",
+            np.zeros(nmeasure) if zero_base else [0.03, 0.04, 0.05, 0.06],
+        )
+    return data
+
+
+def _build_fixed_ou_model(
+    data: xr.Dataset,
+    *,
+    aggregation_mode: str | None = None,
+    fixed_site_amplitudes: float | dict[str, float] | None = None,
+    site_amplitude_prior: dict[str, float | str] | None = None,
+) -> pm.Model:
+    mode = aggregation_mode or (
+        "low_rank" if "low_rank_factor" in data else "none"
+    )
+    with registered_model(coords={"nmeasure": data.nmeasure.values}) as model:
+        mean = pm.Data("completed_mean", np.ones(data.sizes["nmeasure"]), dims="nmeasure")
+        fixed_ou_likelihood_builder(
+            observations=data["mf"],
+            observation_error=data["mf_error"],
+            minimum_error=data["min_error"],
+            aggregation_error=resolve_aggregation_error(data, mode),
+            mean=mean,
+            pollution_mean=mean,
+            pollution_event_baseline=None,
+            output_dim="nmeasure",
+            tau_hours={"TAC": 7.0, "MHD": 5.0},
+            fixed_site_amplitudes=fixed_site_amplitudes,
+            site_amplitude_prior=site_amplitude_prior,
+        )
+    return model
+
+
+def test_low_rank_builder_keeps_the_dynamic_cholesky_rank_sized(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Low-rank OU evaluation does not register or factor an observation square."""
+    model = _build_fixed_ou_model(
+        _ou_inputs(),
+        fixed_site_amplitudes={"TAC": 0.7, "MHD": 0.5},
+    )
+
+    assert "MvNormal" not in type(model["y"].owner.op).__name__
+    assert all(
+        dims != ("nmeasure", "nmeasure_cov")
+        for dims in model.named_vars_to_dims.values()
+    )
+    assert "ou_correlation_template" not in model.named_vars
+    original_cholesky = np.linalg.cholesky
+    cholesky_shapes: list[tuple[int, ...]] = []
+
+    def record_cholesky(value: np.ndarray) -> np.ndarray:
+        cholesky_shapes.append(value.shape)
+        return original_cholesky(value)
+
+    monkeypatch.setattr(np.linalg, "cholesky", record_cholesky)
+    assert np.isfinite(float(model.compile_logp()(model.initial_point())))
+    assert cholesky_shapes == [(1, 1)]
+
+
+def test_fixed_ou_builder_preserves_labels_tau_and_static_base_floor() -> None:
+    """Site mappings follow first occurrence and OU is added above the fixed floor."""
+    model = _build_fixed_ou_model(
+        _ou_inputs(),
+        fixed_site_amplitudes={"TAC": 0.7, "MHD": 0.5},
+    )
+
+    registry = get_coord_registry(model)
+    assert registry is not None
+    assert tuple(registry.original_coords["ou_site"]) == ("MHD", "TAC")
+    np.testing.assert_allclose(model["ou_tau_hours"].eval(), [5.0, 7.0])
+    np.testing.assert_allclose(model["ou_site_amplitude"].eval(), [0.5, 0.7])
+    epsilon = np.asarray(model["epsilon"].eval())
+    np.testing.assert_allclose(epsilon[0], np.sqrt(0.5**2 + 0.5**2))
+    assert epsilon[0] > 0.5
+
+
+def test_fixed_ou_builder_rejects_a_singular_fixed_complete_covariance() -> None:
+    """A zero base and zero OU amplitude fail rather than gaining hidden jitter."""
+    data = _ou_inputs(low_rank=False, zero_base=True)
+    data["min_error"][:] = 0.0
+    with pytest.raises(ValueError, match="positive-definite complete observation covariance"):
+        _build_fixed_ou_model(data, fixed_site_amplitudes=0.0)
+
+
+def test_fixed_ou_builder_creates_an_inferred_labelled_amplitude() -> None:
+    """Inferred OU amplitudes use their own site-labelled variable."""
+    model = _build_fixed_ou_model(
+        _ou_inputs(),
+        site_amplitude_prior={"pdf": "halfnormal", "sigma": 0.75},
+    )
+
+    assert model["ou_site_amplitude"] in model.free_RVs
+    assert model.named_vars_to_dims["ou_site_amplitude"] == ("ou_site",)
+    assert "sigma" not in model.named_vars
+
+
+def test_fixed_ou_builder_samples_state_and_site_amplitudes_together() -> None:
+    data = _ou_inputs(low_rank=True)
+    with registered_model(coords={"nmeasure": data.nmeasure.values}):
+        state = pm.Normal("state", mu=1.0, sigma=0.2)
+        mean = state * pm.Data(
+            "state_design",
+            np.array([0.8, 1.8, 2.8, 3.8]),
+            dims="nmeasure",
+        )
+        fixed_ou_likelihood_builder(
+            observations=data["mf"],
+            observation_error=data["mf_error"],
+            minimum_error=data["min_error"],
+            aggregation_error=resolve_aggregation_error(data, "low_rank"),
+            mean=mean,
+            pollution_mean=mean,
+            pollution_event_baseline=None,
+            output_dim="nmeasure",
+            tau_hours=5.0,
+        )
+        trace = pm.sample(
+            draws=10,
+            tune=10,
+            chains=1,
+            cores=1,
+            random_seed=20260825,
+            progressbar=False,
+            compute_convergence_checks=False,
+        )
+
+    assert trace.posterior["state"].shape == (1, 10)
+    assert trace.posterior["ou_site_amplitude"].shape == (1, 10, 2)
+    assert np.isfinite(trace.posterior["ou_site_amplitude"]).all()
+
+
+@pytest.mark.parametrize("mode", ["none", "diagonal", "low_rank", "dense"])
+def test_builder_logp_matches_dense_covariance_for_every_aggregation_mode(
+    mode: str,
+) -> None:
+    data = _ou_inputs(low_rank=False)
+    factor = np.array([[0.1], [0.2], [0.1], [0.2]])
+    residual_variance = np.array([0.03, 0.04, 0.05, 0.06])
+    if mode == "none":
+        aggregation = np.zeros((4, 4))
+    elif mode == "diagonal":
+        aggregation = np.diag(residual_variance)
+        data["aggregation_error_sd"] = (
+            "nmeasure",
+            np.sqrt(residual_variance),
+        )
+    else:
+        aggregation = factor @ factor.T + np.diag(residual_variance)
+        if mode == "low_rank":
+            data["low_rank_factor"] = (
+                ("nmeasure", "aggregation_rank"),
+                factor,
+            )
+            data["diagonal_residual_variance"] = (
+                "nmeasure",
+                residual_variance,
+            )
+        else:
+            data["aggregation_error_covariance"] = (
+                ("nmeasure", "nmeasure_cov"),
+                aggregation,
+            )
+
+    model = _build_fixed_ou_model(
+        data,
+        aggregation_mode=mode,
+        fixed_site_amplitudes={"TAC": 0.7, "MHD": 0.5},
+    )
+    site_index = np.array([0, 1, 0, 1])
+    # Fixed model data follows the active PyMC graph precision before the
+    # float64 OU evaluation boundary.
+    amplitude = np.asarray(model["ou_site_amplitude"].eval(), dtype=np.float64)
+    tau = np.array([5.0, 7.0])
+    time_hours = np.array([0.0, 0.0, 1.0, 2.0])
+    lag = np.abs(time_hours[:, None] - time_hours[None, :])
+    correlation = np.exp(-lag / tau[site_index, None])
+    correlation[site_index[:, None] != site_index[None, :]] = 0.0
+    observation_variance = np.square(data["mf_error"].values)
+    floor_variance = np.maximum(
+        np.square(data["min_error"].values)
+        - observation_variance
+        - np.diag(aggregation),
+        0.0,
+    )
+    covariance = (
+        aggregation
+        + np.diag(observation_variance + floor_variance)
+        + amplitude[site_index, None]
+        * amplitude[site_index[None, :]]
+        * correlation
+    )
+    expected = multivariate_normal.logpdf(
+        data["mf"].values,
+        mean=np.ones(4),
+        cov=covariance,
+    )
+
+    assert float(model.compile_logp()(model.initial_point())) == pytest.approx(
+        expected,
+        rel=1.0e-10,
+    )
+
+
+@pytest.mark.parametrize("multisector", [False, True])
+def test_standard_recipes_accept_installed_fixed_ou_likelihood(
+    multisector: bool,
+) -> None:
+    """Both ordinary recipes select the installed OU component explicitly."""
+    data = _ou_inputs(low_rank=False)
+    design = xr.DataArray(
+        np.ones((data.sizes["nmeasure"], 1)),
+        dims=("nmeasure", "region"),
+        coords={"nmeasure": data.nmeasure, "region": ["r1"]},
+    )
+    common = {
+        "observations": data["mf"],
+        "observation_error": data["mf_error"],
+        "minimum_error": data["min_error"],
+        "aggregation_error": resolve_aggregation_error(data, "none"),
+        "use_bc": False,
+        "likelihood_builder": fixed_ou_likelihood_builder,
+        "likelihood_kwargs": {"tau_hours": 5.0, "fixed_site_amplitudes": 0.5},
+    }
+    if multisector:
+        source_design = xr.concat(
+            [design, 2.0 * design],
+            dim=xr.IndexVariable("source", ["ff", "ocean"]),
+        )
+        model = build_multisector_rhime_model(
+            source_design,
+            sectors=(
+                SectorSpec(
+                    name="fossil fuel",
+                    flux_source="ff",
+                    variable_suffix="ff",
+                    x_prior={"pdf": "normal", "mu": 1.0, "sigma": 1.0},
+                ),
+                SectorSpec(
+                    name="ocean",
+                    flux_source="ocean",
+                    variable_suffix="ocean",
+                    x_prior={"pdf": "normal", "mu": 1.0, "sigma": 1.0},
+                ),
+            ),
+            **common,
+        )
+    else:
+        model = build_standard_rhime_model(
+            design,
+            x_prior={"pdf": "normal", "mu": 1.0, "sigma": 1.0},
+            **common,
+        )
+
+    assert {"y", "epsilon", "ou_site_amplitude", "ou_tau_hours"} <= set(
+        model.named_vars
+    )
+    assert "sigma" not in model.named_vars
+
+
+def test_likelihood_trace_annotation_round_trips_ou_identity_and_units(tmp_path) -> None:
+    """Raw trace metadata identifies fixed OU configuration and concentration units."""
+    idata = az.InferenceData(
+        posterior=xr.Dataset(
+            {
+                "ou_site_amplitude": (
+                    ("chain", "draw", "ou_site"),
+                    np.ones((1, 1, 2)),
+                ),
+                "epsilon": (("chain", "draw", "nmeasure"), np.ones((1, 1, 4))),
+            },
+            coords={"ou_site": ["MHD", "TAC"]},
+        ),
+        constant_data=xr.Dataset(
+            {"ou_tau_hours": ("ou_site", [5.0, 7.0])},
+            coords={"ou_site": ["MHD", "TAC"]},
+        ),
+    )
+    identity = {
+        "module": "openghg_inversions.rhime.likelihoods",
+        "qualname": "fixed_ou_likelihood_builder",
+    }
+    options = {"tau_hours": {"MHD": 5.0, "TAC": 7.0}}
+    annotate_likelihood_trace(
+        idata,
+        builder_identity=identity,
+        likelihood_kwargs=options,
+        concentration_units="ppm",
+    )
+    path = tmp_path / "ou-trace.nc"
+    idata.to_netcdf(path)
+    loaded = az.from_netcdf(path)
+
+    assert json.loads(loaded.attrs["rhime_likelihood_builder"]) == identity
+    assert json.loads(loaded.attrs["rhime_likelihood_kwargs"]) == options
+    assert loaded.attrs["rhime_mismatch_component"] == "fixed_within_site_ou"
+    assert tuple(loaded.posterior.ou_site.values) == ("MHD", "TAC")
+    assert loaded.posterior["ou_site_amplitude"].attrs["units"] == "ppm"
+    assert loaded.posterior["epsilon"].attrs["units"] == "ppm"
+    assert loaded.constant_data["ou_tau_hours"].attrs["units"] == "h"


### PR DESCRIPTION
* **Summary of changes**

  - Add a labelled fixed-tau, within-site Ornstein–Uhlenbeck mismatch likelihood for
    `A + D_obs + blockdiag_site(sigma_site² T_site(tau))`.
  - Preserve first-occurrence site ordering, exact elapsed-time lags, zero cross-site
    OU covariance, and fixed or inferred per-site amplitudes.
  - Evaluate low-rank aggregation covariance with the verification-games
    generalized-eigen/Woodbury algorithm. The dynamic Cholesky is rank-by-rank;
    the low-rank path never forms an observation-by-observation covariance.
  - Support existing none, diagonal, low-rank-plus-diagonal, and explicitly dense
    aggregation-error inputs; reject singular complete covariance without hidden
    jitter.
  - Expose the component through the standard and multisector RHIME likelihood seam,
    persist component/tau/amplitude provenance and units, and document usage.
  - Keep sampled tau and the accepted-state cached CompoundStep sampler out of scope;
    the latter remains OPE-115.

  **Verification-games parity and performance**

  Frozen WUR25 structure: 4,767 rows, rank 512, 25 sites, ordered-row hash
  `949f69926976e61b2e810354fb35ef6ecd46ad2659f8a934fb5c044da936420d`.

  With GCC loaded and a writable PyTensor compiledir, median warm value+gradient
  evaluation was 0.162349 s in OGI versus 0.139508 s in VG (1.164×). Logp differed
  by 1.46e-11 and the maximum absolute gradient difference was 5.82e-11. Peak RSS
  was 726.3 MiB, with no approximately 173 MiB dense observation covariance.

  **Validation**

  - 83 focused OU and neighboring regression tests passed
  - 11 existing additive-sigma and likelihood-seam cases passed; one provenance
    case needed an immediate retry after an intermittent NetCDF/HDF write error
  - Focused `ruff check` — passed
  - `git diff --check` — passed

* **Please check if the PR fulfills these requirements**

- [x] Closes #567
- [x] Tests added and passing
- [x] Documentation and tutorials updated/added
- [x] Added a Towncrier news fragment in `newsfragments/` for user-visible changes
- [x] Added any new requirements to `requirements.txt` (none required)
