### PR TITLE
Automate monthly releases and branch maintenance

### DIFF
--- a/.github/workflows/monthly-release-reminder.yaml
+++ b/.github/workflows/monthly-release-reminder.yaml
@@ -1,0 +1,53 @@
+name: Monthly release reminder
+
+on:
+  schedule:
+    # First Monday of each month at 09:00 UTC.
+    - cron: '0 9 1-7 * 1'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+concurrency:
+  group: monthly-release-reminder
+  cancel-in-progress: false
+
+jobs:
+  remind:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create this month's release tracker once
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          MONTH=$(date -u +%Y-%m)
+          TITLE="Release ${MONTH}"
+          EXISTING=$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state open \
+            --search "${TITLE} in:title" \
+            --json title \
+            --jq "map(select(.title == \"${TITLE}\")) | length")
+          if [ "$EXISTING" -gt 0 ]; then
+            echo "$TITLE already has an open tracker." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          {
+            echo "The monthly release window has opened."
+            echo
+            echo "- [ ] Choose the next minor version"
+            echo "- [ ] Run the **Prepare release** workflow from \`devel\`"
+            echo "- [ ] Merge the release PR after CI"
+            echo "- [ ] Run and review real-data HPC \`test_inversions\` for the exact main commit"
+            echo "- [ ] Record \`HPC / test_inversions\`"
+            echo "- [ ] Publish the GitHub release"
+            echo "- [ ] Confirm the automatic main-to-devel forward-port"
+            echo
+            echo "See \`docs/development/releasing.rst\`."
+          } > "$RUNNER_TEMP/release-reminder.md"
+          URL=$(gh issue create \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$TITLE" \
+            --body-file "$RUNNER_TEMP/release-reminder.md")
+          echo "Release tracker: $URL" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -1,0 +1,159 @@
+name: Prepare release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version without the v prefix (for example, 0.7.0)
+        required: true
+        type: string
+      source:
+        description: devel for a monthly release, main for a current-line hotfix
+        required: true
+        default: devel
+        type: choice
+        options:
+          - devel
+          - main
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: prepare-release
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out release source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source }}
+          fetch-depth: 0
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+
+      - name: Validate release request
+        id: release
+        env:
+          SOURCE: ${{ inputs.source }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          python - <<'PY'
+          import os
+          import re
+          import tomllib
+
+          source = os.environ["SOURCE"]
+          version = os.environ["VERSION"]
+          match = re.fullmatch(r"(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)", version)
+          if match is None:
+              raise SystemExit("version must be a three-part release such as 0.7.0")
+          patch = int(match.group(3))
+          if source == "devel" and patch != 0:
+              raise SystemExit("monthly releases from devel must have a zero patch component")
+          if source == "main" and patch == 0:
+              raise SystemExit("hotfix releases from main must have a non-zero patch component")
+
+          with open("pyproject.toml", "rb") as stream:
+              current = tomllib.load(stream)["project"]["version"]
+          current_match = re.fullmatch(r"(\d+)\.(\d+)\.(\d+)", current)
+          if current_match is None:
+              raise SystemExit(f"current project version is not a release: {current}")
+          current_parts = tuple(map(int, current_match.groups()))
+          requested_parts = tuple(map(int, match.groups()))
+          if requested_parts <= current_parts:
+              raise SystemExit(f"requested version {version} must be newer than {current}")
+          if source == "main" and requested_parts[:2] != current_parts[:2]:
+              raise SystemExit("a current-line hotfix must retain the main major and minor version")
+          PY
+          echo "branch=release/v${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Refuse an existing release branch or tag
+        env:
+          BRANCH: ${{ steps.release.outputs.branch }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "Branch $BRANCH already exists."
+            exit 1
+          fi
+          if git ls-remote --exit-code --tags origin "refs/tags/v${VERSION}" >/dev/null 2>&1; then
+            echo "Tag v${VERSION} already exists."
+            exit 1
+          fi
+
+      - name: Assemble release commit
+        env:
+          BRANCH: ${{ steps.release.outputs.branch }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          git switch -c "$BRANCH"
+          python - <<'PY'
+          import os
+          import re
+          from pathlib import Path
+
+          path = Path("pyproject.toml")
+          content = path.read_text(encoding="utf-8")
+          updated, count = re.subn(
+              r'(?m)^(version = ")[^"]+("\s*)$',
+              rf'\g<1>{os.environ["VERSION"]}\g<2>',
+              content,
+              count=1,
+          )
+          if count != 1:
+              raise SystemExit("could not update the project version")
+          path.write_text(updated, encoding="utf-8")
+          PY
+          uvx --from 'towncrier>=24.8' towncrier build --version "$VERSION" --yes
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -- pyproject.toml CHANGELOG.md newsfragments
+          git commit -m "Prepare release ${VERSION}"
+          git push --set-upstream origin "$BRANCH"
+
+      - name: Open release pull request
+        id: pull-request
+        env:
+          BRANCH: ${{ steps.release.outputs.branch }}
+          GH_TOKEN: ${{ github.token }}
+          SOURCE: ${{ inputs.source }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          {
+            echo "## Release candidate ${VERSION}"
+            echo
+            echo "Prepared automatically from \`${SOURCE}\`."
+            echo
+            echo "- [ ] CI Gate passes for the final main commit"
+            echo "- [ ] HPC / test_inversions is recorded for the final main commit"
+            echo "- [ ] Scientific output review is approved"
+            echo "- [ ] Publish GitHub release \`v${VERSION}\` only after those gates pass"
+          } > "$RUNNER_TEMP/release-pr.md"
+          URL=$(gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "Release ${VERSION}" \
+            --body-file "$RUNNER_TEMP/release-pr.md")
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+
+      # Pull requests created with GITHUB_TOKEN do not emit another workflow run.
+      - name: Dispatch CI for the release commit
+        env:
+          BRANCH: ${{ steps.release.outputs.branch }}
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run workflow.yaml --ref "$BRANCH"
+
+      - name: Summarize
+        env:
+          URL: ${{ steps.pull-request.outputs.url }}
+        run: |
+          echo "Release PR: $URL" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -3,10 +3,22 @@ name: Publish to PyPI
 on:
   release:
     types: [published]
-  workflow_dispatch:  # Allow manual triggering
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version without the v prefix; publishes the current main commit
+        required: true
+        type: string
 
 permissions:
+  actions: write
   contents: read
+  checks: read
+  statuses: read
+
+concurrency:
+  group: publish-release
+  cancel-in-progress: false
 
 jobs:
   build-and-publish:
@@ -15,10 +27,17 @@ jobs:
       name: pypi
       url: https://pypi.org/p/openghg-inversions
     permissions:
+      actions: write
       id-token: write  # Required for trusted publishing
+      contents: write
+      checks: read
+      statuses: read
     
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && 'main' || github.ref }}
+          fetch-depth: 0
       
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
@@ -30,9 +49,32 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Verify Towncrier release notes were assembled
+      - name: Verify release metadata and exact-commit gates
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_VERSION: ${{ inputs.version }}
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION=$REQUESTED_VERSION
+          else
+            VERSION="${GITHUB_REF_NAME#v}"
+          fi
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Release versions must look like 0.7.0."
+            exit 1
+          fi
+          PACKAGE_VERSION=$(python - <<'PY'
+          import tomllib
+
+          with open("pyproject.toml", "rb") as stream:
+              print(tomllib.load(stream)["project"]["version"])
+          PY
+          )
+          if [ "$PACKAGE_VERSION" != "$VERSION" ]; then
+            echo "Requested version ${VERSION} does not match package version ${PACKAGE_VERSION}."
+            exit 1
+          fi
           if find newsfragments -maxdepth 1 -type f ! -name '.gitkeep' ! -name 'template.md' -print -quit | grep -q .; then
             echo "Unassembled Towncrier fragments found; run 'towncrier build --version ${VERSION}' and commit CHANGELOG.md before creating the release."
             exit 1
@@ -41,9 +83,64 @@ jobs:
             echo "CHANGELOG.md has no Towncrier entry for ${VERSION}."
             exit 1
           }
+
+          SHA=$(git rev-parse HEAD)
+          CI_RESULT=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${SHA}/check-runs" \
+            --jq '[.check_runs[] | select(.name == "CI Gate")] | sort_by(.completed_at) | last | .conclusion // ""')
+          if [ "$CI_RESULT" != "success" ]; then
+            echo "CI Gate is not successful for exact release commit ${SHA}: ${CI_RESULT:-missing}."
+            exit 1
+          fi
+
+          HPC_RESULT=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${SHA}/status" \
+            --jq '[.statuses[] | select(.context == "HPC / test_inversions")] | sort_by(.updated_at) | last | .state // ""')
+          if [ "$HPC_RESULT" != "success" ]; then
+            echo "HPC / test_inversions is not successful for exact release commit ${SHA}: ${HPC_RESULT:-missing}."
+            exit 1
+          fi
+          {
+            echo "sha=$SHA"
+            echo "tag=v$VERSION"
+            echo "version=$VERSION"
+          } >> "$GITHUB_OUTPUT"
       
       - name: Build package
         run: uv build
+
+      - name: Smoke-test the built wheel
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          uv venv "$RUNNER_TEMP/release-smoke"
+          uv pip install --python "$RUNNER_TEMP/release-smoke/bin/python" dist/*.whl
+          EXPECTED_VERSION="$VERSION" "$RUNNER_TEMP/release-smoke/bin/python" - <<'PY'
+          import os
+          from importlib.metadata import version
+
+          installed = version("openghg_inversions")
+          expected = os.environ["EXPECTED_VERSION"]
+          if installed != expected:
+              raise SystemExit(f"installed wheel version {installed} does not match {expected}")
+          import openghg_inversions  # noqa: F401
+          PY
       
       - name: Publish to PyPI
         run: uv publish --trusted-publishing always
+
+      - name: Create GitHub release for an automated publication
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHA: ${{ steps.release.outputs.sha }}
+          TAG: ${{ steps.release.outputs.tag }}
+        run: gh release create "$TAG" --target "$SHA" --title "$TAG" --generate-notes
+
+      # Release events created by GITHUB_TOKEN do not trigger other workflows.
+      - name: Dispatch release follow-up workflows
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          gh workflow run release-follow-up.yaml -f tag="$TAG"
+          gh workflow run docs.yaml --ref "$TAG"

--- a/.github/workflows/pull-request-maintenance.yaml
+++ b/.github/workflows/pull-request-maintenance.yaml
@@ -1,0 +1,198 @@
+name: Pull request maintenance
+
+on:
+  schedule:
+    - cron: '30 9 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: pull-request-maintenance
+  cancel-in-progress: false
+
+jobs:
+  sync-devel:
+    name: Remind and opt-in sync feature PRs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Inspect open pull requests targeting devel
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const marker = "<!-- devel-sync-reminder -->";
+            const labels = {
+              sync: {
+                name: "needs-devel-sync",
+                color: "fbca04",
+                description: "The pull request branch is behind devel",
+              },
+              auto: {
+                name: "auto-sync-devel",
+                color: "0e8a16",
+                description: "Allow the weekly workflow to update this branch from devel",
+              },
+              conflict: {
+                name: "devel-sync-conflict",
+                color: "d73a4a",
+                description: "Automatic synchronization with devel needs human conflict resolution",
+              },
+            };
+
+            for (const label of Object.values(labels)) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name: label.name });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+                await github.rest.issues.createLabel({ owner, repo, ...label });
+              }
+            }
+
+            const pulls = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: "open",
+              base: "devel",
+              per_page: 100,
+            });
+            const base = await github.rest.repos.getBranch({ owner, repo, branch: "devel" });
+            const summary = [];
+
+            for (const pull of pulls) {
+              const comparison = await github.rest.repos.compareCommits({
+                owner,
+                repo,
+                base: pull.head.sha,
+                head: base.data.commit.sha,
+              });
+              const behind = comparison.data.ahead_by;
+              const names = new Set(pull.labels.map((label) => label.name));
+
+              if (behind === 0) {
+                if (names.has(labels.sync.name)) {
+                  await github.rest.issues.removeLabel({
+                    owner,
+                    repo,
+                    issue_number: pull.number,
+                    name: labels.sync.name,
+                  });
+                }
+                if (names.has(labels.conflict.name)) {
+                  await github.rest.issues.removeLabel({
+                    owner,
+                    repo,
+                    issue_number: pull.number,
+                    name: labels.conflict.name,
+                  });
+                }
+                summary.push(`- #${pull.number}: up to date`);
+                continue;
+              }
+
+              if (!names.has(labels.sync.name)) {
+                await github.rest.issues.addLabels({
+                  owner,
+                  repo,
+                  issue_number: pull.number,
+                  labels: [labels.sync.name],
+                });
+              }
+
+              const sameRepository = pull.head.repo?.full_name === `${owner}/${repo}`;
+              const autoSync = sameRepository && names.has(labels.auto.name);
+              let outcome = "reminder sent";
+              if (autoSync) {
+                try {
+                  await github.rest.pulls.updateBranch({
+                    owner,
+                    repo,
+                    pull_number: pull.number,
+                    expected_head_sha: pull.head.sha,
+                  });
+                  outcome = "automatic update requested";
+                  if (names.has(labels.conflict.name)) {
+                    await github.rest.issues.removeLabel({
+                      owner,
+                      repo,
+                      issue_number: pull.number,
+                      name: labels.conflict.name,
+                    });
+                  }
+                } catch (error) {
+                  if (![409, 422].includes(error.status)) throw error;
+                  outcome = "automatic update needs conflict resolution";
+                  await github.rest.issues.addLabels({
+                    owner,
+                    repo,
+                    issue_number: pull.number,
+                    labels: [labels.conflict.name],
+                  });
+                }
+              }
+
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number: pull.number,
+                per_page: 100,
+              });
+              const existing = comments.find(
+                (comment) => comment.user?.login === "github-actions[bot]" && comment.body?.includes(marker),
+              );
+              const forkNote = sameRepository
+                ? "Add the `auto-sync-devel` label to opt into clean automatic updates."
+                : "This branch is in a fork, so it must be updated by its contributor.";
+              const body = `${marker}\nThis branch is behind \`devel\`. ${forkNote}\n\n` +
+                "This comment is updated in place by the weekly maintenance workflow.";
+              if (existing) {
+                if (existing.body !== body) {
+                  await github.rest.issues.updateComment({
+                    owner,
+                    repo,
+                    comment_id: existing.id,
+                    body,
+                  });
+                }
+              } else {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: pull.number,
+                  body,
+                });
+              }
+              summary.push(`- #${pull.number}: ${behind} behind; ${outcome}`);
+            }
+
+            await core.summary
+              .addHeading("Feature PR synchronization")
+              .addRaw(summary.length ? summary.join("\n") : "No open PRs target devel.")
+              .write();
+
+  stale:
+    name: Warn and close inactive pull requests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v10
+        with:
+          repo-token: ${{ github.token }}
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          days-before-pr-stale: 30
+          days-before-pr-close: 14
+          stale-pr-label: stale
+          exempt-pr-labels: keep-open
+          stale-pr-message: >-
+            This pull request has had no activity for 30 days. It will be closed
+            after another 14 days unless work resumes or `keep-open` is applied.
+          close-pr-message: >-
+            Closing after the inactivity grace period. The branch has not been
+            deleted, and this pull request can be reopened when work resumes.
+          remove-pr-stale-when-updated: true
+          delete-branch: false
+          operations-per-run: 1000

--- a/.github/workflows/record-hpc-release-check.yaml
+++ b/.github/workflows/record-hpc-release-check.yaml
@@ -1,0 +1,129 @@
+name: Record HPC release check
+
+on:
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: Full openghg_inversions commit SHA tested on HPC
+        required: true
+        type: string
+      state:
+        description: Reviewed outcome
+        required: true
+        type: choice
+        options:
+          - success
+          - failure
+          - error
+      evidence_url:
+        description: HTTPS URL for the compact hpc-ci evidence and scientific review
+        required: true
+        type: string
+      description:
+        description: Short result summary
+        required: true
+        type: string
+  repository_dispatch:
+    types: [hpc-test-inversions-result]
+
+permissions:
+  contents: read
+  statuses: write
+
+concurrency:
+  group: hpc-release-review-${{ github.event.client_payload.sha || inputs.sha }}
+  cancel-in-progress: false
+
+jobs:
+  record:
+    environment: hpc-release-review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read and validate attestation
+        id: attestation
+        env:
+          DISPATCH_DESCRIPTION: ${{ github.event.client_payload.description }}
+          DISPATCH_EVIDENCE_URL: ${{ github.event.client_payload.evidence_url }}
+          DISPATCH_SHA: ${{ github.event.client_payload.sha }}
+          DISPATCH_STATE: ${{ github.event.client_payload.state }}
+          MANUAL_DESCRIPTION: ${{ inputs.description }}
+          MANUAL_EVIDENCE_URL: ${{ inputs.evidence_url }}
+          MANUAL_SHA: ${{ inputs.sha }}
+          MANUAL_STATE: ${{ inputs.state }}
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = "repository_dispatch" ]; then
+            SHA=$DISPATCH_SHA
+            STATE=$DISPATCH_STATE
+            EVIDENCE_URL=$DISPATCH_EVIDENCE_URL
+            DESCRIPTION=$DISPATCH_DESCRIPTION
+          else
+            SHA=$MANUAL_SHA
+            STATE=$MANUAL_STATE
+            EVIDENCE_URL=$MANUAL_EVIDENCE_URL
+            DESCRIPTION=$MANUAL_DESCRIPTION
+          fi
+
+          if ! [[ "$SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "A full lowercase commit SHA is required."
+            exit 1
+          fi
+          case "$STATE" in
+            success|failure|error) ;;
+            *) echo "Unsupported status state: $STATE"; exit 1 ;;
+          esac
+          if ! [[ "$EVIDENCE_URL" =~ ^https:// ]] || [[ "$EVIDENCE_URL" == *$'\n'* ]] || [[ "$EVIDENCE_URL" == *$'\r'* ]]; then
+            echo "The evidence URL must use HTTPS."
+            exit 1
+          fi
+          if [ -z "$DESCRIPTION" ] || [ "${#DESCRIPTION}" -gt 140 ] || [[ "$DESCRIPTION" == *$'\n'* ]] || [[ "$DESCRIPTION" == *$'\r'* ]]; then
+            echo "The description must contain 1-140 characters."
+            exit 1
+          fi
+
+          git fetch origin main
+          git cat-file -e "${SHA}^{commit}"
+          if ! git merge-base --is-ancestor "$SHA" origin/main; then
+            echo "$SHA is not part of the current main history."
+            exit 1
+          fi
+
+          {
+            echo "sha=$SHA"
+            echo "state=$STATE"
+            echo "evidence_url=$EVIDENCE_URL"
+            echo "description=$DESCRIPTION"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Record exact-commit HPC status
+        env:
+          DESCRIPTION: ${{ steps.attestation.outputs.description }}
+          EVIDENCE_URL: ${{ steps.attestation.outputs.evidence_url }}
+          GH_TOKEN: ${{ github.token }}
+          SHA: ${{ steps.attestation.outputs.sha }}
+          STATE: ${{ steps.attestation.outputs.state }}
+        run: |
+          gh api \
+            --method POST \
+            "repos/${GITHUB_REPOSITORY}/statuses/${SHA}" \
+            -f state="$STATE" \
+            -f context='HPC / test_inversions' \
+            -f target_url="$EVIDENCE_URL" \
+            -f description="$DESCRIPTION"
+
+      - name: Summarize
+        env:
+          EVIDENCE_URL: ${{ steps.attestation.outputs.evidence_url }}
+          SHA: ${{ steps.attestation.outputs.sha }}
+          STATE: ${{ steps.attestation.outputs.state }}
+        run: |
+          {
+            echo "### HPC / test_inversions"
+            echo "- Commit: \`$SHA\`"
+            echo "- Reviewed status: \`$STATE\`"
+            echo "- Evidence: $EVIDENCE_URL"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-follow-up.yaml
+++ b/.github/workflows/release-follow-up.yaml
@@ -1,0 +1,104 @@
+name: Forward released main to devel
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Published release tag
+        required: true
+        type: string
+
+permissions:
+  checks: read
+  contents: write
+  pull-requests: write
+  statuses: read
+
+concurrency:
+  group: release-follow-up
+  cancel-in-progress: false
+
+jobs:
+  forward-port:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Open or reuse main to devel pull request
+        id: pull-request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          REQUESTED_TAG: ${{ inputs.tag }}
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            TAG=$REQUESTED_TAG
+          else
+            TAG=$RELEASE_TAG
+          fi
+          if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Release tags must look like v0.7.0."
+            exit 1
+          fi
+          SHA=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${TAG}" --jq '.sha')
+          CI_RESULT=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${SHA}/check-runs" \
+            --jq '[.check_runs[] | select(.name == "CI Gate")] | sort_by(.completed_at) | last | .conclusion // ""')
+          HPC_RESULT=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${SHA}/status" \
+            --jq '[.statuses[] | select(.context == "HPC / test_inversions")] | sort_by(.updated_at) | last | .state // ""')
+          if [ "$CI_RESULT" != "success" ] || [ "$HPC_RESULT" != "success" ]; then
+            echo "Release follow-up requires successful CI and HPC gates on ${SHA}."
+            exit 1
+          fi
+          AHEAD=$(gh api "repos/${GITHUB_REPOSITORY}/compare/devel...main" --jq '.ahead_by')
+          if [ "$AHEAD" -eq 0 ]; then
+            {
+              echo "needed=false"
+              echo "tag=$TAG"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          URL=$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --base devel \
+            --head main \
+            --state open \
+            --json url \
+            --jq '.[0].url // ""')
+          if [ -z "$URL" ]; then
+            URL=$(gh pr create \
+              --repo "$GITHUB_REPOSITORY" \
+              --base devel \
+              --head main \
+              --title "Forward-port ${TAG} to devel" \
+              --body "Keep the integration branch on the released main history. Created automatically after ${TAG} was published.")
+          fi
+          {
+            echo "needed=true"
+            echo "url=$URL"
+            echo "tag=$TAG"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Enable auto-merge when repository rules allow it
+        if: steps.pull-request.outputs.needed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          URL: ${{ steps.pull-request.outputs.url }}
+        run: gh pr merge --auto --merge "$URL" || echo "Auto-merge is unavailable; the PR remains open."
+
+      - name: Delete the short-lived release branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.pull-request.outputs.tag }}
+        run: |
+          VERSION=${TAG#v}
+          REF="heads/release/v${VERSION}"
+          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/${REF}" >/dev/null 2>&1; then
+            gh api --method DELETE "repos/${GITHUB_REPOSITORY}/git/refs/${REF}"
+          fi
+
+      - name: Summarize
+        if: steps.pull-request.outputs.needed == 'true'
+        env:
+          URL: ${{ steps.pull-request.outputs.url }}
+        run: |
+          echo "Forward-port PR: $URL" >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Repository Guidance
+
+## Work Tracking
+
+Linear is the sole task tracker for this repository.
+
+- For issue IDs such as `OPE-17`, use the Linear MCP integration.
+- Never use agent-tracker or its `task-worker`, `project-manager`, or
+  `agent-coordinator` workflows.
+- If Linear MCP is unavailable or the issue cannot be found, stop and ask; do
+  not fall back to another tracker.

--- a/README.md
+++ b/README.md
@@ -525,13 +525,19 @@ which will pass the positional argument "openghg_inversions/hbmcmc" to the comma
 
 ### Using branches
 
-To contribute new code, make a branch off of the `devel` branch.
-When your code is ready to be added, push it to github (`origin`).
-You can then open a "pull request" on github and request a code review.
-It's helpful to write a description of the changes made in your PR, as well as linking to any relevant issues.
+Published PyPI packages and tagged releases are the supported installation
+targets. The `devel` branch is unsupported integration for the next monthly
+release; users should not run scientific work from it.
 
-Your code must past the tests and be reviewed before it can be merged.
-After this, you can merge your branch and close it (it can always be recovered later if necessary).
+Contributors create feature branches from `devel` and merge only release-ready
+changes through reviewed pull requests. Active feature PRs are checked weekly
+for drift from `devel`; same-repository PRs can opt into clean automatic updates
+with the `auto-sync-devel` label. Current-line hotfixes start from `main`, are
+released as patch versions, and are then forwarded to `devel`.
+
+See the [release and branch maintenance guide](docs/development/releasing.rst)
+for the automated monthly release, HPC approval, hotfix, synchronization, and
+stale-PR workflows.
 
 ## Citation and contributors
 

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -9,3 +9,4 @@ development. They are normative for new RHIME work.
 
    rhime_model_development
    validation_and_xarray
+   releasing

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -1,0 +1,148 @@
+Releases and branch maintenance
+===============================
+
+OpenGHG Inversions supports published PyPI packages and tagged releases. The
+``devel`` branch is an unsupported integration branch: users should not depend
+on it for scientific work.
+
+Branch roles
+------------
+
+``main``
+   The current stable release line. Current-line hotfixes start here. We do not
+   maintain branches for older minor releases.
+
+``devel``
+   Integration for the next monthly release. Only reviewed, release-ready
+   changes merge here.
+
+``feature/*``
+   Work that is not ready to release. Open a draft pull request for visibility.
+   Feature branches track ``devel`` only; do not merge both ``main`` and
+   ``devel`` into them.
+
+``release/vX.Y.Z``
+   A short-lived branch created by the release-preparation workflow. It is
+   deleted after publication.
+
+``hotfix/X.Y.Z-description``
+   A short-lived fix branch from ``main``. A tag is immutable and cannot be a
+   pull-request target. While 0.6 is current, for example, a 0.6 hotfix targets
+   ``main`` rather than ``v0.6.0``.
+
+Monthly release
+---------------
+
+The monthly reminder opens a tracking issue on the first Monday of each month.
+From the Actions page, run **Prepare release** with the next minor version and
+``source=devel``. The workflow:
+
+* creates ``release/vX.Y.0``;
+* updates ``pyproject.toml``;
+* assembles Towncrier fragments into ``CHANGELOG.md``;
+* commits and pushes the result;
+* opens a pull request to ``main``; and
+* dispatches ordinary CI for the generated commit.
+
+``devel`` remains open while the release pull request is stabilized. Apply a
+release-blocking fix to the release branch and ``devel``; do not leave a fix on
+only one side.
+
+After the release pull request merges, run the real-data ``test_inversions``
+suite on the exact resulting ``main`` commit. The local tests marked ``slow``
+are development contracts, not a substitute for this release assessment.
+
+HPC evidence and scientific approval
+------------------------------------
+
+The external ``hpc-ci`` tool pins the tested Git SHA and collects compact
+evidence. For a release pull request, its manual trigger can fetch the PR ref;
+for the final merged commit, pass an explicit ``main`` ref and verify that the
+reported SHA matches ``git rev-parse origin/main``. Keep the ``hpc-ci``
+collection, configuration/data identity, Slurm job references, summaries and
+interpretable scientific outputs together.
+
+Upload or link the compact evidence somewhere reachable by HTTPS, normally the
+release tracking issue or release pull request. A maintainer reviews the real
+results and runs **Record HPC release check** with:
+
+* the full tested commit SHA;
+* the reviewed outcome;
+* the HTTPS evidence link; and
+* a short summary.
+
+The workflow refuses commits outside ``main`` history and records the fixed
+``HPC / test_inversions`` status against that exact SHA. Configure the
+``hpc-release-review`` GitHub environment with required reviewers so both
+manual attestations and future ``hpc-ci`` ``repository_dispatch`` callbacks
+pause for scientific approval.
+
+Publication
+-----------
+
+Run **Publish to PyPI** with the version on the approved ``main`` commit. The
+workflow refuses to publish unless:
+
+* the requested version, ``pyproject.toml`` and Towncrier heading agree;
+* no unassembled news fragments remain;
+* ``CI Gate`` succeeded on the exact commit;
+* ``HPC / test_inversions`` succeeded on the same commit; and
+* the protected ``pypi`` environment is approved.
+
+It builds and clean-installs the wheel, checks the installed metadata version,
+publishes through PyPI trusted publishing, creates the GitHub release, rebuilds
+the released documentation, and opens a ``main`` to ``devel`` forward-port
+pull request. Auto-merge is enabled when repository settings and required
+checks allow it. The release branch is deleted only after publication.
+
+If automated publication fails after PyPI accepts the artifact, do not publish
+the same version again. Create the missing GitHub release for that tag and run
+**Forward released main to devel** manually. If it fails before PyPI accepts
+the artifact, correct the workflow or release commit, rerun the exact-SHA
+tests when the commit changes, and dispatch publication again.
+
+Current-line hotfix
+-------------------
+
+For an urgent bug affecting the published version:
+
+#. Create ``hotfix/X.Y.Z-description`` from ``main``.
+#. Add the fix, a focused regression test, and a Towncrier bugfix fragment.
+#. Merge the reviewed pull request to ``main``.
+#. Run **Prepare release** with the patch version and ``source=main``.
+#. Merge the generated release pull request.
+#. Run and scientifically review ``test_inversions`` on the final ``main`` SHA.
+#. Record the HPC check and run **Publish to PyPI**.
+#. Confirm that the automatic ``main`` to ``devel`` pull request merges.
+
+Once ``main`` advances to a new minor version, the older minor is unsupported.
+Do not create a maintenance branch without first changing this policy.
+
+Feature drift and inactive pull requests
+----------------------------------------
+
+Every Monday, **Pull request maintenance** checks open pull requests targeting
+``devel``. A branch behind ``devel`` receives ``needs-devel-sync`` and one bot
+comment that is updated in place. Apply ``auto-sync-devel`` to a same-repository
+pull request to opt into GitHub's clean update-branch operation. Conflicts get
+``devel-sync-conflict`` and remain for a person to resolve. Forks receive a
+reminder but are never mutated.
+
+Inactive pull requests receive ``stale`` after 30 days and close after another
+14 days. Activity removes the stale state. ``keep-open`` exempts a pull request.
+Closing never deletes its branch, and work can be reopened later.
+
+Manual fallbacks
+----------------
+
+Every automation leaves ordinary Git and GitHub operations available:
+
+* prepare a release branch locally, update the version, and run
+  ``towncrier build --version X.Y.Z --yes``;
+* open release and forward-port pull requests manually;
+* record the exact-SHA HPC status with the attestation workflow after uploading
+  evidence; and
+* create a GitHub release manually only after the same CI and HPC gates pass.
+
+Never bypass or recreate a successful PyPI publication. When a commit changes,
+its previous HPC result does not apply.

--- a/newsfragments/644.feature.md
+++ b/newsfragments/644.feature.md
@@ -1,0 +1,1 @@
+Add automated monthly release preparation, exact-commit HPC approval, guarded PyPI publication, current-line hotfix forwarding, and feature-PR maintenance workflows.

--- a/newsfragments/template.md
+++ b/newsfragments/template.md
@@ -1,9 +1,10 @@
+{{ "\n" }}
 {% for section, categories in sections.items() %}
 {% for category, fragments in categories.items() %}
 ### {{ definitions[category]["name"] }}
 
 {% for text, issues in fragments.items() %}
-- {{ text }}{% if issues %} ({{ issues|join(", ") }}){% endif %}
+- {{ text }}{% if issues %} ({{ issues|join(", ") }}){% endif %}{{ "\n" }}
 {% endfor %}
 {% endfor %}
 {% endfor %}

--- a/tests/test_full_inversion.py
+++ b/tests/test_full_inversion.py
@@ -183,63 +183,6 @@ def mcmc_args(
     return mcmc_args
 
 
-@pytest.fixture
-def satellite_mcmc_args(
-    tmp_path, satellite_ch4_data_args, southamerica_country_file, merged_data_dir, raw_data_path
-):
-    mcmc_args = satellite_ch4_data_args.copy()
-    mcmc_args.update(
-        {
-            "outputname": "satellite_test_run",
-            "outputpath": str(tmp_path),
-            "basis_algorithm": "quadtree",
-            "basis_output_path": str(tmp_path),
-            "nbasis": 4,
-            "nit": 1,
-            "burn": 0,
-            "tune": 0,
-            "nchain": 1,
-            "reload_merged_data": True,
-            "merged_data_dir": merged_data_dir,
-            "xprior": {"pdf": "normal", "mu": 1.0, "sigma": 1.0},
-            "bcprior": {"pdf": "normal", "mu": 1.0, "sigma": 1.0},
-            "sigprior": {"pdf": "uniform", "lower": 0.1, "upper": 10.0},
-            "bc_freq": "monthly",
-            "sigma_freq": "5D",
-            "sigma_per_site": True,
-            "averaging_error": False,
-            "min_error": 0.0,
-            "fix_basis_outer_regions": False,
-            "use_bc": True,
-            "nuts_sampler": "numpyro",
-            "save_trace": True,
-            "min_error_options": {"by_site": True},
-            "pollution_events_from_obs": True,
-            "no_model_error": False,
-            "reparameterise_log_normal": False,
-            "bc_basis_directory": raw_data_path / "satellite" / "bc_basis_directory",
-            "output_format": "paris",
-            "country_file": southamerica_country_file,
-        }
-    )
-    return mcmc_args
-
-
-@pytest.mark.slow
-def test_full_satellite_inversion(satellite_mcmc_args):
-    """Run the satellite/column PARIS path as a slower end-to-end smoke test."""
-    satellite_mcmc_args["reload_merged_data"] = False
-
-    out = fixedbasisMCMC(**satellite_mcmc_args)
-
-    assert "Yobs" in out
-    assert "Yobs_prior_factor" in out
-
-    # sanity check for modelled values to make sure baseline has correct order of magnitude
-    # Below checks are commented as the check passess for nit=100 and morebut fails for nit=1, which is used in this test to speed up the test. The check is not testing the MCMC itself but just that the modelled values are in the correct order of magnitude, which is not the main focus of this test.
-    # assert np.mean(np.abs(out.Yobs.values - out.Yapriori.values)) < 0.5 * np.mean(out.Yobs.values)
-
-
 def test_full_inversion(mcmc_args):
     """Run one real fixed-basis integration with current priors and NumPyro."""
     mcmc_args["reload_merged_data"] = False
@@ -288,18 +231,4 @@ def test_inversion_if_merged_data_does_not_exist(mcmc_args, deterministic_sample
     no merged data exists under the default merged data name.
     """
     mcmc_args["merged_data_name"] = None
-    fixedbasisMCMC(**mcmc_args)
-
-
-@pytest.mark.slow
-def test_full_inversion_long(mcmc_args):
-    mcmc_args.update(
-        {
-            "nbasis": 50,
-            "nit": 5000,
-            "burn": 2000,
-            "tune": 1000,
-            "nchain": 4,
-        }
-    )
     fixedbasisMCMC(**mcmc_args)


### PR DESCRIPTION
## Description

Implements the monthly release, current-line hotfix, and feature-branch maintenance plan from #644.

- prepares monthly and hotfix release PRs automatically, with version and Towncrier checks
- gates publication on the exact commit's `CI Gate` check and `HPC / test_inversions` status
- keeps scientific interpretation human-approved through the `hpc-release-review` environment
- builds and smoke-tests the wheel before trusted PyPI publication
- opens the post-release `main -> devel` forward-merge PR automatically
- adds monthly reminders, weekly feature drift handling, optional safe branch updates, and conservative stale-PR closure
- documents maintainer recovery paths and contributor branch guidance
- removes two obsolete historical slow inversion tests while retaining recent unique real-data contracts
- reconciles the existing `main`-only guidance commit into this branch so release PRs do not start from diverged histories

Closes #644.

## Validation

- `uv run pytest tests/test_full_inversion.py -q` — 5 passed
- `uv run ruff check tests/test_full_inversion.py`
- actionlint 1.7.12 across all six changed workflows
- YAML parsing and shell syntax checks for workflow run blocks
- JavaScript syntax checks for embedded `actions/github-script` programs
- Towncrier draft build
- `git diff --check`
- verified `main` is an ancestor of this branch

A strict repository-wide Sphinx build still reports pre-existing errors in `fixedbasisMCMC`, `inversion_output`, and `concrete_rhime_model.rst`, plus existing unresolved-reference warnings. The new release guide itself is read and written by Sphinx without emitting an error.

## Repository setup before enabling publication

- configure required maintainer reviewers on the `hpc-release-review` GitHub environment
- retain trusted publishing approval/secrets on the existing `pypi` environment
- optionally enable repository auto-merge for automatic conflict-free `main -> devel` follow-up PRs

## Review notes

The full release prerequisite is the external real-data HPC `test_inversions` run for an exact commit, with linked artifacts and human scientific interpretation. The removed local tests were older slow samplers; they are not treated as a substitute release gate.