### PR TITLE
OPE-121 warn and fuse gathered source-level operations

### DIFF
--- a/newsfragments/OPE-121.misc.md
+++ b/newsfragments/OPE-121.misc.md
@@ -1,1 +1,1 @@
-Validated source labels and reused one-pass gathered-state grouping in multisource sensitivity projection.
+Validated source labels, reused one-pass gathered-state grouping in multisource sensitivity projection, and warned before large explicit MultiIndex-level broadcasts.

--- a/newsfragments/OPE-121.misc.md
+++ b/newsfragments/OPE-121.misc.md
@@ -1,0 +1,1 @@
+Validated source labels and reused one-pass gathered-state grouping in multisource sensitivity projection.

--- a/newsfragments/OPE-121.misc.md
+++ b/newsfragments/OPE-121.misc.md
@@ -1,1 +1,1 @@
-Validated source labels, reused one-pass gathered-state grouping in multisource sensitivity projection, and warned before large explicit MultiIndex-level broadcasts.
+Validated source labels, warned before large explicit MultiIndex-level broadcasts, and fused source pairing with the sparse native prolongation during multisource sensitivity projection.

--- a/openghg_inversions/array_ops.py
+++ b/openghg_inversions/array_ops.py
@@ -42,7 +42,7 @@ an xarray issue, which now is written in terms of ``force_align``.
 from __future__ import annotations
 
 import warnings
-from collections.abc import Hashable, Iterable, Mapping, Sequence
+from collections.abc import Hashable, Iterable, Iterator, Mapping, Sequence
 from typing import Any, Literal, TypeVar, overload
 
 import numpy as np
@@ -619,6 +619,77 @@ def _resolve_shared_data_vars(
 # ----------------------------------------
 # Align to multi-index
 # ----------------------------------------
+
+
+def iter_multi_index_level_slices(
+    da: xr.DataArray,
+    *,
+    multi_index: xr.DataArray,
+    multi_dim: str,
+    level: str,
+    array_dim: str,
+) -> Iterator[tuple[Hashable, np.ndarray, xr.DataArray]]:
+    """Pair unique-level values with matching gathered-axis slices.
+
+    This supports split -> operate -> combine algorithms without first
+    broadcasting ``da(array_dim, ...)`` onto every entry of ``multi_dim``.
+    That distinction is essential when the non-index dimensions are large:
+    vectorized selection with repeated level values can create a temporary of
+    shape ``(multi_dim, ...)`` before the expensive dimensions are reduced.
+
+    Target values are visited in first-seen MultiIndex order. Positions are
+    grouped in one pass over the gathered index, and callers retain the
+    positions needed to restore canonical gathered order after combining
+    operation-specific results.
+
+    Args:
+        da: Array indexed once per unique ``level`` value.
+        multi_index: Coordinate backed by the gathered pandas MultiIndex.
+        multi_dim: Gathered dimension name.
+        level: MultiIndex level paired with ``array_dim``.
+        array_dim: Unique-level dimension on ``da``.
+
+    Yields:
+        The level value, its integer positions in ``multi_dim``, and the
+        matching scalar selection from ``da``.
+
+    Raises:
+        ValueError: If the gathered coordinate is not the requested
+            MultiIndex, or the input labels are absent, duplicated, missing,
+            or extra relative to the target level.
+    """
+    if multi_index.dims != (multi_dim,):
+        raise ValueError(
+            f"multi_index must have the single dimension {multi_dim!r}; got {multi_index.dims!r}."
+        )
+    index = multi_index.to_index()
+    if not isinstance(index, pd.MultiIndex):
+        raise ValueError("multi_index must be backed by a pandas.MultiIndex.")
+    if level not in index.names:
+        raise ValueError(f"Requested level {level!r} not found in MultiIndex levels {index.names!r}.")
+    if array_dim not in da.dims or array_dim not in da.coords:
+        raise ValueError(f"Input array must carry labelled dimension {array_dim!r}.")
+
+    array_index = da.get_index(array_dim)
+    if not array_index.is_unique:
+        raise ValueError(f"Input labels for {array_dim!r} must be unique.")
+
+    level_values = index.get_level_values(level)
+    unique_values = level_values.unique()
+    missing = unique_values.difference(array_index)
+    extra = array_index.difference(unique_values)
+    if len(missing) or len(extra):
+        raise ValueError(
+            f"Input labels for {array_dim!r} must exactly cover MultiIndex level {level!r}; "
+            f"missing {missing.tolist()!r}, extra {extra.tolist()!r}."
+        )
+
+    positions: dict[Hashable, list[int]] = {}
+    for position, value in enumerate(level_values):
+        positions.setdefault(value, []).append(position)
+
+    for value in unique_values:
+        yield value, np.asarray(positions[value]), da.sel({array_dim: value}, drop=True)
 
 
 def align_to_multi_index_level_values(

--- a/openghg_inversions/array_ops.py
+++ b/openghg_inversions/array_ops.py
@@ -620,6 +620,9 @@ def _resolve_shared_data_vars(
 # Align to multi-index
 # ----------------------------------------
 
+_MULTI_INDEX_BROADCAST_WARN_BYTES = 1024**3
+_MULTI_INDEX_BROADCAST_WARN_RATIO = 10
+
 
 def iter_multi_index_level_slices(
     da: xr.DataArray,
@@ -766,6 +769,24 @@ def align_to_multi_index_level_values(
             UserWarning,
             stacklevel=2,
         )
+
+    source_size = da.sizes[other_dim]
+    target_size = multi_index.sizes[multi_dim]
+    if source_size:
+        expansion_ratio = target_size / source_size
+        projected_bytes = da.nbytes // source_size * target_size
+        if (
+            expansion_ratio >= _MULTI_INDEX_BROADCAST_WARN_RATIO
+            and projected_bytes >= _MULTI_INDEX_BROADCAST_WARN_BYTES
+        ):
+            warnings.warn(
+                f"Aligning {other_dim!r} to {multi_dim!r} expands {source_size} values to "
+                f"{target_size} ({expansion_ratio:.1f}x) with a projected logical size of "
+                f"{projected_bytes / 1024**3:.1f} GiB. This explicit broadcast may exhaust "
+                "memory; use iter_multi_index_level_slices for split-operate-combine work.",
+                UserWarning,
+                stacklevel=2,
+            )
 
     # Vectorized selection in the order of the level values (dim becomes multi_dim)
     level_values = multi_index[level]

--- a/openghg_inversions/basis/operators.py
+++ b/openghg_inversions/basis/operators.py
@@ -60,6 +60,7 @@ from openghg_inversions.array_ops import (
     concat_gather_data_arrays,
     force_align,
     get_xr_dummies,
+    iter_multi_index_level_slices,
 )
 from openghg_inversions.basis.layout import (
     BasisStateMetadata,
@@ -1016,22 +1017,30 @@ class MultiSourceBucketBasisOperator(BasisOperator):
         mat_aligned = mat_aligned.transpose(*self.meta.grid_dims, ...)
 
         if self.source_dim in fp_x_flux.dims:
-            state_sources = np.asarray(mat_aligned[self.source_dim].values)
             pieces = []
-            for source in self.source_labels:
-                source_flux = fp_x_flux.sel({self.source_dim: source}, drop=True)
+            positions = []
+            for _, source_positions, source_flux in iter_multi_index_level_slices(
+                fp_x_flux,
+                multi_index=mat_aligned[self.meta.state_dim],
+                multi_dim=self.meta.state_dim,
+                level=self.source_dim,
+                array_dim=self.source_dim,
+            ):
                 if fillna:
                     source_flux = source_flux.fillna(0.0)
+                positions.append(source_positions)
                 pieces.append(
                     xr.dot(
                         source_flux,
-                        mat_aligned.isel(
-                            {self.meta.state_dim: np.flatnonzero(state_sources == source)}
-                        ),
+                        mat_aligned.isel({self.meta.state_dim: source_positions}),
                         dim=list(self.meta.grid_dims),
                     )
                 )
-            h = xr.concat(pieces, dim=self.meta.state_dim).as_numpy()
+            gathered_positions = np.concatenate(positions)
+            h = xr.concat(pieces, dim=self.meta.state_dim)
+            if not np.array_equal(gathered_positions, np.arange(mat_aligned.sizes[self.meta.state_dim])):
+                h = h.isel({self.meta.state_dim: np.argsort(gathered_positions)})
+            h = h.as_numpy()
         elif fillna:
             h = xr.dot(fp_x_flux.fillna(0.0), mat_aligned, dim=list(self.meta.grid_dims)).as_numpy()
         else:

--- a/openghg_inversions/basis/operators.py
+++ b/openghg_inversions/basis/operators.py
@@ -1015,17 +1015,45 @@ class MultiSourceBucketBasisOperator(BasisOperator):
         every retained state while keeping the source pairing sparse.
         """
         if self.source_dim in fp_x_flux.dims:
+            state_coordinate = self.basis_matrix[self.meta.state_dim]
             source_order = [
                 source
                 for source, _, _ in iter_multi_index_level_slices(
                     fp_x_flux,
-                    multi_index=self.basis_matrix[self.meta.state_dim],
+                    multi_index=state_coordinate,
                     multi_dim=self.meta.state_dim,
                     level=self.source_dim,
                     array_dim=self.source_dim,
                 )
             ]
-            native_source_dim = f"native_{self.source_dim}"
+            surviving_source_coordinates = {
+                name: align_to_multi_index_level_values(
+                    coordinate,
+                    multi_index=state_coordinate,
+                    multi_dim=self.meta.state_dim,
+                    level=self.source_dim,
+                    other_dim=self.source_dim,
+                )
+                for name, coordinate in fp_x_flux.coords.items()
+                if name != self.source_dim
+                and self.source_dim in coordinate.dims
+                and not set(coordinate.dims).intersection(self.meta.grid_dims)
+            }
+            occupied_names = {
+                name
+                for name in (
+                    *fp_x_flux.dims,
+                    *fp_x_flux.coords,
+                    *self.basis_matrix.dims,
+                    *self.basis_matrix.coords,
+                )
+            }
+            native_source_base = f"native_{self.source_dim}"
+            native_source_dim = native_source_base
+            suffix = 2
+            while native_source_dim in occupied_names:
+                native_source_dim = f"{native_source_base}_{suffix}"
+                suffix += 1
             fp_native = fp_x_flux.sel({self.source_dim: source_order}).rename(
                 {self.source_dim: native_source_dim}
             )
@@ -1045,6 +1073,8 @@ class MultiSourceBucketBasisOperator(BasisOperator):
                 prolongation,
                 dim=(native_source_dim, *self.meta.grid_dims),
             ).as_numpy()
+            if surviving_source_coordinates:
+                h = h.assign_coords(surviving_source_coordinates)
         else:
             mat_aligned = force_align(self.basis_matrix, fp_x_flux, dims=list(self.meta.grid_dims))
             mat_aligned = mat_aligned.transpose(*self.meta.grid_dims, ...)

--- a/openghg_inversions/basis/operators.py
+++ b/openghg_inversions/basis/operators.py
@@ -1010,40 +1010,46 @@ class MultiSourceBucketBasisOperator(BasisOperator):
     def sensitivity(self, fp_x_flux: xr.DataArray, fillna: bool = True) -> xr.DataArray:
         """Compute sensitivity for multisource fp_x_flux.
 
-        Project each source separately before gathering the state axis. This
-        avoids broadcasting the full spatial cache across every retained state.
+        Fuse source selection with the sparse spatial prolongation before
+        contracting. This avoids broadcasting the full spatial cache across
+        every retained state while keeping the source pairing sparse.
         """
-        mat_aligned = force_align(self.basis_matrix, fp_x_flux, dims=list(self.meta.grid_dims))
-        mat_aligned = mat_aligned.transpose(*self.meta.grid_dims, ...)
-
         if self.source_dim in fp_x_flux.dims:
-            pieces = []
-            positions = []
-            for _, source_positions, source_flux in iter_multi_index_level_slices(
-                fp_x_flux,
-                multi_index=mat_aligned[self.meta.state_dim],
-                multi_dim=self.meta.state_dim,
-                level=self.source_dim,
-                array_dim=self.source_dim,
-            ):
-                if fillna:
-                    source_flux = source_flux.fillna(0.0)
-                positions.append(source_positions)
-                pieces.append(
-                    xr.dot(
-                        source_flux,
-                        mat_aligned.isel({self.meta.state_dim: source_positions}),
-                        dim=list(self.meta.grid_dims),
-                    )
+            source_order = [
+                source
+                for source, _, _ in iter_multi_index_level_slices(
+                    fp_x_flux,
+                    multi_index=self.basis_matrix[self.meta.state_dim],
+                    multi_dim=self.meta.state_dim,
+                    level=self.source_dim,
+                    array_dim=self.source_dim,
                 )
-            gathered_positions = np.concatenate(positions)
-            h = xr.concat(pieces, dim=self.meta.state_dim)
-            if not np.array_equal(gathered_positions, np.arange(mat_aligned.sizes[self.meta.state_dim])):
-                h = h.isel({self.meta.state_dim: np.argsort(gathered_positions)})
-            h = h.as_numpy()
-        elif fillna:
-            h = xr.dot(fp_x_flux.fillna(0.0), mat_aligned, dim=list(self.meta.grid_dims)).as_numpy()
+            ]
+            native_source_dim = f"native_{self.source_dim}"
+            fp_native = fp_x_flux.sel({self.source_dim: source_order}).rename(
+                {self.source_dim: native_source_dim}
+            )
+            fp_native = force_align(
+                fp_native,
+                self.basis_matrix,
+                dims=list(self.meta.grid_dims),
+            )
+            if fillna:
+                fp_native = fp_native.fillna(0.0)
+            prolongation = self.native_prolongation(
+                fp_native,
+                native_dims=(native_source_dim, *self.meta.grid_dims),
+            )
+            h = xr.dot(
+                fp_native,
+                prolongation,
+                dim=(native_source_dim, *self.meta.grid_dims),
+            ).as_numpy()
         else:
+            mat_aligned = force_align(self.basis_matrix, fp_x_flux, dims=list(self.meta.grid_dims))
+            mat_aligned = mat_aligned.transpose(*self.meta.grid_dims, ...)
+            if fillna:
+                fp_x_flux = fp_x_flux.fillna(0.0)
             h = xr.dot(fp_x_flux, mat_aligned, dim=list(self.meta.grid_dims)).as_numpy()
 
         if self.meta.state_dim in h.dims:

--- a/scripts/profile_ope121_multiindex_operations.py
+++ b/scripts/profile_ope121_multiindex_operations.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Profile the gathered MultiIndex operations investigated by OPE-121."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import resource
+import subprocess
+import time
+from collections.abc import Callable
+from pathlib import Path
+
+import dask
+import numpy as np
+import xarray as xr
+
+from openghg_inversions.array_ops import (
+    align_to_multi_index_level_values,
+    force_align,
+    iter_multi_index_level_slices,
+    to_dense,
+)
+from openghg_inversions.basis.operators import MultiSourceBucketBasisOperator
+
+
+def make_fixture(args: argparse.Namespace) -> tuple[MultiSourceBucketBasisOperator, xr.DataArray, xr.DataArray, xr.DataArray]:
+    rng = np.random.default_rng(args.seed)
+    counts = tuple(int(value) for value in args.states.split(","))
+    sources = [f"source-{i}" for i in range(len(counts))]
+    coords = {"lat": np.arange(args.lat), "lon": np.arange(args.lon)}
+    cells = np.arange(args.lat * args.lon).reshape(args.lat, args.lon)
+    bases = {
+        source: xr.DataArray(
+            (np.roll(cells, i, axis=1) % count) + 1,
+            dims=("lat", "lon"),
+            coords=coords,
+        )
+        for i, (source, count) in enumerate(zip(sources, counts, strict=True))
+    }
+    chunks = None if args.execution == "eager" else {"lat": args.lat_chunk, "lon": args.lon_chunk}
+    operator = MultiSourceBucketBasisOperator(bases, state_dim="state", chunks=chunks)
+    if args.execution == "eager":
+        operator._basis_matrix = to_dense(operator.basis_matrix).compute()  # noqa: SLF001
+
+    fp_x_flux = xr.DataArray(
+        rng.standard_normal((len(sources), args.time, args.lat, args.lon), dtype=np.float32),
+        dims=("source", "time", "lat", "lon"),
+        coords={"source": sources, "time": np.arange(args.time), **coords},
+    )
+    weights = xr.DataArray(
+        rng.random((len(sources), args.lat, args.lon), dtype=np.float32),
+        dims=("source", "lat", "lon"),
+        coords={"source": sources, **coords},
+    )
+    state = xr.DataArray(
+        rng.standard_normal(
+            (operator.basis_matrix.sizes["state"], args.chain, args.draw), dtype=np.float32
+        ),
+        dims=("state", "chain", "draw"),
+        coords={"state": operator.basis_matrix["state"], "chain": np.arange(args.chain), "draw": np.arange(args.draw)},
+    )
+    if args.execution == "dask":
+        fp_x_flux = fp_x_flux.chunk(
+            {"source": 1, "time": args.time_chunk, "lat": args.lat_chunk, "lon": args.lon_chunk}
+        )
+        weights = weights.chunk({"source": 1, "lat": args.lat_chunk, "lon": args.lon_chunk})
+        state = state.chunk({"state": -1, "chain": 1, "draw": args.draw_chunk})
+    return operator, fp_x_flux, weights, state
+
+
+def sensitivity_broadcast(operator: MultiSourceBucketBasisOperator, fp_x_flux: xr.DataArray) -> xr.DataArray:
+    matrix = force_align(operator.basis_matrix, fp_x_flux, dims=list(operator.meta.grid_dims))
+    matrix = matrix.transpose(*operator.meta.grid_dims, ...)
+    fp_on_state = align_to_multi_index_level_values(
+        fp_x_flux,
+        multi_index=matrix[operator.meta.state_dim],
+        multi_dim=operator.meta.state_dim,
+        level=operator.source_dim,
+        other_dim=operator.source_dim,
+    )
+    result = xr.dot(fp_on_state.fillna(0.0), matrix, dim=list(operator.meta.grid_dims)).as_numpy()
+    return result.transpose(operator.meta.state_dim, "time", ...)
+
+
+def sensitivity_pr651(operator: MultiSourceBucketBasisOperator, fp_x_flux: xr.DataArray) -> xr.DataArray:
+    matrix = force_align(operator.basis_matrix, fp_x_flux, dims=list(operator.meta.grid_dims))
+    matrix = matrix.transpose(*operator.meta.grid_dims, ...)
+    state_sources = np.asarray(matrix[operator.source_dim].values)
+    pieces = [
+        xr.dot(
+            fp_x_flux.sel({operator.source_dim: source}, drop=True).fillna(0.0),
+            matrix.isel({operator.meta.state_dim: np.flatnonzero(state_sources == source)}),
+            dim=list(operator.meta.grid_dims),
+        )
+        for source in operator.source_labels
+    ]
+    result = xr.concat(pieces, dim=operator.meta.state_dim).as_numpy()
+    return result.transpose(operator.meta.state_dim, "time", ...)
+
+
+def interpolation_sourcewise(
+    operator: MultiSourceBucketBasisOperator,
+    state: xr.DataArray,
+    weights: xr.DataArray,
+) -> xr.DataArray:
+    weights = force_align(weights, operator.basis_matrix, dims=list(operator.meta.grid_dims))
+    contributions = []
+    for _, positions, source_weights in iter_multi_index_level_slices(
+        weights,
+        multi_index=operator.basis_matrix[operator.meta.state_dim],
+        multi_dim=operator.meta.state_dim,
+        level=operator.source_dim,
+        array_dim=operator.source_dim,
+    ):
+        source_field = xr.dot(
+            operator.basis_matrix.isel({operator.meta.state_dim: positions}),
+            state.isel({operator.meta.state_dim: positions}),
+            dim=operator.meta.state_dim,
+        )
+        contributions.append(source_field * source_weights)
+    return sum(contributions[1:], contributions[0]).as_numpy().transpose(*operator.meta.grid_dims, ...)
+
+
+def compare(actual: xr.DataArray, expected: xr.DataArray) -> dict[str, object]:
+    expected = expected.transpose(*actual.dims)
+    difference = np.abs(np.asarray(actual) - np.asarray(expected))
+    denominator = np.maximum(np.abs(np.asarray(expected)), np.finfo(expected.dtype).tiny)
+    try:
+        xr.testing.assert_identical(actual.coords.to_dataset(), expected.coords.to_dataset())
+        coordinates_identical = True
+    except AssertionError:
+        coordinates_identical = False
+    return {
+        "coordinates_identical": coordinates_identical,
+        "max_absolute_difference": float(difference.max(initial=0.0)),
+        "max_relative_difference": float((difference / denominator).max(initial=0.0)),
+    }
+
+
+def revision() -> str:
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"], check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+
+def script_sha256() -> str:
+    return hashlib.sha256(Path(__file__).read_bytes()).hexdigest()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "operation",
+        choices=("sensitivity-broadcast", "sensitivity-pr651", "sensitivity-helper", "interpolation-current", "interpolation-sourcewise", "sensitivity-shared", "interpolation-shared"),
+    )
+    parser.add_argument("--execution", choices=("eager", "dask"), default="eager")
+    parser.add_argument("--states", default="12,15,18,8")
+    parser.add_argument("--time", type=int, default=24)
+    parser.add_argument("--lat", type=int, default=80)
+    parser.add_argument("--lon", type=int, default=100)
+    parser.add_argument("--chain", type=int, default=2)
+    parser.add_argument("--draw", type=int, default=40)
+    parser.add_argument("--lat-chunk", type=int, default=40)
+    parser.add_argument("--lon-chunk", type=int, default=50)
+    parser.add_argument("--time-chunk", type=int, default=8)
+    parser.add_argument("--draw-chunk", type=int, default=20)
+    parser.add_argument("--seed", type=int, default=20260826)
+    args = parser.parse_args()
+
+    operator, fp_x_flux, weights, state = make_fixture(args)
+    tasks: set[object] = set()
+    callbacks = dask.callbacks.Callback(pretask=lambda key, _graph, _state: tasks.add(key))
+    operations: dict[str, Callable[[], xr.DataArray]] = {
+        "sensitivity-broadcast": lambda: sensitivity_broadcast(operator, fp_x_flux),
+        "sensitivity-pr651": lambda: sensitivity_pr651(operator, fp_x_flux),
+        "sensitivity-helper": lambda: operator.sensitivity(fp_x_flux),
+        "interpolation-current": lambda: operator.interpolate(state, weights=weights),
+        "interpolation-sourcewise": lambda: interpolation_sourcewise(operator, state, weights),
+        "sensitivity-shared": lambda: operator.sensitivity(fp_x_flux.sum("source")),
+        "interpolation-shared": lambda: operator.interpolate(state, weights=weights.sum("source")),
+    }
+    started = time.perf_counter()
+    with callbacks:
+        output = operations[args.operation]()
+    wall_seconds = time.perf_counter() - started
+    peak_rss_kib = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+
+    if args.operation in {"sensitivity-shared", "interpolation-shared"}:
+        reference = output
+    elif args.operation.startswith("sensitivity") and args.operation != "sensitivity-broadcast":
+        reference = sensitivity_broadcast(operator, fp_x_flux)
+    elif args.operation == "sensitivity-broadcast":
+        reference = operator.sensitivity(fp_x_flux)
+    elif args.operation == "interpolation-sourcewise":
+        reference = operator.interpolate(state, weights=weights)
+    elif args.operation == "interpolation-current":
+        reference = interpolation_sourcewise(operator, state, weights)
+    else:
+        reference = output
+
+    print(
+        json.dumps(
+            {
+                "ogi_revision": revision(),
+                "script_sha256": script_sha256(),
+                "operation": args.operation,
+                "execution": args.execution,
+                "dtype": str(fp_x_flux.dtype),
+                "dimensions": {
+                    "source": fp_x_flux.sizes.get("source", 0),
+                    "states_per_source": args.states,
+                    "state": operator.basis_matrix.sizes["state"],
+                    "time": args.time,
+                    "lat": args.lat,
+                    "lon": args.lon,
+                    "chain": args.chain,
+                    "draw": args.draw,
+                },
+                "chunks": {name: getattr(value.data, "chunks", None) for name, value in {"basis": operator.basis_matrix, "fp_x_flux": fp_x_flux, "weights": weights, "state": state}.items()},
+                "wall_seconds": wall_seconds,
+                "peak_rss_mib": peak_rss_kib / 1024,
+                "dask_tasks": len(tasks),
+                "broadcast_intermediate_shape": [
+                    operator.basis_matrix.sizes["state"],
+                    args.time,
+                    args.lat,
+                    args.lon,
+                ],
+                "broadcast_intermediate_size_mib": (
+                    operator.basis_matrix.sizes["state"]
+                    * args.time
+                    * args.lat
+                    * args.lon
+                    * fp_x_flux.dtype.itemsize
+                    / 1024**2
+                ),
+                "output_shape": output.shape,
+                "output_size_mib": output.nbytes / 1024**2,
+                "comparison": compare(output, reference),
+            },
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/profile_ope121_multiindex_operations.py
+++ b/scripts/profile_ope121_multiindex_operations.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import dask
 import numpy as np
 import xarray as xr
+from sparse import SparseArray
 
 from openghg_inversions.array_ops import (
     align_to_multi_index_level_values,
@@ -100,6 +101,21 @@ def sensitivity_pr651(operator: MultiSourceBucketBasisOperator, fp_x_flux: xr.Da
     return result.transpose(operator.meta.state_dim, "time", ...)
 
 
+def sensitivity_native(operator: MultiSourceBucketBasisOperator, fp_x_flux: xr.DataArray) -> xr.DataArray:
+    native_source_dim = "native_source"
+    fp_native = fp_x_flux.rename({operator.source_dim: native_source_dim})
+    prolongation = operator.native_prolongation(
+        fp_native,
+        native_dims=(native_source_dim, *operator.meta.grid_dims),
+    )
+    result = xr.dot(
+        fp_native.fillna(0.0),
+        prolongation,
+        dim=(native_source_dim, *operator.meta.grid_dims),
+    ).as_numpy()
+    return result.transpose(operator.meta.state_dim, "time", ...)
+
+
 def interpolation_sourcewise(
     operator: MultiSourceBucketBasisOperator,
     state: xr.DataArray,
@@ -153,7 +169,7 @@ def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "operation",
-        choices=("sensitivity-broadcast", "sensitivity-pr651", "sensitivity-helper", "interpolation-current", "interpolation-sourcewise", "sensitivity-shared", "interpolation-shared"),
+        choices=("sensitivity-broadcast", "sensitivity-pr651", "sensitivity-helper", "sensitivity-native", "interpolation-current", "interpolation-sourcewise", "sensitivity-shared", "interpolation-shared"),
     )
     parser.add_argument("--execution", choices=("eager", "dask"), default="eager")
     parser.add_argument("--states", default="12,15,18,8")
@@ -171,11 +187,23 @@ def main() -> None:
 
     operator, fp_x_flux, weights, state = make_fixture(args)
     tasks: set[object] = set()
-    callbacks = dask.callbacks.Callback(pretask=lambda key, _graph, _state: tasks.add(key))
+    observed_chunk_bytes = {"dense": 0, "sparse": 0}
+
+    def record_chunk(_key, result, _graph, _state, _worker_id) -> None:
+        if isinstance(result, np.ndarray):
+            observed_chunk_bytes["dense"] = max(observed_chunk_bytes["dense"], result.nbytes)
+        elif isinstance(result, SparseArray):
+            observed_chunk_bytes["sparse"] = max(observed_chunk_bytes["sparse"], result.nbytes)
+
+    callbacks = dask.callbacks.Callback(
+        pretask=lambda key, _graph, _state: tasks.add(key),
+        posttask=record_chunk,
+    )
     operations: dict[str, Callable[[], xr.DataArray]] = {
         "sensitivity-broadcast": lambda: sensitivity_broadcast(operator, fp_x_flux),
         "sensitivity-pr651": lambda: sensitivity_pr651(operator, fp_x_flux),
         "sensitivity-helper": lambda: operator.sensitivity(fp_x_flux),
+        "sensitivity-native": lambda: sensitivity_native(operator, fp_x_flux),
         "interpolation-current": lambda: operator.interpolate(state, weights=weights),
         "interpolation-sourcewise": lambda: interpolation_sourcewise(operator, state, weights),
         "sensitivity-shared": lambda: operator.sensitivity(fp_x_flux.sum("source")),
@@ -222,6 +250,8 @@ def main() -> None:
                 "wall_seconds": wall_seconds,
                 "peak_rss_mib": peak_rss_kib / 1024,
                 "dask_tasks": len(tasks),
+                "max_observed_dense_chunk_mib": observed_chunk_bytes["dense"] / 1024**2,
+                "max_observed_sparse_chunk_mib": observed_chunk_bytes["sparse"] / 1024**2,
                 "broadcast_intermediate_shape": [
                     operator.basis_matrix.sizes["state"],
                     args.time,

--- a/scripts/profile_ope121_wur25_sensitivity.py
+++ b/scripts/profile_ope121_wur25_sensitivity.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import dask
 import numpy as np
 import xarray as xr
+from sparse import SparseArray
 
 from openghg_inversions.array_ops import force_align
 from openghg_inversions.basis.basis_functions import BasisFunctions
@@ -64,6 +65,49 @@ def _sensitivity_pr651(
     return result.transpose(operator.meta.state_dim, "time", ...)
 
 
+def _sensitivity_native(
+    basis_functions: BasisFunctions, fp_x_flux: xr.DataArray, *, fillna: bool
+) -> xr.DataArray:
+    """Contract source-native input with the sparse block-diagonal prolongation."""
+    operator = basis_functions.operator
+    native_source_dim = "native_source"
+    fp_native = fp_x_flux.rename({operator.source_dim: native_source_dim})
+    prolongation = operator.native_prolongation(
+        fp_native,
+        native_dims=(native_source_dim, *operator.meta.grid_dims),
+    )
+    if fillna:
+        fp_native = fp_native.fillna(0.0)
+    result = xr.dot(
+        fp_native,
+        prolongation,
+        dim=(native_source_dim, *operator.meta.grid_dims),
+    ).as_numpy()
+    return result.transpose(operator.meta.state_dim, "time", ...)
+
+
+def _compare(actual: xr.DataArray, reference: xr.DataArray) -> dict[str, object]:
+    reference = reference.transpose(*actual.dims)
+    difference = np.abs(np.asarray(actual) - np.asarray(reference))
+    denominator = np.maximum(
+        np.abs(np.asarray(reference)), np.finfo(reference.dtype).tiny
+    )
+    try:
+        xr.testing.assert_identical(
+            actual.coords.to_dataset(), reference.coords.to_dataset()
+        )
+        coordinates_identical = True
+    except AssertionError:
+        coordinates_identical = False
+    return {
+        "coordinates_identical": coordinates_identical,
+        "max_absolute_difference": float(difference.max(initial=0.0)),
+        "max_relative_difference": float(
+            (difference / denominator).max(initial=0.0)
+        ),
+    }
+
+
 def main() -> None:
     original = BasisFunctions.sensitivity
     call_count = 0
@@ -86,24 +130,38 @@ def main() -> None:
             reference = _sensitivity_pr651(
                 basis_functions, fp_x_flux, fillna=fillna
             )
-            reference = reference.transpose(*output.dims)
-            difference = np.abs(np.asarray(output) - np.asarray(reference))
-            denominator = np.maximum(
-                np.abs(np.asarray(reference)), np.finfo(reference.dtype).tiny
-            )
-            try:
-                xr.testing.assert_identical(
-                    output.coords.to_dataset(), reference.coords.to_dataset()
+            comparison = _compare(output, reference)
+
+        native_candidate: dict[str, object] | None = None
+        if os.environ.get("OPE121_PROFILE_NATIVE") == "1":
+            native_tasks: set[object] = set()
+            observed_chunk_bytes = {"dense": 0, "sparse": 0}
+
+            def record_chunk(_key, result, _graph, _state, _worker_id) -> None:
+                if isinstance(result, np.ndarray):
+                    observed_chunk_bytes["dense"] = max(
+                        observed_chunk_bytes["dense"], result.nbytes
+                    )
+                elif isinstance(result, SparseArray):
+                    observed_chunk_bytes["sparse"] = max(
+                        observed_chunk_bytes["sparse"], result.nbytes
+                    )
+
+            native_started = time.perf_counter()
+            with dask.callbacks.Callback(
+                pretask=lambda key, _graph, _state: native_tasks.add(key),
+                posttask=record_chunk,
+            ):
+                native_output = _sensitivity_native(
+                    basis_functions, fp_x_flux, fillna=fillna
                 )
-                coordinates_identical = True
-            except AssertionError:
-                coordinates_identical = False
-            comparison = {
-                "coordinates_identical": coordinates_identical,
-                "max_absolute_difference": float(difference.max(initial=0.0)),
-                "max_relative_difference": float(
-                    (difference / denominator).max(initial=0.0)
-                ),
+            native_candidate = {
+                "wall_seconds": time.perf_counter() - native_started,
+                "dask_tasks": len(native_tasks),
+                "max_observed_dense_chunk_mib": observed_chunk_bytes["dense"] / 1024**2,
+                "max_observed_sparse_chunk_mib": observed_chunk_bytes["sparse"] / 1024**2,
+                "process_peak_rss_mib": resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024,
+                "comparison_to_helper": _compare(native_output, output),
             }
 
         payload = {
@@ -126,6 +184,7 @@ def main() -> None:
             "wall_seconds": wall_seconds,
             "process_peak_rss_mib": resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024,
             "comparison_to_pr651": comparison,
+            "native_candidate": native_candidate,
         }
         print("OPE121_SENSITIVITY_PROFILE=" + json.dumps(payload, sort_keys=True), flush=True)
         if os.environ.get("OPE121_STOP_AFTER_FIRST") == "1":

--- a/scripts/profile_ope121_wur25_sensitivity.py
+++ b/scripts/profile_ope121_wur25_sensitivity.py
@@ -16,8 +16,8 @@ import dask
 import numpy as np
 import xarray as xr
 
+from openghg_inversions.array_ops import force_align
 from openghg_inversions.basis.basis_functions import BasisFunctions
-from scripts.profile_ope121_multiindex_operations import sensitivity_pr651
 
 
 class FirstSensitivityComplete(Exception):
@@ -36,6 +36,32 @@ def _script_sha256() -> str:
 
 def _chunks(array: xr.DataArray) -> tuple[tuple[int, ...], ...] | None:
     return getattr(array.data, "chunks", None)
+
+
+def _sensitivity_pr651(
+    basis_functions: BasisFunctions, fp_x_flux: xr.DataArray, *, fillna: bool
+) -> xr.DataArray:
+    """Run PR 651's exact source-wise implementation as a profile reference."""
+    operator = basis_functions.operator
+    matrix = force_align(operator.basis_matrix, fp_x_flux, dims=list(operator.meta.grid_dims))
+    matrix = matrix.transpose(*operator.meta.grid_dims, ...)
+    state_sources = np.asarray(matrix[operator.source_dim].values)
+    pieces = []
+    for source in operator.source_labels:
+        source_flux = fp_x_flux.sel({operator.source_dim: source}, drop=True)
+        if fillna:
+            source_flux = source_flux.fillna(0.0)
+        pieces.append(
+            xr.dot(
+                source_flux,
+                matrix.isel(
+                    {operator.meta.state_dim: np.flatnonzero(state_sources == source)}
+                ),
+                dim=list(operator.meta.grid_dims),
+            )
+        )
+    result = xr.concat(pieces, dim=operator.meta.state_dim).as_numpy()
+    return result.transpose(operator.meta.state_dim, "time", ...)
 
 
 def main() -> None:
@@ -57,7 +83,9 @@ def main() -> None:
 
         comparison: dict[str, object] | None = None
         if os.environ.get("OPE121_COMPARE_PR651") == "1":
-            reference = sensitivity_pr651(basis_functions.operator, fp_x_flux)
+            reference = _sensitivity_pr651(
+                basis_functions, fp_x_flux, fillna=fillna
+            )
             reference = reference.transpose(*output.dims)
             difference = np.abs(np.asarray(output) - np.asarray(reference))
             denominator = np.maximum(

--- a/scripts/profile_ope121_wur25_sensitivity.py
+++ b/scripts/profile_ope121_wur25_sensitivity.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Instrument the OPE-87 WUR25 producer's real multisource sensitivity calls."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import resource
+import runpy
+import subprocess
+import time
+from pathlib import Path
+
+import dask
+import numpy as np
+import xarray as xr
+
+from openghg_inversions.basis.basis_functions import BasisFunctions
+from scripts.profile_ope121_multiindex_operations import sensitivity_pr651
+
+
+class FirstSensitivityComplete(Exception):
+    """Stop the production builder after its first instrumented sensitivity."""
+
+
+def _revision() -> str:
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"], check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+
+def _script_sha256() -> str:
+    return hashlib.sha256(Path(__file__).read_bytes()).hexdigest()
+
+
+def _chunks(array: xr.DataArray) -> tuple[tuple[int, ...], ...] | None:
+    return getattr(array.data, "chunks", None)
+
+
+def main() -> None:
+    original = BasisFunctions.sensitivity
+    call_count = 0
+
+    def profiled_sensitivity(
+        basis_functions: BasisFunctions,
+        fp_x_flux: xr.DataArray,
+        fillna: bool = True,
+    ) -> xr.DataArray:
+        nonlocal call_count
+        call_count += 1
+        tasks: set[object] = set()
+        started = time.perf_counter()
+        with dask.callbacks.Callback(pretask=lambda key, _graph, _state: tasks.add(key)):
+            output = original(basis_functions, fp_x_flux, fillna=fillna)
+        wall_seconds = time.perf_counter() - started
+
+        comparison: dict[str, object] | None = None
+        if os.environ.get("OPE121_COMPARE_PR651") == "1":
+            reference = sensitivity_pr651(basis_functions.operator, fp_x_flux)
+            reference = reference.transpose(*output.dims)
+            difference = np.abs(np.asarray(output) - np.asarray(reference))
+            denominator = np.maximum(
+                np.abs(np.asarray(reference)), np.finfo(reference.dtype).tiny
+            )
+            try:
+                xr.testing.assert_identical(
+                    output.coords.to_dataset(), reference.coords.to_dataset()
+                )
+                coordinates_identical = True
+            except AssertionError:
+                coordinates_identical = False
+            comparison = {
+                "coordinates_identical": coordinates_identical,
+                "max_absolute_difference": float(difference.max(initial=0.0)),
+                "max_relative_difference": float(
+                    (difference / denominator).max(initial=0.0)
+                ),
+            }
+
+        payload = {
+            "call": call_count,
+            "ogi_revision": os.environ.get("OGI_REVISION") or _revision(),
+            "vg_revision": os.environ.get("VG_REVISION"),
+            "script_sha256": _script_sha256(),
+            "fp_x_flux_dims": fp_x_flux.dims,
+            "fp_x_flux_shape": fp_x_flux.shape,
+            "fp_x_flux_dtype": str(fp_x_flux.dtype),
+            "fp_x_flux_chunks": _chunks(fp_x_flux),
+            "basis_dims": basis_functions.operator.basis_matrix.dims,
+            "basis_shape": basis_functions.operator.basis_matrix.shape,
+            "basis_chunks": _chunks(basis_functions.operator.basis_matrix),
+            "source_labels": list(basis_functions.operator.source_labels),
+            "output_dims": output.dims,
+            "output_shape": output.shape,
+            "output_size_mib": output.nbytes / 1024**2,
+            "dask_tasks": len(tasks),
+            "wall_seconds": wall_seconds,
+            "process_peak_rss_mib": resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024,
+            "comparison_to_pr651": comparison,
+        }
+        print("OPE121_SENSITIVITY_PROFILE=" + json.dumps(payload, sort_keys=True), flush=True)
+        if os.environ.get("OPE121_STOP_AFTER_FIRST") == "1":
+            raise FirstSensitivityComplete
+        return output
+
+    BasisFunctions.sensitivity = profiled_sensitivity
+    try:
+        runpy.run_module("scripts.build_ope87_wur25_full_mf_prepared_input", run_name="__main__")
+    except FirstSensitivityComplete:
+        print("OPE121_SINGLE_SITE_GATE_COMPLETE", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/profile_ope121_wur25_sensitivity.py
+++ b/scripts/profile_ope121_wur25_sensitivity.py
@@ -99,8 +99,24 @@ def _compare(actual: xr.DataArray, reference: xr.DataArray) -> dict[str, object]
         coordinates_identical = True
     except AssertionError:
         coordinates_identical = False
+    coordinate_names = sorted(set(actual.coords) | set(reference.coords))
+    coordinate_identity = {}
+    for name in coordinate_names:
+        if name not in actual.coords or name not in reference.coords:
+            coordinate_identity[name] = False
+            continue
+        try:
+            xr.testing.assert_identical(actual.coords[name], reference.coords[name])
+            coordinate_identity[name] = True
+        except AssertionError:
+            coordinate_identity[name] = False
     return {
         "coordinates_identical": coordinates_identical,
+        "coordinate_identity": coordinate_identity,
+        "dimension_index_identity": {
+            dim: actual.get_index(dim).equals(reference.get_index(dim))
+            for dim in actual.dims
+        },
         "max_absolute_difference": float(difference.max(initial=0.0)),
         "max_relative_difference": float(
             (difference / denominator).max(initial=0.0)

--- a/scripts/slurm_profile_ope121_wur25.sh
+++ b/scripts/slurm_profile_ope121_wur25.sh
@@ -12,14 +12,17 @@ VG_REVISION="${VG_REVISION:?VG_REVISION must name the exact VG commit}"
 OGI_CHECKOUT="${OGI_CHECKOUT:?OGI_CHECKOUT must name the exact OGI checkout}"
 OGI_REVISION="${OGI_REVISION:?OGI_REVISION must name the exact OGI commit}"
 OUTPUT_ROOT="${OUTPUT_ROOT:?OUTPUT_ROOT must name a new output directory}"
-PROFILE_MODE="${PROFILE_MODE:?PROFILE_MODE must be single or full}"
+PROFILE_MODE="${PROFILE_MODE:?PROFILE_MODE must be single, single-native, or full}"
 PYTHON="${PYTHON:-/group/chem/acrg/verification_games_round_2/verification-games/.venv/bin/python}"
 OBS_PATH="${OBS_PATH:-/group/chem/acrg/verification_games_round_2/games_catalog/data/verification_games_obs/WUR/CTE_STILT_EUROPE_BASE_co2_concentrations_2021.nc}"
 
+unset OPE121_STOP_AFTER_FIRST OPE121_COMPARE_PR651 OPE121_PROFILE_NATIVE
 if [[ "${PROFILE_MODE}" == "single" ]]; then
   export OPE121_STOP_AFTER_FIRST=1 OPE121_COMPARE_PR651=1
+elif [[ "${PROFILE_MODE}" == "single-native" ]]; then
+  export OPE121_STOP_AFTER_FIRST=1 OPE121_COMPARE_PR651=1 OPE121_PROFILE_NATIVE=1
 elif [[ "${PROFILE_MODE}" != "full" ]]; then
-  echo "PROFILE_MODE must be single or full" >&2
+  echo "PROFILE_MODE must be single, single-native, or full" >&2
   exit 2
 fi
 

--- a/scripts/slurm_profile_ope121_wur25.sh
+++ b/scripts/slurm_profile_ope121_wur25.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=ope121-wur25-profile
+#SBATCH --account=chem007981
+#SBATCH --time=02:00:00
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=48G
+
+set -euo pipefail
+
+VG_CHECKOUT="${VG_CHECKOUT:?VG_CHECKOUT must name the exact verification-games checkout}"
+VG_REVISION="${VG_REVISION:?VG_REVISION must name the exact VG commit}"
+OGI_CHECKOUT="${OGI_CHECKOUT:?OGI_CHECKOUT must name the exact OGI checkout}"
+OGI_REVISION="${OGI_REVISION:?OGI_REVISION must name the exact OGI commit}"
+OUTPUT_ROOT="${OUTPUT_ROOT:?OUTPUT_ROOT must name a new output directory}"
+PROFILE_MODE="${PROFILE_MODE:?PROFILE_MODE must be single or full}"
+PYTHON="${PYTHON:-/group/chem/acrg/verification_games_round_2/verification-games/.venv/bin/python}"
+OBS_PATH="${OBS_PATH:-/group/chem/acrg/verification_games_round_2/games_catalog/data/verification_games_obs/WUR/CTE_STILT_EUROPE_BASE_co2_concentrations_2021.nc}"
+
+if [[ "${PROFILE_MODE}" == "single" ]]; then
+  export OPE121_STOP_AFTER_FIRST=1 OPE121_COMPARE_PR651=1
+elif [[ "${PROFILE_MODE}" != "full" ]]; then
+  echo "PROFILE_MODE must be single or full" >&2
+  exit 2
+fi
+
+task_tmp="${TMPDIR:-/tmp}/ope121-wur25-profile-${SLURM_JOB_ID}"
+mkdir -p "${task_tmp}/matplotlib" "${task_tmp}/numba" "${task_tmp}/pytensor"
+export MPLCONFIGDIR="${task_tmp}/matplotlib"
+export NUMBA_CACHE_DIR="${task_tmp}/numba"
+export PYTENSOR_FLAGS="${PYTENSOR_FLAGS:+${PYTENSOR_FLAGS},}base_compiledir=${task_tmp}/pytensor"
+export PYTHONPATH="${OGI_CHECKOUT}:${VG_CHECKOUT}:${VG_CHECKOUT}/src${PYTHONPATH:+:${PYTHONPATH}}"
+export OMP_NUM_THREADS=8 OPENBLAS_NUM_THREADS=8 MKL_NUM_THREADS=8 NUMEXPR_NUM_THREADS=8
+export VG_REVISION OGI_REVISION
+
+cd "${VG_CHECKOUT}"
+"${PYTHON}" "${OGI_CHECKOUT}/scripts/profile_ope121_wur25_sensitivity.py" \
+  --vg-path /group/chem/acrg/verification_games_round_2 \
+  --output-root "${OUTPUT_ROOT}" \
+  --obs-path "${OBS_PATH}" \
+  --obs-games-scenario BASE \
+  --truth-games-scenario BASE \
+  --truth-domain inner-paris \
+  --sites UTO JFJ OXK CMN HPB PAL RGL GAT SAC STE MHD TOH HTM NOR HEL BSD TAC KRE TRN HUN BIR WES CBW OPE LIN \
+  --start-date 2021-01-01 \
+  --end-date 2021-02-01 \
+  --species co2 \
+  --games-scenario BASE \
+  --sectors GPP TER FF ocean \
+  --basis-mode intem_mixed_outer \
+  --basis-split-step axis-parallel \
+  --basis-per-source \
+  --nbasis 150 \
+  --ocean-nbasis 80 \
+  --basis-random-seed 20260611 \
+  --min-greedy-split-parent-weight-share 0.01 \
+  --prior-uncertainty-mode country-calibrated \
+  --country-total-target-relative-sd 0.5 \
+  --calibration-countries GBR DEU FRA ITA \
+  --aggregation-error-mode none \
+  --prune-zero-h-columns \
+  --zero-h-tolerance 0 \
+  --min-error 0 \
+  --prepared-input-route ogi \
+  --build-only

--- a/tests/test_array_ops.py
+++ b/tests/test_array_ops.py
@@ -1,5 +1,6 @@
 import warnings
 
+import dask.array as da
 import numpy as np
 import pandas as pd
 import pytest
@@ -253,6 +254,32 @@ def test_align_to_multi_index_level_values_with_other_level_as_dim_warns():
         )
 
     xr.testing.assert_equal(da_stack.a, da_aligned.a)
+
+
+def test_align_to_multi_index_level_values_warns_before_large_broadcast() -> None:
+    """Logical metadata exposes an unsafe broadcast without computing lazy data."""
+    values = xr.DataArray(
+        da.zeros((2, 1024, 1024), chunks=(1, 256, 256), dtype=np.float32),
+        dims=("source", "x", "y"),
+        coords={"source": ["A", "B"]},
+    )
+    index = pd.MultiIndex.from_arrays(
+        [np.tile(["A", "B"], 512), np.repeat(np.arange(512), 2)],
+        names=("source", "region_in_source"),
+    )
+    state = xr.Coordinates.from_pandas_multiindex(index, "state")["state"]
+
+    with pytest.warns(UserWarning, match=r"512\.0x.*4\.0 GiB.*may exhaust memory"):
+        aligned = align_to_multi_index_level_values(
+            values,
+            multi_index=state,
+            multi_dim="state",
+            level="source",
+            other_dim="source",
+        )
+
+    assert aligned.shape == (1024, 1024, 1024)
+    assert aligned.chunks is not None
 
 
 def test_select_gathered_data_array_restores_ragged_labels_and_values() -> None:

--- a/tests/test_array_ops.py
+++ b/tests/test_array_ops.py
@@ -11,6 +11,7 @@ from openghg_inversions.array_ops import (
     concat_gather_data_arrays,
     concat_gather_datatree,
     concat_gather_datasets,
+    iter_multi_index_level_slices,
     select_gathered_data_array,
     validate_covariance_coordinates,
 )
@@ -159,6 +160,65 @@ def test_align_to_multi_index_level_values_broadcasts_source_to_state():
     # the coordinate for `other_dim` is not dropped before assigning the MultiIndex.
     # The test here is just that this doesn't cause an error.
     _ = res * expected_da
+
+
+def test_iter_multi_index_level_slices_preserves_target_order_and_positions() -> None:
+    """Unique-level inputs may be reordered while gathered positions remain canonical."""
+    values = xr.DataArray(
+        [[20.0, 21.0], [10.0, 11.0]],
+        dims=("source", "time"),
+        coords={"source": ["B", "A"]},
+    )
+    index = pd.MultiIndex.from_tuples(
+        [("B", 0), ("A", 0), ("B", 1), ("A", 1)],
+        names=("source", "region_in_source"),
+    )
+    state = xr.Coordinates.from_pandas_multiindex(index, "state")["state"]
+
+    slices = list(
+        iter_multi_index_level_slices(
+            values,
+            multi_index=state,
+            multi_dim="state",
+            level="source",
+            array_dim="source",
+        )
+    )
+
+    assert [value for value, _, _ in slices] == ["B", "A"]
+    np.testing.assert_array_equal(slices[0][1], [0, 2])
+    np.testing.assert_array_equal(slices[1][1], [1, 3])
+    xr.testing.assert_identical(slices[0][2], values.sel(source="B", drop=True))
+    xr.testing.assert_identical(slices[1][2], values.sel(source="A", drop=True))
+
+
+@pytest.mark.parametrize(
+    ("labels", "match"),
+    [
+        (["A"], "missing.*B"),
+        (["A", "B", "C"], "extra.*C"),
+        (["A", "A", "B"], "must be unique"),
+    ],
+)
+def test_iter_multi_index_level_slices_rejects_invalid_unique_labels(labels, match) -> None:
+    """Split application requires one input for every represented level value."""
+    values = xr.DataArray(np.arange(len(labels)), dims="source", coords={"source": labels})
+    index = pd.MultiIndex.from_tuples(
+        [("A", 0), ("B", 0), ("B", 1)],
+        names=("source", "region_in_source"),
+    )
+    state = xr.Coordinates.from_pandas_multiindex(index, "state")["state"]
+
+    with pytest.raises(ValueError, match=match):
+        list(
+            iter_multi_index_level_slices(
+                values,
+                multi_index=state,
+                multi_dim="state",
+                level="source",
+                array_dim="source",
+            )
+        )
 
 
 def test_align_to_multi_index_level_values_with_other_level_as_coord_raises():

--- a/tests/test_basis_functions.py
+++ b/tests/test_basis_functions.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
+from sparse import SparseArray
 
 import openghg_inversions.basis as basis_package
 import openghg_inversions.basis._functions as basis_module
@@ -2213,8 +2214,8 @@ def test_multisource_sensitivity_matches_legacy_padded_conversion_smoke():
     xr.testing.assert_allclose(H_new, H_old_gathered)
 
 
-def test_multisource_sensitivity_projects_each_source_before_gathering(monkeypatch):
-    """Spatial caches must not be broadcast across the gathered state axis."""
+def test_multisource_sensitivity_contracts_sparse_native_prolongation(monkeypatch):
+    """Source pairing stays sparse until the spatial contraction produces H."""
     sources = ["A", "B"]
     basis = make_basis_flat_from_blocks([[1, 1], [2, 2]])
     basis_functions = BasisFunctions.from_multi_source_flat_basis(
@@ -2224,17 +2225,20 @@ def test_multisource_sensitivity_projects_each_source_before_gathering(monkeypat
     )
     fp_x_flux = make_fp_x_flux_sectoral(sources=sources, nlat=2, nlon=2, ntime=3)
     original_dot = xr.dot
-    projected_dims = []
+    projected = []
 
     def checked_dot(left, right, *args, **kwargs):
-        projected_dims.append(left.dims)
+        projected.append((left, right))
         return original_dot(left, right, *args, **kwargs)
 
     monkeypatch.setattr(xr, "dot", checked_dot)
     basis_functions.sensitivity(fp_x_flux)
 
-    assert len(projected_dims) == len(sources)
-    assert all("region" not in dims and "source" not in dims for dims in projected_dims)
+    assert len(projected) == 1
+    left, right = projected[0]
+    assert left.dims == ("native_source", "lat", "lon", "time")
+    assert right.dims == ("native_source", "lat", "lon", "region")
+    assert isinstance(right.data._meta, SparseArray)
 
 
 def test_multisource_sensitivity_accepts_reordered_exact_sources() -> None:
@@ -2252,6 +2256,21 @@ def test_multisource_sensitivity_accepts_reordered_exact_sources() -> None:
     actual = basis_functions.sensitivity(fp_x_flux.sel(source=["B", "A"]))
 
     xr.testing.assert_identical(actual, expected)
+
+
+def test_multisource_sensitivity_rejects_reordered_grid() -> None:
+    """The native contraction keeps the existing exact grid-order contract."""
+    sources = ["A", "B"]
+    basis = make_basis_flat_from_blocks([[1, 1], [2, 2]])
+    basis_functions = BasisFunctions.from_multi_source_flat_basis(
+        basis_flat={source: basis for source in sources},
+        flux=xr.ones_like(basis, dtype=float),
+        operator_kwargs={"state_dim": "region"},
+    )
+    fp_x_flux = make_fp_x_flux_sectoral(sources=sources, nlat=2, nlon=2, ntime=3)
+
+    with pytest.raises(ValueError, match="Coordinate mismatch along 'lat'"):
+        basis_functions.sensitivity(fp_x_flux.isel(lat=[1, 0], lon=[1, 0]))
 
 
 def test_multisource_sensitivity_source_independent_control() -> None:

--- a/tests/test_basis_functions.py
+++ b/tests/test_basis_functions.py
@@ -2237,6 +2237,42 @@ def test_multisource_sensitivity_projects_each_source_before_gathering(monkeypat
     assert all("region" not in dims and "source" not in dims for dims in projected_dims)
 
 
+def test_multisource_sensitivity_accepts_reordered_exact_sources() -> None:
+    """Source labels, rather than input position, select each gathered state block."""
+    sources = ["A", "B"]
+    basis = make_basis_flat_from_blocks([[1, 1], [2, 2]])
+    basis_functions = BasisFunctions.from_multi_source_flat_basis(
+        basis_flat={source: basis for source in sources},
+        flux=xr.ones_like(basis, dtype=float),
+        operator_kwargs={"state_dim": "region"},
+    )
+    fp_x_flux = make_fp_x_flux_sectoral(sources=sources, nlat=2, nlon=2, ntime=3)
+
+    expected = basis_functions.sensitivity(fp_x_flux)
+    actual = basis_functions.sensitivity(fp_x_flux.sel(source=["B", "A"]))
+
+    xr.testing.assert_identical(actual, expected)
+
+
+def test_multisource_sensitivity_source_independent_control() -> None:
+    """A shared spatial input retains the ordinary single-dot path."""
+    basis = make_basis_flat_from_blocks([[1, 1], [2, 2]])
+    basis_functions = BasisFunctions.from_multi_source_flat_basis(
+        basis_flat={"A": basis, "B": basis},
+        flux=xr.ones_like(basis, dtype=float),
+        operator_kwargs={"state_dim": "region"},
+    )
+    fp_x_flux = make_fp_x_flux(nlat=2, nlon=2, ntime=3)
+
+    sensitivity = basis_functions.sensitivity(fp_x_flux)
+
+    assert sensitivity.dims == ("region", "time")
+    xr.testing.assert_identical(
+        sensitivity.sel(source="A", drop=True),
+        sensitivity.sel(source="B", drop=True),
+    )
+
+
 def test_basis_functions_from_fp_all_flat_basis(tac_ch4_data_args):
     """Construct BasisFunctions object from fp_all side-channel flux data."""
     fp_all, *_ = data_processing_surface_notracer(**tac_ch4_data_args)

--- a/tests/test_basis_functions.py
+++ b/tests/test_basis_functions.py
@@ -2258,6 +2258,82 @@ def test_multisource_sensitivity_accepts_reordered_exact_sources() -> None:
     xr.testing.assert_identical(actual, expected)
 
 
+def test_multisource_sensitivity_avoids_configured_state_dimension_collision() -> None:
+    """The temporary native source axis must not collide with the retained state axis."""
+    sources = ["A", "B"]
+    basis = make_basis_flat_from_blocks([[1, 1], [2, 2]])
+    colliding = BasisFunctions.from_multi_source_flat_basis(
+        basis_flat={source: basis for source in sources},
+        flux=xr.ones_like(basis, dtype=float),
+        operator_kwargs={"state_dim": "native_source"},
+    )
+    reference = BasisFunctions.from_multi_source_flat_basis(
+        basis_flat={source: basis for source in sources},
+        flux=xr.ones_like(basis, dtype=float),
+        operator_kwargs={"state_dim": "region"},
+    )
+    fp_x_flux = make_fp_x_flux_sectoral(sources=sources, nlat=2, nlon=2, ntime=3)
+
+    actual = colliding.sensitivity(fp_x_flux)
+    expected = reference.sensitivity(fp_x_flux)
+
+    assert actual.dims == ("native_source", "time")
+    assert actual.get_index("native_source").equals(expected.get_index("region"))
+    np.testing.assert_allclose(actual.values, expected.values)
+
+
+def test_multisource_sensitivity_avoids_extra_dimension_collision() -> None:
+    """A valid surviving ``native_source`` dimension remains distinct from the temporary axis."""
+    sources = ["A", "B"]
+    basis = make_basis_flat_from_blocks([[1, 1], [2, 2]])
+    basis_functions = BasisFunctions.from_multi_source_flat_basis(
+        basis_flat={source: basis for source in sources},
+        flux=xr.ones_like(basis, dtype=float),
+        operator_kwargs={"state_dim": "region"},
+    )
+    fp_x_flux = make_fp_x_flux_sectoral(sources=sources, nlat=2, nlon=2, ntime=3)
+    factor = xr.DataArray(
+        [1.0, 2.0],
+        dims="native_source",
+        coords={"native_source": ["first", "second"]},
+    )
+
+    actual = basis_functions.sensitivity(fp_x_flux.expand_dims(native_source=factor.native_source) * factor)
+    expected = (basis_functions.sensitivity(fp_x_flux) * factor).transpose(
+        "region", "time", "native_source"
+    )
+
+    xr.testing.assert_identical(actual, expected)
+
+
+def test_multisource_sensitivity_preserves_source_dependent_auxiliary_coordinate() -> None:
+    """Source coordinates on surviving dimensions are gathered onto retained state."""
+    sources = ["A", "B"]
+    basis = make_basis_flat_from_blocks([[1, 1], [2, 2]])
+    basis_functions = BasisFunctions.from_multi_source_flat_basis(
+        basis_flat={source: basis for source in sources},
+        flux=xr.ones_like(basis, dtype=float),
+        operator_kwargs={"state_dim": "region"},
+    )
+    fp_x_flux = make_fp_x_flux_sectoral(sources=sources, nlat=2, nlon=2, ntime=3)
+    calibration = xr.DataArray(
+        np.arange(6).reshape(2, 3),
+        dims=("source", "time"),
+        coords={"source": sources, "time": fp_x_flux.time},
+        name="calibration",
+        attrs={"units": "1"},
+    )
+    fp_x_flux = fp_x_flux.assign_coords(calibration=calibration)
+
+    actual = basis_functions.sensitivity(fp_x_flux).coords["calibration"]
+    expected_values = calibration.sel(source=["A", "A", "B", "B"]).values
+
+    assert actual.dims == ("region", "time")
+    assert actual.get_index("region").equals(basis_functions.operator.basis_matrix.get_index("region"))
+    assert actual.attrs == calibration.attrs
+    np.testing.assert_array_equal(actual.values, expected_values)
+
+
 def test_multisource_sensitivity_rejects_reordered_grid() -> None:
     """The native contraction keeps the existing exact grid-order contract."""
     sources = ["A", "B"]


### PR DESCRIPTION
* **Summary of changes**

Closes #653. Implements the useful parts of Linear OPE-121 as a draft PR stacked on #651.

- adds `iter_multi_index_level_slices`, which validates exact unique-level coverage and groups gathered positions in one O(states) pass without broadcasting the dense operand;
- adds a metadata-only warning before `align_to_multi_index_level_values` performs an explicit broadcast when both the projected logical size is at least 1 GiB and the expansion is at least 10x;
- fuses source selection with `MultiSourceBucketBasisOperator.native_prolongation()` and performs one sparse block-diagonal contraction for multisource sensitivity;
- preserves the existing weighted-interpolation path because profiling rejects the proposed source-wise replacement;
- adds missing/extra/duplicate/reordered label regressions, exact grid-order coverage, sparse-contraction structural coverage, and source-independent controls;
- chooses a collision-free temporary source dimension and preserves source-dependent auxiliary coordinates on dimensions that survive the contraction;
- includes reproducible reduced and WUR25/SLURM profiling harnesses.

Related: #653, #651, [Linear OPE-121](https://linear.app/openghg-inversions/issue/OPE-121/profile-multiindex-level-operations-in-multisource-sensitivity-and).

### Decisions

#### Cheap broadcast warning: adopt

The warning uses metadata only:

`projected bytes = da.nbytes / da.sizes[array_dim] * multi_index.sizes[multi_dim]`

It does not compute lazy data. The two-part threshold avoids noise for small arrays and low-ratio reshaping. For the WUR25 sensitivity shape, it predicts the forbidden 168.062 GiB `(state, time, lat, lon)` representation before vectorized selection builds it. The safe iterator is unaffected.

#### Sparse selector/native prolongation: adopt for sensitivity

The source selector is fused with the sparse basis first. The dense input is contracted as `(time, source × grid) @ sparse(source × grid, state)`; no dense `(source, grid, state)` or `(state, grid, time)` block is constructed. Production uses the existing `native_prolongation()` object, with a distinct `native_source` dimension to avoid collision with the state MultiIndex level.

Reduced Dask fixture (float32; four sources; 80×100 grid; 24 times):

| sensitivity | wall | tasks | peak RSS |
|---|---:|---:|---:|
| #651 source-wise loop | 5.57–5.69 s | 189 | 393–398 MiB |
| sparse native contraction | 3.82–4.11 s | 105 | about 381 MiB |

The largest observed native payloads were 0.0049 MiB dense and 0.275 MiB sparse. Coordinates matched the broadcast reference; max float32 difference was `3.0518e-5`, caused by reduction order.

#### Source-wise weighted interpolation: reject

| weighted interpolation | eager wall / peak RSS | Dask wall / peak RSS / tasks |
|---|---:|---:|
| current weight expansion | 0.029 s / 482.1 MiB | 0.933 s / 343.1 MiB / 1,309 |
| proposed source-wise | 0.040 s / 413.7 MiB | 4.623 s / 393.5 MiB / 149 |

The proposed interpolation saved 68.4 MiB eager but was 36% slower; in the production-relevant lazy mode it was 5.0× slower and used 50.4 MiB more peak RSS. Outputs and coordinates were identical under Dask. It is not adopted.

### WUR25 production evidence

Immutable revisions: OGI `3a5234cadf53ab96ec5fd295994c23bd284e9ad6` (stacked on #651 `3c7deceea3006d724b0b9131094da1cdfd690660`); VG `0fe7a2ecec976fcc4bb50d9802f419e9ba0bfc7f`; reduced harness SHA-256 `b786bc75c5a3eb92b0a3c87a30bff3e64f9f47d654877c090cdab32697196c34`; WUR25 harness SHA-256 `09b9b316186c4dee24767a40f40218ec59ae994bbc0c8ce879e40c94084dc59b`.

- PR651 reference gate `18730242`: real `fp_x_flux(4, 293, 391, 743)`, basis `(530, 293, 391)`, 10.652 s and 71 tasks.
- Sparse-native immutable gate `18730624`: completed in 4m42s with scheduler MaxRSS 36,618,292 KiB. The production contraction returned `(530, 743)` in 7.182 s with 36 tasks. Every coordinate, including exact `region` and `time` indexes, matched PR651. Max absolute/relative float32 differences were `1.6689e-5` / `4.3365e-5`. The largest observed payloads were 1.502 MiB dense (the output) and 15.733 MiB sparse.
- Full 25-site build `18730778`: completed in 3m56s with scheduler MaxRSS 37,786,232 KiB. All 25 calls completed in 0.903–6.690 s (mean 1.393 s), using 17–36 tasks. The reopened DataTree contained 5,899 observations, 530 active states, four sources, and 25 sites. Identity, labels/order, units, inner/outer coverage, NESW reconstruction, state activity, and fixed-one closure passed; maximum closure delta was 0.0 ppm at every site.

### Validation

- [x] `137 passed` across `tests/test_array_ops.py` and `tests/test_basis_functions.py`
- [x] Ruff passed on every changed Python path
- [x] `bash -n scripts/slurm_profile_ope121_wur25.sh`
- [x] `git diff --check`
- [x] Towncrier fragment added
- [x] No new dependency

This remains draft while stacked on #651. Repository PR workflows target `main`/`devel`, so the stacked base does not trigger them; retarget after #651 lands.
