### PR TITLE
OPE-87 bound multisource sensitivity memory

### DIFF
--- a/newsfragments/OPE-87.bugfix.md
+++ b/newsfragments/OPE-87.bugfix.md
@@ -1,0 +1,1 @@
+Project multisource sensitivities source by source, avoiding a state-by-grid temporary array that made large prepared-input builds exhaust memory.

--- a/openghg_inversions/basis/operators.py
+++ b/openghg_inversions/basis/operators.py
@@ -1009,17 +1009,33 @@ class MultiSourceBucketBasisOperator(BasisOperator):
     def sensitivity(self, fp_x_flux: xr.DataArray, fillna: bool = True) -> xr.DataArray:
         """Compute sensitivity for multisource fp_x_flux.
 
-        Overrides base method to broadcast the fp_x_flux `source` dim onto the gathered `state` dim.
+        Project each source separately before gathering the state axis. This
+        avoids broadcasting the full spatial cache across every retained state.
         """
         mat_aligned = force_align(self.basis_matrix, fp_x_flux, dims=list(self.meta.grid_dims))
         mat_aligned = mat_aligned.transpose(*self.meta.grid_dims, ...)
 
-        fp_on_state = self._align_source_like_state(fp_x_flux)
-
-        if fillna:
-            h = xr.dot(fp_on_state.fillna(0.0), mat_aligned, dim=list(self.meta.grid_dims)).as_numpy()
+        if self.source_dim in fp_x_flux.dims:
+            state_sources = np.asarray(mat_aligned[self.source_dim].values)
+            pieces = []
+            for source in self.source_labels:
+                source_flux = fp_x_flux.sel({self.source_dim: source}, drop=True)
+                if fillna:
+                    source_flux = source_flux.fillna(0.0)
+                pieces.append(
+                    xr.dot(
+                        source_flux,
+                        mat_aligned.isel(
+                            {self.meta.state_dim: np.flatnonzero(state_sources == source)}
+                        ),
+                        dim=list(self.meta.grid_dims),
+                    )
+                )
+            h = xr.concat(pieces, dim=self.meta.state_dim).as_numpy()
+        elif fillna:
+            h = xr.dot(fp_x_flux.fillna(0.0), mat_aligned, dim=list(self.meta.grid_dims)).as_numpy()
         else:
-            h = xr.dot(fp_on_state, mat_aligned, dim=list(self.meta.grid_dims)).as_numpy()
+            h = xr.dot(fp_x_flux, mat_aligned, dim=list(self.meta.grid_dims)).as_numpy()
 
         if self.meta.state_dim in h.dims:
             if "time" in h.dims:

--- a/tests/test_basis_functions.py
+++ b/tests/test_basis_functions.py
@@ -1845,7 +1845,8 @@ def test_multisector_ragged_new_matches_old_after_conversion(openghg_test_store)
     )
 
     H_new_gathered = multisector_bf.sensitivity(fp_all_sectoral[site].fp_x_flux_sectoral)
-    xr.testing.assert_allclose(H_new_gathered, H_old_gathered)
+    # Source-wise projection changes the float32 summation order over the grid.
+    xr.testing.assert_allclose(H_new_gathered, H_old_gathered, atol=2e-5)
 
 
 def _make_simple_state_trace(
@@ -2210,6 +2211,30 @@ def test_multisource_sensitivity_matches_legacy_padded_conversion_smoke():
     H_old_gathered = H_old_gathered.transpose("region", "time")
 
     xr.testing.assert_allclose(H_new, H_old_gathered)
+
+
+def test_multisource_sensitivity_projects_each_source_before_gathering(monkeypatch):
+    """Spatial caches must not be broadcast across the gathered state axis."""
+    sources = ["A", "B"]
+    basis = make_basis_flat_from_blocks([[1, 1], [2, 2]])
+    basis_functions = BasisFunctions.from_multi_source_flat_basis(
+        basis_flat={source: basis for source in sources},
+        flux=xr.ones_like(basis, dtype=float),
+        operator_kwargs={"state_dim": "region"},
+    )
+    fp_x_flux = make_fp_x_flux_sectoral(sources=sources, nlat=2, nlon=2, ntime=3)
+    original_dot = xr.dot
+    projected_dims = []
+
+    def checked_dot(left, right, *args, **kwargs):
+        projected_dims.append(left.dims)
+        return original_dot(left, right, *args, **kwargs)
+
+    monkeypatch.setattr(xr, "dot", checked_dot)
+    basis_functions.sensitivity(fp_x_flux)
+
+    assert len(projected_dims) == len(sources)
+    assert all("region" not in dims and "source" not in dims for dims in projected_dims)
 
 
 def test_basis_functions_from_fp_all_flat_basis(tac_ch4_data_args):


### PR DESCRIPTION
* **Summary of changes**

Project multisource footprint-times-flux sensitivities one source at a time before gathering the state axis. This avoids the state-by-grid temporary array that exhausted memory in the 25-site OPE-87 prepared-input build while preserving labels and numerical results. The legacy float32 comparison now has an explicit 2e-5 absolute tolerance for the changed reduction order (observed maximum delta 1.33e-5).

* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx (tracked by Linear OPE-87; no GitHub issue)
- [x] Tests added and passing (`125 passed` across basis function/operator suites)
- [ ] Documentation and tutorials updated/added (no public API change; method docstring updated)
- [x] Added a Towncrier news fragment in `newsfragments/` for user-visible changes
- [ ] Added any new requirements to `requirements.txt` (none)