### PR TITLE
Make documentation previews incremental

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -43,7 +43,7 @@ jobs:
           enable-cache: true
 
       - name: Build docs using tox
-        run: uvx --with tox-uv tox -e docs
+        run: uvx --with tox-uv tox -e docs-full
         
       - name: Show built docs (debug)
         run: |
@@ -65,8 +65,8 @@ jobs:
 
       - name: Fail if publish dir empty
         run: |
-          if [ ! -d docs/_build/ ] || [ -z "$(ls -A docs/_build/ 2>/dev/null)" ]; then
-            echo "ERROR: publish_dir docs/_build/ is empty or missing. Aborting deploy."
+          if [ ! -d docs/_build/html/ ] || [ -z "$(ls -A docs/_build/html/ 2>/dev/null)" ]; then
+            echo "ERROR: publish_dir docs/_build/html/ is empty or missing. Aborting deploy."
             exit 1
           fi
 
@@ -74,5 +74,5 @@ jobs:
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: docs/_build/
+          publish_dir: docs/_build/html/
           publish_branch: gh-pages

--- a/README.md
+++ b/README.md
@@ -42,18 +42,24 @@ pixi run -e dev docs-preview
 The `tox` Pixi task runs the fast default tox set (current OpenGHG plus Ruff)
 in parallel without an interactive spinner.
 
-The `docs-preview` task builds the Sphinx documentation with `tox -e docs`,
-serves it at `http://127.0.0.1:8765/`, and opens it in Safari on macOS. Keep the
-command running while reading the docs and press Ctrl-C to stop the server. To
-use another port or avoid opening Safari, run, for example:
+The `docs-preview` task incrementally builds the Sphinx documentation with
+`tox -e docs`, serves it at `http://127.0.0.1:8765/`, and opens it in Safari on
+macOS. Keep the command running while reading the docs and press Ctrl-C to stop
+the server. Each invocation builds once before starting the static server, so
+stop and rerun it after changing a source file. To use another port, avoid
+opening Safari, or discard Sphinx's cached doctrees before building, run, for
+example:
 
 ```bash
 pixi run -e dev docs-preview --port 8766 --no-open
+pixi run -e dev docs-preview --fresh
 ```
 
-Preview output is built in a temporary directory and removed when the server
-stops. `uv run python scripts/preview_docs.py clean` removes any legacy
-`docs/_build` output.
+Preview output and cached doctrees remain in the ignored `docs/_build`
+directory so later builds only rebuild changed pages. Regenerate the checked-in
+API reference pages separately with `pixi run -e dev tox -e docs-api` after
+changing the package layout. `uv run python scripts/preview_docs.py clean`
+removes all preview output without rebuilding it.
 
 The default uv group is intentionally limited to pytest and Ruff. To opt into
 the larger development group for documentation work, use:
@@ -61,6 +67,7 @@ the larger development group for documentation work, use:
 ```bash
 uv run --group uv_dev python scripts/preview_docs.py
 uv run --group uv_dev python scripts/preview_docs.py --port 8766 --no-open
+uv run --group uv_dev python scripts/preview_docs.py --fresh
 uv run python scripts/preview_docs.py clean
 ```
 

--- a/docs/usage/installation.rst
+++ b/docs/usage/installation.rst
@@ -37,18 +37,24 @@ tools used by the repository:
    pixi run -e dev tox
    pixi run -e dev docs-preview
 
-The ``docs-preview`` task builds the Sphinx documentation with ``tox -e docs``,
-serves it at ``http://127.0.0.1:8765/``, and opens it in Safari on macOS. Keep
-the task running while reading the docs and press Ctrl-C to stop the server.
-Use a different port or disable automatic browser opening if needed:
+The ``docs-preview`` task incrementally builds the Sphinx documentation with
+``tox -e docs``, serves it at ``http://127.0.0.1:8765/``, and opens it in Safari
+on macOS. Keep the task running while reading the docs and press Ctrl-C to stop
+the server. Each invocation builds once before starting the static server, so
+stop and rerun it after changing a source file. Use a different port, disable
+automatic browser opening, or discard Sphinx's cached doctrees before building
+if needed:
 
 .. code:: bash
 
    pixi run -e dev docs-preview --port 8766 --no-open
+   pixi run -e dev docs-preview --fresh
 
-Preview output is built in a temporary directory and removed when the server
-stops. ``uv run python scripts/preview_docs.py clean`` removes any legacy
-``docs/_build`` output.
+Preview output and cached doctrees remain in the ignored ``docs/_build``
+directory so later builds only rebuild changed pages. Regenerate the checked-in
+API reference pages separately with ``pixi run -e dev tox -e docs-api`` after
+changing the package layout. ``uv run python scripts/preview_docs.py clean``
+removes all preview output without rebuilding it.
 
 The default uv group is intentionally limited to pytest and Ruff. To opt into
 the larger development group for documentation work, use:
@@ -57,6 +63,7 @@ the larger development group for documentation work, use:
 
    uv run --group uv_dev python scripts/preview_docs.py
    uv run --group uv_dev python scripts/preview_docs.py --port 8766 --no-open
+   uv run --group uv_dev python scripts/preview_docs.py --fresh
    uv run python scripts/preview_docs.py clean
 
 To run the optional real country-file HDF5 smoke check on a machine that

--- a/newsfragments/629.misc.md
+++ b/newsfragments/629.misc.md
@@ -1,0 +1,1 @@
+Keep Sphinx's cached doctrees between local documentation previews, add a fresh-build option, and separate API reference generation from ordinary preview builds.

--- a/scripts/preview_docs.py
+++ b/scripts/preview_docs.py
@@ -1,13 +1,14 @@
-"""Build and locally preview the project's Sphinx documentation.
+"""Incrementally build and locally preview the project's Sphinx documentation.
 
-The ``preview`` command runs the repository's ``tox -e docs`` environment in
-a temporary directory before serving the generated HTML on the IPv4 loopback
-interface. The ``clean`` command removes legacy ``docs/_build`` output. On
-macOS the preview opens in Safari unless browser opening is disabled. The
-server runs until interrupted and does not expose the preview to other
-machines on the network. Call :func:`main` or run the script directly; the
-default port is 8765, ``--port`` overrides it, and ``--no-open`` suppresses
-Safari.
+The ``preview`` command runs the repository's ``tox -e docs`` environment and
+keeps Sphinx's cached doctrees in ``docs/_build`` for later builds. Pass
+``--fresh`` to discard that cache first. The ``clean`` command removes all
+generated documentation output. On macOS the preview opens in Safari unless
+browser opening is disabled. The server runs until interrupted and does not
+expose the preview to other machines on the network. Each invocation builds
+once before starting the static server; stop and rerun it after editing a
+source file. Call :func:`main` or run the script directly; the default port is
+8765, ``--port`` overrides it, and ``--no-open`` suppresses Safari.
 """
 
 from __future__ import annotations
@@ -21,14 +22,15 @@ from pathlib import Path
 import shutil
 import subprocess
 import sys
-import tempfile
 
 
 _DEFAULT_PORT = 8765
 _HOST = "127.0.0.1"
 _REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 _DOCS_DIRECTORY = _REPOSITORY_ROOT / "docs"
-_BUILD_DIRECTORY = _REPOSITORY_ROOT / "docs" / "_build"
+_BUILD_ROOT = _DOCS_DIRECTORY / "_build"
+# Jupyter-Sphinx writes notebook artifacts beside the HTML output directory.
+_BUILD_DIRECTORY = _BUILD_ROOT / "html"
 
 
 def _port(value: str) -> int:
@@ -40,7 +42,15 @@ def _port(value: str) -> int:
 
 
 def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
-    """Parse command-line arguments for the documentation preview."""
+    """Parse command-line arguments for the documentation preview.
+
+    Args:
+        argv: Arguments to parse, or ``None`` to read :data:`sys.argv`. An
+            omitted subcommand or an options-first invocation selects preview.
+
+    Returns:
+        Parsed preview or clean command arguments.
+    """
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="command")
     preview_parser = subparsers.add_parser("preview", help="build and serve the documentation")
@@ -55,6 +65,11 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
         action="store_true",
         help="do not open the preview in Safari on macOS",
     )
+    preview_parser.add_argument(
+        "--fresh",
+        action="store_true",
+        help="discard cached Sphinx output before building",
+    )
     subparsers.add_parser("clean", help="remove generated documentation output")
     arguments = list(sys.argv[1:] if argv is None else argv)
     if not arguments or arguments[0].startswith("-"):
@@ -64,20 +79,28 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
 
 def _clean_docs() -> None:
     """Remove the documentation build output without touching source files."""
-    shutil.rmtree(_BUILD_DIRECTORY, ignore_errors=True)
+    shutil.rmtree(_BUILD_ROOT, ignore_errors=True)
 
 
-def _build_docs(source_directory: Path, build_directory: Path) -> int:
-    """Build the HTML documentation and return the tox process exit code."""
+def _build_docs(source_directory: Path, build_root: Path) -> int:
+    """Build the HTML documentation through the repository's tox environment.
+
+    Args:
+        source_directory: Sphinx source directory passed through
+            ``DOCS_SOURCE_DIR``.
+        build_root: Persistent Sphinx build root passed through
+            ``DOCS_BUILD_DIR``.
+
+    Returns:
+        The tox process exit code.
+    """
     print("Building documentation with tox -e docs ...", flush=True)
     environment = {
         **os.environ,
         "DOCS_SOURCE_DIR": str(source_directory),
-        "DOCS_BUILD_DIR": str(build_directory),
+        "DOCS_BUILD_DIR": str(build_root),
     }
-    result = subprocess.run(
-        ["tox", "-e", "docs"], cwd=_REPOSITORY_ROOT, check=False, env=environment
-    )
+    result = subprocess.run(["tox", "-e", "docs"], cwd=_REPOSITORY_ROOT, check=False, env=environment)
     return result.returncode
 
 
@@ -97,14 +120,14 @@ def _serve_docs(port: int, *, open_safari: bool, build_directory: Path | None = 
     Args:
         port: TCP port to bind on the IPv4 loopback interface.
         open_safari: Whether to open the preview URL in Safari after binding.
+        build_directory: Directory to serve, or ``None`` for the project
+            default.
 
     Returns:
         Zero when serving ends normally or after a keyboard interrupt, or one
         when the server cannot bind to the requested port.
     """
-    handler = partial(
-        SimpleHTTPRequestHandler, directory=str(build_directory or _BUILD_DIRECTORY)
-    )
+    handler = partial(SimpleHTTPRequestHandler, directory=str(build_directory or _BUILD_DIRECTORY))
     try:
         server = ThreadingHTTPServer((_HOST, port), handler)
     except OSError as error:
@@ -128,9 +151,10 @@ def _serve_docs(port: int, *, open_safari: bool, build_directory: Path | None = 
 def main(argv: Sequence[str] | None = None) -> int:
     """Build and serve the project documentation until interrupted.
 
-    With the default ``preview`` command, this writes the Sphinx output to a
-    temporary directory, prints the preview URL, and may open Safari on macOS.
-    The ``clean`` command removes legacy output in ``docs/_build`` instead.
+    With the default ``preview`` command, this updates the Sphinx output in
+    ``docs/_build``, prints the preview URL, and may open Safari on macOS. Pass
+    ``--fresh`` to remove existing output before building. The ``clean``
+    command removes the output without building or serving it.
 
     Args:
         argv: Optional command-line arguments. When omitted, arguments are read
@@ -139,28 +163,28 @@ def main(argv: Sequence[str] | None = None) -> int:
     Returns:
         The docs build exit code, or the local server exit code after a
         successful build.
+
+    Raises:
+        SystemExit: If command-line arguments are invalid or request help.
     """
     args = _parse_args(argv)
     if args.command == "clean":
         _clean_docs()
         return 0
 
-    with tempfile.TemporaryDirectory(prefix="openghg-inversions-docs-") as temporary_directory:
-        temporary_path = Path(temporary_directory)
-        source_directory = temporary_path / "source"
-        build_directory = temporary_path / "build"
-        shutil.copytree(_DOCS_DIRECTORY, source_directory, ignore=shutil.ignore_patterns("_build"))
+    if args.fresh:
+        _clean_docs()
 
-        build_status = _build_docs(source_directory, build_directory)
-        if build_status:
-            print("Documentation build failed; preview server was not started.", file=sys.stderr)
-            return build_status
+    build_status = _build_docs(_DOCS_DIRECTORY, _BUILD_ROOT)
+    if build_status:
+        print("Documentation build failed; preview server was not started.", file=sys.stderr)
+        return build_status
 
-        return _serve_docs(
-            args.port,
-            open_safari=sys.platform == "darwin" and not args.no_open,
-            build_directory=build_directory,
-        )
+    return _serve_docs(
+        args.port,
+        open_safari=sys.platform == "darwin" and not args.no_open,
+        build_directory=_BUILD_DIRECTORY,
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_preview_docs.py
+++ b/tests/test_preview_docs.py
@@ -10,15 +10,17 @@ from scripts import preview_docs
 
 
 def test_parse_args_uses_non_mkdocs_default_and_accepts_overrides() -> None:
-    """The CLI defaults away from port 8000 and accepts explicit options."""
+    """Preview applies defaults and accepts port, browser, and freshness overrides."""
     defaults = preview_docs._parse_args([])
-    overridden = preview_docs._parse_args(["--port", "9123", "--no-open"])
+    overridden = preview_docs._parse_args(["--port", "9123", "--no-open", "--fresh"])
 
     assert defaults.port == 8765
     assert defaults.no_open is False
+    assert defaults.fresh is False
     assert defaults.command == "preview"
     assert overridden.port == 9123
     assert overridden.no_open is True
+    assert overridden.fresh is True
     assert overridden.command == "preview"
 
 
@@ -47,29 +49,35 @@ def test_build_docs_runs_the_documentation_tox_environment(monkeypatch: pytest.M
     monkeypatch.setattr(preview_docs.subprocess, "run", run_fake)
 
     source_directory = Path("/tmp/docs-source")
-    build_directory = Path("/tmp/docs-build")
+    build_root = Path("/tmp/docs-build")
 
-    assert preview_docs._build_docs(source_directory, build_directory) == 7
+    assert preview_docs._build_docs(source_directory, build_root) == 7
     assert len(calls) == 1
     command, kwargs = calls[0]
     assert command == ["tox", "-e", "docs"]
     assert kwargs["cwd"] == preview_docs._REPOSITORY_ROOT
     assert kwargs["check"] is False
     assert kwargs["env"]["DOCS_SOURCE_DIR"] == str(source_directory)
-    assert kwargs["env"]["DOCS_BUILD_DIR"] == str(build_directory)
+    assert kwargs["env"]["DOCS_BUILD_DIR"] == str(build_root)
 
 
-def test_clean_docs_removes_only_the_generated_build_directory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Cleaning removes the generated Sphinx output when it exists."""
-    build_directory = tmp_path / "docs" / "_build"
+def test_clean_docs_removes_only_the_generated_build_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Cleaning removes the build root while preserving documentation sources."""
+    build_root = tmp_path / "docs" / "_build"
+    build_directory = build_root / "html"
     build_directory.mkdir(parents=True)
+    source_file = build_root.parent / "conf.py"
+    source_file.touch()
     generated_file = build_directory / "index.html"
     generated_file.touch()
-    monkeypatch.setattr(preview_docs, "_BUILD_DIRECTORY", build_directory)
+    monkeypatch.setattr(preview_docs, "_BUILD_ROOT", build_root)
 
     preview_docs._clean_docs()
 
-    assert not build_directory.exists()
+    assert not build_root.exists()
+    assert source_file.exists()
 
 
 def test_main_cleans_without_building_or_serving(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -159,6 +167,7 @@ def test_serve_docs_reports_bind_errors_without_opening_browser(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     """A bind error is reported and never attempts to launch Safari."""
+
     def fail_to_bind(address, handler):
         raise OSError("address already in use")
 
@@ -187,34 +196,50 @@ def test_main_stops_when_the_documentation_build_fails(
     assert "Documentation build failed" in capsys.readouterr().err
 
 
-def test_main_builds_and_serves_from_a_temporary_directory(
+def test_main_builds_and_serves_from_persistent_directories(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Preview generation must not write to the repository documentation directory."""
-    paths = {}
+    """Preview reuses the project docs and build directories for incremental builds."""
 
-    def build_fake(source_directory: Path, build_directory: Path) -> int:
-        paths["source"] = source_directory
-        paths["build"] = build_directory
-        assert source_directory != preview_docs._DOCS_DIRECTORY
-        assert build_directory != preview_docs._BUILD_DIRECTORY
-        assert (source_directory / "conf.py").exists()
-        build_directory.mkdir()
+    def build_fake(source_directory: Path, build_root: Path) -> int:
+        assert source_directory == preview_docs._DOCS_DIRECTORY
+        assert build_root == preview_docs._BUILD_ROOT
         return 0
 
     def serve_fake(port, *, open_safari, build_directory):
         assert port == 9123
         assert open_safari is False
-        assert build_directory == paths["build"]
-        assert build_directory.exists()
+        assert build_directory == preview_docs._BUILD_DIRECTORY
         return 0
 
     monkeypatch.setattr(preview_docs, "_build_docs", build_fake)
     monkeypatch.setattr(preview_docs, "_serve_docs", serve_fake)
 
     assert preview_docs.main(["--port", "9123", "--no-open"]) == 0
-    assert not paths["source"].exists()
-    assert not paths["build"].exists()
+
+
+def test_main_fresh_cleans_before_building(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A fresh preview discards cached output before starting the docs build."""
+    calls = []
+    monkeypatch.setattr(preview_docs, "_clean_docs", lambda: calls.append("clean"))
+
+    def build_fake(source_directory: Path, build_root: Path) -> int:
+        calls.append(("build", source_directory, build_root))
+        return 0
+
+    monkeypatch.setattr(preview_docs, "_build_docs", build_fake)
+    monkeypatch.setattr(
+        preview_docs,
+        "_serve_docs",
+        lambda port, *, open_safari, build_directory: calls.append("serve") or 0,
+    )
+
+    assert preview_docs.main(["--fresh", "--no-open"]) == 0
+    assert calls == [
+        "clean",
+        ("build", preview_docs._DOCS_DIRECTORY, preview_docs._BUILD_ROOT),
+        "serve",
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,6 @@ commands =
     pytest {posargs:tests/typing/test_borrowed_typing.py}
 
 [testenv:docs-strict]
-#skip_install = True
 deps =
   sphinx>=4
   pydata-sphinx-theme
@@ -64,23 +63,46 @@ commands =
       --separate \
       -o {env:DOCS_SOURCE_DIR:docs}/reference/ \
       openghg_inversions/
-  sphinx-build -n -W --keep-going -b html {env:DOCS_SOURCE_DIR:docs}/ {env:DOCS_BUILD_DIR:docs/_build}
+  sphinx-build -M html {env:DOCS_SOURCE_DIR:docs}/ {env:DOCS_BUILD_DIR:docs/_build} -n -W --keep-going
+
+[testenv:docs-full]
+description = "Regenerate the API reference and build all documentation."
+deps =
+  sphinx>=4
+  pydata-sphinx-theme
+  jupyter-sphinx>=0.5.3
+commands =
+  sphinx-apidoc \
+      --templatedir {env:DOCS_SOURCE_DIR:docs}/_templates \
+      --force \
+      --implicit-namespaces \
+      --module-first \
+      --separate \
+      -o {env:DOCS_SOURCE_DIR:docs}/reference/ \
+      openghg_inversions/
+  sphinx-build -M html {env:DOCS_SOURCE_DIR:docs}/ {env:DOCS_BUILD_DIR:docs/_build} --keep-going
+
+[testenv:docs-api]
+description = "Regenerate the Sphinx API reference files."
+skip_install = true
+deps =
+  sphinx>=4
+commands =
+  sphinx-apidoc \
+      --templatedir {env:DOCS_SOURCE_DIR:docs}/_templates \
+      --force \
+      --implicit-namespaces \
+      --module-first \
+      --separate \
+      -o {env:DOCS_SOURCE_DIR:docs}/reference/ \
+      openghg_inversions/
 
 [testenv:docs]
-#skip_install = True
+description = "Incrementally build the Sphinx documentation for local preview."
 deps =
   sphinx>=4
   pydata-sphinx-theme
   jupyter-sphinx>=0.5.3
 commands =
-  sphinx-apidoc \
-      --templatedir {env:DOCS_SOURCE_DIR:docs}/_templates \
-      --force \
-      --implicit-namespaces \
-      --module-first \
-      --separate \
-      -o {env:DOCS_SOURCE_DIR:docs}/reference/ \
-      openghg_inversions/
-
   # don't be nitpicky or convert warnings to errors
-  sphinx-build --keep-going -b html {env:DOCS_SOURCE_DIR:docs}/ {env:DOCS_BUILD_DIR:docs/_build}
+  sphinx-build -M html {env:DOCS_SOURCE_DIR:docs}/ {env:DOCS_BUILD_DIR:docs/_build} --keep-going


### PR DESCRIPTION
* **Summary of changes**

- preserve Sphinx doctrees and HTML under the ignored `docs/_build` directory so local previews rebuild only affected pages
- add `--fresh` and retain `clean` for explicit cache invalidation
- separate incremental `docs`, API-only `docs-api`, deployment `docs-full`, and warning-strict `docs-strict` tox environments
- use Sphinx's standard make-mode output layout so Jupyter-Sphinx notebook artifacts stay under `docs/_build`, while GitHub Pages publishes only `docs/_build/html`
- update preview documentation, focused tests, CI deployment routing, and the Towncrier fragment
- leave the RHIME tutorial source conversion to its separate in-progress change

Refs #629.

* **Please check if the PR fulfills these requirements**

- [ ] Closes #629 — this PR implements the build infrastructure; the tutorial conversion is separate
- [x] Tests added and passing
- [x] Documentation and tutorials updated/added
- [x] Added a Towncrier news fragment in `newsfragments/` for user-visible changes
- [x] Added any new requirements to `requirements.txt` — no new requirements are needed

**Validation**

- `uv run pytest tests/test_preview_docs.py -q` — 16 passed
- `uv run ruff check scripts/preview_docs.py tests/test_preview_docs.py`
- `uv run ruff format --check scripts/preview_docs.py tests/test_preview_docs.py`
- `.venv/bin/pyright scripts/preview_docs.py tests/test_preview_docs.py` — 0 errors
- `git diff --check`
- an earlier full docs build passed with four baseline warnings; the final `docs-full` layout will be exercised by CI
