### PR TITLE
Fix sparse-site percentile minimum error

### DIFF
--- a/newsfragments/+.bugfix.md
+++ b/newsfragments/+.bugfix.md
@@ -1,0 +1,1 @@
+Percentile minimum error is now calculated independently per site, avoiding cross-site alignment artifacts for sparse observations; validation also reports NaN and infinite values separately from negative values.

--- a/openghg_inversions/model_error.py
+++ b/openghg_inversions/model_error.py
@@ -97,8 +97,10 @@ class MinimumError:
             raise ValueError(f"Option '{value}' is not valid.")
 
         source = np.asarray(source, dtype=float)
-        if not np.isfinite(source).all() or (source < 0).any():
-            raise ValueError("Minimum-error values must be finite and non-negative.")
+        if not np.isfinite(source).all():
+            raise ValueError("Minimum-error values contain NaN or infinite values.")
+        if (source < 0).any():
+            raise ValueError("Minimum-error values must be non-negative.")
 
         if varies_by_site:
             if site_coord is None:
@@ -260,15 +262,13 @@ def percentile_error_method(ds_dict: dict[str, xr.Dataset]) -> np.ndarray:
     Returns:
         np.ndarray: estimated value(s) for model error.
     """
-    # Combine mf data from each site into a single dataset with a site dimension
-    ds = xr.concat(
-        [v[["mf"]].expand_dims({"site": [k]}) for k, v in ds_dict.items() if not k.startswith(".")],
-        dim="site",
-    )
+    result = []
+    for site, dataset in ds_dict.items():
+        if site.startswith("."):
+            continue
+        mf = dataset.mf.as_numpy()
+        monthly_50pc = mf.resample(time="MS").quantile(0.5)
+        monthly_5pc = mf.resample(time="MS").quantile(0.05)
+        result.append((monthly_50pc - monthly_5pc).mean().item())
 
-    # Calculate monthly percentiles, then take the annual mean difference for each site
-    monthly_50pc = ds.mf.as_numpy().resample(time="MS").quantile(0.5)
-    monthly_5pc = ds.mf.as_numpy().resample(time="MS").quantile(0.05)
-    res_err = (monthly_50pc - monthly_5pc).groupby("site").mean(dim="time")
-
-    return res_err.values
+    return np.asarray(result)

--- a/tests/test_inversion_inputs.py
+++ b/tests/test_inversion_inputs.py
@@ -27,7 +27,7 @@ from openghg_inversions.inversion_inputs import (
     concat_gather_datasets,
     make_inv_inputs,
 )
-from openghg_inversions.model_error import MinimumError
+from openghg_inversions.model_error import MinimumError, percentile_error_method
 from openghg_inversions.sigma import SigmaAlignment
 
 
@@ -612,12 +612,36 @@ def test_minimum_error_uses_declared_site_order_and_records_provenance(tmp_path:
     result.values.to_netcdf(tmp_path / "minimum_error.nc")
 
 
-@pytest.mark.parametrize("value", [-1.0, np.inf, np.nan])
-def test_minimum_error_rejects_invalid_values(value: float):
+@pytest.mark.parametrize(
+    ("value", "message"),
+    [
+        pytest.param(-1.0, "must be non-negative", id="negative"),
+        pytest.param(np.inf, "contain NaN or infinite", id="infinite"),
+        pytest.param(np.nan, "contain NaN or infinite", id="nan"),
+    ],
+)
+def test_minimum_error_rejects_invalid_values(value: float, message: str):
     observations = xr.Dataset({"mf": ("nmeasure", [1.0])})
 
-    with pytest.raises(ValueError, match="finite and non-negative"):
+    with pytest.raises(ValueError, match=message):
         MinimumError.prepare(observations, {}, value)
+
+
+def test_percentile_error_resamples_each_site_independently():
+    sites = {
+        "AAA": xr.Dataset(
+            {"mf": ("time", [1.0, 3.0, 5.0])},
+            coords={"time": pd.to_datetime(["2024-01-01", "2024-01-02", "2024-03-01"])},
+        ),
+        "BBB": xr.Dataset(
+            {"mf": ("time", [10.0, 20.0, 30.0])},
+            coords={"time": pd.to_datetime(["2024-01-01", "2024-02-01", "2024-03-01"])},
+        ),
+    }
+
+    result = percentile_error_method(sites)
+
+    np.testing.assert_allclose(result, [0.45, 0.0])
 
 
 def test_scalar_minimum_error_preserves_lazy_borrowed_observations():


### PR DESCRIPTION
* **Summary of changes**

  - calculate monthly percentile differences independently per site, avoiding cross-site xarray alignment artifacts when sites have sparse or disjoint observations
  - report NaN or infinite minimum-error values separately from genuinely negative values
  - add a regression case with a site missing a whole month and a Towncrier bugfix fragment

* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx (no linked issue)
- [x] Tests added and passing
- [ ] Documentation and tutorials updated/added (not needed for this focused calculation fix)
- [x] Added a Towncrier news fragment in `newsfragments/`
- [x] Added any new requirements to `requirements.txt` (none required)

**Reproduction**

The old implementation returned −0.0170 ppt for JFJ in the retained 2024 annual SF6 observations because months with no JFJ data acquired values during the combined-site resample. Calculating each site independently returns 0.0434 ppt; all 24 annual site values are then finite and non-negative.

**Validation**

- `.venv/bin/pytest tests/test_inversion_inputs.py -q` — 24 passed, 1 deselected
- `.venv/bin/ruff check openghg_inversions/model_error.py tests/test_inversion_inputs.py`
- `git diff --check`