### PR TITLE
Add version-aware PARIS output merge command

### DIFF
--- a/docs/usage/cli.rst
+++ b/docs/usage/cli.rst
@@ -147,3 +147,22 @@ into a multisector configuration. For new batch jobs, start from the RHIME
 template, use ``flux_sources`` for standard runs, and configure the sector
 sources described in :doc:`rhime` before selecting
 ``run-rhime-multisector``.
+
+Merging PARIS outputs
+---------------------
+
+Merge sequential annual or sub-annual PARIS NetCDF files with the installed
+CLI. The command detects legacy and latest PARIS concentration and flux
+templates from their schema:
+
+.. code-block:: console
+
+   $ openghg-inversions merge-paris-outputs \
+       SF6_EUROPE_PARIS_flux_2019-01-01.nc \
+       SF6_EUROPE_PARIS_flux_2020-01-01.nc \
+       --output SF6_EUROPE_PARIS_flux_2019-2020.nc
+
+Use ``--type flux`` or ``--type concentration`` to check the detected output
+type explicitly. Inputs to one invocation must use the same template version;
+run the command separately for legacy and latest products because their
+variable contracts differ.

--- a/docs/usage/cli.rst
+++ b/docs/usage/cli.rst
@@ -162,7 +162,7 @@ templates from their schema:
        SF6_EUROPE_PARIS_flux_2020-01-01.nc \
        --output SF6_EUROPE_PARIS_flux_2019-2020.nc
 
-Use ``--type flux`` or ``--type concentration`` to check the detected output
-type explicitly. Inputs to one invocation must use the same template version;
-run the command separately for legacy and latest products because their
-variable contracts differ.
+Use ``--type flux`` or ``--type concentration`` (also accepted as ``conc``) to
+select one product when a broad input glob matches both. Inputs selected for
+one invocation must use the same template version; run the command separately
+for legacy and latest products because their variable contracts differ.

--- a/newsfragments/+.feature.md
+++ b/newsfragments/+.feature.md
@@ -1,0 +1,1 @@
+Add a ``merge-paris-outputs`` CLI command that safely merges sequential legacy or latest PARIS flux and concentration files.

--- a/openghg_inversions/cli.py
+++ b/openghg_inversions/cli.py
@@ -47,6 +47,13 @@ def _run_rhime_multisector_command(args: argparse.Namespace) -> None:
     run_rhime_multisector(config_file=args.config, **_command_kwargs(args))
 
 
+def _merge_paris_outputs_command(args: argparse.Namespace) -> None:
+    """Merge sequential PARIS output files with lazy imports for fast help output."""
+    from openghg_inversions.postprocessing.merge_paris_outputs import merge_paris_outputs
+
+    merge_paris_outputs(args.input_files, args.output, output_type=args.type)
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build the OpenGHG inversions CLI argument parser.
 
@@ -65,6 +72,19 @@ def build_parser() -> argparse.ArgumentParser:
     )
     _add_run_args(run_multi_parser)
     run_multi_parser.set_defaults(func=_run_rhime_multisector_command)
+
+    merge_parser = subparsers.add_parser(
+        "merge-paris-outputs",
+        help="Merge sequential PARIS flux or concentration NetCDF outputs",
+    )
+    merge_parser.add_argument("input_files", nargs="+", help="PARIS NetCDF files to merge")
+    merge_parser.add_argument("-o", "--output", required=True, help="Merged NetCDF output path")
+    merge_parser.add_argument(
+        "--type",
+        choices=("flux", "concentration"),
+        help="Expected output type (auto-detected when omitted)",
+    )
+    merge_parser.set_defaults(func=_merge_paris_outputs_command)
 
     return parser
 

--- a/openghg_inversions/cli.py
+++ b/openghg_inversions/cli.py
@@ -51,7 +51,8 @@ def _merge_paris_outputs_command(args: argparse.Namespace) -> None:
     """Merge sequential PARIS output files with lazy imports for fast help output."""
     from openghg_inversions.postprocessing.merge_paris_outputs import merge_paris_outputs
 
-    merge_paris_outputs(args.input_files, args.output, output_type=args.type)
+    output_type = "concentration" if args.type == "conc" else args.type
+    merge_paris_outputs(args.input_files, args.output, output_type=output_type)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -81,8 +82,8 @@ def build_parser() -> argparse.ArgumentParser:
     merge_parser.add_argument("-o", "--output", required=True, help="Merged NetCDF output path")
     merge_parser.add_argument(
         "--type",
-        choices=("flux", "concentration"),
-        help="Expected output type (auto-detected when omitted)",
+        choices=("flux", "concentration", "conc"),
+        help="Output type to select (auto-detected when omitted; 'conc' is an alias)",
     )
     merge_parser.set_defaults(func=_merge_paris_outputs_command)
 

--- a/openghg_inversions/postprocessing/merge_paris_outputs.py
+++ b/openghg_inversions/postprocessing/merge_paris_outputs.py
@@ -1,0 +1,189 @@
+"""Merge sequential PARIS NetCDF outputs without losing template coordinates."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from contextlib import ExitStack
+from pathlib import Path
+from typing import Literal
+
+import numpy as np
+import xarray as xr
+
+ParisOutputType = Literal["flux", "concentration"]
+ParisTemplateVersion = Literal["legacy", "latest"]
+
+_PLATFORM_IDENTIFIER = "_platform_identifier"
+
+
+def _output_type(ds: xr.Dataset) -> ParisOutputType:
+    if {"latitude", "longitude"} <= set(ds.dims):
+        return "flux"
+    if "index" in ds.dims or {"time", "nsite"} <= set(ds.dims):
+        return "concentration"
+    raise ValueError("Could not identify the input as a PARIS flux or concentration output.")
+
+
+def _template_version(ds: xr.Dataset, output_type: ParisOutputType) -> ParisTemplateVersion:
+    if output_type == "concentration":
+        return "latest" if "index" in ds.dims else "legacy"
+    latest_names = {"flux_total_prior_country", "flux_total_posterior_country"}
+    return "latest" if latest_names & set(ds.data_vars) else "legacy"
+
+
+def _repair_duplicate_dimensions(ds: xr.Dataset) -> xr.Dataset:
+    """Give repeated covariance axes distinct names before xarray operations."""
+    result = ds
+    for name in list(ds.data_vars):
+        variable = ds[name].variable
+        if len(variable.dims) == len(set(variable.dims)):
+            continue
+
+        counts: dict[str, int] = {}
+        dimensions = []
+        repeated_coordinates: dict[str, tuple[str, np.ndarray]] = {}
+        for dimension in variable.dims:
+            counts[dimension] = counts.get(dimension, 0) + 1
+            replacement = dimension if counts[dimension] == 1 else f"{dimension}_{counts[dimension]}"
+            dimensions.append(replacement)
+            if replacement != dimension:
+                values = (
+                    np.asarray(ds[dimension].values)
+                    if dimension in ds.coords
+                    else np.arange(ds.sizes[dimension])
+                )
+                repeated_coordinates[replacement] = (replacement, values)
+
+        attrs = dict(variable.attrs)
+        encoding = dict(variable.encoding)
+        data = variable.data
+        result = result.drop_vars(name)
+        result[name] = xr.DataArray(data, dims=dimensions, attrs=attrs)
+        result[name].encoding = encoding
+        result = result.assign_coords(repeated_coordinates)
+
+    return result
+
+
+def _prepare_legacy_concentration(ds: xr.Dataset) -> xr.Dataset:
+    if "sitenames" not in ds.coords or ds["sitenames"].dims != ("nsite",):
+        raise ValueError("Legacy PARIS concentration outputs require sitenames(nsite).")
+    return ds.rename_vars(sitenames="nsite").set_xindex("nsite")
+
+
+def _restore_legacy_concentration(ds: xr.Dataset) -> xr.Dataset:
+    return ds.rename_vars(nsite="sitenames")
+
+
+def _prepare_latest_concentration(ds: xr.Dataset) -> xr.Dataset:
+    if "platform" not in ds.coords or "number_of_identifier" not in ds:
+        if "site" in ds.coords and ds["site"].dims == ("index",):
+            identifiers = np.asarray(ds["site"].values, dtype=str)
+            return ds.drop_vars("site").assign_coords(
+                {_PLATFORM_IDENTIFIER: ("index", identifiers)}
+            )
+        raise ValueError(
+            "Latest PARIS concentration outputs require platform(platform) and "
+            "number_of_identifier(index)."
+        )
+
+    platforms = np.asarray(ds["platform"].values, dtype=str)
+    indices = np.asarray(ds["number_of_identifier"].values)
+    if not np.issubdtype(indices.dtype, np.integer):
+        raise ValueError("number_of_identifier must contain integer platform indices.")
+    if np.any(indices < 0) or np.any(indices >= len(platforms)):
+        raise ValueError("number_of_identifier contains an out-of-range platform index.")
+
+    identifiers = platforms[indices]
+    return ds.drop_vars(["platform", "number_of_identifier"]).assign_coords(
+        {_PLATFORM_IDENTIFIER: ("index", identifiers)}
+    )
+
+
+def _restore_latest_concentration(ds: xr.Dataset, source: xr.Dataset) -> xr.Dataset:
+    identifiers = np.asarray(ds[_PLATFORM_IDENTIFIER].values, dtype=str)
+    platforms = list(dict.fromkeys(identifiers))
+    platform_indices = {platform: index for index, platform in enumerate(platforms)}
+
+    result = ds.drop_vars(_PLATFORM_IDENTIFIER)
+    result["number_of_identifier"] = (
+        "index",
+        np.asarray([platform_indices[value] for value in identifiers], dtype="int16"),
+    )
+    result = result.assign_coords(platform=("platform", np.asarray(platforms, dtype=object)))
+
+    if "number_of_identifier" in source:
+        result["number_of_identifier"].attrs = dict(source["number_of_identifier"].attrs)
+    if "platform" in source:
+        result["platform"].attrs = dict(source["platform"].attrs)
+    return result
+
+
+def merge_paris_outputs(
+    input_files: Sequence[str | Path],
+    output_file: str | Path,
+    *,
+    output_type: ParisOutputType | None = None,
+) -> Path:
+    """Merge PARIS files from one template version along their observation time axis.
+
+    The template version is detected from the dataset schema. All inputs must use
+    the same output type and template version; legacy and latest files can both be
+    merged, but their different variable contracts cannot be mixed in one output.
+    """
+    paths = [Path(path) for path in input_files]
+    if len(paths) < 2:
+        raise ValueError("At least two PARIS input files are required.")
+
+    output_path = Path(output_file)
+    with ExitStack() as stack:
+        datasets = [stack.enter_context(xr.open_dataset(path)) for path in paths]
+        detected_types = {_output_type(ds) for ds in datasets}
+        if len(detected_types) != 1:
+            raise ValueError("PARIS flux and concentration files cannot be merged together.")
+
+        detected_type = detected_types.pop()
+        if output_type is not None and detected_type != output_type:
+            raise ValueError(f"Inputs are {detected_type} outputs, not {output_type} outputs.")
+
+        versions = {_template_version(ds, detected_type) for ds in datasets}
+        if len(versions) != 1:
+            raise ValueError("PARIS files from different template versions cannot be mixed in one output.")
+        version = versions.pop()
+
+        repaired = [_repair_duplicate_dimensions(ds) for ds in datasets]
+        if detected_type == "concentration" and version == "legacy":
+            prepared = [_prepare_legacy_concentration(ds) for ds in repaired]
+            concat_dim = "time"
+        elif detected_type == "concentration":
+            prepared = [_prepare_latest_concentration(ds) for ds in repaired]
+            concat_dim = "index"
+        else:
+            prepared = repaired
+            concat_dim = "time"
+
+        country_fraction = None
+        if detected_type == "flux" and "country_fraction" in prepared[0]:
+            country_fraction = prepared[0]["country_fraction"]
+            prepared = [ds.drop_vars("country_fraction", errors="ignore") for ds in prepared]
+
+        merged = xr.concat(
+            prepared,
+            dim=concat_dim,
+            data_vars="minimal",
+            coords="minimal",
+            compat="equals",
+            join="outer",
+        ).sortby("time")
+
+        if detected_type == "concentration" and version == "legacy":
+            merged = _restore_legacy_concentration(merged)
+        elif detected_type == "concentration":
+            merged = _restore_latest_concentration(merged, datasets[0])
+        if country_fraction is not None:
+            merged["country_fraction"] = country_fraction
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        merged.to_netcdf(output_path)
+
+    return output_path

--- a/openghg_inversions/postprocessing/merge_paris_outputs.py
+++ b/openghg_inversions/postprocessing/merge_paris_outputs.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Sequence
 from contextlib import ExitStack
 from pathlib import Path
@@ -62,6 +63,11 @@ def _repair_duplicate_dimensions(ds: xr.Dataset) -> xr.Dataset:
         result[name].encoding = encoding
         result = result.assign_coords(repeated_coordinates)
 
+        if name == "covariance_flux_sectors_posterior_country":
+            result[name] = result[name].transpose("sector_2", "sector", "country", "time")
+        elif name.startswith("covariance_flux_") and name.endswith("_country"):
+            result[name] = result[name].transpose("country", "country_2", "time")
+
     return result
 
 
@@ -95,7 +101,7 @@ def _prepare_latest_concentration(ds: xr.Dataset) -> xr.Dataset:
         raise ValueError("number_of_identifier contains an out-of-range platform index.")
 
     identifiers = platforms[indices]
-    return ds.drop_vars(["platform", "number_of_identifier"]).assign_coords(
+    return ds.drop_vars(["platform", "number_of_identifier", "site"], errors="ignore").assign_coords(
         {_PLATFORM_IDENTIFIER: ("index", identifiers)}
     )
 
@@ -127,9 +133,10 @@ def merge_paris_outputs(
 ) -> Path:
     """Merge PARIS files from one template version along their observation time axis.
 
-    The template version is detected from the dataset schema. All inputs must use
-    the same output type and template version; legacy and latest files can both be
-    merged, but their different variable contracts cannot be mixed in one output.
+    The template version is detected from the dataset schema. When ``output_type``
+    is supplied, inputs of the other type are ignored so broad shell globs can be
+    reused. Selected inputs must share one template version; legacy and latest
+    files cannot be mixed in one output because their variable contracts differ.
     """
     paths = [Path(path) for path in input_files]
     if len(paths) < 2:
@@ -137,14 +144,33 @@ def merge_paris_outputs(
 
     output_path = Path(output_file)
     with ExitStack() as stack:
+        stack.enter_context(warnings.catch_warnings())
+        warnings.filterwarnings("ignore", message="Duplicate dimension names present")
         datasets = [stack.enter_context(xr.open_dataset(path)) for path in paths]
-        detected_types = {_output_type(ds) for ds in datasets}
-        if len(detected_types) != 1:
-            raise ValueError("PARIS flux and concentration files cannot be merged together.")
-
-        detected_type = detected_types.pop()
-        if output_type is not None and detected_type != output_type:
-            raise ValueError(f"Inputs are {detected_type} outputs, not {output_type} outputs.")
+        types = [_output_type(ds) for ds in datasets]
+        if output_type is not None:
+            selected = [
+                ds for ds, kind in zip(datasets, types) if kind == output_type
+            ]
+            if not selected:
+                raise ValueError(f"No {output_type} outputs were found in the input files.")
+            if len(selected) < 2:
+                raise ValueError(f"At least two {output_type} output files are required.")
+            datasets = selected
+            detected_type = output_type
+        else:
+            detected_types = set(types)
+            if len(detected_types) != 1:
+                flux_files = [path.name for path, kind in zip(paths, types) if kind == "flux"]
+                concentration_files = [
+                    path.name for path, kind in zip(paths, types) if kind == "concentration"
+                ]
+                raise ValueError(
+                    "PARIS flux and concentration files cannot be merged together. "
+                    f"Flux files: {flux_files}; concentration files: {concentration_files}. "
+                    "Pass --type flux or --type concentration to select one product from a broad glob."
+                )
+            detected_type = detected_types.pop()
 
         versions = {_template_version(ds, detected_type) for ds in datasets}
         if len(versions) != 1:

--- a/tests/postprocessing/test_merge_paris_outputs.py
+++ b/tests/postprocessing/test_merge_paris_outputs.py
@@ -126,8 +126,8 @@ def test_merge_repairs_repeated_latest_covariance_dimensions(tmp_path: Path) -> 
                 {
                     "flux_total_prior": (("time", "latitude", "longitude"), [[[1.0]]]),
                     "covariance_flux_total_posterior_country": (
-                        ("country", "country", "time"),
-                        np.ones((2, 2, 1)),
+                        ("time", "country", "country"),
+                        np.ones((1, 2, 2)),
                     ),
                 },
                 coords={
@@ -159,3 +159,21 @@ def test_merge_rejects_mixed_template_versions(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="different template versions"):
         merge_paris_outputs([legacy, latest], tmp_path / "merged.nc")
+
+
+def test_output_type_selects_concentrations_from_broad_inputs(tmp_path: Path) -> None:
+    first = tmp_path / "first-conc.nc"
+    second = tmp_path / "second-conc.nc"
+    flux = tmp_path / "flux.nc"
+    _write_legacy_concentration(first, "2020-01-01", ["MHD"], [1.0])
+    _write_legacy_concentration(second, "2021-01-01", ["MHD"], [2.0])
+    xr.Dataset(
+        {"flux_total_prior": (("time", "latitude", "longitude"), [[[3.0]]])},
+        coords={"time": [0], "latitude": [50.0], "longitude": [0.0]},
+    ).to_netcdf(flux)
+
+    output = tmp_path / "merged.nc"
+    merge_paris_outputs([first, flux, second], output, output_type="concentration")
+
+    with xr.open_dataset(output) as result:
+        assert result.Yobs.values[:, 0].tolist() == [1.0, 2.0]

--- a/tests/postprocessing/test_merge_paris_outputs.py
+++ b/tests/postprocessing/test_merge_paris_outputs.py
@@ -1,0 +1,161 @@
+"""Tests for merging sequential PARIS products."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from openghg_inversions.postprocessing.merge_paris_outputs import merge_paris_outputs
+
+
+def _write_legacy_concentration(path: Path, time: str, sites: list[str], values: list[float]) -> None:
+    xr.Dataset(
+        {"Yobs": (("time", "nsite"), [values])},
+        coords={"time": [np.datetime64(time)], "sitenames": ("nsite", sites)},
+    ).to_netcdf(path)
+
+
+def _write_latest_concentration(
+    path: Path,
+    times: list[str],
+    platforms: list[str],
+    identifiers: list[int],
+    values: list[float],
+) -> None:
+    xr.Dataset(
+        {
+            "mf_observed": ("index", values),
+            "number_of_identifier": ("index", np.asarray(identifiers, dtype="int16")),
+        },
+        coords={
+            "time": ("index", np.asarray(times, dtype="datetime64[ns]")),
+            "platform": ("platform", platforms),
+        },
+        attrs={"paris_concentration_template_version": "v04"},
+    ).to_netcdf(path)
+
+
+def test_merge_legacy_concentrations_aligns_sites_and_restores_sitenames(tmp_path: Path) -> None:
+    first = tmp_path / "first.nc"
+    second = tmp_path / "second.nc"
+    output = tmp_path / "merged.nc"
+    _write_legacy_concentration(first, "2020-01-01", ["MHD", "TAC"], [1.0, 2.0])
+    _write_legacy_concentration(second, "2021-01-01", ["TAC", "BSD"], [3.0, 4.0])
+
+    merge_paris_outputs([second, first], output, output_type="concentration")
+
+    with xr.open_dataset(output) as result:
+        assert "nsite" not in result.coords
+        assert result.sitenames.values.tolist() == ["BSD", "MHD", "TAC"]
+        np.testing.assert_array_equal(
+            result.Yobs.values,
+            [[np.nan, 1.0, 2.0], [4.0, np.nan, 3.0]],
+        )
+
+
+def test_merge_latest_concentrations_rebuilds_platform_lookup(tmp_path: Path) -> None:
+    first = tmp_path / "first.nc"
+    second = tmp_path / "second.nc"
+    output = tmp_path / "merged.nc"
+    _write_latest_concentration(
+        first,
+        ["2020-01-02", "2020-01-01"],
+        ["MHD-10", "TAC-100"],
+        [0, 1],
+        [2.0, 1.0],
+    )
+    _write_latest_concentration(
+        second,
+        ["2021-01-01", "2021-01-02"],
+        ["BSD-250", "MHD-10"],
+        [0, 1],
+        [3.0, 4.0],
+    )
+
+    merge_paris_outputs([second, first], output)
+
+    with xr.open_dataset(output) as result:
+        assert result.platform.values.tolist() == ["TAC-100", "MHD-10", "BSD-250"]
+        assert result.number_of_identifier.values.tolist() == [0, 1, 2, 1]
+        assert result.mf_observed.values.tolist() == [1.0, 2.0, 3.0, 4.0]
+        assert _platforms_for_observations(result) == ["TAC-100", "MHD-10", "BSD-250", "MHD-10"]
+        assert "_platform_identifier" not in result
+
+
+def _platforms_for_observations(ds: xr.Dataset) -> list[str]:
+    return np.asarray(ds.platform.values)[ds.number_of_identifier.values].tolist()
+
+
+def test_merge_fluxes_concatenates_time_but_not_static_country_fraction(tmp_path: Path) -> None:
+    paths = []
+    for year, value, country_fraction in ((2020, 1.0, 1.0), (2021, 2.0, 9.0)):
+        path = tmp_path / f"flux-{year}.nc"
+        xr.Dataset(
+            {
+                "flux_total_prior": (("time", "latitude", "longitude"), [[[value]]]),
+                "country_fraction": (
+                    ("country", "latitude", "longitude"),
+                    [[[country_fraction]]],
+                ),
+            },
+            coords={
+                "time": [np.datetime64(f"{year}-01-01")],
+                "latitude": [50.0],
+                "longitude": [0.0],
+                "country": ["GBR"],
+            },
+        ).to_netcdf(path)
+        paths.append(path)
+
+    output = tmp_path / "merged.nc"
+    merge_paris_outputs(paths, output, output_type="flux")
+
+    with xr.open_dataset(output) as result:
+        assert result.flux_total_prior.values[:, 0, 0].tolist() == [1.0, 2.0]
+        assert result.country_fraction.dims == ("country", "latitude", "longitude")
+        assert result.country_fraction.item() == 1.0
+
+
+def test_merge_repairs_repeated_latest_covariance_dimensions(tmp_path: Path) -> None:
+    paths = []
+    with pytest.warns(UserWarning, match="Duplicate dimension names"):
+        for year in (2020, 2021):
+            path = tmp_path / f"flux-{year}.nc"
+            xr.Dataset(
+                {
+                    "flux_total_prior": (("time", "latitude", "longitude"), [[[1.0]]]),
+                    "covariance_flux_total_posterior_country": (
+                        ("country", "country", "time"),
+                        np.ones((2, 2, 1)),
+                    ),
+                },
+                coords={
+                    "time": [np.datetime64(f"{year}-01-01")],
+                    "latitude": [50.0],
+                    "longitude": [0.0],
+                    "country": ["GBR", "IRL"],
+                },
+            ).to_netcdf(path)
+            paths.append(path)
+
+        output = tmp_path / "merged.nc"
+        merge_paris_outputs(paths, output)
+
+    with xr.open_dataset(output) as result:
+        assert result.covariance_flux_total_posterior_country.dims == (
+            "country",
+            "country_2",
+            "time",
+        )
+        assert result.country_2.values.tolist() == ["GBR", "IRL"]
+
+
+def test_merge_rejects_mixed_template_versions(tmp_path: Path) -> None:
+    legacy = tmp_path / "legacy.nc"
+    latest = tmp_path / "latest.nc"
+    _write_legacy_concentration(legacy, "2020-01-01", ["MHD"], [1.0])
+    _write_latest_concentration(latest, ["2021-01-01"], ["MHD-10"], [0], [2.0])
+
+    with pytest.raises(ValueError, match="different template versions"):
+        merge_paris_outputs([legacy, latest], tmp_path / "merged.nc")


### PR DESCRIPTION
* **Summary of changes**

  - add `openghg-inversions merge-paris-outputs` for sequential flux and concentration NetCDF products
  - align legacy site coordinates and rebuild latest-template platform lookup codes around concatenation
  - repair pre-fix repeated covariance axes to the current `(country, country_2, time)` PARIS contract
  - let `--type flux`, `--type concentration`, or `--type conc` select one product from a broad input glob
  - preserve the first static country-fraction mask, sort merged observations by time, document the CLI, and add a Towncrier fragment

* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx (no linked issue)
- [x] Tests added and passing
- [x] Documentation and tutorials updated/added
- [x] Added a Towncrier news fragment in `newsfragments/` for user-visible changes
- [x] No new requirements are needed

**Validation**

- `uv run pytest -q tests/postprocessing/test_merge_paris_outputs.py tests/postprocessing/test_make_paris_outputs.py` (14 passed)
- `uv run ruff check openghg_inversions/postprocessing/merge_paris_outputs.py openghg_inversions/cli.py tests/postprocessing/test_merge_paris_outputs.py`
- `git diff --check`
- created and validated 56 repaired flux and 56 repaired concentration copies from the reviewer’s SF6 PARIS NID2027 data
- merged all 112 repaired files from one broad glob with `--type conc` and `--type flux`; concentration result has 126,201 observations and flux result has 56 periods